### PR TITLE
Irange tests

### DIFF
--- a/src/test-fbp/irange-buffer.fbp
+++ b/src/test-fbp/irange-buffer.fbp
@@ -39,5 +39,15 @@ median_result OUT -> IN1 median_equal
 
 median_equal OUT -> RESULT test_median(test/result)
 
+# --------------------------
 
+median_result2(constant/int:value=1)
+median_buffer2(int/buffer:operation=median)
+median_equal2(int/equal)
+gen2(test/int-generator:sequence="1 2") OUT -> IN median_buffer2
+timeout(constant/int:value=1) OUT -> TIMEOUT median_buffer2
 
+median_buffer2 OUT -> IN0 median_equal2
+median_result2 OUT -> IN1 median_equal2
+
+median_equal2 OUT -> RESULT test_median2(test/result)

--- a/src/test-fbp/irange-math.fbp
+++ b/src/test-fbp/irange-math.fbp
@@ -48,3 +48,5 @@ negative_val OUT -> IN abs(int/abs) OUT -> IN0 cmp_abs(int/equal)
 absolute_val OUT -> IN1 cmp_abs
 cmp_abs OUT -> RESULT abs_result(test/result)
 
+constrain_int(constant/int:value=50) OUT -> IN  constrain(int/constrain) OUT -> IN0 constrain_equal(int/equal)
+constrain_int OUT -> IN1 constrain_equal OUT -> RESULT constrain_test(test/result)


### PR DESCRIPTION
The int nodes are missing some tests: the  Timeout on the int/buffer and the int/constrain nodes. this patch adds them.