### PR TITLE
Add support for array ports

### DIFF
--- a/data/schemas/node-type.schema
+++ b/data/schemas/node-type.schema
@@ -81,7 +81,7 @@
           "properties": {
             "name": {
               "type": "string",
-              "pattern": "^[A-Z][A-Z0-9_]*$"
+              "pattern": "^[A-Z][A-Z0-9_]*(\\[[0-9]+\\])?$"
             },
             "data_type": { "$ref": "#/definitions/port_data_type" },
             "methods": {
@@ -107,7 +107,7 @@
           "properties": {
             "name": {
               "type": "string",
-              "pattern": "^[A-Z][A-Z0-9_]*$",
+              "pattern": "^[A-Z][A-Z0-9_]*(\\[[0-9]+\\])?$",
               "not": { "enum": [ "ERROR" ] }
             },
             "flags": { "enum": [ "SOL_FLOW_PORT_TYPE_FLAGS_REPLACE_PACKET" ] },

--- a/src/bin/sol-fbp-runner/inspector.c
+++ b/src/bin/sol-fbp-runner/inspector.c
@@ -72,18 +72,24 @@ inspector_show_node_id(const struct sol_flow_node *node)
 }
 
 static void
+inspector_print_port_name(uint16_t port, const struct sol_flow_port_description *desc)
+{
+    if (desc->array_size == 0) {
+        fputs(desc->name, stdout);
+        return;
+    }
+    fprintf(stdout, "%s[%d]", desc->name, port - desc->base_port_idx);
+}
+
+static void
 inspector_show_in_port(const struct sol_flow_node *node, uint16_t port_idx)
 {
-    const struct sol_flow_node_type *type = sol_flow_node_get_type(node);
-    const struct sol_flow_node_type_description *desc;
+    const struct sol_flow_port_description *port;
 
-    if (!type)
-        return;
-    desc = type->description;
-    if (desc && desc->ports_in) {
-        const struct sol_flow_port_description *port = desc->ports_in[port_idx];
+    port = sol_flow_node_get_port_in_description(node, port_idx);
+    if (port) {
         if (port->name) {
-            fputs(port->name, stdout);
+            inspector_print_port_name(port_idx, port);
             if (port->data_type)
                 fprintf(stdout, "(%s)", port->data_type);
             return;
@@ -95,23 +101,17 @@ inspector_show_in_port(const struct sol_flow_node *node, uint16_t port_idx)
 static void
 inspector_show_out_port(const struct sol_flow_node *node, uint16_t port_idx)
 {
-    const struct sol_flow_node_type *type = sol_flow_node_get_type(node);
-    const struct sol_flow_node_type_description *desc;
+    const struct sol_flow_port_description *port;
 
-    if (!type)
+    if (port_idx == SOL_FLOW_NODE_PORT_ERROR) {
+        fputs(SOL_FLOW_NODE_PORT_ERROR_NAME, stdout);
         return;
-    desc = type->description;
-    if (desc && desc->ports_out) {
-        const struct sol_flow_port_description *port;
+    }
 
-        if (port_idx == SOL_FLOW_NODE_PORT_ERROR) {
-            fputs(SOL_FLOW_NODE_PORT_ERROR_NAME, stdout);
-            return;
-        }
-
-        port = desc->ports_out[port_idx];
+    port = sol_flow_node_get_port_out_description(node, port_idx);
+    if (port) {
         if (port->name) {
-            fputs(port->name, stdout);
+            inspector_print_port_name(port_idx, port);
             if (port->data_type)
                 fprintf(stdout, "(%s)", port->data_type);
             return;

--- a/src/bin/sol-flow-node-types/main.c
+++ b/src/bin/sol-flow-node-types/main.c
@@ -139,6 +139,7 @@ list_ports(FILE *fp, const struct sol_flow_port_description *const *ports)
 #undef OUT
 #undef STR
 
+        fprintf(fp, ", \"array_size\": %d\n", port->array_size);
         fprintf(fp,
             ", \"required\": %s\n"
             "}\n",

--- a/src/lib/flow/sol-flow-builder.h
+++ b/src/lib/flow/sol-flow-builder.h
@@ -80,12 +80,12 @@ int sol_flow_builder_add_node_by_type(struct sol_flow_builder *builder, const ch
  * description struct. If no description was declared,
  * sol_flow_builder_connect_by_index() should be used instead.
  */
-int sol_flow_builder_connect(struct sol_flow_builder *builder, const char *src_name, const char *src_port_name, const char *dst_name, const char *dst_port_name);
+int sol_flow_builder_connect(struct sol_flow_builder *builder, const char *src_name, const char *src_port_name, int src_port_idx, const char *dst_name, const char *dst_port_name, int dst_port_idx);
 
 int sol_flow_builder_connect_by_index(struct sol_flow_builder *builder, const char *src_name, uint16_t src_port_index, const char *dst_name, uint16_t dst_port_index);
 
-int sol_flow_builder_export_in_port(struct sol_flow_builder *builder, const char *node_name, const char *port_name, const char *exported_name);
-int sol_flow_builder_export_out_port(struct sol_flow_builder *builder, const char *node_name, const char *port_name, const char *exported_name);
+int sol_flow_builder_export_in_port(struct sol_flow_builder *builder, const char *node_name, const char *port_name, int port_idx, const char *exported_name);
+int sol_flow_builder_export_out_port(struct sol_flow_builder *builder, const char *node_name, const char *port_name, int port_idx, const char *exported_name);
 
 /* Returns the node type generated with the builder. It should be used
  * to create nodes with sol_flow_node_new(). After the type is

--- a/src/lib/flow/sol-flow-parser.c
+++ b/src/lib/flow/sol-flow-parser.c
@@ -502,8 +502,8 @@ build_flow(struct parse_state *state)
             goto end;
 
         err = sol_flow_builder_connect(state->builder,
-            state->node_names[c->src], src_port_buf.data,
-            state->node_names[c->dst], dst_port_buf.data);
+            state->node_names[c->src], src_port_buf.data, c->src_port_idx,
+            state->node_names[c->dst], dst_port_buf.data, c->dst_port_idx);
         if (err < 0) {
             sol_fbp_log_print(state->filename, c->position.line, c->position.column,
                 "Couldn't connect '%s %s -> %s %s'",
@@ -529,7 +529,7 @@ build_flow(struct parse_state *state)
 
         sol_flow_builder_export_in_port(
             state->builder, state->node_names[ep->node],
-            dst_port_buf.data, exported_name);
+            dst_port_buf.data, ep->port_idx, exported_name);
     }
 
     SOL_VECTOR_FOREACH_IDX (&graph->exported_out_ports, ep, i) {
@@ -548,7 +548,7 @@ build_flow(struct parse_state *state)
 
         sol_flow_builder_export_out_port(
             state->builder, state->node_names[ep->node],
-            src_port_buf.data, exported_name);
+            src_port_buf.data, ep->port_idx, exported_name);
     }
 
     type = sol_flow_builder_get_node_type(state->builder);

--- a/src/lib/flow/sol-flow.c
+++ b/src/lib/flow/sol-flow.c
@@ -440,4 +440,39 @@ sol_flow_foreach_builtin_node_type(bool (*cb)(void *data, const struct sol_flow_
     }
 #endif
 }
+
+static const struct sol_flow_port_description *
+sol_flow_node_type_get_port_description(const struct sol_flow_port_description *const *ports, uint16_t port)
+{
+    const struct sol_flow_port_description *desc;
+    uint16_t next = 0;
+
+    for (desc = *ports; desc; desc++) {
+        next += desc->array_size ? : 1;
+        if (port < next)
+            return desc;
+    }
+
+    return NULL;
+}
+
+SOL_API const struct sol_flow_port_description *
+sol_flow_node_get_port_in_description(const struct sol_flow_node *node, uint16_t port)
+{
+    SOL_FLOW_NODE_CHECK(node, NULL);
+
+    SOL_NULL_CHECK(node->type->description, NULL);
+    SOL_NULL_CHECK(node->type->description->ports_in, NULL);
+    return sol_flow_node_type_get_port_description(node->type->description->ports_in, port);
+}
+
+SOL_API const struct sol_flow_port_description *
+sol_flow_node_get_port_out_description(const struct sol_flow_node *node, uint16_t port)
+{
+    SOL_FLOW_NODE_CHECK(node, NULL);
+
+    SOL_NULL_CHECK(node->type->description, NULL);
+    SOL_NULL_CHECK(node->type->description->ports_out, NULL);
+    return sol_flow_node_type_get_port_description(node->type->description->ports_out, port);
+}
 #endif

--- a/src/lib/flow/sol-flow.h
+++ b/src/lib/flow/sol-flow.h
@@ -224,6 +224,8 @@ struct sol_flow_port_description {
     const char *name; /**< port's name */
     const char *description; /**< port's description */
     const char *data_type; /**< textual representation of the port's accepted packet data type(s), e. g. "int" */
+    uint16_t array_size; /**< Size of array for array ports, or 0 for single ports */
+    uint16_t base_port_idx; /**< For array ports, the port number where the array begins */
     bool required; /**< whether at least one connection has to be made on this port in order to the node to function (Soletta does not check that at runtime, this is mostly a hint for visual editors that can output flows/code from visual representations of a flow) */
 };
 
@@ -338,6 +340,24 @@ const struct sol_flow_port_type_out *sol_flow_node_type_get_port_out(const struc
  *
  */
 void sol_flow_foreach_builtin_node_type(bool (*cb)(void *data, const struct sol_flow_node_type *type), const void *data);
+
+/**
+ * Get the port description associated with a given input port index.
+ *
+ * @param node The node the port belongs to
+ * @param port The port index
+ * @return The port description for the given port
+ */
+const struct sol_flow_port_description *sol_flow_node_get_port_in_description(const struct sol_flow_node *node, uint16_t port);
+
+/**
+ * Get the port description associated with a given output port index.
+ *
+ * @param node The node the port belongs to
+ * @param port The port index
+ * @return The port description for the given port
+ */
+const struct sol_flow_port_description *sol_flow_node_get_port_out_description(const struct sol_flow_node *node, uint16_t port);
 #endif
 
 /* When a node type is a container (i.e. may act as parent of other

--- a/src/modules/flow/converter/converter.c
+++ b/src/modules/flow/converter/converter.c
@@ -1039,7 +1039,8 @@ byte_to_bits_convert(struct sol_flow_node *node, void *data, uint16_t port, uint
         if (mdata->output_initialized && last_bit == next_bit)
             continue;
 
-        sol_flow_send_boolean_packet(node, i, next_bit);
+        sol_flow_send_boolean_packet(node,
+            SOL_FLOW_NODE_TYPE_CONVERTER_BYTE_TO_BITS__OUT__OUT_0 + i, next_bit);
     }
 
     mdata->last = in_val;
@@ -1388,8 +1389,9 @@ static int
 irange_compose_connect(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id)
 {
     struct sol_converter_irange_compose *mdata = data;
+    int idx = port - SOL_FLOW_NODE_TYPE_CONVERTER_INT_COMPOSE__IN__IN_0;
 
-    mdata->connected_ports |= 1 << port;
+    mdata->connected_ports |= 1 << idx;
     return 0;
 }
 
@@ -1398,6 +1400,7 @@ irange_compose(struct sol_flow_node *node, void *data, uint16_t port, uint16_t c
 {
     struct sol_converter_irange_compose *mdata = data;
     struct sol_irange out_val = { .min = INT32_MIN, .max = INT32_MAX, .step = 1 };
+    int idx = port - SOL_FLOW_NODE_TYPE_CONVERTER_INT_COMPOSE__IN__IN_0;
     unsigned int tmp;
     unsigned char in_val;
     int r;
@@ -1405,10 +1408,10 @@ irange_compose(struct sol_flow_node *node, void *data, uint16_t port, uint16_t c
     r = sol_flow_packet_get_byte(packet, &in_val);
     SOL_INT_CHECK(r, < 0, r);
 
-    mdata->port_has_value |= 1 << port;
+    mdata->port_has_value |= 1 << idx;
 
-    tmp = mdata->output_value & ~(0xff << (port * CHAR_BIT));
-    tmp |= in_val << (port * CHAR_BIT);
+    tmp = mdata->output_value & ~(0xff << (idx * CHAR_BIT));
+    tmp |= in_val << (idx * CHAR_BIT);
     mdata->output_value = tmp;
 
     if (mdata->port_has_value != mdata->connected_ports)
@@ -1431,10 +1434,10 @@ irange_decompose(struct sol_flow_node *node, void *data, uint16_t port, uint16_t
     value = (unsigned)in.val;
     for (i = 0; i < 4; i++) {
         uint16_t out_port[] = {
-            SOL_FLOW_NODE_TYPE_CONVERTER_INT_DECOMPOSE__OUT__OUT0,
-            SOL_FLOW_NODE_TYPE_CONVERTER_INT_DECOMPOSE__OUT__OUT1,
-            SOL_FLOW_NODE_TYPE_CONVERTER_INT_DECOMPOSE__OUT__OUT2,
-            SOL_FLOW_NODE_TYPE_CONVERTER_INT_DECOMPOSE__OUT__OUT3
+            SOL_FLOW_NODE_TYPE_CONVERTER_INT_DECOMPOSE__OUT__OUT_0,
+            SOL_FLOW_NODE_TYPE_CONVERTER_INT_DECOMPOSE__OUT__OUT_1,
+            SOL_FLOW_NODE_TYPE_CONVERTER_INT_DECOMPOSE__OUT__OUT_2,
+            SOL_FLOW_NODE_TYPE_CONVERTER_INT_DECOMPOSE__OUT__OUT_3
         };
         unsigned char byte;
         byte = value & 0xff;
@@ -1467,8 +1470,9 @@ static int
 bits_to_byte_connect(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id)
 {
     struct sol_converter_bits *mdata = data;
+    int idx = port - SOL_FLOW_NODE_TYPE_CONVERTER_BITS_TO_BYTE__IN__IN_0;
 
-    mdata->connected_ports |= 1 << port;
+    mdata->connected_ports |= 1 << idx;
     return 0;
 }
 
@@ -1481,17 +1485,18 @@ static int
 bits_to_byte_convert(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
 {
     struct sol_converter_bits *mdata = data;
+    int idx = port - SOL_FLOW_NODE_TYPE_CONVERTER_BITS_TO_BYTE__IN__IN_0;
     bool in_val;
 
     sol_flow_packet_get_boolean(packet, &in_val);
 
-    if ((mdata->output_initialized >> port) & 1) {
-        if ((mdata->last >> port) == in_val)
+    if ((mdata->output_initialized >> idx) & 1) {
+        if ((mdata->last >> idx) == in_val)
             return 0;
     } else
-        mdata->output_initialized |= 1 << port;
+        mdata->output_initialized |= 1 << idx;
 
-    SET_BIT(mdata->last, port, in_val);
+    SET_BIT(mdata->last, idx, in_val);
 
     if (mdata->output_initialized != mdata->connected_ports)
         return 0;

--- a/src/modules/flow/converter/converter.json
+++ b/src/modules/flow/converter/converter.json
@@ -296,43 +296,8 @@
       "out_ports": [
         {
           "data_type": "boolean",
-          "description": "Least significant bit",
-          "name": "OUT0"
-        },
-        {
-          "data_type": "boolean",
-          "description": "Binary output",
-          "name": "OUT1"
-        },
-        {
-          "data_type": "boolean",
-          "description": "Binary output",
-          "name": "OUT2"
-        },
-        {
-          "data_type": "boolean",
-          "description": "Binary output",
-          "name": "OUT3"
-        },
-        {
-          "data_type": "boolean",
-          "description": "Binary output",
-          "name": "OUT4"
-        },
-        {
-          "data_type": "boolean",
-          "description": "Binary output",
-          "name": "OUT5"
-        },
-        {
-          "data_type": "boolean",
-          "description": "Binary output",
-          "name": "OUT6"
-        },
-        {
-          "data_type": "boolean",
-          "description": "Most significant bit",
-          "name": "OUT7"
+          "description": "Byte turned to bits, index 0 is the least significant, 7 the most",
+          "name": "OUT[8]"
         }
       ],
       "private_data_type": "sol_converter_bits",
@@ -1122,39 +1087,12 @@
       "in_ports": [
         {
           "data_type": "byte",
-          "description": "Least significant byte",
+          "description": "Array of bytes to turn into an int. Index 0 is the least significant, 3 is the most",
           "methods": {
             "connect": "irange_compose_connect",
             "process": "irange_compose"
           },
-          "name": "IN0"
-        },
-        {
-          "data_type": "byte",
-          "description": "Second byte",
-          "methods": {
-            "connect": "irange_compose_connect",
-            "process": "irange_compose"
-          },
-          "name": "IN1"
-        },
-        {
-          "data_type": "byte",
-          "description": "Third byte",
-          "methods": {
-            "connect": "irange_compose_connect",
-            "process": "irange_compose"
-          },
-          "name": "IN2"
-        },
-        {
-          "data_type": "byte",
-          "description": "Most significant byte",
-          "methods": {
-            "connect": "irange_compose_connect",
-            "process": "irange_compose"
-          },
-          "name": "IN3"
+          "name": "IN[4]"
         }
       ],
       "name": "converter/int-compose",
@@ -1185,23 +1123,8 @@
       "out_ports": [
         {
           "data_type": "byte",
-          "description": "Least significant byte",
-          "name": "OUT0"
-        },
-        {
-          "data_type": "byte",
-          "description": "Second byte",
-          "name": "OUT1"
-        },
-        {
-          "data_type": "byte",
-          "description": "Third byte",
-          "name": "OUT2"
-        },
-        {
-          "data_type": "byte",
-          "description": "Most significant byte",
-          "name": "OUT3"
+          "description": "Int turned to bytes, index 0 is the least significant, 3 the most",
+          "name": "OUT[4]"
         }
       ],
       "url": "http://solettaproject.org/doc/latest/node_types/converter/irange-decompose.html"
@@ -1615,82 +1538,12 @@
       "in_ports": [
         {
           "data_type": "boolean",
-          "description": "Receives the least significant bit",
+          "description": "Array of bits to turn into a byte. Index 0 is the least significant, 7 is the most",
           "methods": {
             "connect": "bits_to_byte_connect",
             "process": "bits_to_byte_convert"
           },
-          "name": "IN0",
-          "required": true
-        },
-        {
-          "data_type": "boolean",
-          "description": "Receives bit to be used in conversion",
-          "methods": {
-            "connect": "bits_to_byte_connect",
-            "process": "bits_to_byte_convert"
-          },
-          "name": "IN1",
-          "required": true
-        },
-        {
-          "data_type": "boolean",
-          "description": "Receives bit to be used in conversion",
-          "methods": {
-            "connect": "bits_to_byte_connect",
-            "process": "bits_to_byte_convert"
-          },
-          "name": "IN2",
-          "required": true
-        },
-        {
-          "data_type": "boolean",
-          "description": "Receives bit to be used in conversion",
-          "methods": {
-            "connect": "bits_to_byte_connect",
-            "process": "bits_to_byte_convert"
-          },
-          "name": "IN3",
-          "required": true
-        },
-        {
-          "data_type": "boolean",
-          "description": "Receives bit to be used in conversion",
-          "methods": {
-            "connect": "bits_to_byte_connect",
-            "process": "bits_to_byte_convert"
-          },
-          "name": "IN4",
-          "required": true
-        },
-        {
-          "data_type": "boolean",
-          "description": "Receives bit to be used in conversion",
-          "methods": {
-            "connect": "bits_to_byte_connect",
-            "process": "bits_to_byte_convert"
-          },
-          "name": "IN5",
-          "required": true
-        },
-        {
-          "data_type": "boolean",
-          "description": "Receives bit to be used in conversion",
-          "methods": {
-            "connect": "bits_to_byte_connect",
-            "process": "bits_to_byte_convert"
-          },
-          "name": "IN6",
-          "required": true
-        },
-        {
-          "data_type": "boolean",
-          "description": "Receives the most significant bit",
-          "methods": {
-            "connect": "bits_to_byte_connect",
-            "process": "bits_to_byte_convert"
-          },
-          "name": "IN7",
+          "name": "IN[8]",
           "required": true
         }
       ],

--- a/src/samples/flow/c-api/highlevel.c
+++ b/src/samples/flow/c-api/highlevel.c
@@ -79,8 +79,8 @@ startup(void)
     sol_flow_builder_add_node(builder, "writer",
         _CUSTOM_NODE_TYPES_WRITER,
         &writer_opts.base);
-    sol_flow_builder_connect(builder, "reader", "OUT", "logic", "IN");
-    sol_flow_builder_connect(builder, "logic", "OUT", "writer", "IN");
+    sol_flow_builder_connect(builder, "reader", "OUT", 0, "logic", "IN", 0);
+    sol_flow_builder_connect(builder, "logic", "OUT", 0, "writer", "IN", 0);
 
     /* Also output to console using soletta's console node type.  If
      * console is builtin libsoletta, it is used, otherwise a module
@@ -90,8 +90,8 @@ startup(void)
      * sol_flow_builder_add_node().
      */
     sol_flow_builder_add_node_by_type(builder, "console", "console", NULL);
-    sol_flow_builder_connect(builder, "reader", "OUT", "console", "IN");
-    sol_flow_builder_connect(builder, "logic", "OUT", "console", "IN");
+    sol_flow_builder_connect(builder, "reader", "OUT", 0, "console", "IN", 0);
+    sol_flow_builder_connect(builder, "logic", "OUT", 0, "console", "IN", 0);
 
     /* this creates a static flow using the low-level API that will
      * actually run the flow. Note that its memory is bound to

--- a/src/samples/flow/minnow-calamari/calamari-rgb-led.fbp
+++ b/src/samples/flow/minnow-calamari/calamari-rgb-led.fbp
@@ -39,7 +39,7 @@ accumulator(int/accumulator:setup_value=val:0|min:0|max:255|step:1)
 timer(wallclock/second) OUT -> INC accumulator
 accumulator OUT -> IN int_to_byte(converter/int-to-byte)
 int_to_byte OUT -> IN byte_to_bits(converter/byte-to-bits)
-byte_to_bits OUT0 -> RED led(calamari/rgb-led)
-byte_to_bits OUT1 -> GREEN led
-byte_to_bits OUT2 -> BLUE led
+byte_to_bits OUT[0] -> RED led(calamari/rgb-led)
+byte_to_bits OUT[1] -> GREEN led
+byte_to_bits OUT[2] -> BLUE led
 

--- a/src/shared/FBP.txt
+++ b/src/shared/FBP.txt
@@ -2,8 +2,6 @@ The input format used to describe flows is based on
 https://github.com/noflo/fbp/blob/master/README.md with some
 differences described below
 
-* Notation for ARRAY ports is still not supported.
-
 * Accepts ':' and '|' in the meta section.
 
 * Statements with zero connections, just a node alone.

--- a/src/shared/sol-fbp-graph.c
+++ b/src/shared/sol-fbp-graph.c
@@ -211,8 +211,8 @@ sol_fbp_graph_add_out_port(struct sol_fbp_graph *g,
 
 int
 sol_fbp_graph_add_conn(struct sol_fbp_graph *g,
-    int src, struct sol_str_slice src_port,
-    int dst, struct sol_str_slice dst_port,
+    int src, struct sol_str_slice src_port, int src_port_idx,
+    int dst, struct sol_str_slice dst_port, int dst_port_idx,
     struct sol_fbp_position position)
 {
     struct sol_fbp_conn *conn;
@@ -236,15 +236,17 @@ sol_fbp_graph_add_conn(struct sol_fbp_graph *g,
 
     conn->src = src;
     conn->src_port = src_port;
+    conn->src_port_idx = src_port_idx;
     conn->dst = dst;
     conn->dst_port = dst_port;
+    conn->dst_port_idx = dst_port_idx;
     conn->position = position;
     return i;
 }
 
 int
 sol_fbp_graph_add_exported_in_port(struct sol_fbp_graph *g,
-    int node, struct sol_str_slice port, struct sol_str_slice exported_name,
+    int node, struct sol_str_slice port, int port_idx, struct sol_str_slice exported_name,
     struct sol_fbp_position position, struct sol_fbp_exported_port **out_ep)
 {
     struct sol_fbp_exported_port *ep;
@@ -256,7 +258,9 @@ sol_fbp_graph_add_exported_in_port(struct sol_fbp_graph *g,
             err = -EEXIST;
             goto end;
         }
-        if (ep->node == node && sol_str_slice_eq(ep->port, port)) {
+        if (ep->node == node && (ep->port_idx == port_idx
+                || (ep->port_idx == -1 || port_idx == -1))
+                && sol_str_slice_eq(ep->port, port)) {
             err = -EADDRINUSE;
             goto end;
         }
@@ -267,6 +271,7 @@ sol_fbp_graph_add_exported_in_port(struct sol_fbp_graph *g,
 
     ep->node = node;
     ep->port = port;
+    ep->port_idx = port_idx;
     ep->exported_name = exported_name;
     ep->position = position;
     err = 0;
@@ -279,7 +284,7 @@ end:
 
 int
 sol_fbp_graph_add_exported_out_port(struct sol_fbp_graph *g,
-    int node, struct sol_str_slice port, struct sol_str_slice exported_name,
+    int node, struct sol_str_slice port, int port_idx, struct sol_str_slice exported_name,
     struct sol_fbp_position position, struct sol_fbp_exported_port **out_ep)
 {
     struct sol_fbp_exported_port *ep;
@@ -291,7 +296,9 @@ sol_fbp_graph_add_exported_out_port(struct sol_fbp_graph *g,
             err = -EEXIST;
             goto end;
         }
-        if (ep->node == node && sol_str_slice_eq(ep->port, port)) {
+        if (ep->node == node && (ep->port_idx == port_idx
+                || (ep->port_idx == -1 || port_idx == -1))
+                && sol_str_slice_eq(ep->port, port)) {
             err = -EADDRINUSE;
             goto end;
         }
@@ -302,6 +309,7 @@ sol_fbp_graph_add_exported_out_port(struct sol_fbp_graph *g,
 
     ep->node = node;
     ep->port = port;
+    ep->port_idx = port_idx;
     ep->exported_name = exported_name;
     ep->position = position;
     err = 0;

--- a/src/shared/sol-fbp-graph.c
+++ b/src/shared/sol-fbp-graph.c
@@ -226,6 +226,8 @@ sol_fbp_graph_add_conn(struct sol_fbp_graph *g,
 
     SOL_VECTOR_FOREACH_IDX (&g->conns, conn, i) {
         if (conn->src == src && conn->dst == dst
+            && conn->src_port_idx == src_port_idx
+            && conn->dst_port_idx == dst_port_idx
             && sol_str_slice_eq(conn->src_port, src_port)
             && sol_str_slice_eq(conn->dst_port, dst_port))
             return -EEXIST;

--- a/src/shared/sol-fbp-internal-scanner.h
+++ b/src/shared/sol-fbp-internal-scanner.h
@@ -41,6 +41,8 @@
 #define SOL_FBP_TOKEN_LIST(X)                           \
     X(NONE)                                            \
     X(ARROW)                                           \
+    X(BRACKET_CLOSE)                                   \
+    X(BRACKET_OPEN)                                    \
     X(COLON)                                           \
     X(COMMA)                                           \
     X(DOT)                                             \
@@ -49,6 +51,7 @@
     X(EQUAL)                                           \
     X(IDENTIFIER)                                      \
     X(INPORT_KEYWORD)                                  \
+    X(INTEGER)                                         \
     X(OUTPORT_KEYWORD)                                 \
     X(PAREN_CLOSE)                                     \
     X(PAREN_OPEN)                                      \

--- a/src/shared/sol-fbp-parser.c
+++ b/src/shared/sol-fbp-parser.c
@@ -125,7 +125,7 @@ set_parse_error(struct sol_fbp_parser *p, const char *fmt, ...)
 
 static bool
 parse_exported_port(struct sol_fbp_parser *p,
-    struct sol_str_slice *node, struct sol_str_slice *port,
+    struct sol_str_slice *node, struct sol_str_slice *port, int *port_idx,
     struct sol_str_slice *exported_port)
 {
     if (next_token(p) != SOL_FBP_TOKEN_EQUAL)
@@ -143,6 +143,24 @@ parse_exported_port(struct sol_fbp_parser *p,
         return set_parse_error(p, "Expected port identifier in export port statement");
 
     *port = get_token_slice(p);
+
+    if (peek_token(p) == SOL_FBP_TOKEN_BRACKET_OPEN) {
+        struct sol_str_slice idx;
+
+        /* consume '[' */
+        next_token(p);
+
+        if (next_token(p) != SOL_FBP_TOKEN_INTEGER)
+            return set_parse_error(p, "Expected integer number for port index");
+
+        idx = get_token_slice(p);
+
+        if (next_token(p) != SOL_FBP_TOKEN_BRACKET_CLOSE) {
+            return set_parse_error(p, "Expected ']' after port index");
+        }
+
+        sol_str_slice_to_int(idx, port_idx);
+    }
 
     if (next_token(p) != SOL_FBP_TOKEN_COLON)
         return set_parse_error(p, "Expected ':' after port identifier in export port statement");
@@ -232,11 +250,11 @@ parse_inport_stmt(struct sol_fbp_parser *p)
     struct sol_fbp_position node_position;
     struct sol_fbp_node *err_node;
     struct sol_fbp_exported_port *ep;
-    int node_idx;
+    int node_idx, port_idx = -1;
     int err;
 
     assert(next_token(p) == SOL_FBP_TOKEN_INPORT_KEYWORD);
-    if (!parse_exported_port(p, &node, &port, &exported_port))
+    if (!parse_exported_port(p, &node, &port, &port_idx, &exported_port))
         return false;
 
     node_position = get_token_position(&p->current_token);
@@ -247,7 +265,7 @@ parse_inport_stmt(struct sol_fbp_parser *p)
 
     sol_fbp_graph_add_in_port(p->graph, node_idx, port, get_token_position(&p->current_token));
 
-    err = sol_fbp_graph_add_exported_in_port(p->graph, node_idx, port, exported_port, get_token_position(&p->current_token), &ep);
+    err = sol_fbp_graph_add_exported_in_port(p->graph, node_idx, port, port_idx, exported_port, get_token_position(&p->current_token), &ep);
     if (err == -EEXIST) {
         return set_parse_error(p,
             "Exported input port with name '%.*s' already declared in %d:%d",
@@ -271,11 +289,11 @@ parse_outport_stmt(struct sol_fbp_parser *p)
     struct sol_fbp_position node_position;
     struct sol_fbp_node *err_node;
     struct sol_fbp_exported_port *ep;
-    int node_idx;
+    int node_idx, port_idx = -1;
     int err;
 
     assert(next_token(p) == SOL_FBP_TOKEN_OUTPORT_KEYWORD);
-    if (!parse_exported_port(p, &node, &port, &exported_port))
+    if (!parse_exported_port(p, &node, &port, &port_idx, &exported_port))
         return false;
 
     node_position = get_token_position(&p->current_token);
@@ -286,7 +304,7 @@ parse_outport_stmt(struct sol_fbp_parser *p)
 
     sol_fbp_graph_add_out_port(p->graph, node_idx, port, get_token_position(&p->current_token));
 
-    err = sol_fbp_graph_add_exported_out_port(p->graph, node_idx, port, exported_port, get_token_position(&p->current_token), &ep);
+    err = sol_fbp_graph_add_exported_out_port(p->graph, node_idx, port, port_idx, exported_port, get_token_position(&p->current_token), &ep);
     if (err == -EEXIST) {
         return set_parse_error(p,
             "Exported output port with name '%.*s' already declared in %d:%d",
@@ -446,14 +464,34 @@ end:
 }
 
 static bool
-parse_port(struct sol_fbp_parser *p, struct sol_str_slice *name)
+parse_port(struct sol_fbp_parser *p, struct sol_str_slice *name, int *port_idx)
 {
+    struct sol_str_slice idx;
+
     if (next_token(p) != SOL_FBP_TOKEN_IDENTIFIER) {
         return set_parse_error(p, "Expected port identifier."
             " e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'");
     }
 
     *name = get_token_slice(p);
+
+    if (peek_token(p) != SOL_FBP_TOKEN_BRACKET_OPEN)
+        return true;
+
+    next_token(p);
+
+    if (next_token(p) != SOL_FBP_TOKEN_INTEGER) {
+        return set_parse_error(p, "Expected integer number for port index");
+    }
+
+    idx = get_token_slice(p);
+
+    if (next_token(p) != SOL_FBP_TOKEN_BRACKET_CLOSE) {
+        return set_parse_error(p, "Expected ']' after port index");
+    }
+
+    sol_str_slice_to_int(idx, port_idx);
+
     return true;
 }
 
@@ -476,7 +514,8 @@ parse_conn_stmt(struct sol_fbp_parser *p)
     }
 
     while (peek_token(p) == SOL_FBP_TOKEN_IDENTIFIER) {
-        if (!parse_port(p, &src_port_name))
+        int src_port_idx = -1, dst_port_idx = -1;
+        if (!parse_port(p, &src_port_name, &src_port_idx))
             return false;
 
         conn_position = get_token_position(&p->current_token);
@@ -498,7 +537,7 @@ parse_conn_stmt(struct sol_fbp_parser *p)
                 " e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'");
         }
 
-        if (!parse_port(p, &dst_port_name))
+        if (!parse_port(p, &dst_port_name, &dst_port_idx))
             return false;
 
         in_port_position = get_token_position(&p->current_token);
@@ -513,7 +552,7 @@ parse_conn_stmt(struct sol_fbp_parser *p)
 
         sol_fbp_graph_add_in_port(p->graph, dst, dst_port_name, in_port_position);
 
-        r = sol_fbp_graph_add_conn(p->graph, src, src_port_name, dst, dst_port_name, conn_position);
+        r = sol_fbp_graph_add_conn(p->graph, src, src_port_name, src_port_idx, dst, dst_port_name, dst_port_idx, conn_position);
         if (r < 0)
             return handle_conn_error(p, src, &src_port_name, dst, &dst_port_name, &conn_position, r);
 

--- a/src/shared/sol-fbp.h
+++ b/src/shared/sol-fbp.h
@@ -69,12 +69,14 @@ struct sol_fbp_conn {
 
     int src, dst;
     struct sol_str_slice src_port, dst_port;
+    int src_port_idx, dst_port_idx;
 };
 
 struct sol_fbp_exported_port {
     struct sol_fbp_position position;
 
     int node;
+    int port_idx;
     struct sol_str_slice port, exported_name;
 };
 
@@ -124,20 +126,20 @@ int sol_fbp_graph_add_meta(struct sol_fbp_graph *g,
 /* May return -EEXIST to indicate duplicate entries. */
 
 int sol_fbp_graph_add_conn(struct sol_fbp_graph *g,
-    int src, struct sol_str_slice src_port,
-    int dst, struct sol_str_slice dst_port,
+    int src, struct sol_str_slice src_port, int src_port_idx,
+    int dst, struct sol_str_slice dst_port, int dst_port_idx,
     struct sol_fbp_position position);
 
 /* Return -EEXIST if exported port with same name exists, and
  * -EADDRINUSE if the same node/port is already exported. */
 int sol_fbp_graph_add_exported_in_port(struct sol_fbp_graph *g,
-    int node, struct sol_str_slice port, struct sol_str_slice exported_name,
+    int node, struct sol_str_slice port, int port_idx, struct sol_str_slice exported_name,
     struct sol_fbp_position position, struct sol_fbp_exported_port **out_ep);
 
 /* Return -EEXIST if exported port with same name exists, and
  * -EADDRINUSE if the same node/port is already exported. */
 int sol_fbp_graph_add_exported_out_port(struct sol_fbp_graph *g,
-    int node, struct sol_str_slice port, struct sol_str_slice exported_name,
+    int node, struct sol_str_slice port, int port_idx, struct sol_str_slice exported_name,
     struct sol_fbp_position position, struct sol_fbp_exported_port **out_ep);
 
 int sol_fbp_graph_declare(struct sol_fbp_graph *g,

--- a/src/test-fbp/converter-byte-bits-byte.fbp
+++ b/src/test-fbp/converter-byte-bits-byte.fbp
@@ -34,9 +34,9 @@ Byte(constant/byte:value=134)
 Byte731(constant/byte:value=130)
 
 Byte OUT -> IN ByteBits(converter/byte-to-bits)
-ByteBits OUT7 -> IN7 BitsByte(converter/bits-to-byte)
-ByteBits OUT3 -> IN3 BitsByte
-ByteBits OUT1 -> IN1 BitsByte
+ByteBits OUT[7] -> IN[7] BitsByte(converter/bits-to-byte)
+ByteBits OUT[3] -> IN[3] BitsByte
+ByteBits OUT[1] -> IN[1] BitsByte
 
 BitsByte OUT -> IN  _(converter/byte-to-int) OUT -> IN0 Equal(int/equal)
 Byte731 OUT -> IN _(converter/byte-to-int) OUT -> IN1 Equal

--- a/src/test-fbp/converter-int-compose.fbp
+++ b/src/test-fbp/converter-int-compose.fbp
@@ -34,21 +34,21 @@ byte_2(constant/byte:value=244)
 byte_3(constant/byte:value=18)
 int_compose(converter/int-compose)
 
-byte_0 OUT -> IN0 int_compose
-byte_1 OUT -> IN1 int_compose
-byte_2 OUT -> IN2 int_compose
-byte_3 OUT -> IN3 int_compose
+byte_0 OUT -> IN[0] int_compose
+byte_1 OUT -> IN[1] int_compose
+byte_2 OUT -> IN[2] int_compose
+byte_3 OUT -> IN[3] int_compose
 
 int_decompose(converter/int-decompose)
 int_compose OUT -> IN int_decompose
-int_decompose OUT0 -> IN _(converter/byte-to-int) OUT -> IN0 cmp_least_significant_byte(int/equal)
+int_decompose OUT[0] -> IN _(converter/byte-to-int) OUT -> IN0 cmp_least_significant_byte(int/equal)
 byte_0 OUT -> IN _(converter/byte-to-int) OUT -> IN1 cmp_least_significant_byte OUT -> RESULT r_byte_0(test/result)
 
-int_decompose OUT1 -> IN _(converter/byte-to-int) OUT -> IN0 cmp_second_byte(int/equal)
+int_decompose OUT[1] -> IN _(converter/byte-to-int) OUT -> IN0 cmp_second_byte(int/equal)
 byte_1 OUT -> IN _(converter/byte-to-int) OUT -> IN1 cmp_second_byte OUT -> RESULT r_byte_1(test/result)
 
-int_decompose OUT2 -> IN _(converter/byte-to-int) OUT -> IN0 cmp_third_byte(int/equal)
+int_decompose OUT[2] -> IN _(converter/byte-to-int) OUT -> IN0 cmp_third_byte(int/equal)
 byte_2 OUT -> IN _(converter/byte-to-int) OUT -> IN1 cmp_third_byte OUT -> RESULT r_byte_2(test/result)
 
-int_decompose OUT3 -> IN _(converter/byte-to-int) OUT -> IN0 cmp_fourth_byte(int/equal)
+int_decompose OUT[3] -> IN _(converter/byte-to-int) OUT -> IN0 cmp_fourth_byte(int/equal)
 byte_3 OUT -> IN _(converter/byte-to-int) OUT -> IN1 cmp_fourth_byte OUT -> RESULT r_byte_3(test/result)

--- a/src/test-fbp/parser-errors/conn-without-port-index-closing-bracket-expected-fail.txt
+++ b/src/test-fbp/parser-errors/conn-without-port-index-closing-bracket-expected-fail.txt
@@ -1,0 +1,1 @@
+parser-errors/conn-without-port-index-closing-bracket.fbp:31:13 Expected ']' after port index

--- a/src/test-fbp/parser-errors/conn-without-port-index-closing-bracket.fbp
+++ b/src/test-fbp/parser-errors/conn-without-port-index-closing-bracket.fbp
@@ -1,0 +1,31 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+foo PORT[123

--- a/src/test-fbp/parser-errors/conn-without-port-index-expected-fail.txt
+++ b/src/test-fbp/parser-errors/conn-without-port-index-expected-fail.txt
@@ -1,0 +1,1 @@
+parser-errors/conn-without-port-index.fbp:31:10 Expected integer number for port index

--- a/src/test-fbp/parser-errors/conn-without-port-index.fbp
+++ b/src/test-fbp/parser-errors/conn-without-port-index.fbp
@@ -1,0 +1,31 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+foo PORT[

--- a/src/test-fbp/parser-errors/exported-port-missing-closing-bracket-expected-fail.txt
+++ b/src/test-fbp/parser-errors/exported-port-missing-closing-bracket-expected-fail.txt
@@ -1,0 +1,1 @@
+parser-errors/exported-port-missing-closing-bracket.fbp:31:17 Expected ']' after port index

--- a/src/test-fbp/parser-errors/exported-port-missing-closing-bracket.fbp
+++ b/src/test-fbp/parser-errors/exported-port-missing-closing-bracket.fbp
@@ -1,0 +1,33 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+INPORT=node.IN[0:IN
+
+node(boolean/and)

--- a/src/test-fbp/parser-errors/exported-port-no-index-expected-fail.txt
+++ b/src/test-fbp/parser-errors/exported-port-no-index-expected-fail.txt
@@ -1,0 +1,1 @@
+parser-errors/exported-port-no-index.fbp:31:16 Expected integer number for port index

--- a/src/test-fbp/parser-errors/exported-port-no-index.fbp
+++ b/src/test-fbp/parser-errors/exported-port-no-index.fbp
@@ -1,0 +1,33 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+INPORT=node.IN[:IN
+
+node(boolean/and)

--- a/src/test/test-fbp-scanner.c
+++ b/src/test/test-fbp-scanner.c
@@ -409,6 +409,23 @@ static struct test_entry scan_tests[] = {
             SOL_FBP_TOKEN_EOF,
         },
     },
+    { /* Connection with array ports */
+        "a OUT[1] -> IN[0] b",
+        TOKENS {
+            SOL_FBP_TOKEN_IDENTIFIER,
+            SOL_FBP_TOKEN_IDENTIFIER,
+            SOL_FBP_TOKEN_BRACKET_OPEN,
+            SOL_FBP_TOKEN_INTEGER,
+            SOL_FBP_TOKEN_BRACKET_CLOSE,
+            SOL_FBP_TOKEN_ARROW,
+            SOL_FBP_TOKEN_IDENTIFIER,
+            SOL_FBP_TOKEN_BRACKET_OPEN,
+            SOL_FBP_TOKEN_INTEGER,
+            SOL_FBP_TOKEN_BRACKET_CLOSE,
+            SOL_FBP_TOKEN_IDENTIFIER,
+            SOL_FBP_TOKEN_EOF,
+        },
+    },
 };
 
 #define TOKEN_NAME(T) #T,
@@ -471,6 +488,9 @@ scan_errors(void)
         SOL_STR_SLICE_LITERAL("DECLARE=A"),
         SOL_STR_SLICE_LITERAL("DECLARE=A:B"),
         SOL_STR_SLICE_LITERAL("DECLARE=A:B:C:"),
+        SOL_STR_SLICE_LITERAL("PORT["),
+        SOL_STR_SLICE_LITERAL("PORT]"),
+        SOL_STR_SLICE_LITERAL("PORT[NaN]"),
     };
 
     for (i = 0; i < ARRAY_SIZE(tests); i++) {

--- a/src/test/test-flow-builder.c
+++ b/src/test/test-flow-builder.c
@@ -274,10 +274,10 @@ connect_two_nodes(void)
     sol_flow_builder_add_node(builder, "node1", &test_node_type, NULL);
     sol_flow_builder_add_node(builder, "node2", &test_node_type, NULL);
 
-    sol_flow_builder_connect(builder, "node1", "OUT1", "node2", "IN2");
-    sol_flow_builder_connect(builder, "node1", "OUT2", "node2", "IN1");
-    sol_flow_builder_connect(builder, "node2", "OUT1", "node1", "IN1");
-    sol_flow_builder_connect(builder, "node2", "OUT2", "node1", "IN1");
+    sol_flow_builder_connect(builder, "node1", "OUT1", -1, "node2", "IN2", -1);
+    sol_flow_builder_connect(builder, "node1", "OUT2", -1, "node2", "IN1", -1);
+    sol_flow_builder_connect(builder, "node2", "OUT1", -1, "node1", "IN1", -1);
+    sol_flow_builder_connect(builder, "node2", "OUT2", -1, "node1", "IN1", -1);
 
     node_type = sol_flow_builder_get_node_type(builder);
 
@@ -316,8 +316,8 @@ connections_nodes_are_ordered(void)
     sol_flow_builder_add_node(builder, "node2", &test_node_type, NULL);
 
     /* nodes out of order */
-    sol_flow_builder_connect(builder, "node2", "OUT1", "node1", "IN1");
-    sol_flow_builder_connect(builder, "node1", "OUT1", "node2", "IN1");
+    sol_flow_builder_connect(builder, "node2", "OUT1", -1, "node1", "IN1", -1);
+    sol_flow_builder_connect(builder, "node1", "OUT1", -1, "node2", "IN1", -1);
 
     node_type = sol_flow_builder_get_node_type(builder);
 
@@ -345,8 +345,8 @@ connections_ports_are_ordered(void)
     sol_flow_builder_add_node(builder, "node2", &test_node_type, NULL);
 
     /* ports out of order */
-    sol_flow_builder_connect(builder, "node1", "OUT2", "node2", "IN1");
-    sol_flow_builder_connect(builder, "node1", "OUT1", "node2", "IN2");
+    sol_flow_builder_connect(builder, "node1", "OUT2", -1, "node2", "IN1", -1);
+    sol_flow_builder_connect(builder, "node1", "OUT1", -1, "node2", "IN2", -1);
 
     node_type = sol_flow_builder_get_node_type(builder);
 
@@ -425,12 +425,12 @@ ports_can_be_exported(void)
 
     sol_flow_builder_add_node(builder, "node", &test_node_type, NULL);
     sol_flow_builder_add_node(builder, "other", &test_node_type, NULL);
-    sol_flow_builder_connect(builder, "node", "OUT2", "other", "IN2");
+    sol_flow_builder_connect(builder, "node", "OUT2", -1, "other", "IN2", -1);
 
-    ret = sol_flow_builder_export_in_port(builder, "node", "IN1", in_name);
+    ret = sol_flow_builder_export_in_port(builder, "node", "IN1", -1, in_name);
     ASSERT(ret >= 0);
 
-    ret = sol_flow_builder_export_out_port(builder, "other", "OUT2", out_name);
+    ret = sol_flow_builder_export_out_port(builder, "other", "OUT2", -1, out_name);
     ASSERT(ret >= 0);
 
     type = sol_flow_builder_get_node_type(builder);


### PR DESCRIPTION
This patch set adds support to generate node types using array ports,
instead of having several ports that will use the same set of functions.

The parser is changed to understand the notation PORT[idx] and the
necessary work in the building blocks is done to turn said notation
into the port numbers that the base framework undestands.

Exporting ports from an FBP file can be done by exporting individual
members of an array, using the corresponding index, or if no index is
given, the entire array is exported.

A few node types have been converted to use these feature to show case
it.