### PR TITLE
File writer tests

### DIFF
--- a/src/modules/flow/file/file.json
+++ b/src/modules/flow/file/file.json
@@ -89,6 +89,12 @@
           },
           {
             "data_type": "int",
+            "default": {
+              "max": "INT32_MAX",
+              "min": "INT32_MIN",
+              "step": 1,
+              "val": 644
+            },
             "description": "file permissions in POSIX mode such as 0644.",
             "name": "permissions"
           }

--- a/src/test-fbp/file-writer-data.txt
+++ b/src/test-fbp/file-writer-data.txt
@@ -1,0 +1,1 @@
+file writer expected contents

--- a/src/test-fbp/file-writer.fbp
+++ b/src/test-fbp/file-writer.fbp
@@ -1,0 +1,40 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+file_writer(file/writer)
+
+path(constant/string:value="file-writer-test.txt") OUT -> PATH file_writer
+permissions(constant/int:value=0644) OUT -> PERMISSIONS file_writer
+file_reader(file/reader:path="file-writer-data.txt") OUT -> IN file_writer
+
+file_writer DONE -> IN FilterNoise(int/filter:min=29,max=29)
+FilterNoise OUT -> IN ResultToTrue(converter/int-to-boolean:true_range=min:29|max:29)
+ResultToTrue OUT -> RESULT FileWriterResult(test/result)
+


### PR DESCRIPTION
Adds a test for the file/writer node. The test tries to read and replicate a file on disk. as soon as the DONE port from the file/writer sends '29' ( the number of bytes on the file) it will be closed as passed.