### PR TITLE
I2c fix

### DIFF
--- a/src/modules/flow/test/boolean-generator.c
+++ b/src/modules/flow/test/boolean-generator.c
@@ -53,7 +53,7 @@ timer_tick(void *data)
         out_packet = true;
     } else if (*mdata->it == 'F') {
         out_packet = false;
-    } else  {
+    } else {
         sol_flow_send_error_packet(node, ECANCELED,
             "Unknown sample: %c. Option 'sequence' must be composed by 'T' and/or 'F' chars.");
         return false;

--- a/src/shared/sol-i2c-linux.c
+++ b/src/shared/sol-i2c-linux.c
@@ -151,7 +151,9 @@ sol_i2c_write_quick(const struct sol_i2c *i2c, bool rw)
     SOL_NULL_CHECK(i2c, false);
 
     if (ioctl(i2c->dev, I2C_SMBUS, &ioctldata) == -1) {
-        SOL_WRN("%u,%u: Unable to write I2C quick", i2c->bus, i2c->addr);
+        SOL_WRN("Unable to perform SMBus write quick (bus = %u,"
+            " device address = %u): %s", i2c->bus, i2c->addr,
+            sol_util_strerrora(errno));
         return false;
     }
 
@@ -169,7 +171,7 @@ write_byte(const struct sol_i2c *i2c, uint8_t byte)
     };
 
     if (ioctl(i2c->dev, I2C_SMBUS, &ioctldata) == -1) {
-        SOL_WRN("Unable to perform I2C-SMBUS write byte (bus = %u,"
+        SOL_WRN("Unable to perform SMBus write byte (bus = %u,"
             " device address = %u): %s",
             i2c->bus, i2c->addr, sol_util_strerrora(errno));
         return false;
@@ -189,7 +191,7 @@ read_byte(const struct sol_i2c *i2c, uint8_t *byte)
     };
 
     if (ioctl(i2c->dev, I2C_SMBUS, &ioctldata) == -1) {
-        SOL_WRN("Unable to perform I2C-SMBUS read byte (bus = %u,"
+        SOL_WRN("Unable to perform SMBus read byte (bus = %u,"
             " device address = %u): %s",
             i2c->bus, i2c->addr, sol_util_strerrora(errno));
         return false;
@@ -248,7 +250,9 @@ sol_i2c_read_register(const struct sol_i2c *i2c, uint8_t command, uint8_t *value
     SOL_INT_CHECK(count, == 0, -EINVAL);
 
     if ((error = _i2c_smbus_ioctl(i2c->dev, I2C_SMBUS_READ, command, count, &data)) < 0) {
-        SOL_WRN("%u,0x%x,0x%x: Unable to read I2C data: %d", i2c->bus, i2c->addr, command, error);
+        SOL_WRN("Unable to perform SMBus read (byte/word/block) data "
+            "(bus = %u, device address = 0x%x, register = 0x%x): %s",
+            i2c->bus, i2c->addr, command, sol_util_strerrora(-error));
         return error;
     }
 
@@ -278,7 +282,9 @@ sol_i2c_write_register(const struct sol_i2c *i2c, uint8_t command, const uint8_t
     SOL_INT_CHECK(count, == 0, false);
 
     if (count > I2C_SMBUS_BLOCK_MAX) {
-        SOL_WRN("%u,0x%x,0x%x: Block data limited to %d bytes", i2c->bus, i2c->addr, command, I2C_SMBUS_BLOCK_MAX);
+        SOL_WRN("Block data limited to %d bytes, writing only up to that"
+            " (bus = %u, device address = 0x%x, register = 0x%x: )",
+            I2C_SMBUS_BLOCK_MAX, i2c->bus, i2c->addr, command);
         count = I2C_SMBUS_BLOCK_MAX;
     }
 
@@ -295,7 +301,9 @@ sol_i2c_write_register(const struct sol_i2c *i2c, uint8_t command, const uint8_t
     }
 
     if ((error = _i2c_smbus_ioctl(i2c->dev, I2C_SMBUS_WRITE, command, count, &data)) < 0) {
-        SOL_WRN("%u,0x%x,0x%x: Unable to write I2C data: %d", i2c->bus, i2c->addr, command, error);
+        SOL_WRN("Unable to perform SMBus write (byte/word/block) data "
+            " (bus = %u, device address = 0x%x, register = 0x%x:): %s",
+            i2c->bus, i2c->addr, command, sol_util_strerrora(-error));
         return false;
     }
 
@@ -308,7 +316,8 @@ sol_i2c_set_slave_address(struct sol_i2c *i2c, uint8_t slave_address)
     SOL_NULL_CHECK(i2c, false);
 
     if (ioctl(i2c->dev, I2C_SLAVE, slave_address) == -1) {
-        SOL_WRN("i2c #%u 0x%x: could not specify device address", i2c->bus, slave_address);
+        SOL_WRN("I2C (bus = %u): could not specify device address 0x%x",
+            i2c->bus, slave_address);
         return false;
     }
     i2c->addr = slave_address;

--- a/src/shared/sol-i2c-riot.c
+++ b/src/shared/sol-i2c-riot.c
@@ -145,6 +145,27 @@ sol_i2c_read_register(const struct sol_i2c *i2c, uint8_t reg, uint8_t *data, siz
 }
 
 bool
+sol_i2c_plain_read_register(const struct sol_i2c *i2c,
+    uint8_t command,
+    uint8_t *values,
+    size_t count)
+{
+    //TODO
+    return false;
+}
+
+bool
+sol_i2c_plain_read_register_multiple(const struct sol_i2c *i2c,
+    uint8_t command,
+    uint8_t *values,
+    uint8_t len,
+    uint8_t count)
+{
+    //TODO
+    return false;
+}
+
+bool
 sol_i2c_write_register(const struct sol_i2c *i2c, uint8_t reg, const uint8_t *data, size_t count)
 {
     int write;

--- a/src/shared/sol-i2c.h
+++ b/src/shared/sol-i2c.h
@@ -51,14 +51,60 @@ enum sol_i2c_speed {
 struct sol_i2c *sol_i2c_open(uint8_t bus, enum sol_i2c_speed speed) SOL_ATTR_WARN_UNUSED_RESULT;
 void sol_i2c_close(struct sol_i2c *i2c);
 
-bool sol_i2c_write_quick(const struct sol_i2c *i2c, bool rw);
+/* SMBUS calls */
 
+bool sol_i2c_set_slave_address(struct sol_i2c *i2c, uint8_t slave_address);
+uint8_t sol_i2c_get_slave_address(struct sol_i2c *i2c);
+bool sol_i2c_write_quick(const struct sol_i2c *i2c, bool rw);
 ssize_t sol_i2c_read(const struct sol_i2c *i2c, uint8_t *data, size_t count);
 bool sol_i2c_write(const struct sol_i2c *i2c, uint8_t *data, size_t count);
-
 /* Returns the number of read bytes */
 ssize_t sol_i2c_read_register(const struct sol_i2c *i2c, uint8_t reg, uint8_t *data, size_t count);
 bool sol_i2c_write_register(const struct sol_i2c *i2c, uint8_t reg, const uint8_t *data, size_t count);
 
-bool sol_i2c_set_slave_address(struct sol_i2c *i2c, uint8_t slave_address);
-uint8_t sol_i2c_get_slave_address(struct sol_i2c *i2c);
+/* Plain-I2C calls */
+
+/**
+ * Read an arbitrary number of bytes from a register, usually to be
+ * used with auto-increment capable devices
+ *
+ * This will issue a plain-I2C read/write transaction, with the first
+ * (write) message specifying the register to operate on and the
+ * second (read) message specifying the lenght and the destination of
+ * the read operation.
+ *
+ * @param i2c bus The I2C bus handle
+ * @param reg The register to start reading from
+ * @param values Where to store the read bytes
+ * @param count The number of bytes to read
+ *
+ * @warn This function will fail if the target I2C device does not
+ *       accept plain-I2C messages
+ *
+ * @return @c true on succes, @c false otherwise
+ */
+bool sol_i2c_plain_read_register(const struct sol_i2c *i2c, uint8_t reg, uint8_t *values, size_t count);
+
+/**
+ * Read an arbitrary number of bytes from a register in bursts of a
+ * given size (serves burst reads of arbitrary lenght on devices with
+ * no auto-increment capability)
+ *
+ * This will issue multiple plain-I2C read/write transaction with the
+ * first (write) message specifying the register to operate on and the
+ * second (read) message specifying the lenght (always @a len per
+ * read) and the destination of the read operation.
+ *
+ * @param i2c bus The I2C bus handle
+ * @param reg The register to start reading from
+ * @param values Where to store the read bytes
+ * @param len The size of a single read block
+ * @param count How many reads of size @a len to perform (on success,
+ *              @a len * @a count bytes will be read)
+ *
+ * @warn This function will fail if the target I2C device does not
+ *       accept plain-I2C messages
+ *
+ * @return @c true on succes, @c false otherwise
+ */
+bool sol_i2c_plain_read_register_multiple(const struct sol_i2c *i2c, uint8_t reg, uint8_t *values, uint8_t len, uint8_t count);

--- a/src/shared/sol-i2c.h
+++ b/src/shared/sol-i2c.h
@@ -48,18 +48,140 @@ enum sol_i2c_speed {
     SOL_I2C_SPEED_3MBIT_400KBIT
 };
 
+/**
+ * Open an I2C bus.
+ *
+ * @param type bus The I2C bus number to open
+ * @param speed The speed to open I2C bus @a bus at
+ * @return A new I2C bus handle
+ *
+ */
 struct sol_i2c *sol_i2c_open(uint8_t bus, enum sol_i2c_speed speed) SOL_ATTR_WARN_UNUSED_RESULT;
+
+/**
+ * Close an I2C bus.
+ *
+ * @param i2c bus The I2C bus handle to close
+ *
+ */
 void sol_i2c_close(struct sol_i2c *i2c);
 
-/* SMBUS calls */
+/* SMBus calls */
 
+
+/**
+ * Set a (slave) device address on a I2C bus to deliver SMBus commands
+ * to.
+ *
+ * All other SMBus functions, after this call, will act on the given
+ * @a slave_address device address. Since other I2C calls might happen
+ * in between your own ones, though, it's highly advisable that you
+ * issue this call before using any of the SMBus read/write functions.
+ *
+ * @param i2c bus The I2C bus handle
+ * @param slave_address The slave device address to deliver commands to
+ *
+ * @return @c true on success, @c false otherwise.
+ *
+ */
 bool sol_i2c_set_slave_address(struct sol_i2c *i2c, uint8_t slave_address);
+
+/**
+ * Get the (slave) device address set on an I2C bus (to deliver SMBus
+ * commands)
+ *
+ * @param i2c bus The I2C bus handle
+ * @return The slave device address set on @a bus. @c 0x0 means @a bus
+ *         was not set to any device yet
+ */
 uint8_t sol_i2c_get_slave_address(struct sol_i2c *i2c);
+
+/**
+ * Perform a SMBus write quick operation
+ *
+ * This sends a single bit to a device (command designed to turn on
+ * and off simple devices)
+ *
+ * @param i2c bus The I2C bus handle
+ * @param rw The value to write
+ *
+ * @return @c true on succes, @c false otherwise
+ */
 bool sol_i2c_write_quick(const struct sol_i2c *i2c, bool rw);
+
+/**
+ * Perform successive SMBus byte read operations, with no specified
+ * register
+ *
+ * This makes @a count read byte SMBus operations on the device @a bus
+ * is set to operate on, at no specific register. Some devices are so
+ * simple that this interface is enough. For others, it is a shorthand
+ * if you want to read the same register as in the previous SMBus
+ * command.
+ *
+ * @param i2c bus The I2C bus handle
+ * @param data The output buffer for the read operation
+ * @param count The bytes count for the read operation
+ *
+ * @return The number of bytes read, on success, or a negative value,
+ *         on errors.
+ */
 ssize_t sol_i2c_read(const struct sol_i2c *i2c, uint8_t *data, size_t count);
+
+/**
+ * Perform successive SMBus byte write operations, with no specified
+ * register
+ *
+ * This makes @a count write byte SMBus operations on the device @a
+ * bus is set to operate on, at no specific register. Some devices are
+ * so simple that this interface is enough. For others, it is a
+ * shorthand if you want to write the same register as in the previous
+ * SMBus command.
+ *
+ * @param i2c bus The I2C bus handle
+ * @param data The output buffer for the write operation
+ * @param count The bytes count for the write operation
+ *
+ * @return The number of bytes write, on success, or a negative value,
+ *         on errors.
+ */
 bool sol_i2c_write(const struct sol_i2c *i2c, uint8_t *data, size_t count);
-/* Returns the number of read bytes */
+
+/**
+ * Perform a SMBus (byte/word/block) read operation on a given device
+ * register
+ *
+ * This reads a block of up to 32 bytes from a device, at the
+ * specified register @a reg. Depending on @a count, the underlying
+ * SMBus call might be read byte (@a count is 1), read word (@a count
+ * is 2) or read block (@a count is greater than 2 and less than 33).
+ *
+ * @param i2c bus The I2C bus handle
+ * @param data The output buffer for the read operation
+ * @param count The bytes count for the read operation
+ *
+ * @return The number of bytes read, on success, or a negative value,
+ *         on errors.
+ */
 ssize_t sol_i2c_read_register(const struct sol_i2c *i2c, uint8_t reg, uint8_t *data, size_t count);
+
+/**
+ * Perform a SMBus (byte/word/block) write operation on a given device
+ * register
+ *
+ * This writes a block of up to 32 bytes from a device, at the
+ * specified register @a reg. Depending on @a count, the underlying
+ * SMBus call might be write byte (@a count is 1), write word (@a
+ * count is 2) or write block (@a count is greater than 2 and less
+ * than 33).
+ *
+ * @param i2c bus The I2C bus handle
+ * @param data The output buffer for the write operation
+ * @param count The bytes count for the write operation
+ *
+ * @return The number of bytes write, on success, or a negative value,
+ *         on errors.
+ */
 bool sol_i2c_write_register(const struct sol_i2c *i2c, uint8_t reg, const uint8_t *data, size_t count);
 
 /* Plain-I2C calls */


### PR DESCRIPTION
This is a complement to the initial read/write bytes fix. We now
have two plain-i2c block read calls, that were tested with real hardware:
     * ADXL345 accelerometer and
     * L3G4200D gyroscope

The first has auto-increment registers, while the second doesn't. Two
burst reads (capable of > SMBus 32 bytes limit) were added, one
contemplating each case.

Lots of documentation was added to the i2c headers too.

On ardupilot's i2c API, they got a get_semaphore() too. We could have
one of those (maybe per bus) too, if we'll ever have multi-thread i2c
accesses.