### PR TITLE
flow: add a way to fill builder type description

### DIFF
--- a/src/lib/flow/sol-flow-builder.h
+++ b/src/lib/flow/sol-flow-builder.h
@@ -60,6 +60,10 @@ int sol_flow_builder_del(struct sol_flow_builder *builder);
  * fallback to using the default resolver. */
 void sol_flow_builder_set_resolver(struct sol_flow_builder *builder, const struct sol_flow_resolver *resolver);
 
+/* Set type description to use. Input/output ports,
+ * and options descriptions are automatically set. */
+void sol_flow_builder_set_type_description(struct sol_flow_builder *builder, const char *name, const char *category, const char *description, const char *author, const char *url, const char *license, const char *version);
+
 /* Add nodes to nodes spec.
  * Node names can't be NULL and must to be unique */
 int sol_flow_builder_add_node(struct sol_flow_builder *builder, const char *name, const struct sol_flow_node_type *type, const struct sol_flow_node_options *option);

--- a/src/test/test-flow-builder.c
+++ b/src/test/test-flow-builder.c
@@ -527,4 +527,36 @@ add_node_by_type(void)
     sol_flow_builder_del(builder);
 }
 
+DEFINE_TEST(add_type_descriptions);
+
+static void
+add_type_descriptions(void)
+{
+    struct sol_flow_builder *builder;
+    struct sol_flow_node_type *type;
+
+    builder = sol_flow_builder_new();
+    ASSERT(builder);
+
+    sol_flow_builder_add_node_by_type(builder, "node", "boolean/and", NULL);
+
+    sol_flow_builder_set_type_description(builder, "MyName", "MyCategory", "MyDescription", "MyAuthor", "MyUrl", "MyLicense", "MyVersion");
+
+    type = sol_flow_builder_get_node_type(builder);
+    ASSERT(type);
+
+    ASSERT(streq(type->description->name, "MyName"));
+    ASSERT(streq(type->description->category, "MyCategory"));
+    ASSERT(streq(type->description->description, "MyDescription"));
+    ASSERT(streq(type->description->author, "MyAuthor"));
+    ASSERT(streq(type->description->url, "MyUrl"));
+    ASSERT(streq(type->description->license, "MyLicense"));
+    ASSERT(streq(type->description->version, "MyVersion"));
+
+    ASSERT(streq(type->description->symbol, "SOL_FLOW_NODE_TYPE_MYNAME"));
+    ASSERT(streq(type->description->options_symbol, "sol_flow_node_type_myname_options"));
+
+    sol_flow_builder_del(builder);
+}
+
 TEST_MAIN_WITH_RESET_FUNC(clear_events);


### PR DESCRIPTION
Set type description to use, input/output ports and options
are automatically set.