### PR TITLE
oicgen.py enhancements

### DIFF
--- a/data/oic/oicgen.py
+++ b/data/oic/oicgen.py
@@ -237,6 +237,7 @@ def get_field_integer_client_c(id, name, prop):
     return '''if (decode_mask & (1<<%(id)d) && sol_json_token_str_eq(&key, "%(field_name)s", %(field_name_len)d)) {
     if (!json_token_to_int32(&value, &fields.%(field_name)s))
         RETURN_ERROR(-EINVAL);
+    decode_mask &= ~(1<<%(id)d);
     continue;
 }
 ''' % {
@@ -249,6 +250,7 @@ def get_field_number_client_c(id, name, prop):
     return '''if (decode_mask & (1<<%(id)d) && sol_json_token_str_eq(&key, "%(field_name)s", %(field_name_len)d)) {
     if (!json_token_to_float(&value, &fields.%(field_name)s))
         RETURN_ERROR(-EINVAL);
+    decode_mask &= ~(1<<%(id)d);
     continue;
 }
 ''' % {
@@ -261,6 +263,7 @@ def get_field_string_client_c(id, name, prop):
     return '''if (decode_mask & (1<<%(id)d) && sol_json_token_str_eq(&key, "%(field_name)s", %(field_name_len)d)) {
     if (!json_token_to_string(&value, &fields.%(field_name)s))
         RETURN_ERROR(-EINVAL);
+    decode_mask &= ~(1<<%(id)d);
     continue;
 }
 ''' % {
@@ -273,6 +276,7 @@ def get_field_boolean_client_c(id, name, prop):
     return '''if (decode_mask & (1<<%(id)d) && sol_json_token_str_eq(&key, "%(field_name)s", %(field_name_len)d)) {
     if (!json_token_to_bool(&value, &fields.%(field_name)s))
         RETURN_ERROR(-EINVAL);
+    decode_mask &= ~(1<<%(id)d);
     continue;
 }
 ''' % {
@@ -288,6 +292,7 @@ def get_field_enum_client_c(id, struct_name, name, prop):
     if (val < 0)
         RETURN_ERROR(-EINVAL);
     fields.%(field_name)s = (enum %(struct_name)s_%(field_name)s)val;
+    decode_mask &= ~(1<<%(id)d);
     continue;
 }
 ''' % {

--- a/data/oic/oicgen.py
+++ b/data/oic/oicgen.py
@@ -906,8 +906,7 @@ def master_json_as_string(generated):
 
 def master_c_as_string(generated):
     generated = list(generated)
-
-    return '''#include <arpa/inet.h>
+    code = '''#include <arpa/inet.h>
 #include <errno.h>
 #include <math.h>
 #include <netinet/in.h>
@@ -1635,8 +1634,10 @@ json_token_to_bool(struct sol_json_token *token, bool *out)
 ''' % {
         'generated_c_common': '\n'.join(t['c_common'] for t in generated),
         'generated_c_client': '\n'.join(t['c_client'] for t in generated),
-        'generated_c_server': '\n'.join(t['c_server'] for t in generated)
+        'generated_c_server': '\n'.join(t['c_server'] for t in generated),
     }
+
+    return code.replace('\n\n\n', '\n')
 
 if __name__ == '__main__':
     def seems_schema(path):


### PR DESCRIPTION
These two patches reduces the amount of generated code for OIC node types. One is essentially cosmetic (removing too much whitespace), the other makes use of `sol_str_table` (slightly reducing code size), and the other only tries to decode a value once (won't be a huge performance boost, but should help a little bit).