### PR TITLE
modules/converter: Add converter from empty to rgb and from rgb to empty

### DIFF
--- a/src/modules/flow/converter/converter.c
+++ b/src/modules/flow/converter/converter.c
@@ -551,6 +551,22 @@ empty_to_boolean_open(struct sol_flow_node *node, void *data, const struct sol_f
 }
 
 static int
+empty_to_rgb_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
+{
+    struct sol_rgb *mdata = data;
+    const struct sol_flow_node_type_converter_empty_to_rgb_options *opts =
+        (const struct sol_flow_node_type_converter_empty_to_rgb_options *)
+        options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_CONVERTER_EMPTY_TO_RGB_OPTIONS_API_VERSION,
+        -EINVAL);
+
+    *mdata = opts->output_value;
+    return 0;
+}
+
+static int
 empty_to_byte_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
 {
     struct sol_converter_byte *mdata = data;
@@ -655,6 +671,16 @@ empty_to_boolean_convert(struct sol_flow_node *node, void *data, uint16_t port, 
     return sol_flow_send_boolean_packet(node,
         SOL_FLOW_NODE_TYPE_CONVERTER_EMPTY_TO_BOOLEAN__OUT__OUT,
         mdata->output_value);
+}
+
+static int
+empty_to_rgb_convert(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct sol_rgb *mdata = data;
+
+    return sol_flow_send_rgb_packet(node,
+        SOL_FLOW_NODE_TYPE_CONVERTER_EMPTY_TO_RGB__OUT__OUT,
+        mdata);
 }
 
 static int
@@ -978,6 +1004,16 @@ empty_boolean_output_set(struct sol_flow_node *node, void *data, uint16_t port, 
 {
     struct sol_converter_boolean *mdata = data;
     int r = sol_flow_packet_get_boolean(packet, &mdata->output_value);
+
+    SOL_INT_CHECK(r, < 0, r);
+    return 0;
+}
+
+static int
+empty_rgb_output_set(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct sol_rgb *mdata = data;
+    int r = sol_flow_packet_get_rgb(packet, mdata);
 
     SOL_INT_CHECK(r, < 0, r);
     return 0;

--- a/src/modules/flow/converter/converter.json
+++ b/src/modules/flow/converter/converter.json
@@ -816,6 +816,59 @@
     },
     {
       "category": "converter",
+      "description": "Receives an empty packet and convert it to rgb.",
+      "in_ports": [
+        {
+          "data_type": "any",
+          "description": "Where to receive the empty packet.",
+          "methods": {
+            "process": "empty_to_rgb_convert"
+          },
+          "name": "IN"
+        },
+        {
+          "data_type": "rgb",
+          "description": "RGB value of output when an empty packet is received.",
+          "methods": {
+            "process": "empty_rgb_output_set"
+          },
+          "name": "OUTPUT_VALUE"
+        }
+      ],
+      "methods": {
+        "open": "empty_to_rgb_open"
+      },
+      "name": "converter/empty-to-rgb",
+      "options": {
+        "members": [
+          {
+            "data_type": "rgb",
+            "description": "RGB value of output when an empty packet is received.",
+            "name": "output_value",
+            "default": {
+              "red": 255,
+              "green": 255,
+              "blue": 255,
+              "red_max": 255,
+              "green_max": 255,
+              "blue_max": 255
+            }
+          }
+        ],
+        "version": 1
+      },
+      "out_ports": [
+        {
+          "data_type": "rgb",
+          "description": "RGB defined by OUTPUT_VALUE port or output_value option.",
+          "name": "OUT"
+        }
+      ],
+      "private_data_type": "sol_rgb",
+      "url": "http://solettaproject.org/doc/latest/node_types/converter/empty-to-rgb.html"
+    },
+    {
+      "category": "converter",
       "description": "Receives an empty packet and convert it to byte.",
       "in_ports": [
         {

--- a/src/test-fbp/converter-empty-rgb.fbp
+++ b/src/test-fbp/converter-empty-rgb.fbp
@@ -1,0 +1,47 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+RedInt(constant/int:value=80)
+GreenInt(constant/int:value=10)
+BlueInt(constant/int:value=150)
+
+empty_to_rgb(converter/empty-to-rgb:output_value=80|10|150)
+empty(constant/empty)
+
+empty OUT -> IN empty_to_rgb OUT -> IN rgb_to_int(converter/rgb-to-int)
+
+rgb_to_int RED -> IN0 eq_red(int/equal)
+RedInt OUT -> IN1 eq_red OUT -> RESULT red(test/result)
+
+rgb_to_int GREEN -> IN0 eq_green(int/equal)
+GreenInt OUT -> IN1 eq_green OUT -> RESULT green(test/result)
+
+rgb_to_int BLUE -> IN0 eq_blue(int/equal)
+BlueInt OUT -> IN1 eq_blue OUT -> RESULT blue(test/result)


### PR DESCRIPTION
Converters created based on the idea of int-to-empty and empty-to-int
converters.
Empty to rgb converter can be used, for example to change the color of
an rgb led when empty packets are received. Rgb to int converter can be
used, for example, to filter rgb input by rgb color.

Changelog from v2:
 - Use red_max, green_max and blue_max to use the color proportion in order to compare rgb.