### PR TITLE
Builder set type desc v2

### DIFF
--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -32,6 +32,7 @@
 
 #include <stdlib.h>
 
+#include "sol-arena.h"
 #include "sol-flow-builder.h"
 #include "sol-flow-internal.h"
 #include "sol-flow-resolver.h"
@@ -52,6 +53,8 @@ struct sol_flow_builder {
     struct sol_ptr_vector ports_out_desc;
 
     struct sol_flow_node_type_description type_desc;
+
+    struct sol_arena *str_arena;
 };
 
 struct sol_flow_builder_node_spec {
@@ -71,6 +74,9 @@ sol_flow_builder_init(struct sol_flow_builder *builder)
     sol_vector_init(&builder->exported_out, sizeof(struct sol_flow_static_port_spec));
     sol_ptr_vector_init(&builder->ports_in_desc);
     sol_ptr_vector_init(&builder->ports_out_desc);
+
+    builder->str_arena = sol_arena_new();
+    SOL_NULL_CHECK(builder->str_arena);
 
     sol_flow_builder_set_resolver(builder, NULL);
 
@@ -100,20 +106,12 @@ sol_flow_builder_del(struct sol_flow_builder *builder)
 
     SOL_NULL_CHECK(builder, -EBADR);
 
-    SOL_PTR_VECTOR_FOREACH_IDX (&builder->ports_in_desc, port_desc, i) {
-        if (port_desc) {
-            free((char *)port_desc->name);
-            free(port_desc);
-        }
-    }
+    SOL_PTR_VECTOR_FOREACH_IDX (&builder->ports_in_desc, port_desc, i)
+        free(port_desc);
     sol_ptr_vector_clear(&builder->ports_in_desc);
 
-    SOL_PTR_VECTOR_FOREACH_IDX (&builder->ports_out_desc, port_desc, i) {
-        if (port_desc) {
-            free((char *)port_desc->name);
-            free(port_desc);
-        }
-    }
+    SOL_PTR_VECTOR_FOREACH_IDX (&builder->ports_out_desc, port_desc, i)
+        free(port_desc);
     sol_ptr_vector_clear(&builder->ports_out_desc);
 
     sol_vector_clear(&builder->exported_in);
@@ -127,7 +125,6 @@ sol_flow_builder_del(struct sol_flow_builder *builder)
         if (builder_node_spec->owns_opts && builder_node_spec->spec.opts)
             sol_flow_node_options_del(builder_node_spec->spec.type,
                 (struct sol_flow_node_options *)builder_node_spec->spec.opts);
-        free(builder_node_spec->name);
     }
     sol_vector_clear(&builder->nodes);
 
@@ -136,6 +133,8 @@ sol_flow_builder_del(struct sol_flow_builder *builder)
 
     if (builder->node_type)
         sol_flow_static_del_type(builder->node_type);
+
+    sol_arena_del(builder->str_arena);
 
     free(builder);
     return 0;
@@ -258,7 +257,7 @@ sol_flow_builder_add_node(struct sol_flow_builder *builder, const char *name, co
           find_duplicated_port_names(type->description->ports_out, true))))
         return -EEXIST;
 
-    node_name = strdup(name);
+    node_name = sol_arena_strdup(builder->str_arena, name);
     if (!node_name)
         return -errno;
 
@@ -801,7 +800,7 @@ export_port(struct sol_flow_builder *builder, uint16_t node, uint16_t port,
     char *name;
     int i = 0, r;
 
-    name = strdup(exported_name);
+    name = sol_arena_strdup(builder->str_arena, exported_name);
     SOL_NULL_CHECK_GOTO(name, error_name);
 
     port_desc = calloc(1, sizeof(struct sol_flow_port_description));

--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -81,6 +81,8 @@ sol_flow_builder_init(struct sol_flow_builder *builder)
     sol_flow_builder_set_resolver(builder, NULL);
 
     builder->type_desc.api_version = SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION;
+    builder->type_desc.symbol = "SOL_FLOW_NODE_TYPE_BUILDER";
+    builder->type_desc.options_symbol = "sol_flow_node_type_builder_options";
 }
 
 SOL_API struct sol_flow_builder *
@@ -148,6 +150,26 @@ sol_flow_builder_set_resolver(struct sol_flow_builder *builder,
     if (!resolver)
         resolver = sol_flow_get_default_resolver();
     builder->resolver = resolver;
+}
+
+SOL_API void
+sol_flow_builder_set_type_description(struct sol_flow_builder *builder, const char *name, const char *category,
+    const char *description, const char *author, const char *url, const char *license, const char *version)
+{
+    SOL_NULL_CHECK(builder);
+
+    if (builder->node_type) {
+        SOL_WRN("Couldn't set builder node type description, node type created already");
+        return;
+    }
+
+    builder->type_desc.name = name;
+    builder->type_desc.category = category;
+    builder->type_desc.description = description;
+    builder->type_desc.author = author;
+    builder->type_desc.url = url;
+    builder->type_desc.license = license;
+    builder->type_desc.version = version;
 }
 
 static uint16_t

--- a/src/lib/flow/sol-flow-builder.h
+++ b/src/lib/flow/sol-flow-builder.h
@@ -60,6 +60,9 @@ int sol_flow_builder_del(struct sol_flow_builder *builder);
  * fallback to using the default resolver. */
 void sol_flow_builder_set_resolver(struct sol_flow_builder *builder, const struct sol_flow_resolver *resolver);
 
+/* Set type description to use. */
+void sol_flow_builder_set_type_description(struct sol_flow_builder *builder, const char *name, const char *category, const char *description, const char *author, const char *url, const char *license, const char *version);
+
 /* Add nodes to nodes spec.
  * Node names can't be NULL and must to be unique */
 int sol_flow_builder_add_node(struct sol_flow_builder *builder, const char *name, const struct sol_flow_node_type *type, const struct sol_flow_node_options *option);

--- a/src/test/test-flow-builder.c
+++ b/src/test/test-flow-builder.c
@@ -527,4 +527,35 @@ add_node_by_type(void)
     sol_flow_builder_del(builder);
 }
 
+DEFINE_TEST(add_type_descriptions);
+
+static void
+add_type_descriptions(void)
+{
+    struct sol_flow_builder *builder;
+    struct sol_flow_node_type *type;
+
+    builder = sol_flow_builder_new();
+    ASSERT(builder);
+
+    sol_flow_builder_add_node_by_type(builder, "node", "boolean/and", NULL);
+
+    sol_flow_builder_set_type_description(builder, "MyName", "MyCategory", "MyDescription", "MyAuthor", "MyUrl", "MyLicense", "MyVersion");
+
+    type = sol_flow_builder_get_node_type(builder);
+    ASSERT(type);
+
+    ASSERT(streq(type->description->name, "MyName"));
+    ASSERT(streq(type->description->category, "MyCategory"));
+    ASSERT(streq(type->description->description, "MyDescription"));
+    ASSERT(streq(type->description->author, "MyAuthor"));
+    ASSERT(streq(type->description->url, "MyUrl"));
+    ASSERT(streq(type->description->license, "MyLicense"));
+    ASSERT(streq(type->description->version, "MyVersion"));
+    ASSERT(streq(type->description->symbol, "SOL_FLOW_NODE_TYPE_BUILDER"));
+    ASSERT(streq(type->description->options_symbol, "sol_flow_node_type_builder_options"));
+
+    sol_flow_builder_del(builder);
+}
+
 TEST_MAIN_WITH_RESET_FUNC(clear_events);


### PR DESCRIPTION
Set type description to use.

Since this type is not a generated one, symbol and options_symbol
will not be used by the fbp-generator, therefore, they are hardcoded
strings that indicate they're "builder types".

This is useful for debugging, libsoletta.so-gdb.py uses this
information.

v1 changelog:
    * start using sol_arena on builder
    * check if the type is already "closed" before changing its description
    * do not override api_version on type_desc struct
    * change symbol and options_symbol handling