### PR TITLE
Calamari: using child opts

### DIFF
--- a/src/modules/flow/calamari/calamari.json
+++ b/src/modules/flow/calamari/calamari.json
@@ -239,6 +239,31 @@
         "init_type": "segments_init_type"
       },
       "name": "calamari/7seg",
+      "options": {
+        "members": [
+          {
+            "data_type": "int",
+            "description": "CLOCK GPIO pin",
+            "name": "clock_pin"
+          },
+          {
+            "data_type": "int",
+            "description": "CLEAR GPIO pin",
+            "name": "clear_pin"
+          },
+          {
+            "data_type": "int",
+            "description": "DATA GPIO pin",
+            "name": "data_pin"
+          },
+          {
+            "data_type": "int",
+            "description": "LATCH GPIO pin",
+            "name": "latch_pin"
+          }
+        ],
+        "version": 1
+      },
       "url": "http://solettaproject.org/doc/latest/components/calamari-7seg.html"
     },
     {
@@ -277,6 +302,26 @@
         "init_type": "rgb_led_init_type"
       },
       "name": "calamari/rgb-led",
+      "options": {
+        "members": [
+          {
+            "data_type": "int",
+            "description": "Red LED GPIO pin",
+            "name": "red_pin"
+          },
+          {
+            "data_type": "int",
+            "description": "Green LED GPIO pin",
+            "name": "green_pin"
+          },
+          {
+            "data_type": "int",
+            "description": "Blue LED GPIO pin",
+            "name": "blue_pin"
+          }
+        ],
+        "version": 1
+      },
       "url": "http://solettaproject.org/doc/latest/node_types/calamari_rgb_led.html"
     }
   ]

--- a/src/samples/flow/minnow-calamari/calamari-3.17.conf
+++ b/src/samples/flow/minnow-calamari/calamari-3.17.conf
@@ -1,5 +1,10 @@
 [SolettaNodeEntry 7seg]
 Type=calamari/7seg
+Options=clock_pin=84;clear_pin=217;data_pin=218;latch_pin=219
+
+[Solettanodeentry RGBLed]
+Type=calamari/rgb-led
+Options=red_pin=82;green_pin=83;blue_pin=208
 
 [SolettaNodeEntry LedRed]
 Type=gpio/writer

--- a/src/samples/flow/minnow-calamari/calamari-3.19.conf
+++ b/src/samples/flow/minnow-calamari/calamari-3.19.conf
@@ -1,5 +1,10 @@
 [SolettaNodeEntry 7seg]
 Type=calamari/7seg
+Options=clock_pin=340;clear_pin=473;data_pin=474;latch_pin=475
+
+[Solettanodeentry RGBLed]
+Type=calamari/rgb-led
+Options=red_pin=338;green_pin=339;blue_pin=464
 
 [SolettaNodeEntry LedRed]
 Type=gpio/writer

--- a/src/samples/flow/minnow-calamari/calamari-7seg.fbp
+++ b/src/samples/flow/minnow-calamari/calamari-7seg.fbp
@@ -35,5 +35,5 @@
 accumulator(int/accumulator:setup_value=val:0|min:0|max:15|step:1)
 
 timer(wallclock/second) OUT -> INC accumulator
-accumulator OUT -> VALUE seven_segments(calamari/7seg)
+accumulator OUT -> VALUE seg(SevenSegments)
 

--- a/src/samples/flow/minnow-calamari/calamari-buttons-rgb-led.fbp
+++ b/src/samples/flow/minnow-calamari/calamari-buttons-rgb-led.fbp
@@ -35,10 +35,10 @@
 #
 # The button presses will also go to console on stdout.
 
-btn1(Button1) OUT -> IN red(LedRed)
+btn1(Button1) OUT -> RED led(RGBLed)
 btn1 OUT -> IN log(console:prefix="btn1_pressed ")
-btn2(Button2) OUT -> IN green(LedGreen)
+btn2(Button2) OUT -> GREEN led
 btn2 OUT -> IN log2(console:prefix="btn2_pressed ")
-btn3(Button3) OUT -> IN blue(LedBlue)
+btn3(Button3) OUT -> BLUE led
 btn3 OUT -> IN log3(console:prefix="btn3_pressed ")
 

--- a/src/samples/flow/minnow-calamari/calamari-lever.fbp
+++ b/src/samples/flow/minnow-calamari/calamari-lever.fbp
@@ -32,5 +32,5 @@
 # This example links the Calamari lever (SPI) to the 7segment display,
 # displaying the level from 0-15 (in hexadecimal)
 
-lever(Lever) OUT -> VALUE seven_segments(calamari/7seg)
+lever(Lever) OUT -> VALUE seven_segments(SevenSegments)
 

--- a/src/samples/flow/minnow-calamari/calamari-rgb-led.fbp
+++ b/src/samples/flow/minnow-calamari/calamari-rgb-led.fbp
@@ -39,7 +39,6 @@ accumulator(int/accumulator:setup_value=val:0|min:0|max:255|step:1)
 timer(wallclock/second) OUT -> INC accumulator
 accumulator OUT -> IN int_to_byte(converter/int-to-byte)
 int_to_byte OUT -> IN byte_to_bits(converter/byte-to-bits)
-byte_to_bits OUT[0] -> RED led(calamari/rgb-led)
+byte_to_bits OUT[0] -> RED led(RGBLed)
 byte_to_bits OUT[1] -> GREEN led
 byte_to_bits OUT[2] -> BLUE led
-

--- a/src/samples/flow/minnow-calamari/sol-flow.conf
+++ b/src/samples/flow/minnow-calamari/sol-flow.conf
@@ -1,3 +1,11 @@
+[Solettanodeentry RGBLed]
+Type=calamari/rgb-led
+Options=red_pin=82;green_pin=83;blue_pin=208
+
+[Solettanodeentry SevenSegments]
+Type=calamari/7seg
+Options=clock_pin=84;clear_pin=217;data_pin=218;latch_pin=219
+
 [SolettaNodeEntry LedRed]
 Type=gpio/writer
 Options=pin=82


### PR DESCRIPTION
Getting rid of hardcoded GPIO pins.