### PR TITLE
Add support to export options in FBP files.

### DIFF
--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -756,7 +756,7 @@ static const struct %(name_c)s_options %(name_c)s_options_defaults = %(NAME_C)s_
         new_options_func = "%s_new_options_internal" % data["name_c"]
         outfile.write("""
 static struct sol_flow_node_options *
-%(name_func)s(const struct sol_flow_node_options *copy_from)
+%(name_func)s(const struct sol_flow_node_type *type, const struct sol_flow_node_options *copy_from)
 {
     struct %(name_c)s_options *opts;
     const struct %(name_c)s_options *from;

--- a/src/lib/flow/sol-flow-builder.h
+++ b/src/lib/flow/sol-flow-builder.h
@@ -87,6 +87,8 @@ int sol_flow_builder_connect_by_index(struct sol_flow_builder *builder, const ch
 int sol_flow_builder_export_in_port(struct sol_flow_builder *builder, const char *node_name, const char *port_name, int port_idx, const char *exported_name);
 int sol_flow_builder_export_out_port(struct sol_flow_builder *builder, const char *node_name, const char *port_name, int port_idx, const char *exported_name);
 
+int sol_flow_builder_export_option(struct sol_flow_builder *builder, const char *node_name, const char *option_name, const char *exported_name);
+
 /* Returns the node type generated with the builder. It should be used
  * to create nodes with sol_flow_node_new(). After the type is
  * created, no more nodes or connections can be added.

--- a/src/lib/flow/sol-flow-node-options.c
+++ b/src/lib/flow/sol-flow-node-options.c
@@ -570,7 +570,7 @@ sol_flow_node_options_new_from_strv(const struct sol_flow_node_type *type, const
     SOL_NULL_CHECK(type->description->options, NULL);
     SOL_NULL_CHECK(type->description->options->members, NULL);
     SOL_NULL_CHECK(type->new_options, NULL);
-    opts = type->new_options(NULL);
+    opts = type->new_options(type, NULL);
     SOL_NULL_CHECK(opts, NULL);
     if (!options_from_strv(type->description->options, opts, strv)) {
         type->free_options(opts);
@@ -594,7 +594,7 @@ sol_flow_node_options_copy(const struct sol_flow_node_type *type, const struct s
     SOL_NULL_CHECK(type->description->options, NULL);
     SOL_NULL_CHECK(type->description->options->members, NULL);
     SOL_NULL_CHECK(type->new_options, NULL);
-    return type->new_options(opts);
+    return type->new_options(type, opts);
 #endif
 }
 

--- a/src/lib/flow/sol-flow-parser.c
+++ b/src/lib/flow/sol-flow-parser.c
@@ -228,7 +228,7 @@ sol_flow_parser_del(struct sol_flow_parser *parser)
 
     SOL_NULL_CHECK(parser, -EBADF);
 
-    SOL_PTR_VECTOR_FOREACH_IDX (&parser->builders, b, i)
+    SOL_PTR_VECTOR_FOREACH_REVERSE_IDX (&parser->builders, b, i)
         sol_flow_builder_del(b);
     sol_ptr_vector_clear(&parser->builders);
 

--- a/src/lib/flow/sol-flow.c
+++ b/src/lib/flow/sol-flow.c
@@ -156,7 +156,7 @@ sol_flow_node_get_options(const struct sol_flow_node_type *type, const struct so
     struct sol_flow_node_options *opts = &empty_defaults;
 
     if (type->new_options)
-        opts = type->new_options(copy_from);
+        opts = type->new_options(type, copy_from);
     return opts;
 }
 

--- a/src/lib/flow/sol-flow.h
+++ b/src/lib/flow/sol-flow.h
@@ -293,7 +293,9 @@ struct sol_flow_node_type {
     uint16_t data_size; /**< size of the whole sol_flow_node_type derivate */
     uint16_t flags; /**< @see #sol_flow_node_type_flags */
 
-    struct sol_flow_node_options *(*new_options)(const struct sol_flow_node_options *copy_from); /**< member function to instantiate new options for the node (if @a copy_from is not @c NULL, its members will be copied into the new returned struct */
+    const void *type_data; /**< pointer to per-type user data */
+
+    struct sol_flow_node_options *(*new_options)(const struct sol_flow_node_type *type, const struct sol_flow_node_options *copy_from); /**< member function to instantiate new options for the node (if @a copy_from is not @c NULL, its members will be copied into the new returned struct */
     void (*free_options)(struct sol_flow_node_options *opts); /**< member function to delete the node options */
 
     void (*get_ports_counts)(const struct sol_flow_node_type *type, uint16_t *ports_in_count, uint16_t *ports_out_count); /**< member function to get the number of input/output ports of the node */
@@ -490,6 +492,9 @@ struct sol_flow_node *sol_flow_static_get_node(struct sol_flow_node *node, uint1
  *                     own output ports
  * @param child_opts_set member function to forward option members of
  *                       the container node to child nodes
+ * @param type_data user pointer that will be passed to @a child_opts_set, so
+ *                  that dynamically created types can identify the options
+ *                  members that belong to each child node
  *
  * @return A new container node type on success, otherwise @c NULL.
  */

--- a/src/samples/flow/foosball/foosball.fbp
+++ b/src/samples/flow/foosball/foosball.fbp
@@ -35,13 +35,8 @@
 DECLARE=Tracker:fbp:tracker.fbp
 
 # and create two nodes using this type, each representing a side of the table
-red_tracker(Tracker)
-yellow_tracker(Tracker)
-
-# we declare a winner on the 5th goal
-win_score(constant/int:value=5)
-win_score OUT -> WIN_SCORE red_tracker
-win_score OUT -> WIN_SCORE yellow_tracker
+red_tracker(Tracker:win_score=5)
+yellow_tracker(Tracker:win_score=5)
 
 # if there is a winner, turn on its LED
 red_tracker WON -> IN red_won_output(gtk/led:rgb=255|0|0)

--- a/src/samples/flow/foosball/tracker.fbp
+++ b/src/samples/flow/foosball/tracker.fbp
@@ -30,13 +30,16 @@
 
 # This is a subflow to be used in fossball.fbp
 #
-# It exports two input ports (RESET and WIN_SCORE) and one output port
+# It has one option (win_score), which takes the score that must be reached
+# to declare the winner.
+# It exports input port (RESET) and one output port
 # (WON).
 
 INPORT=score.RESET:RESET
-INPORT=won.IN1:WIN_SCORE
 OUTPORT=won.OUT:WON
+OPTION=win_score.value:win_score
 
 goal(gtk/pushbutton) OUT -> PULSE_IF_TRUE toggle(converter/boolean-to-empty) OUT -> INC score(int/accumulator) OUT -> IN output(gtk/label)
 
 score OUT -> IN0 won(int/greater-or-equal)
+win_score(constant/int:value=10) OUT -> IN1 won

--- a/src/shared/sol-fbp-graph.c
+++ b/src/shared/sol-fbp-graph.c
@@ -47,6 +47,7 @@ sol_fbp_graph_init(struct sol_fbp_graph *g)
     sol_vector_init(&g->exported_in_ports, sizeof(struct sol_fbp_exported_port));
     sol_vector_init(&g->exported_out_ports, sizeof(struct sol_fbp_exported_port));
     sol_vector_init(&g->declarations, sizeof(struct sol_fbp_declaration));
+    sol_vector_init(&g->options, sizeof(struct sol_fbp_option));
     g->arena = sol_arena_new();
     return 0;
 }
@@ -70,6 +71,7 @@ sol_fbp_graph_fini(struct sol_fbp_graph *g)
     sol_vector_clear(&g->exported_in_ports);
     sol_vector_clear(&g->exported_out_ports);
     sol_vector_clear(&g->declarations);
+    sol_vector_clear(&g->options);
 
     sol_arena_del(g->arena);
 
@@ -344,5 +346,30 @@ sol_fbp_graph_declare(struct sol_fbp_graph *g,
     dec->kind = kind;
     dec->contents = contents;
     dec->position = position;
+    return i;
+}
+
+int
+sol_fbp_graph_option(struct sol_fbp_graph *g,
+    int node, struct sol_str_slice name, struct sol_str_slice node_opt, struct sol_fbp_position position)
+{
+    struct sol_fbp_option *opt;
+    uint16_t i;
+
+    if (name.len == 0 || node_opt.len == 0)
+        return -EINVAL;
+
+    SOL_VECTOR_FOREACH_IDX (&g->options, opt, i) {
+        if (sol_str_slice_eq(opt->name, name))
+            return -EEXIST;
+    }
+
+    opt = sol_vector_append(&g->options);
+    SOL_NULL_CHECK(opt, -errno);
+
+    opt->name = name;
+    opt->node = node;
+    opt->node_option = node_opt;
+    opt->position = position;
     return i;
 }

--- a/src/shared/sol-fbp-internal-scanner.c
+++ b/src/shared/sol-fbp-internal-scanner.c
@@ -319,10 +319,90 @@ declare_state(struct sol_fbp_scanner *s)
     return declare_equal_state;
 }
 
+static void *
+option_end_state(struct sol_fbp_scanner *s)
+{
+    switch (peek(s)) {
+    case ',':
+    case ' ':
+    case '\n':
+    case '\r':
+    case '\t':
+    case '#':
+    case 0:
+        return default_state;
+
+    default:
+        next(s);
+        return error_state;
+    }
+}
+
+static void *
+option_name_state(struct sol_fbp_scanner *s)
+{
+    while (is_node_ident(peek(s)))
+        next(s);
+    set_token(s, SOL_FBP_TOKEN_IDENTIFIER);
+    return option_end_state;
+}
+
+static void *
+option_second_sep_state(struct sol_fbp_scanner *s)
+{
+    if (next(s) != ':')
+        return error_state;
+    set_token(s, SOL_FBP_TOKEN_COLON);
+    return option_name_state;
+}
+static void *
+option_node_option_state(struct sol_fbp_scanner *s)
+{
+    while (is_node_ident(peek(s)))
+        next(s);
+    set_token(s, SOL_FBP_TOKEN_IDENTIFIER);
+    return option_second_sep_state;
+}
+
+static void *
+option_first_sep_state(struct sol_fbp_scanner *s)
+{
+    if (next(s) != '.')
+        return error_state;
+    set_token(s, SOL_FBP_TOKEN_DOT);
+    return option_node_option_state;
+}
+
+static void *
+option_node_name_state(struct sol_fbp_scanner *s)
+{
+    while (is_node_ident(peek(s)))
+        next(s);
+    set_token(s, SOL_FBP_TOKEN_IDENTIFIER);
+    return option_first_sep_state;
+}
+
+static void *
+option_equal_state(struct sol_fbp_scanner *s)
+{
+    if (next(s) != '=')
+        return error_state;
+    set_token(s, SOL_FBP_TOKEN_EQUAL);
+    return option_node_name_state;
+}
+
+static void *
+option_state(struct sol_fbp_scanner *s)
+{
+    set_token(s, SOL_FBP_TOKEN_OPTION_KEYWORD);
+    return option_equal_state;
+}
+
 static const struct sol_str_table_ptr keyword_table[] = {
     SOL_STR_TABLE_PTR_ITEM("INPORT", inport_state),
     SOL_STR_TABLE_PTR_ITEM("OUTPORT", outport_state),
     SOL_STR_TABLE_PTR_ITEM("DECLARE", declare_state),
+    SOL_STR_TABLE_PTR_ITEM("OPTION", option_state),
     { }
 };
 

--- a/src/shared/sol-fbp-internal-scanner.h
+++ b/src/shared/sol-fbp-internal-scanner.h
@@ -57,7 +57,8 @@
     X(PAREN_OPEN)                                      \
     X(STMT_SEPARATOR)                                  \
     X(STRING)                                          \
-    X(DECLARE_KEYWORD)
+    X(DECLARE_KEYWORD)                                 \
+    X(OPTION_KEYWORD)
 
 #define TOKEN_ENUM(T) SOL_FBP_TOKEN_ ## T,
 

--- a/src/shared/sol-fbp-parser.c
+++ b/src/shared/sol-fbp-parser.c
@@ -371,6 +371,57 @@ parse_declare_stmt(struct sol_fbp_parser *p)
 }
 
 static bool
+parse_option_stmt(struct sol_fbp_parser *p)
+{
+    struct sol_str_slice opt_name, node_name, node_opt, empty = SOL_STR_SLICE_EMPTY;
+    struct sol_fbp_node *err_node;
+    struct sol_fbp_position pos;
+    int node_idx, err;
+
+    assert(next_token(p) == SOL_FBP_TOKEN_OPTION_KEYWORD);
+
+    if (next_token(p) != SOL_FBP_TOKEN_EQUAL)
+        return set_parse_error(p, "Expected '=' after OPTION keyword");
+
+    if (next_token(p) != SOL_FBP_TOKEN_IDENTIFIER)
+        return set_parse_error(p, "Expected node name in option statement");
+
+    node_name = get_token_slice(p);
+    pos = get_token_position(&p->current_token);
+
+    if (next_token(p) != SOL_FBP_TOKEN_DOT)
+        return set_parse_error(p, "Expected '.' after node name in option statement");
+
+    if (next_token(p) != SOL_FBP_TOKEN_IDENTIFIER)
+        return set_parse_error(p, "Expected node option's original name in option statement");
+
+    node_opt = get_token_slice(p);
+
+    if (next_token(p) != SOL_FBP_TOKEN_COLON)
+        return set_parse_error(p, "Expected ':' after option name in option statement");
+
+    if (next_token(p) != SOL_FBP_TOKEN_IDENTIFIER)
+        return set_parse_error(p, "Expected exported option name in option statement");
+
+    opt_name = get_token_slice(p);
+
+    node_idx = sol_fbp_graph_add_node(p->graph, node_name, empty, pos, &err_node);
+    if (node_idx < 0)
+        return handle_node_error(p, &node_name, &pos, node_idx, err_node);
+
+    err = sol_fbp_graph_option(p->graph, node_idx, opt_name, node_opt, pos);
+    if (err == -EEXIST) {
+        p->error_pos = pos;
+        return set_parse_error(p, "Option '%.*s' already declared", SOL_STR_SLICE_PRINT(opt_name));
+    } else if (err == -EINVAL) {
+        p->error_pos = pos;
+        return set_parse_error(p, "Option '%.*s' with invalid values", SOL_STR_SLICE_PRINT(opt_name));
+    }
+
+    return true;
+}
+
+static bool
 parse_meta(struct sol_fbp_parser *p, int node)
 {
     struct sol_str_slice key, value;
@@ -579,6 +630,9 @@ parse_stmt(struct sol_fbp_parser *p)
 
     case SOL_FBP_TOKEN_DECLARE_KEYWORD:
         return parse_declare_stmt(p);
+
+    case SOL_FBP_TOKEN_OPTION_KEYWORD:
+        return parse_option_stmt(p);
 
     case SOL_FBP_TOKEN_IDENTIFIER:
         return parse_conn_stmt(p);

--- a/src/shared/sol-fbp.h
+++ b/src/shared/sol-fbp.h
@@ -88,6 +88,14 @@ struct sol_fbp_declaration {
     struct sol_fbp_position position;
 };
 
+struct sol_fbp_option {
+    struct sol_str_slice name;
+    struct sol_str_slice node_option;
+    int node;
+
+    struct sol_fbp_position position;
+};
+
 struct sol_fbp_graph {
     struct sol_vector nodes;
     struct sol_vector conns;
@@ -95,6 +103,7 @@ struct sol_fbp_graph {
     struct sol_vector exported_in_ports;
     struct sol_vector exported_out_ports;
     struct sol_vector declarations;
+    struct sol_vector options;
 
     struct sol_arena *arena;
 };
@@ -144,6 +153,9 @@ int sol_fbp_graph_add_exported_out_port(struct sol_fbp_graph *g,
 
 int sol_fbp_graph_declare(struct sol_fbp_graph *g,
     struct sol_str_slice name, struct sol_str_slice kind, struct sol_str_slice contents, struct sol_fbp_position);
+
+int sol_fbp_graph_option(struct sol_fbp_graph *g,
+    int node, struct sol_str_slice name, struct sol_str_slice node_opt, struct sol_fbp_position position);
 
 /* Given an input string written using the "FBP file format" described
  * in https://github.com/noflo/fbp/blob/master/README.md, returns a

--- a/src/test/test-fbp-scanner.c
+++ b/src/test/test-fbp-scanner.c
@@ -426,6 +426,19 @@ static struct test_entry scan_tests[] = {
             SOL_FBP_TOKEN_EOF,
         },
     },
+    { /* Export options in FBP files */
+        "OPTION=Subnode.option:MyOption",
+        TOKENS {
+            SOL_FBP_TOKEN_OPTION_KEYWORD,
+            SOL_FBP_TOKEN_EQUAL,
+            SOL_FBP_TOKEN_IDENTIFIER,
+            SOL_FBP_TOKEN_DOT,
+            SOL_FBP_TOKEN_IDENTIFIER,
+            SOL_FBP_TOKEN_COLON,
+            SOL_FBP_TOKEN_IDENTIFIER,
+            SOL_FBP_TOKEN_EOF,
+        },
+    },
 };
 
 #define TOKEN_NAME(T) #T,
@@ -491,6 +504,10 @@ scan_errors(void)
         SOL_STR_SLICE_LITERAL("PORT["),
         SOL_STR_SLICE_LITERAL("PORT]"),
         SOL_STR_SLICE_LITERAL("PORT[NaN]"),
+        SOL_STR_SLICE_LITERAL("OPTION=A"),
+        SOL_STR_SLICE_LITERAL("OPTION=A:B"),
+        SOL_STR_SLICE_LITERAL("OPTION=A.B"),
+        SOL_STR_SLICE_LITERAL("OPTION=A:B.C"),
     };
 
     for (i = 0; i < ARRAY_SIZE(tests); i++) {

--- a/src/test/test-flow-parser.c
+++ b/src/test/test-flow-parser.c
@@ -161,6 +161,11 @@ test_node_get_port_out(const struct sol_flow_node_type *type, uint16_t port)
     return test_ports_out[port];
 }
 
+struct test_node_options {
+    struct sol_flow_node_options base;
+    bool opt;
+};
+
 static const struct sol_flow_node_type_description test_node_description = {
     .ports_in = (const struct sol_flow_port_description *const []){
         &((const struct sol_flow_port_description){
@@ -180,10 +185,48 @@ static const struct sol_flow_node_type_description test_node_description = {
           }),
         NULL
     },
+    .options = &((const struct sol_flow_node_options_description){
+        .data_size = sizeof(struct test_node_options),
+        .sub_api = 1,
+        .required = false,
+        .members = (const struct sol_flow_node_options_member_description[]){
+                    {
+            .name="opt",
+            .description="An optional option",
+            .data_type="boolean",
+            .required=false,
+            .offset=offsetof(struct test_node_options, opt),
+            .size=sizeof(bool),
+            .defvalue.b = true,
+        },
+            {}
+        }
+    })
 };
+
+static struct sol_flow_node_options *
+test_node_type_new_options(const struct sol_flow_node_type *type,
+        const struct sol_flow_node_options *copy_from)
+{
+    struct test_node_options *opts, *from = (struct test_node_options *)copy_from;
+    opts = malloc(sizeof(*opts));
+    opts->base.api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION;
+    opts->base.sub_api = 1;
+    opts->opt = from ? from->opt : true;
+    return &opts->base;
+}
+
+static void
+test_node_type_free_options(struct sol_flow_node_options *opts)
+{
+    free(opts);
+}
 
 static const struct sol_flow_node_type test_node_type = {
     .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
+
+    .new_options = test_node_type_new_options,
+    .free_options = test_node_type_free_options,
 
     .get_ports_counts = test_node_get_ports_counts,
     .get_port_in = test_node_get_port_in,
@@ -460,6 +503,51 @@ declare_fbp(void)
 
     type = sol_flow_parse_string(parser, input, NULL);
     ASSERT(type);
+
+    sol_flow_parser_del(parser);
+}
+
+DEFINE_TEST(exported_options);
+
+static void
+exported_options(void)
+{
+    struct sol_flow_parser *parser;
+    struct sol_flow_node_type *type;
+    const struct sol_flow_node_options_member_description *myopt, *myotheropt, *opt;
+
+    static const char input[] =
+        "OPTION=a.opt:myopt\n"
+        "OPTION=b.opt:myotheropt\n"
+        "a(whatever) OUT1 -> IN1 b(whatever:opt=false)";
+
+    parser = sol_flow_parser_new(NULL, &test_resolver);
+    ASSERT(parser);
+
+    type = sol_flow_parse_string(parser, input, NULL);
+    ASSERT(type);
+
+    ASSERT(type->description);
+    ASSERT(type->description->options);
+    ASSERT(type->description->options->members);
+
+    myopt = &type->description->options->members[0];
+    ASSERT(myopt);
+
+    ASSERT(streq(myopt->name, "myopt"));
+
+    opt = &test_node_description.options->members[0];
+
+    ASSERT(streq(myopt->data_type, opt->data_type));
+    ASSERT(myopt->required == opt->required);
+    ASSERT(myopt->size == opt->size);
+    ASSERT(myopt->defvalue.b == opt->defvalue.b);
+
+    myotheropt = &type->description->options->members[1];
+    ASSERT(myotheropt);
+
+    ASSERT(streq(myotheropt->name, "myotheropt"));
+    ASSERT(myotheropt->defvalue.b == false);
 
     sol_flow_parser_del(parser);
 }


### PR DESCRIPTION
Make FBPs configurable by allowing them to export options from their
sub-nodes.

An options_description will be created for the type, copying the
option_description_member from the corresponding option of the node,
which means that required options from a sub-node will turn into
required options for the parent. Defaults are taken from the default
from the sub-node type, or the current value for that node's instance
if it has options.