### PR TITLE
minnow-calamari: Make lever sample work again

### DIFF
--- a/src/samples/flow/minnow-calamari/calamari-led.fbp
+++ b/src/samples/flow/minnow-calamari/calamari-led.fbp
@@ -33,6 +33,6 @@
 # Led1 and Led2 (PWM leds), as defined in sol-flow.conf in this
 # directory.
 
-lever(Lever) OUT -> INTENSITY led1(Led1)
+lever(LedLever) OUT -> INTENSITY led1(Led1)
 lever OUT -> INTENSITY led2(Led2)
 

--- a/src/samples/flow/minnow-calamari/calamari-lever.fbp
+++ b/src/samples/flow/minnow-calamari/calamari-lever.fbp
@@ -32,5 +32,4 @@
 # This example links the Calamari lever (SPI) to the 7segment display,
 # displaying the level from 0-15 (in hexadecimal)
 
-lever(Lever) OUT -> VALUE seven_segments(SevenSegments)
-
+lever(SegmentsLever) OUT -> VALUE seven_segments(SevenSegments)

--- a/src/samples/flow/minnow-calamari/sol-flow.conf
+++ b/src/samples/flow/minnow-calamari/sol-flow.conf
@@ -38,6 +38,10 @@ Options=address=1;period=1000;range=min:0|max:10000|step:1
 Type=calamari/led
 Options=address=2;period=1000;range=min:0|max:10000|step:1
 
-[SolettaNodeEntry Lever]
+[SolettaNodeEntry LedLever]
 Type=calamari/lever
-Options=poll_interval=100;range=min:0|max:10000|step:1;bus=0;chip_select=0
+Options=poll_interval=100;range=min:0|max:1000|step:1;bus=0;chip_select=0
+
+[SolettaNodeEntry SegmentsLever]
+Type=calamari/lever
+Options=poll_interval=100;range=min:0|max:15|step:1;bus=0;chip_select=0


### PR DESCRIPTION
Both calamari-led and calamari-lever were using the same
lever config, however max=1000 was valid only for
calamari-led.

Signed-off-by: Anselmo L. S. Melo <anselmo.melo@intel.com>