### PR TITLE
log: embed log domain inits on node generation scripts

### DIFF
--- a/data/oic/oicgen.py
+++ b/data/oic/oicgen.py
@@ -904,9 +904,7 @@ def master_c_as_string(generated):
 #include <stdlib.h>
 #include <sys/socket.h>
 
-#define SOL_LOG_DOMAIN &_log_domain
-#include "sol-log-internal.h"
-static SOL_LOG_INTERNAL_DECLARE(_log_domain, "oic");
+#include "oic-gen.h"
 
 #include "sol-coap.h"
 #include "sol-json.h"
@@ -917,8 +915,6 @@ static SOL_LOG_INTERNAL_DECLARE(_log_domain, "oic");
 #include "sol-str-slice.h"
 #include "sol-str-table.h"
 #include "sol-util.h"
-
-#include "oic-gen.h"
 
 #define DEFAULT_UDP_PORT 5683
 #define MULTICAST_ADDRESS_IPv4 "224.0.1.187"

--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -409,12 +409,32 @@ extern "C" {
     "float_h": uses_float(data),
 })
 
+# "ifndef SOL_LOG_DOMAIN" is there to aid on cases where a node
+# aggregates sub-node types, thus including their log domains. In that
+# case, the first generated header to be included must be the one with
+# the actual log domain to apply
 def generate_header_tail(outfile, data):
     outfile.write("""
+#ifdef SOL_FLOW_NODE_TYPE_MODULE_EXTERNAL
+#ifndef SOL_LOG_DOMAIN
+#define SOL_LOG_DOMAIN &_log_domain
+#include "sol-log-internal.h"
+SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, \"%(domain)s\");
+
+static void
+log_init(void)
+{
+    SOL_LOG_INTERNAL_INIT_ONCE;
+}
+#endif // ifdef SOL_FLOW_NODE_TYPE_MODULE_EXTERNAL
+#endif // ifndef SOL_LOG_DOMAIN
+
 #ifdef __cplusplus
 }
 #endif
-""")
+"""  % {
+    "domain": "flow-" + c_clean(data["name"].lower())
+})
 
 
 def generate_header_entry(outfile, data):
@@ -741,6 +761,13 @@ static void
 
     if "init_type" in methods:
         outfile.write("    %s();\n" % methods.get("init_type"))
+
+    outfile.write(
+"""
+#ifdef SOL_FLOW_NODE_TYPE_MODULE_EXTERNAL
+    log_init();
+#endif
+""")
 
     outfile.write("""\
 }

--- a/data/scripts/sol-flow-node-type-stub-gen.py
+++ b/data/scripts/sol-flow-node-type-stub-gen.py
@@ -458,15 +458,6 @@ static int
 """)
 
 
-def set_log_domain(outfile, name):
-    outfile.write("""\
-#define SOL_LOG_DOMAIN &_log_domain
-#include "sol-log-internal.h"
-static SOL_LOG_INTERNAL_DECLARE(_log_domain, "%s");
-
-""" % name)
-
-
 def generate_stub(stub_file, inputs_list, prefix, is_module):
     data = []
     base_names = []
@@ -482,14 +473,12 @@ def generate_stub(stub_file, inputs_list, prefix, is_module):
     except:
         raise
 
-    if is_module:
-        set_log_domain(stub_file, data[0]["name"])
-
     license_header(stub_file)
-    include_common_headers(stub_file)
 
     for base_name in base_names:
         include_header(stub_file, base_name)
+
+    include_common_headers(stub_file)
 
     add_empty_line(stub_file)
 

--- a/src/lib/common/sol-log-internal.h
+++ b/src/lib/common/sol-log-internal.h
@@ -60,5 +60,5 @@
 #ifdef SOL_LOG_DOMAIN
 #undef SOL_LOG_DOMAIN
 #define SOL_LOG_DOMAIN NULL
-#endif
-#endif
+#endif // #ifdef SOL_LOG_DOMAIN
+#endif // #ifdef SOL_LOG_ENABLED

--- a/src/lib/common/sol-macros.h
+++ b/src/lib/common/sol-macros.h
@@ -42,6 +42,7 @@
 #define SOL_ATTR_NONNULL(...) __attribute__((nonnull(__VA_ARGS__)))
 #define SOL_ATTR_SECTION(secname) __attribute__((section(secname)))
 #define SOL_ATTR_USED __attribute__((__used__))
+#define SOL_ATTR_UNUSED __attribute__((__unused__))
 #else
 #define SOL_API
 #define SOL_ATTR_WARN_UNUSED_RESULT

--- a/src/modules/flow/accelerometer/accelerometer.c
+++ b/src/modules/flow/accelerometer/accelerometer.c
@@ -30,18 +30,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sol-util.h>
 #include <errno.h>
 #include <math.h>
 
-#define SOL_LOG_DOMAIN &_log_domain
-#include "sol-log-internal.h"
-SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "flow-accelerometer");
+#include "accelerometer-gen.h"
 
 #include "sol-i2c.h"
 #include "sol-mainloop.h"
-
-#include "accelerometer-gen.h"
+#include "sol-util.h"
 
 /* speed only works for riot */
 #define I2C_SPEED SOL_I2C_SPEED_10KBIT
@@ -348,12 +344,6 @@ accel_init(struct accelerometer_adxl345_data *mdata)
     return accel_init_power(mdata) ? 0 : -EIO;
 }
 
-static void
-log_init(void)
-{
-    SOL_LOG_INTERNAL_INIT_ONCE;
-}
-
 static int
 accelerometer_adxl345_open(struct sol_flow_node *node,
     void *data,
@@ -365,7 +355,6 @@ accelerometer_adxl345_open(struct sol_flow_node *node,
 
     SOL_NULL_CHECK(options, -EINVAL);
 
-    log_init();
     mdata->i2c = sol_i2c_open(opts->i2c_bus.val, I2C_SPEED);
     if (!mdata->i2c) {
         SOL_WRN("Failed to open i2c bus");

--- a/src/modules/flow/app/app.c
+++ b/src/modules/flow/app/app.c
@@ -30,13 +30,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "sol-flow-internal.h"
-
-#include <sol-util.h>
-#include <sol-mainloop.h>
 #include <errno.h>
 
 #include "app-gen.h"
+#include "sol-flow-internal.h"
+#include "sol-mainloop.h"
+#include "sol-util.h"
 
 static int
 check_index(struct sol_flow_node *node, int index)

--- a/src/modules/flow/calamari/calamari.c
+++ b/src/modules/flow/calamari/calamari.c
@@ -30,14 +30,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "calamari-gen.h"
+#include "gpio-gen.h"
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
-
-#define SOL_LOG_DOMAIN &_log_domain
-#include "sol-log-internal.h"
-SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "flow-calamari");
 
 #include "sol-flow.h"
 #include "sol-mainloop.h"
@@ -45,8 +44,7 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "flow-calamari");
 #include "sol-spi.h"
 #include "sol-util.h"
 
-#include "gpio-gen.h"
-#include "calamari-gen.h"
+#include "sol-flow-node-types.h"
 
 ///////// SEGMENTS CTL ///////////
 

--- a/src/modules/flow/evdev/evdev.c
+++ b/src/modules/flow/evdev/evdev.c
@@ -40,10 +40,6 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 
-#define SOL_LOG_DOMAIN &_log_domain
-#include "sol-log-internal.h"
-SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "flow-evdev");
-
 #include "evdev-gen.h"
 #include "sol-flow.h"
 #include "sol-mainloop.h"

--- a/src/modules/flow/file/file.c
+++ b/src/modules/flow/file/file.c
@@ -37,17 +37,13 @@
 #include <fcntl.h>
 #include <stdio.h>
 
-#define SOL_LOG_DOMAIN &_log_domain
-#include "sol-log-internal.h"
-SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "flow-file");
+#include "file-gen.h"
 
 #include "sol-file-reader.h"
 #include "sol-flow-internal.h"
 #include "sol-worker-thread.h"
 #include "sol-util.h"
 #include "sol-mainloop.h"
-
-#include "file-gen.h"
 
 /*
  * TODO:
@@ -57,12 +53,6 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "flow-file");
  * writing to disk as they arrive at input. In such cases there must
  * be a "reset" port so readers fseek() to start and writers truncate.
  */
-
-static void
-log_init(void)
-{
-    SOL_LOG_INTERNAL_INIT_ONCE;
-}
 
 static void
 file_reader_blob_free(struct sol_blob *blob)
@@ -183,8 +173,6 @@ file_reader_open(struct sol_flow_node *node, void *data, const struct sol_flow_n
 {
     const struct sol_flow_node_type_file_reader_options *opts = (const struct sol_flow_node_type_file_reader_options *)options;
     struct file_reader_data *mdata = data;
-
-    log_init();
 
     mdata->node = node;
 
@@ -450,8 +438,6 @@ file_writer_open(struct sol_flow_node *node, void *data, const struct sol_flow_n
 {
     const struct sol_flow_node_type_file_writer_options *opts = (const struct sol_flow_node_type_file_writer_options *)options;
     struct file_writer_data *mdata = data;
-
-    log_init();
 
     mdata->node = node;
 

--- a/src/modules/flow/filter-repeated/filter-repeated.c
+++ b/src/modules/flow/filter-repeated/filter-repeated.c
@@ -30,12 +30,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "sol-flow-internal.h"
-
-#include <sol-util.h>
 #include <errno.h>
 
 #include "filter-repeated-gen.h"
+#include "sol-flow-internal.h"
+#include "sol-util.h"
+
 
 struct filter_boolean_data {
     bool value;

--- a/src/modules/flow/fs/fs.c
+++ b/src/modules/flow/fs/fs.c
@@ -40,14 +40,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define SOL_LOG_DOMAIN &_log_domain
-#include "sol-log-internal.h"
-SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "flow-fs");
+#include "fs-gen.h"
 
 #include "sol-flow.h"
 #include "sol-util.h"
-
-#include "fs-gen.h"
 
 struct fs_persist_data {
     FILE *file;

--- a/src/modules/flow/gtk/common.h
+++ b/src/modules/flow/gtk/common.h
@@ -35,9 +35,11 @@
 #include <errno.h>
 #include <gtk/gtk.h>
 
+#ifndef SOL_LOG_DOMAIN
 #define SOL_LOG_DOMAIN &_log_domain
 extern struct sol_log_domain _log_domain;
 #include "sol-log-internal.h"
+#endif
 
 #include "sol-flow.h"
 #include "sol-util.h"

--- a/src/modules/flow/gtk/gtk.c
+++ b/src/modules/flow/gtk/gtk.c
@@ -34,25 +34,29 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "sol-vector.h"
-
+// The gtk module is a bit of an alien WRT logging, as it has to share
+// the domain symbol externally with the various .o objects that will
+// be linked together. Let's redeclare it by hand, then, and before
+// including gtk-gen.h. Also, log_init() is defined here instead.
 #include "common.h"
-
 SOL_LOG_INTERNAL_DECLARE(_log_domain, "flow-gtk");
 
+#include "gtk-gen.h"
+
+#include "sol-mainloop.h"
+#include "sol-util.h"
+#include "sol-vector.h"
+
 #include "byte-editor.h"
-#include "led.h"
 #include "label.h"
+#include "led.h"
+#include "pushbutton.h"
 #include "pwm-editor.h"
 #include "pwm-viewer.h"
-#include "pushbutton.h"
 #include "rgb-editor.h"
 #include "slider.h"
 #include "spinbutton.h"
 #include "toggle.h"
-#include "gtk-gen.h"
-#include "sol-mainloop.h"
-#include "sol-util.h"
 #include "window.h"
 
 struct gtk_state {
@@ -62,6 +66,12 @@ struct gtk_state {
 
 static struct gtk_state *gtk_state = NULL;
 static struct gtk_state _gtk_state;
+
+static void
+log_init(void)
+{
+    SOL_LOG_INTERNAL_INIT_ONCE;
+}
 
 static void
 init(void)

--- a/src/modules/flow/gyroscope/gyroscope.c
+++ b/src/modules/flow/gyroscope/gyroscope.c
@@ -33,14 +33,10 @@
 #include <sol-util.h>
 #include <errno.h>
 
-#define SOL_LOG_DOMAIN &_log_domain
-#include "sol-log-internal.h"
-SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "flow-gyroscope");
+#include "gyroscope-gen.h"
 
 #include "sol-i2c.h"
 #include "sol-mainloop.h"
-
-#include "gyroscope-gen.h"
 
 /* speed only works for riot */
 #define I2C_SPEED SOL_I2C_SPEED_10KBIT
@@ -345,12 +341,6 @@ gyro_init(struct gyroscope_l3g4200d_data *mdata)
         gyro_init_sampling, mdata) == 0;
 }
 
-static void
-log_init(void)
-{
-    SOL_LOG_INTERNAL_INIT_ONCE;
-}
-
 static int
 gyroscope_l3g4200d_open(struct sol_flow_node *node,
     void *data,
@@ -362,7 +352,6 @@ gyroscope_l3g4200d_open(struct sol_flow_node *node,
 
     SOL_NULL_CHECK(options, -EINVAL);
 
-    log_init();
     mdata->i2c = sol_i2c_open(opts->i2c_bus.val, I2C_SPEED);
     if (!mdata->i2c) {
         SOL_WRN("Failed to open i2c bus");

--- a/src/modules/flow/hub/hub.c
+++ b/src/modules/flow/hub/hub.c
@@ -30,12 +30,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "sol-flow-internal.h"
-
-#include <sol-util.h>
 #include <errno.h>
 
 #include "hub-gen.h"
+#include "sol-flow-internal.h"
+#include "sol-util.h"
+
 
 static int
 boolean_forward(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)

--- a/src/modules/flow/keyboard/keyboard.c
+++ b/src/modules/flow/keyboard/keyboard.c
@@ -41,16 +41,12 @@
 #include <inttypes.h>
 #include <fcntl.h>
 
-#define SOL_LOG_DOMAIN &_log_domain
-#include "sol-log-internal.h"
-SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "flow-keyboard");
+#include "keyboard-gen.h"
 
 #include "sol-flow.h"
 #include "sol-mainloop.h"
 #include "sol-vector.h"
 #include "sol-util.h"
-
-#include "keyboard-gen.h"
 
 struct keyboard_common_data {
     struct sol_flow_node *node;

--- a/src/modules/flow/lcd-grove/lcd-grove.c
+++ b/src/modules/flow/lcd-grove/lcd-grove.c
@@ -32,17 +32,13 @@
 
 #include <errno.h>
 
-#define SOL_LOG_DOMAIN &_log_domain
-#include "sol-log-internal.h"
-SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "grove-lcd");
+#include "lcd-grove-gen.h"
 
 #include "sol-flow-internal.h"
+#include "sol-util.h"
 #include "sol-i2c.h"
 #include "sol-mainloop.h"
-#include "sol-util.h"
 #include "sol-vector.h"
-
-#include "lcd-grove-gen.h"
 
 /* TODO move me to options - speed only works for riot */
 #define I2C_BUS 0

--- a/src/modules/flow/network/network.c
+++ b/src/modules/flow/network/network.c
@@ -37,10 +37,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define SOL_LOG_DOMAIN &_log_domain
-#include "sol-log-internal.h"
-SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "flow-network");
-
 #include "network-gen.h"
 #include "sol-flow.h"
 #include "sol-mainloop.h"

--- a/src/modules/flow/piezo-speaker/piezo-speaker.c
+++ b/src/modules/flow/piezo-speaker/piezo-speaker.c
@@ -37,9 +37,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define SOL_LOG_DOMAIN &_log_domain
-#include "sol-log-internal.h"
-SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "flow-piezo-speaker");
+#include "piezo-speaker-gen.h"
 
 #include "sol-flow.h"
 #include "sol-mainloop.h"
@@ -47,8 +45,6 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "flow-piezo-speaker");
 #include "sol-str-table.h"
 #include "sol-util.h"
 #include "sol-worker-thread.h"
-
-#include "piezo-speaker-gen.h"
 
 static bool be_quiet(void *data);
 

--- a/src/modules/flow/process/output.c
+++ b/src/modules/flow/process/output.c
@@ -167,8 +167,6 @@ common_process(struct output_data *output, const struct sol_flow_packet *packet)
     struct write_data *d;
     int ret;
 
-    process_log_init();
-
     ret = sol_flow_packet_get_blob(packet, &blob);
     SOL_INT_CHECK(ret, < 0, ret);
 
@@ -195,8 +193,6 @@ err:
 static int
 common_open(struct output_data *output, struct sol_flow_node *node)
 {
-    process_log_init();
-
     if (sol_ptr_vector_append(&output->monitors, node) < 0)
         return -ENOMEM;
 

--- a/src/modules/flow/process/process.c
+++ b/src/modules/flow/process/process.c
@@ -1,9 +1,12 @@
 #include "common.h"
 
+// The process module is a bit of an alien WRT logging, as it has to
+// share the domain symbol externally with the various .o objects that
+// will be linked together. Also, log_init() is defined here instead.
 SOL_LOG_INTERNAL_DECLARE(_log_domain, "flow-process");
 
-void
-process_log_init(void)
+static void
+log_init(void)
 {
     SOL_LOG_INTERNAL_INIT_ONCE;
 }

--- a/src/modules/flow/process/stdin.c
+++ b/src/modules/flow/process/stdin.c
@@ -204,8 +204,6 @@ stdin_monitor_find(const struct sol_flow_node *node)
     struct stdin_monitor *m;
     uint16_t i;
 
-    process_log_init();
-
     SOL_VECTOR_FOREACH_REVERSE_IDX (&stdin_monitors, m, i) {
         if (m->node == node)
             return i;
@@ -247,8 +245,6 @@ process_stdin_out_connect(struct sol_flow_node *node, void *data, uint16_t port,
     struct stdin_monitor *m;
     int ret;
 
-    process_log_init();
-
     ret = stdin_common_connect(node, &m);
     if (ret < 0)
         return ret;
@@ -262,8 +258,6 @@ process_stdin_out_disconnect(struct sol_flow_node *node, void *data, uint16_t po
 {
     struct stdin_monitor *m;
     uint16_t i;
-
-    process_log_init();
 
     i = stdin_monitor_find(node);
     if (i == UINT16_MAX)
@@ -282,8 +276,6 @@ process_stdin_closed_connect(struct sol_flow_node *node, void *data, uint16_t po
     struct stdin_monitor *m;
     int ret, flags;
 
-    process_log_init();
-
     ret = stdin_common_connect(node, &m);
     if (ret < 0)
         return ret;
@@ -300,8 +292,6 @@ process_stdin_closed_disconnect(struct sol_flow_node *node, void *data, uint16_t
 {
     struct stdin_monitor *m;
     uint16_t i;
-
-    process_log_init();
 
     i = stdin_monitor_find(node);
     if (i == UINT16_MAX)

--- a/src/modules/flow/servo-motor/servo-motor.c
+++ b/src/modules/flow/servo-motor/servo-motor.c
@@ -37,10 +37,6 @@
 #include <math.h>
 #include <stdlib.h>
 
-#define SOL_LOG_DOMAIN &_log_domain
-#include "sol-log-internal.h"
-SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "servo-motor");
-
 #include "servo-motor-gen.h"
 
 struct servo_motor_data {

--- a/src/modules/flow/test/test-module.h
+++ b/src/modules/flow/test/test-module.h
@@ -35,11 +35,11 @@
 #include "sol-flow.h"
 #include "sol-log.h"
 
-extern struct sol_log_domain test_log_domain;
+extern struct sol_log_domain _log_domain;
 void test_init_log_domain(void);
 
 #undef SOL_LOG_DOMAIN
-#define SOL_LOG_DOMAIN &test_log_domain
+#define SOL_LOG_DOMAIN &_log_domain
 
 #define DECLARE_PROCESS_FUNCTION(_name)             \
     int _name(                                      \

--- a/src/modules/flow/test/test.c
+++ b/src/modules/flow/test/test.c
@@ -31,12 +31,22 @@
  */
 
 #include <float.h>
+
+
 #include "sol-util.h"
 #include "sol-log-internal.h"
 
+#include "test-module.h"
+
+// The test module is a bit of an alien WRT logging, as it has to
+// share the domain symbol externally with the various .o objects that
+// will be linked together. Let's redeclare it by hand, then, and
+// before including test-gen.h. Also, log_init() is defined here
+// instead.
+SOL_LOG_INTERNAL_DECLARE(_log_domain, "flow-test");
+
 #include "test-gen.h"
 
-#include "test-module.h"
 #include "result.h"
 #include "boolean-generator.h"
 #include "boolean-validator.h"
@@ -46,17 +56,10 @@
 #include "int-generator.h"
 #include "blob-validator.h"
 
-SOL_LOG_INTERNAL_DECLARE(test_log_domain, "flow-test");
-
-void
-test_init_log_domain(void)
+static void
+log_init(void)
 {
-    static bool done = false;
-
-    if (done)
-        return;
-    sol_log_domain_init_level(&test_log_domain);
-    done = true;
+    SOL_LOG_INTERNAL_INIT_ONCE;
 }
 
 #include "test-gen.c"

--- a/src/modules/flow/udev/udev.c
+++ b/src/modules/flow/udev/udev.c
@@ -38,10 +38,6 @@
 
 #include <libudev.h>
 
-#define SOL_LOG_DOMAIN &_log_domain
-#include "sol-log-internal.h"
-SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "flow-udev");
-
 #include "udev-gen.h"
 #include "sol-flow.h"
 #include "sol-mainloop.h"

--- a/src/modules/flow/unix-socket/unix-socket.c
+++ b/src/modules/flow/unix-socket/unix-socket.c
@@ -36,10 +36,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#define SOL_LOG_DOMAIN &_log_domain
-#include "sol-log-internal.h"
-SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "flow-unix-socket");
-
 #include "unix-socket.h"
 #include "unix-socket-gen.h"
 #include "sol-flow.h"


### PR DESCRIPTION
This way freeing the user to have to worry with log domains for their
nodes. If a node is built-in, the log domain is the global one. If not,
a domain following the node's name-space is automatically created from
the .json declaration, with the declaration on its *-gen.h. The
difference now is that this file has to be the 1st Soletta header
getting an #include in a node. The *-gen.c file will have, at the type
init function, a call to actually init (once) the log domain, so we
don't have to do that at node opening time anymore.

Exceptions had to be made for modules that shared a domain via an
external log domain variable.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>