### PR TITLE
fbp-generator: accept strings like "INT32_MIN" for int/float default values v2

### DIFF
--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -1096,21 +1096,6 @@ def generate_description_entry(descriptions, data):
                 data_type = m["data_type"]
                 value = m["default"]
                 value = expand_value(value, data_type)
-                # TODO: should we pass thru the symbols as strings?
-                # TODO: this would solve the DBL_MIN being platform
-                # TODO: dependent and here stated INCORRECTLY as '0.0'
-                if isinstance(value, dict):
-                    for k, v in list(value.items()):
-                        if v == "INT32_MAX":
-                            value[k] = 2147483647
-                        elif v == "INT32_MIN":
-                            value[k] = -2147483648
-                        elif v == "DBL_MAX":
-                            value[k] = 1.7976931348623157e+308
-                        elif v == "-DBL_MAX":
-                            value[k] = -1.7976931348623157e+308
-                        elif v == "DBL_MIN":
-                            value[k] = 0.0 # TODO
 
                 m["default"] = value
                 m["required"] = False

--- a/src/bin/sol-fbp-generator/type-store.c
+++ b/src/bin/sol-fbp-generator/type-store.c
@@ -351,7 +351,10 @@ read_default_value(struct decoder *d, struct option_description *o)
 static bool
 get_value(struct sol_json_token *value, char **value_data, struct sol_json_token *key, struct sol_str_slice *key_slice)
 {
-    if (sol_json_token_get_type(value) != SOL_JSON_TYPE_NUMBER)
+    enum sol_json_type type;
+
+    type = sol_json_token_get_type(value);
+    if (type != SOL_JSON_TYPE_NUMBER && type != SOL_JSON_TYPE_STRING)
         return false;
 
     *key_slice = get_slice(key);


### PR DESCRIPTION
Differences from v1:
    - remove useless loop.

This should solve the DBL_MIN being platform dependent.

Signed-off-by: Ricardo de Almeida Gonzaga <ricardo.gonzaga@intel.com>