### PR TITLE
Fix exiting of forked process by way of _exit()

### DIFF
--- a/src/lib/common/sol-platform-linux-common.c
+++ b/src/lib/common/sol-platform-linux-common.c
@@ -111,7 +111,7 @@ sol_platform_linux_fork_run(void (*on_fork)(void *data), void (*on_child_exit)(v
 
         errno = 0;
         on_fork((void *)data);
-        exit(EXIT_SUCCESS);
+        _exit(EXIT_SUCCESS);
     } else if (pid < 0) {
         close(pfds[0]);
         close(pfds[1]);

--- a/src/modules/linux-micro/rc-d/rc-d.c
+++ b/src/modules/linux-micro/rc-d/rc-d.c
@@ -82,7 +82,7 @@ find_exec(const char *service, const char *arg)
     }
 
     SOL_WRN("service not found: %s", service);
-    exit(EXIT_FAILURE);
+    _exit(EXIT_FAILURE);
 }
 
 static void

--- a/src/test/test-mainloop-linux.c
+++ b/src/test/test-mainloop-linux.c
@@ -118,7 +118,7 @@ main(int argc, char *argv[])
 
         usleep(100);
         close(fds[1]);
-        exit(EXIT_SUCCESS);
+        _exit(EXIT_SUCCESS);
     }
 
     /* test if we handle graceful termination with SIGTERM */
@@ -126,7 +126,7 @@ main(int argc, char *argv[])
     if (pid == 0) {
         usleep(100000);
         kill(getppid(), SIGTERM);
-        exit(EXIT_SUCCESS);
+        _exit(EXIT_SUCCESS);
     }
 
     err = sol_init();


### PR DESCRIPTION
Only one of the two sides of a fork() can exit via regular
exit(). That's because it will try to flush any open FILE* and run
atexit() functions, among other things (e.g., running C++
destructors). If both sides do it, weird things happen, which are very,
VERY hard to debug.

Since the parent is not exiting with _exit() in any of those cases, we
conclude the child process must.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>