### PR TITLE
sol-aio: Add C API to handle Analog I/O

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -347,6 +347,8 @@ src_shared_libshared_la_LIBADD =
 
 noinst_LTLIBRARIES += src/shared/libshared.la
 src_shared_libshared_la_SOURCES = \
+src/shared/sol-aio-common.c \
+src/shared/sol-aio.h \
 src/shared/sol-arena.c \
 src/shared/sol-arena.h \
 src/shared/sol-buffer.c \
@@ -396,6 +398,7 @@ endif # HAVE_GLIB
 
 if HAVE_PLATFORM_LINUX
 src_shared_libshared_la_SOURCES += \
+src/shared/sol-aio-linux.c \
 src/shared/sol-file-reader.c \
 src/shared/sol-gpio-linux.c \
 src/shared/sol-network-linux.c \
@@ -413,6 +416,7 @@ endif
 
 if HAVE_PLATFORM_RIOT
 src_shared_libshared_la_SOURCES += \
+src/shared/sol-aio-riot.c \
 src/shared/sol-gpio-riot.c \
 src/shared/sol-i2c-riot.c \
 src/shared/sol-pwm-riot.c \

--- a/src/modules/flow/aio/aio.c
+++ b/src/modules/flow/aio/aio.c
@@ -32,6 +32,7 @@
 
 #include "aio-gen.h"
 
+#include "sol-aio.h"
 #include "sol-flow-internal.h"
 #include "sol-flow.h"
 #include "sol-mainloop.h"
@@ -43,35 +44,16 @@
 #include <sys/stat.h>
 #include <limits.h>
 
-#define AIO_BASE_PATH "/sys/bus/iio/devices/iio:device0/in_voltage%d_raw"
-
 struct aio_data {
     struct sol_flow_node *node;
     struct sol_timeout *timer;
-    FILE *fp;
+    struct sol_aio *aio;
+    int device;
     int pin;
     int mask;
     int last_value;
     bool is_first;
 };
-
-static bool
-_aio_open_fd(struct aio_data *mdata)
-{
-    char path[PATH_MAX];
-    int len;
-
-    len = snprintf(path, sizeof(path), AIO_BASE_PATH, mdata->pin);
-    if (len < 0 || len > PATH_MAX)
-        return false;
-
-    mdata->fp = fopen(path, "re");
-    if (!mdata->fp)
-        return false;
-    setvbuf(mdata->fp, NULL, _IONBF, 0);
-
-    return true;
-}
 
 static void
 aio_close(struct sol_flow_node *node, void *data)
@@ -80,8 +62,8 @@ aio_close(struct sol_flow_node *node, void *data)
 
     SOL_NULL_CHECK(mdata);
 
-    if (mdata->fp)
-        fclose(mdata->fp);
+    if (mdata->aio)
+            sol_aio_close(mdata->aio);
     if (mdata->timer)
         sol_timeout_del(mdata->timer);
 }
@@ -98,21 +80,11 @@ _on_reader_timeout(void *data)
 
     SOL_NULL_CHECK(data, true);
 
-    if (!mdata->fp) {
-        if (!_aio_open_fd(mdata)) {
-            SOL_WRN("aio #%d: Could not open file.", mdata->pin);
-            return false;
-        }
-    }
-
-    rewind(mdata->fp);
-
-    if (fscanf(mdata->fp, "%d", &i.val) < 1) {
-        SOL_WRN("aio #%d: Could not read value.", mdata->pin);
+    i.val = sol_aio_get_value(mdata->aio);
+    if (i.val < 0) {
+        SOL_WRN("aio #%d,%d: Could not read value.", mdata->device, mdata->pin);
         return false;
     }
-
-    i.val &= mdata->mask;
 
     if (mdata->is_first || i.val != mdata->last_value) {
         mdata->is_first = false;
@@ -130,8 +102,6 @@ _on_reader_timeout(void *data)
 static int
 aio_reader_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
 {
-    char path[PATH_MAX];
-    struct stat st;
     struct aio_data *mdata = data;
     const struct sol_flow_node_type_aio_reader_options *opts =
         (const struct sol_flow_node_type_aio_reader_options *)options;
@@ -140,24 +110,24 @@ aio_reader_open(struct sol_flow_node *node, void *data, const struct sol_flow_no
 
     mdata->is_first = true;
     mdata->node = node;
-    mdata->pin = opts->pin.val;
 
-    snprintf(path, sizeof(path), AIO_BASE_PATH, mdata->pin);
-    if (stat(path, &st) == -1) {
-        SOL_WRN("aio #%d: Couldn't open pin.", mdata->pin);
+    if (opts->mask.val <= 0) {
+        SOL_WRN("aio #%d,%d: Invalid bit mask value=%" PRId32 ".", opts->device.val, opts->pin.val,
+            opts->mask.val);
         return -EINVAL;
     }
+
+    mdata->aio = sol_aio_open(opts->device.val, opts->pin.val, opts->mask.val);
+    SOL_NULL_CHECK(mdata->aio, -EINVAL);
 
     if (opts->poll_timeout.val <= 0) {
-        SOL_WRN("aio #%d: Invalid polling time=%" PRId32 ".", mdata->pin, opts->poll_timeout.val);
+        SOL_WRN("aio #%d,%d: Invalid polling time=%" PRId32 ".", opts->device.val, opts->pin.val,
+            opts->poll_timeout.val);
         return -EINVAL;
     }
 
-    if (opts->mask.val == 0) {
-        SOL_WRN("aio #%d: Invalid bit mask value=%" PRId32 ".", mdata->pin, opts->mask.val);
-        return -EINVAL;
-    }
-
+    mdata->device = opts->device.val;
+    mdata->pin = opts->pin.val;
     mdata->mask = (0x01 << opts->mask.val) - 1;
     mdata->timer = sol_timeout_add(opts->poll_timeout.val, _on_reader_timeout, mdata);
 

--- a/src/modules/flow/aio/aio.json
+++ b/src/modules/flow/aio/aio.json
@@ -18,6 +18,11 @@
         "members": [
           {
             "data_type": "int",
+            "description": "Device number on platform.",
+            "name": "device"
+          },
+          {
+            "data_type": "int",
             "description": "Pin",
             "name": "pin"
           },

--- a/src/shared/sol-aio-common.c
+++ b/src/shared/sol-aio-common.c
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+
+#define SOL_LOG_DOMAIN &_log_domain
+#include "sol-log-internal.h"
+SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "aio");
+
+#include "sol-aio.h"
+#include "sol-pin-mux.h"
+
+struct sol_aio *
+sol_aio_open(const int device, const int pin, const unsigned int precision)
+{
+    struct sol_aio *aio;
+
+    SOL_LOG_INTERNAL_INIT_ONCE;
+
+    aio = sol_aio_open_raw(device, pin, precision);
+#ifdef HAVE_PIN_MUX
+    if (aio && sol_pin_mux_setup_aio(device, pin)) {
+        SOL_WRN("Pin Multiplexer Recipe for aio device=%d pin=%d found, \
+            but couldn't be applied.", device, pin);
+        sol_aio_close(aio);
+        aio = NULL;
+    }
+#endif
+
+    return aio;
+}

--- a/src/shared/sol-aio-linux.c
+++ b/src/shared/sol-aio-linux.c
@@ -1,0 +1,152 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#define SOL_LOG_DOMAIN &_log_domain
+#include "sol-log-internal.h"
+SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "aio");
+
+#include "sol-aio.h"
+
+#define AIO_BASE_PATH "/sys/bus/iio/devices"
+
+#define AIO_PATH(dst, device, pin) \
+    snprintf(dst, sizeof(dst), AIO_BASE_PATH "/iio:device%d/in_voltage%d_raw", device, pin);
+
+#define AIO_DEV_PATH(dst, device) \
+    snprintf(dst, sizeof(dst), AIO_BASE_PATH "/iio:device%d", device);
+
+struct sol_aio {
+    FILE *fp;
+    int device;
+    int pin;
+    unsigned int mask;
+};
+
+static bool
+_aio_open_fd(struct sol_aio *aio)
+{
+    int len;
+    char path[PATH_MAX];
+
+    len = AIO_PATH(path, aio->device, aio->pin);
+    if (len < 0 || len > PATH_MAX)
+        return false;
+
+    aio->fp = fopen(path, "re");
+    if (!aio->fp)
+        return false;
+    setvbuf(aio->fp, NULL, _IONBF, 0);
+
+    return true;
+}
+
+struct sol_aio *
+sol_aio_open_raw(const int device, const int pin, const unsigned int precision)
+{
+    int len;
+    char path[PATH_MAX];
+    struct stat st;
+    struct sol_aio *aio;
+
+    SOL_LOG_INTERNAL_INIT_ONCE;
+
+    if (!precision) {
+        SOL_WRN("aio #%d,%d: Invalid precision value=%d. Precision needs to be different of zero.",
+            device, pin, precision);
+        return NULL;
+    }
+
+    len = AIO_DEV_PATH(path, device);
+    if (len < 0 || len > PATH_MAX || stat(path, &st)) {
+        SOL_WRN("aio #%d,%d: aio device %d does not exist", device, pin, device);
+        return NULL;
+    }
+
+    len = AIO_PATH(path, device, pin);
+    if (len < 0 || len > PATH_MAX || stat(path, &st)) {
+        SOL_WRN("aio #%d,%d: Couldn't open pin %d on device %d", device, pin, pin, device);
+        return NULL;
+    }
+
+    aio = calloc(1, sizeof(*aio));
+    if (!aio) {
+        SOL_WRN("aio #%d,%d: could not allocate aio context", device, pin);
+        return NULL;
+    }
+
+    aio->device = device;
+    aio->pin = pin;
+    aio->mask = (0x01 << precision) - 1;
+
+    return aio;
+}
+
+void
+sol_aio_close(struct sol_aio *aio)
+{
+    SOL_NULL_CHECK(aio);
+
+    if (aio->fp)
+        fclose(aio->fp);
+
+    free(aio);
+}
+
+int
+sol_aio_get_value(const struct sol_aio *aio)
+{
+    unsigned int val;
+
+    SOL_NULL_CHECK(aio, -1);
+
+    if (!aio->fp) {
+        if (!_aio_open_fd((struct sol_aio*)aio)) {
+            SOL_WRN("aio #%d,%d: Could not open device file.", aio->device, aio->pin);
+            return -1;
+        }
+    }
+
+    rewind(aio->fp);
+
+    if (fscanf(aio->fp, "%u", &val) < 1) {
+        SOL_WRN("aio #%d,%d: Could not read value.", aio->device, aio->pin);
+        return -1;
+    }
+
+    return (int)(val & aio->mask);
+}

--- a/src/shared/sol-aio-riot.c
+++ b/src/shared/sol-aio-riot.c
@@ -1,0 +1,133 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define SOL_LOG_DOMAIN &_log_domain
+#include "sol-log-internal.h"
+SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "aio");
+
+#include "sol-aio.h"
+
+#include "periph/adc.h"
+
+struct sol_aio {
+    int device;
+    int pin;
+};
+
+bool
+_check_precision(const unsigned int precision, enum adc_precision_t *output)
+{
+    switch (precision) {
+    case 6:
+        *output = ADC_RES_6BIT;
+        break;
+    case 8:
+        *output = ADC_RES_8BIT;
+        break;
+    case 10:
+        *output = ADC_RES_10BIT;
+        break;
+    case 12:
+        *output = ADC_RES_12BIT;
+        break;
+    case 14:
+        *output = ADC_RES_14BIT;
+        break;
+    case 16:
+        *output = ADC_RES_16BIT;
+        break;
+    default:
+        return false;
+    }
+
+    return true;
+}
+
+struct sol_aio *
+sol_aio_open_raw(const int device, const int pin, const unsigned int precision)
+{
+    struct sol_aio *aio;
+    enum adc_precision_t prec;
+
+    SOL_LOG_INTERNAL_INIT_ONCE;
+
+    if (!_check_precision(precision, &prec)) {
+        SOL_WRN("aio #%d,%d: Invalid precision=%d. \
+            See 'enum adc_precision_t' for valid values on riot.",
+            device, pin, precision);
+        return NULL;
+    }
+
+    aio = calloc(1, sizeof(*aio));
+    if (!aio) {
+        SOL_WRN("aio #%d,%d: could not allocate aio context", device, pin);
+        return NULL;
+    }
+
+    aio->device = device;
+    aio->pin = pin;
+
+    adc_poweron(device);
+
+    if (adc_init(device, prec)) {
+        SOL_WRN("aio #%d,%d: Couldn't initialize aio device with given precision=%d.",
+            device, pin, precision);
+        goto error;
+    }
+
+    return aio;
+
+error:
+    poweroff(device);
+    free(aio);
+    return NULL;
+}
+
+void
+sol_aio_close(struct sol_aio *aio)
+{
+    SOL_NULL_CHECK(aio);
+    adc_poweroff(aio->device);
+    free(aio);
+}
+
+int
+sol_aio_get_value(const struct sol_aio *aio)
+{
+    SOL_NULL_CHECK(aio, -1);
+
+    return adc_sample(aio->device, aio->pin);
+}

--- a/src/shared/sol-aio.h
+++ b/src/shared/sol-aio.h
@@ -1,0 +1,81 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+struct sol_aio; /**< Structure of the AIO handler */
+
+/**
+ * Open the given Analog I/O 'pin' on 'device' to be used.
+ *
+ * This function also applies any Pin Multiplexer rules needed if a multiplexer for
+ * the current platform was previously loaded.
+ *
+ * @param device The AIO device number.
+ * @param device The AIO pin on device.
+ * @param precision The number of valid bits on the data received from the analog to digital converter.
+ * @return A new AIO handler
+ *
+ * @see sol_aio_open_raw
+ */
+struct sol_aio *sol_aio_open(const int device, const int pin, const unsigned int precision);
+
+/**
+ * Open the given Analog I/O 'pin' on 'device' to be used.
+ *
+ * 'precision' is used to filter the valid bits from the data received from hardware
+ * (which is manufacturer dependent), therefore should not be used as a way to change
+ * the output range because is applied to the least significant bits.
+ *
+ * @param device The AIO device number
+ * @param device The AIO pin on device
+ * @param precision The number of valid bits on the data received from the analog to digital converter.
+ * @return A new AIO handler
+ */
+struct sol_aio *sol_aio_open_raw(const int device, const int pin, const unsigned int precision);
+
+/**
+ * Close the given AIO handler.
+ *
+ * @param aio AIO handler to be closed.
+ */
+void sol_aio_close(struct sol_aio *aio);
+
+/**
+ * Read the value of AIO 'pin' on 'device'.
+ *
+ * @param aio A valid AIO handler for the desired 'device'/'pin' pair.
+ * @return The value read. -1 in case of error.
+ */
+int sol_aio_get_value(const struct sol_aio *aio);


### PR DESCRIPTION
This also remove the code from aio node that would be Linux specific
(which was used to create sol-aio-linux).

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>


WARNING: Riot code needs to be tested, I'm working on it. But is here for general review.