### PR TITLE
Fix array port export

### DIFF
--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -904,7 +904,7 @@ export_port(struct sol_flow_builder *builder, uint16_t node, uint16_t port,
         SOL_NULL_CHECK_GOTO(port_spec, error_export);
 
         port_spec->node = node;
-        port_spec->port = port;
+        port_spec->port = port_desc->array_size ? base_port_idx + i : port;
         i++;
     } while (i < psize);
 


### PR DESCRIPTION
When trying to export an array port, sub indexes for that port
were all being set to zero, raising a "exported in/out ports
not sorted" warning and failing the flow creation.