### PR TITLE
[v4] worker-threads: move to common and organize different implementations

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -149,6 +149,9 @@ src/lib/common/sol-log-impl.h \
 src/lib/common/sol-log-internal.h \
 src/lib/common/sol-mainloop.c \
 src/lib/common/sol-mainloop-impl.h \
+src/lib/common/sol-worker-thread.c \
+src/lib/common/sol-worker-thread.h \
+src/lib/common/sol-worker-thread-impl.h \
 src/lib/common/sol-platform.c \
 src/lib/common/sol-platform-impl.h \
 src/lib/common/sol-blob.c \
@@ -253,11 +256,21 @@ src_lib_libsoletta_la_SOURCES += \
 src/lib/common/sol-mainloop-impl-glib.c
 src_lib_libsoletta_la_CFLAGS += @GLIB_CFLAGS@
 src_lib_libsoletta_la_LIBADD += @GLIB_LIBS@
+
+if PTHREAD_LIBS
+src_lib_libsoletta_la_SOURCES += \
+src/lib/common/sol-worker-thread-impl-glib.c
+endif
 endif
 
 if HAVE_MAINLOOP_POSIX
 src_lib_libsoletta_la_SOURCES += \
 src/lib/common/sol-mainloop-impl-posix.c
+
+if PTHREAD_LIBS
+src_lib_libsoletta_la_SOURCES += \
+src/lib/common/sol-worker-thread-impl-posix.c
+endif
 endif
 
 if HAVE_MAINLOOP_RIOT
@@ -385,7 +398,6 @@ src/shared/sol-str-table.h \
 src/shared/sol-vector.c \
 src/shared/sol-uart.h \
 src/shared/sol-vector.h \
-src/shared/sol-worker-thread.h \
 src/shared/sol-json.h \
 src/shared/sol-json.c
 
@@ -409,12 +421,6 @@ src/shared/sol-pwm-linux.c \
 src/shared/sol-i2c-linux.c \
 src/shared/sol-spi-linux.c \
 src/shared/sol-uart-linux.c
-
-if PTHREAD_LIBS
-src_shared_libshared_la_SOURCES += \
-src/shared/sol-worker-thread-pthread.c
-endif
-
 endif
 
 if HAVE_PLATFORM_RIOT

--- a/src/lib/common/sol-mainloop-impl-posix.c
+++ b/src/lib/common/sol-mainloop-impl-posix.c
@@ -368,6 +368,24 @@ static unsigned char siginfo_storage_used;
 #define SIGINFO_HANDLER_FOREACH(ptr) \
     for (ptr = siginfo_handler; ptr < siginfo_handler + SIGINFO_HANDLER_COUNT; ptr++) if (ptr->sig)
 
+#ifdef HAVE_PTHREAD_H
+void sol_mainloop_posix_signals_block(void);
+void sol_mainloop_posix_signals_unblock(void);
+
+/* used externally by worker threads management */
+void
+sol_mainloop_posix_signals_block(void)
+{
+    pthread_sigmask(SIG_BLOCK, &sig_blockset, NULL);
+}
+
+void
+sol_mainloop_posix_signals_unblock(void)
+{
+    pthread_sigmask(SIG_UNBLOCK, &sig_blockset, NULL);
+}
+#endif
+
 static void
 sighandler(int sig, siginfo_t *si, void *context)
 {

--- a/src/lib/common/sol-worker-thread-impl-glib.c
+++ b/src/lib/common/sol-worker-thread-impl-glib.c
@@ -30,25 +30,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* TODO: threads it is common to have blocking calls and for those
- * soletta should offer a way to help.
- *
- * I think that a sol_worker_add(setup, iterate, flush, data) would
- * work, in systems with threads it would start a thread and call
- * those functions from there, on non-threaded systems it would use
- * idlers to run each iteration.
- */
-#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <glib.h>
 
-#define SOL_LOG_DOMAIN &_log_domain
-#include "sol-log-internal.h"
 #include "sol-mainloop.h"
-#include "sol-util.h"
-#include "sol-worker-thread.h"
+#include "sol-worker-thread-impl.h"
 
-SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "worker-thread-pthread");
-
-struct sol_worker_thread {
+struct sol_worker_thread_glib {
     const void *data;
     bool (*setup)(void *data);
     void (*cleanup)(void *data);
@@ -57,39 +46,20 @@ struct sol_worker_thread {
     void (*finished)(void *data);
     void (*feedback)(void *data);
     struct sol_idle *idler;
-    pthread_mutex_t lock;
-    pthread_t thread;
+    GMutex lock;
+    GThread *thread;
 };
-
-static bool
-sol_worker_thread_lock(struct sol_worker_thread *thread)
-{
-    int error = pthread_mutex_lock(&thread->lock);
-
-    if (!error)
-        return true;
-    if (error == EDEADLK)
-        abort();
-
-    return false;
-}
-
-static void
-sol_worker_thread_unlock(struct sol_worker_thread *thread)
-{
-    pthread_mutex_unlock(&thread->lock);
-}
 
 static bool
 sol_worker_thread_finished(void *data)
 {
-    struct sol_worker_thread *thread = data;
+    struct sol_worker_thread_glib *thread = data;
 
     if (thread->thread) {
-        pthread_join(thread->thread, NULL);
-        thread->thread = 0;
+        g_thread_join(thread->thread);
+        thread->thread = NULL;
     }
-    pthread_mutex_destroy(&thread->lock);
+    g_mutex_clear(&thread->lock);
 
     /* no locks since thread is now dead */
     thread->idler = NULL;
@@ -103,10 +73,10 @@ sol_worker_thread_finished(void *data)
     return false;
 }
 
-static void *
-sol_worker_thread_do(void *data)
+static gpointer
+sol_worker_thread_do(gpointer data)
 {
-    struct sol_worker_thread *thread = data;
+    struct sol_worker_thread_glib *thread = data;
 
     SOL_DBG("worker thread %p started", thread);
 
@@ -124,20 +94,19 @@ sol_worker_thread_do(void *data)
         thread->cleanup((void *)thread->data);
 
 end:
-    if (sol_worker_thread_lock(thread)) {
-        if (thread->idler)
-            sol_idle_del(thread->idler);
-        thread->idler = sol_idle_add(sol_worker_thread_finished, thread);
-        sol_worker_thread_unlock(thread);
-    }
+    g_mutex_lock(&thread->lock);
+    if (thread->idler)
+        sol_idle_del(thread->idler);
+    thread->idler = sol_idle_add(sol_worker_thread_finished, thread);
+    g_mutex_unlock(&thread->lock);
 
     SOL_DBG("worker thread %p stopped", thread);
 
     return thread;
 }
 
-SOL_API struct sol_worker_thread *
-sol_worker_thread_new(bool (*setup)(void *data),
+void *
+sol_worker_thread_impl_new(bool (*setup)(void *data),
     void (*cleanup)(void *data),
     bool (*iterate)(void *data),
     void (*cancel)(void *data),
@@ -145,9 +114,9 @@ sol_worker_thread_new(bool (*setup)(void *data),
     void (*feedback)(void *data),
     const void *data)
 {
-    pthread_mutexattr_t attrs;
-    struct sol_worker_thread *thread;
-    int r;
+    static uint16_t thr_cnt = 0;
+    struct sol_worker_thread_glib *thread;
+    char name[16];
 
     SOL_NULL_CHECK(iterate, NULL);
 
@@ -162,47 +131,32 @@ sol_worker_thread_new(bool (*setup)(void *data),
     thread->finished = finished;
     thread->feedback = feedback;
 
-    r = pthread_mutexattr_init(&attrs);
-    SOL_INT_CHECK_GOTO(r, != 0, error_mutex);
+    g_mutex_init(&thread->lock);
 
-    pthread_mutexattr_setpshared(&attrs, PTHREAD_PROCESS_SHARED);
-#if defined(PTHREAD_MUTEX_ADAPTIVE_NP)
-    pthread_mutexattr_settype(&attrs, PTHREAD_MUTEX_ADAPTIVE_NP);
-#endif
-
-    r = pthread_mutex_init(&thread->lock, &attrs);
-    pthread_mutexattr_destroy(&attrs);
-    SOL_INT_CHECK_GOTO(r, != 0, error_mutex);
-
-    r = pthread_create(&thread->thread, NULL,
-        sol_worker_thread_do, thread);
-    SOL_INT_CHECK_GOTO(r, != 0, error_thread);
+    snprintf(name, 16, "thr-%u",
+             __atomic_fetch_add(&thr_cnt, 1, __ATOMIC_SEQ_CST));
+    thread->thread = g_thread_new(name, sol_worker_thread_do, thread);
+    SOL_NULL_CHECK_GOTO(thread->thread, error_thread);
 
     return thread;
 
 error_thread:
-    pthread_mutex_destroy(&thread->lock);
-
-error_mutex:
     free(thread);
-    errno = r;
     return NULL;
 }
 
-SOL_API void
-sol_worker_thread_cancel(struct sol_worker_thread *thread)
+void
+sol_worker_thread_impl_cancel(void *handle)
 {
-    pthread_t tid;
-    int r;
+    struct sol_worker_thread_glib *thread = handle;
 
     SOL_NULL_CHECK(thread);
 
-    tid = thread->thread;
-    if (!tid) {
+    if (!thread->thread) {
         SOL_WRN("worker thread %p is not running.", thread);
         return;
     }
-    if (thread->thread == pthread_self()) {
+    if (thread->thread == g_thread_self()) {
         SOL_WRN("trying to cancel from worker thread %p.", thread);
         return;
     }
@@ -210,9 +164,8 @@ sol_worker_thread_cancel(struct sol_worker_thread *thread)
     if (thread->cancel)
         thread->cancel((void *)thread->data);
 
-    thread->thread = 0;
-    r = pthread_join(tid, NULL);
-    SOL_INT_CHECK(r, != 0);
+    g_thread_join(thread->thread);
+    thread->thread = NULL;
 
     /* no locks since thread is now dead */
     sol_idle_del(thread->idler);
@@ -222,20 +175,20 @@ sol_worker_thread_cancel(struct sol_worker_thread *thread)
 static bool
 sol_worker_thread_feedback_dispatch(void *data)
 {
-    struct sol_worker_thread *thread = data;
+    struct sol_worker_thread_glib *thread = data;
 
-    if (sol_worker_thread_lock(thread)) {
-        thread->idler = NULL;
-        sol_worker_thread_unlock(thread);
-    }
+    g_mutex_lock(&thread->lock);
+    thread->idler = NULL;
+    g_mutex_unlock(&thread->lock);
 
     thread->feedback((void *)thread->data);
     return false;
 }
 
-SOL_API void
-sol_worker_thread_feedback(struct sol_worker_thread *thread)
+void
+sol_worker_thread_impl_feedback(void *handle)
 {
+    struct sol_worker_thread_glib *thread = handle;
     SOL_NULL_CHECK(thread);
     SOL_NULL_CHECK(thread->feedback);
 
@@ -243,13 +196,14 @@ sol_worker_thread_feedback(struct sol_worker_thread *thread)
         SOL_WRN("worker thread %p is not running.", thread);
         return;
     }
-    if (thread->thread != pthread_self()) {
+    if (thread->thread != g_thread_self()) {
         SOL_WRN("trying to feedback from different worker thread %p.", thread);
         return;
     }
-    if (sol_worker_thread_lock(thread)) {
-        if (!thread->idler)
-            thread->idler = sol_idle_add(sol_worker_thread_feedback_dispatch, thread);
-        sol_worker_thread_unlock(thread);
-    }
+
+    g_mutex_lock(&thread->lock);
+    if (!thread->idler)
+        thread->idler = sol_idle_add(sol_worker_thread_feedback_dispatch,
+                                     thread);
+    g_mutex_unlock(&thread->lock);
 }

--- a/src/lib/common/sol-worker-thread-impl-posix.c
+++ b/src/lib/common/sol-worker-thread-impl-posix.c
@@ -1,0 +1,251 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <errno.h>
+#include <pthread.h>
+
+#include "sol-mainloop.h"
+#include "sol-worker-thread-impl.h"
+
+struct sol_worker_thread_posix {
+    const void *data;
+    bool (*setup)(void *data);
+    void (*cleanup)(void *data);
+    bool (*iterate)(void *data);
+    void (*cancel)(void *data);
+    void (*finished)(void *data);
+    void (*feedback)(void *data);
+    struct sol_idle *idler;
+    pthread_mutex_t lock;
+    pthread_t thread;
+};
+
+static bool
+sol_worker_thread_lock(struct sol_worker_thread_posix *thread)
+{
+    int error = pthread_mutex_lock(&thread->lock);
+
+    if (!error)
+        return true;
+    if (error == EDEADLK)
+        abort();
+
+    return false;
+}
+
+static void
+sol_worker_thread_unlock(struct sol_worker_thread_posix *thread)
+{
+    pthread_mutex_unlock(&thread->lock);
+}
+
+static bool
+sol_worker_thread_finished(void *data)
+{
+    struct sol_worker_thread_posix *thread = data;
+
+    if (thread->thread) {
+        pthread_join(thread->thread, NULL);
+        thread->thread = 0;
+    }
+    pthread_mutex_destroy(&thread->lock);
+
+    /* no locks since thread is now dead */
+    thread->idler = NULL;
+
+    SOL_DBG("worker thread %p finished", thread);
+
+    if (thread->finished)
+        thread->finished((void *)thread->data);
+
+    free(thread);
+    return false;
+}
+
+static void *
+sol_worker_thread_do(void *data)
+{
+    struct sol_worker_thread_posix *thread = data;
+
+    SOL_DBG("worker thread %p started", thread);
+
+    if (thread->setup) {
+        if (!thread->setup((void *)thread->data))
+            goto end;
+    }
+
+    while (thread->thread) {
+        if (!thread->iterate((void *)thread->data))
+            break;
+    }
+
+    if (thread->cleanup)
+        thread->cleanup((void *)thread->data);
+
+end:
+    if (sol_worker_thread_lock(thread)) {
+        if (thread->idler)
+            sol_idle_del(thread->idler);
+        thread->idler = sol_idle_add(sol_worker_thread_finished, thread);
+        sol_worker_thread_unlock(thread);
+    }
+
+    SOL_DBG("worker thread %p stopped", thread);
+
+    return thread;
+}
+
+extern void sol_mainloop_posix_signals_block(void);
+extern void sol_mainloop_posix_signals_unblock(void);
+
+void *
+sol_worker_thread_impl_new(bool (*setup)(void *data),
+    void (*cleanup)(void *data),
+    bool (*iterate)(void *data),
+    void (*cancel)(void *data),
+    void (*finished)(void *data),
+    void (*feedback)(void *data),
+    const void *data)
+{
+    pthread_mutexattr_t attrs;
+    struct sol_worker_thread_posix *thread;
+    int r;
+
+    SOL_NULL_CHECK(iterate, NULL);
+
+    thread = calloc(1, sizeof(*thread));
+    SOL_NULL_CHECK(thread, NULL);
+
+    thread->data = data;
+    thread->setup = setup;
+    thread->cleanup = cleanup;
+    thread->iterate = iterate;
+    thread->cancel = cancel;
+    thread->finished = finished;
+    thread->feedback = feedback;
+
+    r = pthread_mutexattr_init(&attrs);
+    SOL_INT_CHECK_GOTO(r, != 0, error_mutex);
+
+    pthread_mutexattr_setpshared(&attrs, PTHREAD_PROCESS_SHARED);
+#if defined(PTHREAD_MUTEX_ADAPTIVE_NP)
+    pthread_mutexattr_settype(&attrs, PTHREAD_MUTEX_ADAPTIVE_NP);
+#endif
+
+    r = pthread_mutex_init(&thread->lock, &attrs);
+    pthread_mutexattr_destroy(&attrs);
+    SOL_INT_CHECK_GOTO(r, != 0, error_mutex);
+
+    sol_mainloop_posix_signals_block();
+    r = pthread_create(&thread->thread, NULL,
+        sol_worker_thread_do, thread);
+    sol_mainloop_posix_signals_unblock();
+    SOL_INT_CHECK_GOTO(r, != 0, error_thread);
+
+    return thread;
+
+error_thread:
+    pthread_mutex_destroy(&thread->lock);
+
+error_mutex:
+    free(thread);
+    errno = r;
+    return NULL;
+}
+
+void
+sol_worker_thread_impl_cancel(void *handle)
+{
+    struct sol_worker_thread_posix *thread = handle;
+    pthread_t tid;
+    int r;
+
+    SOL_NULL_CHECK(thread);
+
+    tid = thread->thread;
+    if (!tid) {
+        SOL_WRN("worker thread %p is not running.", thread);
+        return;
+    }
+    if (thread->thread == pthread_self()) {
+        SOL_WRN("trying to cancel from worker thread %p.", thread);
+        return;
+    }
+
+    if (thread->cancel)
+        thread->cancel((void *)thread->data);
+
+    thread->thread = 0;
+    r = pthread_join(tid, NULL);
+    SOL_INT_CHECK(r, != 0);
+
+    /* no locks since thread is now dead */
+    sol_idle_del(thread->idler);
+    sol_worker_thread_finished(thread);
+}
+
+static bool
+sol_worker_thread_feedback_dispatch(void *data)
+{
+    struct sol_worker_thread_posix *thread = data;
+
+    if (sol_worker_thread_lock(thread)) {
+        thread->idler = NULL;
+        sol_worker_thread_unlock(thread);
+    }
+
+    thread->feedback((void *)thread->data);
+    return false;
+}
+
+void
+sol_worker_thread_impl_feedback(void *handle)
+{
+    struct sol_worker_thread_posix *thread = handle;
+    SOL_NULL_CHECK(thread);
+    SOL_NULL_CHECK(thread->feedback);
+
+    if (!thread->thread) {
+        SOL_WRN("worker thread %p is not running.", thread);
+        return;
+    }
+    if (thread->thread != pthread_self()) {
+        SOL_WRN("trying to feedback from different worker thread %p.", thread);
+        return;
+    }
+    if (sol_worker_thread_lock(thread)) {
+        if (!thread->idler)
+            thread->idler = sol_idle_add(sol_worker_thread_feedback_dispatch, thread);
+        sol_worker_thread_unlock(thread);
+    }
+}

--- a/src/lib/common/sol-worker-thread-impl.h
+++ b/src/lib/common/sol-worker-thread-impl.h
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+#define SOL_LOG_DOMAIN &_sol_worker_thread_log_domain
+extern struct sol_log_domain _sol_worker_thread_log_domain;
+#include "sol-log-internal.h"
+#include "sol-worker-thread.h"
+
+void *sol_worker_thread_impl_new(bool (*setup)(void *data), void (*cleanup)(void *data), bool (*iterate)(void *data), void (*cancel)(void *data), void (*finished)(void *data), void (*feedback)(void *data), const void *data);
+void sol_worker_thread_impl_cancel(void *handle);
+void sol_worker_thread_impl_feedback(void *handle);

--- a/src/lib/common/sol-worker-thread.c
+++ b/src/lib/common/sol-worker-thread.c
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+
+#include "sol-worker-thread.h"
+#include "sol-worker-thread-impl.h"
+
+SOL_LOG_INTERNAL_DECLARE(_sol_worker_thread_log_domain, "worker-thread");
+
+SOL_API struct sol_worker_thread *
+sol_worker_thread_new(bool (*setup)(void *data),
+    void (*cleanup)(void *data),
+    bool (*iterate)(void *data),
+    void (*cancel)(void *data),
+    void (*finished)(void *data),
+    void (*feedback)(void *data),
+    const void *data)
+{
+    SOL_NULL_CHECK(iterate, NULL);
+    return sol_worker_thread_impl_new(setup, cleanup, iterate,
+                                      cancel, finished, feedback, data);
+}
+
+SOL_API void
+sol_worker_thread_cancel(struct sol_worker_thread *thread)
+{
+    SOL_NULL_CHECK(thread);
+    sol_worker_thread_impl_cancel(thread);
+}
+
+SOL_API void
+sol_worker_thread_feedback(struct sol_worker_thread *thread)
+{
+    SOL_NULL_CHECK(thread);
+    sol_worker_thread_impl_feedback(thread);
+}

--- a/src/lib/common/sol-worker-thread.h
+++ b/src/lib/common/sol-worker-thread.h
@@ -33,8 +33,6 @@
 #pragma once
 
 #include <stdbool.h>
-#include <stdlib.h>
-#include <errno.h>
 
 // TODO abstract locks? see eina_lock.h
 struct sol_worker_thread;


### PR DESCRIPTION
v4:
   - rebased

v3:
   - use atomic inc to maintain the static counter consistent among threads

v2:
   - added simple static counter for setting glib worker threads' names