### PR TITLE
sol-flow-builder: Fix wrong pointer arithmetic.

### DIFF
--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -745,7 +745,7 @@ strv_join(const char *const *first, const char *const *second)
     first_size = first_count * sizeof(char *);
     second_size = second_count * sizeof(char *);
     memcpy(joined, first, first_size);
-    memcpy(joined + first_size, second, second_size);
+    memcpy(joined + first_count, second, second_size);
 
     return joined;
 }


### PR DESCRIPTION
This was making the joint of .conf and .fbp node options impossible.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>