### PR TITLE
flow:converter: Add string to blob

### DIFF
--- a/src/modules/flow/converter/converter.c
+++ b/src/modules/flow/converter/converter.c
@@ -1867,6 +1867,33 @@ bits_to_byte_convert(struct sol_flow_node *node, void *data, uint16_t port, uint
         SOL_FLOW_NODE_TYPE_CONVERTER_BITS_TO_BYTE__OUT__OUT, mdata->last);
 }
 
+static int
+string_to_blob_convert(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    char *mem;
+    const char *str;
+    struct sol_blob *blob;
+    int ret;
+
+    ret = sol_flow_packet_get_string(packet, &str);
+    SOL_INT_CHECK(ret, < 0, -EINVAL);
+
+    mem = strdup(str);
+    SOL_NULL_CHECK(mem, -ENOMEM);
+
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, mem, strlen(mem) + 1);
+    if (!blob) {
+        free(mem);
+        return -ENOMEM;
+    }
+
+    ret = sol_flow_send_blob_packet(node,
+        SOL_FLOW_NODE_TYPE_CONVERTER_STRING_TO_BLOB__OUT__OUT, blob);
+
+    sol_blob_unref(blob);
+    return ret;
+}
+
 #undef SET_BIT
 
 #include "converter-gen.c"

--- a/src/modules/flow/converter/converter.json
+++ b/src/modules/flow/converter/converter.json
@@ -1940,6 +1940,29 @@
       ],
       "private_data_type": "sol_converter_bits",
       "url": "http://solettaproject.org/doc/latest/node_types/converter/bits-to-byte.html"
+    },
+    {
+      "category": "converter",
+      "description": "Receives a string packet and convert to blob.",
+      "in_ports": [
+        {
+          "data_type": "string",
+          "description": "Where to receive the string value to be converted.",
+          "methods": {
+            "process": "string_to_blob_convert"
+          },
+          "name": "IN"
+        }
+      ],
+      "name": "converter/string-to-blob",
+      "out_ports": [
+        {
+          "data_type": "blob",
+          "description": "Send blob with the contents of the string received in the port IN.",
+          "name": "OUT"
+        }
+      ],
+      "url": "http://solettaproject.org/doc/latest/node_types/converter/string-to-blob.htmlhtml"
     }
   ]
 }


### PR DESCRIPTION
A converter node that receives a string packet in its IN port
and send a blob packet in the OUT port.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>