### PR TITLE
Container nodes: Avoid issues when options are missing

### DIFF
--- a/src/modules/flow/calamari/calamari.c
+++ b/src/modules/flow/calamari/calamari.c
@@ -248,6 +248,7 @@ calamari_7seg_new_type(const struct sol_flow_node_type **current)
     type->description = (*current)->description;
 #endif
     type->new_options = (*current)->new_options;
+    type->free_options = (*current)->free_options;
     *current = type;
 }
 
@@ -553,6 +554,7 @@ calamari_rgb_led_new_type(const struct sol_flow_node_type **current)
     type->description = (*current)->description;
 #endif
     type->new_options = (*current)->new_options;
+    type->free_options = (*current)->free_options;
     *current = type;
 }
 

--- a/src/modules/flow/grove/grove.c
+++ b/src/modules/flow/grove/grove.c
@@ -104,6 +104,7 @@ grove_rotary_sensor_new_type(const struct sol_flow_node_type **current)
     type->description = (*current)->description;
 #endif
     type->new_options = (*current)->new_options;
+    type->free_options = (*current)->free_options;
     *current = type;
 }
 
@@ -211,6 +212,7 @@ grove_light_sensor_new_type(const struct sol_flow_node_type **current)
     type->description = (*current)->description;
 #endif
     type->new_options = (*current)->new_options;
+    type->free_options = (*current)->free_options;
     *current = type;
 }
 
@@ -380,6 +382,7 @@ grove_temperature_sensor_new_type(const struct sol_flow_node_type **current)
     type->description = (*current)->description;
 #endif
     type->new_options = (*current)->new_options;
+    type->free_options = (*current)->free_options;
     *current = type;
 }
 


### PR DESCRIPTION
Container nodes should copy the free_options function in order
to avoid issues when options are omitted in conf files.

Signed-off-by: Anselmo L. S. Melo <anselmo.melo@intel.com>