### PR TITLE
If no priv data exists for a node, don't pass a valid data ptr to it.

### DIFF
--- a/src/lib/flow/sol-flow.c
+++ b/src/lib/flow/sol-flow.c
@@ -127,7 +127,7 @@ sol_flow_node_init(struct sol_flow_node *node, struct sol_flow_node *parent, con
         node->id = strdup(name);
 
     if (type->open) {
-        int r = type->open(node, node->data, options);
+        int r = type->open(node, type->data_size ? node->data : NULL, options);
         if (r < 0) {
             if (parent_type) {
                 if (parent_type->remove)


### PR DESCRIPTION
This way, on

* int (*open)(struct sol_flow_node *node, void *data, const struct  sol_flow_node_options *options)
* void (*close)(struct sol_flow_node *node, void *data)

The node won't get a non-NULL but invalid pointer to act on.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>