### PR TITLE
kbuild: resolver conffile must select use_glib

### DIFF
--- a/src/lib/flow/Kconfig
+++ b/src/lib/flow/Kconfig
@@ -4,6 +4,7 @@ config FLOW
 
 config RESOLVER_CONFFILE
 	bool "Resolver conffile"
+	select USE_GLIB
 	default y
 
 config FLOW_RESOLVER


### PR DESCRIPTION
Since it also uses glib and may be used with different mainloop's
(which will not select use_glib) we need to explicitly select it
for resolver conffile.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>