### PR TITLE
build: fix issue with systemd-journal dependent code

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -30,6 +30,10 @@ config USE_SYSTEMD
 	bool
 	default n
 
+config USE_SYSTEMD_JOURNAL
+	bool
+	default n
+
 config USE_GLIB
 	bool
 	default n

--- a/data/scripts/dependency-resolver.py
+++ b/data/scripts/dependency-resolver.py
@@ -42,6 +42,7 @@ pkg_config_deps = {
     "GLIB": "glib-2.0",
     "GTK": "gtk+-3.0",
     "SYSTEMD": "libsystemd",
+    "SYSTEMD_JOURNAL": "libsystemd-journal",
     "UDEV": "libudev",
 }
 

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -53,6 +53,7 @@ endchoice
 
 config LOG
 	bool "Log"
+	select USE_SYSTEMD_JOURNAL
 	default y
 
 choice

--- a/src/lib/common/Makefile
+++ b/src/lib/common/Makefile
@@ -16,6 +16,7 @@ obj-core-$(SOCKET_LINUX)     += sol-socket-linux.o
 obj-core-$(PLATFORM_RIOTOS)  += sol-platform-impl-riot.o
 obj-core-$(PLATFORM_DUMMY)   += sol-platform-impl-dummy.o
 obj-core-$(SOL_PLATFORM_LINUX) += sol-platform-linux-common.o sol-log-impl-linux.o
+obj-core-$(SOL_PLATFORM_LINUX)-extra-cflags += $(SYSTEMD_JOURNAL_CFLAGS)
 
 obj-core-$(PLATFORM_SYSTEMD) += sol-platform-impl-systemd.o
-obj-core-$(PLATFORM_SYSTEMD)-extra-cflags += $(SYSTEMD_CFLAGS) $(UDEV_CFLAGS)
+obj-core-$(PLATFORM_SYSTEMD)-extra-cflags += $(SYSTEMD_CFLAGS) $(SYSTEMD_JOURNAL_CFLAGS) $(UDEV_CFLAGS)

--- a/src/lib/common/sol-log-impl-linux.c
+++ b/src/lib/common/sol-log-impl-linux.c
@@ -637,7 +637,7 @@ sol_log_print_function_syslog(void *data, const struct sol_log_domain *domain, u
 SOL_API void
 sol_log_print_function_journal(void *data, const struct sol_log_domain *domain, uint8_t message_level, const char *file, const char *function, int line, const char *format, va_list args)
 {
-#ifdef HAVE_SYSTEMD
+#ifdef HAVE_SYSTEMD && HAVE_SYSTEMD_JOURNAL
     char *code_file = NULL;
     char *code_line = NULL;
     char *msg = NULL;


### PR DESCRIPTION
Since the libs are split the build system is not using the systemd-journal
flags. This patch introduces SYSTEM_JOURNAL dependency to the resolver
and use it wherever it's needed.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>