### PR TITLE
build: fix issue with systemd-journal dependent code

### DIFF
--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -53,6 +53,7 @@ endchoice
 
 config LOG
 	bool "Log"
+	select USE_SYSTEMD
 	default y
 
 choice

--- a/src/lib/common/Makefile
+++ b/src/lib/common/Makefile
@@ -15,7 +15,9 @@ obj-core-$(PLATFORM_LINUX_MICRO) += sol-platform-impl-linux-micro.o
 obj-core-$(SOCKET_LINUX)     += sol-socket-linux.o
 obj-core-$(PLATFORM_RIOTOS)  += sol-platform-impl-riot.o
 obj-core-$(PLATFORM_DUMMY)   += sol-platform-impl-dummy.o
+
 obj-core-$(SOL_PLATFORM_LINUX) += sol-platform-linux-common.o sol-log-impl-linux.o
+obj-core-$(SOL_PLATFORM_LINUX)-extra-cflags += $(SYSTEMD_CFLAGS)
 
 obj-core-$(PLATFORM_SYSTEMD) += sol-platform-impl-systemd.o
 obj-core-$(PLATFORM_SYSTEMD)-extra-cflags += $(SYSTEMD_CFLAGS) $(UDEV_CFLAGS)


### PR DESCRIPTION
v2:
  + don't need to search for libsystemd-journal since the flags are the same as the systemd itself;


sol-log-impl-linux.c should get the SYSTEMD_CFLAGS as extra-cflags
in order to link agains systemd-journal.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>