### PR TITLE
Fix signature of sd-bus functions now that it's officially supported

### DIFF
--- a/src/lib/common/sol-bus.h
+++ b/src/lib/common/sol-bus.h
@@ -55,5 +55,5 @@ int sol_bus_unmap_cached_properties(const struct sol_bus_properties property_tab
     const void *data);
 
 /* convenience methods */
-int sol_bus_log_callback(sd_bus *bus, sd_bus_message *reply, void *userdata,
+int sol_bus_log_callback(sd_bus_message *reply, void *userdata,
     sd_bus_error *ret_error);

--- a/src/lib/common/sol-platform-impl-systemd.c
+++ b/src/lib/common/sol-platform-impl-systemd.c
@@ -250,7 +250,7 @@ static const struct sol_bus_properties _service_properties[] = {
 };
 
 static int
-_add_service_monitor(sd_bus *bus, sd_bus_message *reply, void *userdata,
+_add_service_monitor(sd_bus_message *reply, void *userdata,
     sd_bus_error *ret_error)
 {
     struct service *x = userdata;
@@ -259,13 +259,13 @@ _add_service_monitor(sd_bus *bus, sd_bus_message *reply, void *userdata,
 
     x->slot = sd_bus_slot_unref(x->slot);
 
-    if (sol_bus_log_callback(bus, reply, userdata, ret_error) < 0)
+    if (sol_bus_log_callback(reply, userdata, ret_error) < 0)
         return 0;
 
     r = sd_bus_message_read(reply, "o", &path);
     SOL_INT_CHECK(r, < 0, r);
 
-    sol_bus_map_cached_properties(bus,
+    sol_bus_map_cached_properties(sd_bus_message_get_bus(reply),
         "org.freedesktop.systemd1",
         path,
         "org.freedesktop.systemd1.Unit",


### PR DESCRIPTION
Starting with systemd 221, sd-bus is officially supported and the
signature of the functions changed from the ones we were using.