### PR TITLE
log: Fix extern log domain variable names so they don't clash

### DIFF
--- a/src/modules/flow/gtk/common.h
+++ b/src/modules/flow/gtk/common.h
@@ -36,8 +36,8 @@
 #include <gtk/gtk.h>
 
 #ifndef SOL_LOG_DOMAIN
-#define SOL_LOG_DOMAIN &_log_domain
-extern struct sol_log_domain _log_domain;
+#define SOL_LOG_DOMAIN &_gtk_log_domain
+extern struct sol_log_domain _gtk_log_domain;
 #include "sol-log-internal.h"
 #endif
 

--- a/src/modules/flow/gtk/gtk.c
+++ b/src/modules/flow/gtk/gtk.c
@@ -39,7 +39,7 @@
 // be linked together. Let's redeclare it by hand, then, and before
 // including gtk-gen.h. Also, log_init() is defined here instead.
 #include "common.h"
-SOL_LOG_INTERNAL_DECLARE(_log_domain, "flow-gtk");
+SOL_LOG_INTERNAL_DECLARE(_gtk_log_domain, "flow-gtk");
 
 #include "gtk-gen.h"
 

--- a/src/modules/flow/process/common.h
+++ b/src/modules/flow/process/common.h
@@ -32,9 +32,9 @@
 
 #pragma once
 
-#define SOL_LOG_DOMAIN &_log_domain
+#define SOL_LOG_DOMAIN &_process_log_domain
 #include "sol-log-internal.h"
-extern struct sol_log_domain _log_domain;
+extern struct sol_log_domain _process_log_domain;
 
 #include "process-gen.h"
 #include "sol-mainloop.h"

--- a/src/modules/flow/process/process.c
+++ b/src/modules/flow/process/process.c
@@ -3,7 +3,7 @@
 // The process module is a bit of an alien WRT logging, as it has to
 // share the domain symbol externally with the various .o objects that
 // will be linked together. Also, log_init() is defined here instead.
-SOL_LOG_INTERNAL_DECLARE(_log_domain, "flow-process");
+SOL_LOG_INTERNAL_DECLARE(_process_log_domain, "flow-process");
 
 static void
 log_init(void)

--- a/src/modules/flow/test/test-module.h
+++ b/src/modules/flow/test/test-module.h
@@ -35,11 +35,11 @@
 #include "sol-flow.h"
 #include "sol-log.h"
 
-extern struct sol_log_domain _log_domain;
+extern struct sol_log_domain _test_log_domain;
 void test_init_log_domain(void);
 
 #undef SOL_LOG_DOMAIN
-#define SOL_LOG_DOMAIN &_log_domain
+#define SOL_LOG_DOMAIN &_test_log_domain
 
 #define DECLARE_PROCESS_FUNCTION(_name)             \
     int _name(                                      \

--- a/src/modules/flow/test/test.c
+++ b/src/modules/flow/test/test.c
@@ -43,7 +43,7 @@
 // will be linked together. Let's redeclare it by hand, then, and
 // before including test-gen.h. Also, log_init() is defined here
 // instead.
-SOL_LOG_INTERNAL_DECLARE(_log_domain, "flow-test");
+SOL_LOG_INTERNAL_DECLARE(_test_log_domain, "flow-test");
 
 #include "test-gen.h"
 


### PR DESCRIPTION
when we built all modules as built-in.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>