### PR TITLE
kconfig: sort platform options and select dummy as default

### DIFF
--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -8,9 +8,13 @@ config SOL_PLATFORM_LINUX
 
 choice
 	prompt "Target platform"
-	default PLATFORM_LINUX_MICRO
+	default PLATFORM_DUMMY
 	help
 	  The platform of your target.
+
+config PLATFORM_DUMMY
+	bool "dummy"
+	select SOL_PLATFORM_LINUX
 
 config PLATFORM_LINUX_MICRO
 	select SOL_PLATFORM_LINUX
@@ -18,10 +22,6 @@ config PLATFORM_LINUX_MICRO
 
 config PLATFORM_RIOTOS
 	bool "riotos"
-
-config PLATFORM_DUMMY
-	bool "dummy"
-	select SOL_PLATFORM_LINUX
 
 config PLATFORM_SYSTEMD
 	bool "systemd"


### PR DESCRIPTION
All the other options are sorted alphabetically.
Also using dummy as default instead of micro-linux
seems more straighforward for general users.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>