### PR TITLE
kconfig: use SOL_PLATFORM_LINUX to check if it's linux

### DIFF
--- a/src/bin/sol-fbp-generator/Kconfig
+++ b/src/bin/sol-fbp-generator/Kconfig
@@ -1,4 +1,4 @@
 config FBP_GENERATOR
 	bool "fbp generator"
-	depends on SOCKET_LINUX && FLOW && RESOLVER_CONFFILE && INSPECTOR
+	depends on SOL_PLATFORM_LINUX && FLOW && RESOLVER_CONFFILE && INSPECTOR
 	default y

--- a/src/bin/sol-fbp-runner/Kconfig
+++ b/src/bin/sol-fbp-runner/Kconfig
@@ -1,4 +1,4 @@
 config FBP_RUNNER
 	bool "fbp runner"
-	depends on SOCKET_LINUX && FLOW && RESOLVER_CONFFILE && INSPECTOR
+	depends on SOL_PLATFORM_LINUX && FLOW && RESOLVER_CONFFILE && INSPECTOR
 	default y

--- a/src/bin/sol-fbp-to-dot/Kconfig
+++ b/src/bin/sol-fbp-to-dot/Kconfig
@@ -1,4 +1,4 @@
 config FBP_TO_DOT
 	bool "fbp-to-dot converter"
-	depends on SOCKET_LINUX && RESOLVER_CONFFILE && INSPECTOR
+	depends on SOL_PLATFORM_LINUX && RESOLVER_CONFFILE && INSPECTOR
 	default y

--- a/src/bin/sol-flow-node-types/Kconfig
+++ b/src/bin/sol-flow-node-types/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPES
 	bool "flow node types"
-	depends on SOCKET_LINUX && RESOLVER_CONFFILE && INSPECTOR
+	depends on SOL_PLATFORM_LINUX && RESOLVER_CONFFILE && INSPECTOR
 	default y

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -38,12 +38,12 @@ choice
 
 config MAINLOOP_GLIB
 	bool "glib"
-	depends on (PLATFORM_LINUX_MICRO || PLATFORM_SYSTEMD) && HAVE_GLIB
+	depends on SOL_PLATFORM_LINUX && HAVE_GLIB
 	select USE_GLIB
 
 config MAINLOOP_POSIX
 	bool "posix"
-	depends on PLATFORM_LINUX_MICRO || PLATFORM_SYSTEMD
+	depends on SOL_PLATFORM_LINUX
 
 config MAINLOOP_RIOTOS
 	bool "riotos"
@@ -85,11 +85,11 @@ config INSPECTOR
 
 config KDBUS
 	bool "Kdbus"
-	depends on (PLATFORM_LINUX_MICRO || PLATFORM_SYSTEMD) && HAVE_SYSTEMD && HAVE_KDBUS
+	depends on SOL_PLATFORM_LINUX && HAVE_SYSTEMD && HAVE_KDBUS
 	select USE_GLIB
 	default n
 
 config SOCKET_LINUX
 	bool "Linux sockets"
-	depends on PLATFORM_LINUX_MICRO || PLATFORM_SYSTEMD
+	depends on SOL_PLATFORM_LINUX
 	default y

--- a/src/modules/flow/oic/Kconfig
+++ b/src/modules/flow/oic/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_OIC
 	tristate "Node type: oic"
-	depends on FLOW && COAP && SOCKET_LINUX
+	depends on FLOW && COAP && SOL_PLATFORM_LINUX
 	default m


### PR DESCRIPTION
Dorileo, please check if it's the expected behaviour.

Instead of using SYSTEMD || MICROLINUX, or even SOCKET_LINUX

Using such approaches were leaving dummy without many stuff,
including tools.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>