### PR TITLE
build: Fix installing with the wrong prefix

### DIFF
--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -59,6 +59,7 @@ $(foreach bin,$(rpath-bins),$(eval $(call rpath-cleanup,$(bin))))
 
 pre-install: $(PRE_INSTALL)
 	$(Q)echo "     "INSTALLING SYSROOT TO: $(DESTDIR)
+	$(Q)$(MKDIR) -p $(DESTDIR)
 	$(Q)$(CP) -R $(build_sysroot)/* $(DESTDIR)
 
 post-install: pre-install $(addsuffix -rpath-cleanup,$(rpath-bins))


### PR DESCRIPTION
When DESTDIR is specified and it doesn't exist, cp -R will not create
it, which will cause the first part of the prefix to be omitted.

For example, prefix=/usr/x86_64-pc-linux-gnu and DESTDIR=/tmp/soletta
will cause it to be installed on /tmp/soletta/x86_64-pc-linux-gnu, if
/tmp/soletta doesn't exist.

Signed-off-by: Vinicius Costa Gomes <vinicius.gomes@intel.com>