### PR TITLE
samples: add example of password queues

### DIFF
--- a/src/samples/flow/misc/password_queues.fbp
+++ b/src/samples/flow/misc/password_queues.fbp
@@ -1,0 +1,86 @@
+#!/usr/bin/env sol-fbp-runner
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This is an example that simulates two password machines:
+# one for regular and other for preferencial passwords.
+# And a cashier, that when press the button call the next
+# password, preferencials first. It won't call anybody
+# if such queues are empty already.
+#
+# To test it, press 'p' to emit a preferencial ticket,
+# 'n' for regular ticket and 'c' to call the next ticket.
+
+# preferencial passwords emissor
+PrefBt(keyboard/boolean:binary_code=112)
+PrefPasswd(int/accumulator:setup_value=0|0)
+PrefPrinter(console)
+PrefLess(int/less)
+
+PrefBt OUT -> PULSE_IF_TRUE _(converter/boolean-to-empty) OUT -> INC PrefPasswd
+PrefPasswd OUT -> IN PrefPrinter
+PrefPasswd OUT -> IN1 PrefLess
+
+# regular passwords emissor
+NormBt(keyboard/boolean:binary_code=110)
+NormPasswd (int/accumulator:setup_value=0|0)
+NormPrinter(console)
+NormLess(int/less)
+
+NormBt OUT -> PULSE_IF_TRUE _(converter/boolean-to-empty) OUT -> INC NormPasswd
+NormPasswd OUT -> IN NormPrinter
+NormPasswd OUT -> IN1 NormLess
+
+# cashier calls all preferencial passwords before regular passwords.
+CashierBt(keyboard/boolean:binary_code=99)
+CallPref(boolean/and)
+CallPrefPasswd(int/accumulator:setup_value=0|0)
+CallPrefPrinter(console)
+CouldCallNorm(boolean/and)
+CallNorm(boolean/and)
+CallNormPasswd(int/accumulator:setup_value=0|0)
+CallNormPrinter(console)
+
+CashierBt OUT -> IN0 CallPref
+PrefLess OUT -> IN1 CallPref
+
+CallPref OUT -> IN _(boolean/filter) TRUE -> INC CallPrefPasswd
+CallPrefPasswd OUT -> IN0 PrefLess
+CallPrefPasswd OUT -> IN CallPrefPrinter
+
+CashierBt OUT -> IN0 CouldCallNorm
+PrefLess OUT -> IN _(boolean/not) OUT -> IN1 CouldCallNorm
+
+CouldCallNorm OUT -> IN0 CallNorm
+NormLess OUT -> IN1 CallNorm
+
+CallNorm OUT -> IN _(boolean/filter) TRUE -> INC CallNormPasswd
+CallNormPasswd OUT -> IN0 NormLess
+CallNormPasswd OUT -> IN CallNormPrinter


### PR DESCRIPTION
--

It's based on a discussion with Ederson a few weeks ago.
It wasn't doable until REPLACE_PACKET flag was finally
removed.

--

This is an example that simulates two password machines:
one for regular and other for preferencial passwords.
And a cashier, that when press the button call the next
password, preferencials first. It won't call anybody
if such queues are empty already.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>