### PR TITLE
build: make sure all the compilation uses the same -std flag

### DIFF
--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -175,6 +175,7 @@ COMMON_CFLAGS += -D_GNU_SOURCE=1 -DHAVE_DECL_STRNDUPA=1 -DHAVE_ACCEPT4=1
 ## since we no other flow resolver, couldn't we remove this parametrization?
 COMMON_CFLAGS += -Dsol_flow_default_resolver=sol_flow_resolver_conffile
 
+COMMON_CFLAGS += -std=gnu99
 COMMON_CFLAGS += -include $(abspath $(KCONFIG_AUTOHEADER))
 COMMON_CFLAGS += -DPKGSYSCONFDIR=\"$(SYSCONF)\"
 COMMON_CFLAGS += -DFLOWMODULESDIR=\"$(MODULESDIR)/flow/\"
@@ -187,7 +188,7 @@ TEST_CFLAGS := $(CHECK_CFLAGS)
 
 LIB_CFLAGS := $(COMMON_CFLAGS)
 LIB_CFLAGS += $(addprefix -L,$(LIB_OUTPUTDIR))
-LIB_CFLAGS += -lshared -lsoletta -fPIC -std=gnu99
+LIB_CFLAGS += -lshared -lsoletta -fPIC
 
 BIN_CFLAGS := $(COMMON_CFLAGS)
 BIN_CFLAGS += $(addprefix -L,$(LIB_OUTPUTDIR))


### PR DESCRIPTION
The language standard is being set only for lib cflags, it should
be applied to common_cflags and be used to all compilations.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>