### PR TITLE
calamari: Move check out of the ifdefs

### DIFF
--- a/src/modules/flow/calamari/calamari.c
+++ b/src/modules/flow/calamari/calamari.c
@@ -243,8 +243,8 @@ calamari_7seg_new_type(const struct sol_flow_node_type **current)
     nodes[SEG_CLEAR].type = nodes[SEG_LATCH].type = nodes[SEG_CLOCK].type = nodes[SEG_DATA].type = SOL_FLOW_NODE_TYPE_GPIO_WRITER;
 
     type = sol_flow_static_new_type(nodes, conns, exported_in, NULL, calamari_7seg_child_opts_set);
-#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
     SOL_NULL_CHECK(type);
+#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
     type->description = (*current)->description;
 #endif
     type->new_options = (*current)->new_options;
@@ -549,8 +549,8 @@ calamari_rgb_led_new_type(const struct sol_flow_node_type **current)
     nodes[RGB_LED_RED].type = nodes[RGB_LED_GREEN].type = nodes[RGB_LED_BLUE].type = SOL_FLOW_NODE_TYPE_GPIO_WRITER;
 
     type = sol_flow_static_new_type(nodes, conns, exported_in, NULL, calamari_rgb_child_opts_set);
-#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
     SOL_NULL_CHECK(type);
+#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
     type->description = (*current)->description;
 #endif
     type->new_options = (*current)->new_options;


### PR DESCRIPTION
These SOL_NULL_CHECK should have been moved out of the ifdefs
when new_options and free_options were assigned to type.

Signed-off-by: Anselmo L. S. Melo <anselmo.melo@intel.com>