### PR TITLE
Build dep resolver v2

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -17,26 +17,6 @@ config MODULES
 config PREFIX
         string "Installation prefix"
 	default "/usr"
-
-config USE_GTK
-	bool
-	default n
-
-config USE_UDEV
-	bool
-	default n
-
-config USE_SYSTEMD
-	bool
-	default n
-
-config USE_GLIB
-	bool
-	default n
-
-config USE_CHECK
-	bool
-	default y
 endmenu
 
 menu "Core library"

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -1,0 +1,123 @@
+{
+    "dependencies": [
+	{
+	    "dependency": "check",
+	    "type": "pkg-config",
+	    "pkgname": "check"
+	},
+	{
+	    "dependency": "glib",
+	    "type": "pkg-config",
+	    "pkgname": "glib-2.0"
+	},
+	{
+	    "dependency": "gtk",
+	    "type": "pkg-config",
+	    "pkgname": "gtk+-3.0"
+	},
+	{
+	    "dependency": "systemd",
+	    "type": "pkg-config",
+	    "pkgname": "libsystemd"
+	},
+	{
+	    "dependency": "udev",
+	    "type": "pkg-config",
+	    "pkgname": "libudev"
+	},
+	{
+	    "dependency": "kdbus",
+	    "type": "ccode",
+	    "headers": [
+		"<systemd/sd-bus.h>"
+	    ]
+	},
+	{
+	    "dependency": "pthread_h",
+	    "type": "ccode",
+	    "headers": [
+		"<pthread.h>"
+	    ],
+            "ldflags": "-lpthread"
+	},
+	{
+	    "dependency": "riotos",
+	    "type": "ccode",
+	    "headers": [
+		"<riotos/cpu.h>"
+	    ]
+	},
+	{
+	    "dependency": "dlfcn_h",
+	    "type": "ccode",
+	    "headers": [
+		"<dlfcn.h>"
+	    ]
+	},
+	{
+	    "dependency": "accept4",
+	    "type": "ccode",
+	    "headers": [
+		"<sys/socket.h>"
+	    ],
+	    "fragment": "accept4(0, 0, 0, 0);"
+	},
+	{
+	    "dependency": "isatty",
+	    "type": "ccode",
+	    "headers": [
+		"<unistd.h>"
+	    ],
+	    "fragment": "isatty(0);"
+	},
+	{
+	    "dependency": "ppoll",
+	    "type": "ccode",
+	    "headers": [
+		"<poll.h>"
+	    ],
+	    "fragment": "ppoll(0, 0, 0, 0);"
+	},
+	{
+	    "dependency": "decl_strndupa",
+	    "type": "ccode",
+	    "headers": [
+		"<string.h>"
+	    ],
+	    "fragment": "strndupa(0, 0);"
+	},
+	{
+	    "dependency": "decl_ifla_inet6_addr_gen_mode",
+	    "type": "ccode",
+	    "headers": [
+		"<netinet/in.h>",
+		"<netinet/ether.h>",
+                "<linux/rtnetlink.h>",
+		"<net/if.h>",
+                "<linux/if_link.h>",
+		"<linux/if_addr.h>"
+	    ],
+	    "fragment": "int v = IFLA_INET6_ADDR_GEN_MODE;"
+	},
+	{
+	    "dependency": "valgrind",
+	    "type": "exec",
+	    "exec": "valgrind"
+	},
+	{
+	    "dependency": "lcov",
+	    "type": "exec",
+	    "exec": "lcov"
+	},
+	{
+	    "dependency": "genhtml",
+	    "type": "exec",
+	    "exec": "genhtml"
+	},
+	{
+	    "dependency": "jsonschema",
+	    "type": "python",
+	    "pkgname": "jsonschema"
+	}
+    ]
+}

--- a/data/scripts/dependency-resolver.py
+++ b/data/scripts/dependency-resolver.py
@@ -47,7 +47,7 @@ pkg_config_deps = {
 
 header_deps = {
     "KDBUS": "<systemd/sd-bus.h>",
-    "PTHREAD": "<pthread.h>",
+    "PTHREAD_H": "<pthread.h>",
     "RIOTOS": "<riotos/cpu.h>",
     "DLFCN_H": "<dlfcn.h>",
 }

--- a/data/scripts/dependency-resolver.py
+++ b/data/scripts/dependency-resolver.py
@@ -31,192 +31,151 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import json
 import os
 import subprocess
 import sys
 import tempfile
 from shutil import which
 
-pkg_config_deps = {
-    "CHECK": "check",
-    "GLIB": "glib-2.0",
-    "GTK": "gtk+-3.0",
-    "SYSTEMD": "libsystemd",
-    "UDEV": "libudev",
+cfg_cflags = {}
+cfg_ldflags = {}
+cfg_kconfig = {}
+makefile_vars = {}
+
+def run_command(cmd):
+    try:
+        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT,
+                                         shell=True, universal_newlines=True)
+        return output.replace("\n", "").strip(), True
+    except subprocess.CalledProcessError as e:
+        return e.output, False
+
+def handle_pkgconfig_check(args, conf):
+    dep = conf["dependency"].upper()
+    pkg = conf["pkgname"]
+
+    cflags_cmd = "pkg-config --cflags %s" % pkg
+    ldflags_cmd = "pkg-config --libs %s" % pkg
+
+    cflags, cflags_stat = run_command(cflags_cmd)
+    ldflags, ldflags_stat = run_command(ldflags_cmd)
+
+    if cflags_stat:
+        cfg_cflags["%s_CFLAGS" % dep] = cflags
+
+    if ldflags_stat:
+        cfg_ldflags["%s_LDFLAGS" % dep] = ldflags
+
+    have_var = "y" if (cflags_stat or ldflags_stat) else "n"
+    cfg_kconfig["HAVE_%s" % dep] = have_var
+
+def compile_test(source, compiler, cflags):
+    f = tempfile.NamedTemporaryFile(suffix=".c",delete=False)
+    f.write(bytes(source, 'UTF-8'))
+    f.close()
+    output = "%s-bin" % f.name
+    cmd = "{compiler} {cflags} {src} -o {out}".format(compiler=compiler, cflags=cflags,
+                                                      src=f.name, out=output)
+    out, status = run_command(cmd)
+    if os.path.exists(output):
+        os.unlink(output)
+    os.unlink(f.name)
+
+    return status
+
+def handle_ccode_check(args, conf):
+    dep = conf["dependency"].upper()
+    source = ""
+    for i in conf["headers"]:
+        source += "#include %s\n" % i
+
+    fragment = conf.get("fragment") or ""
+    cstub = "{headers}\nint main(int argc, char **argv){{\n {fragment} return 0;\n}}"
+    source = cstub.format(headers=source, fragment=fragment)
+    success = compile_test(source, args.compiler, args.cflags)
+
+    if success:
+        cfg_cflags["%s_CFLAGS" % dep] = conf.get("cflags") or ""
+        cfg_ldflags["%s_LDFLAGS" % dep] = conf.get("ldflags") or ""
+        cfg_kconfig["HAVE_%s" % dep] = "y"
+    else:
+        cfg_kconfig["HAVE_%s" % dep] = "n"
+
+def handle_exec_check(args, conf):
+    dep = conf["dependency"].upper()
+    path = which(conf["exec"]) or None
+
+    makefile_vars[dep] = path
+
+def handle_python_check(args, conf):
+    dep = conf["dependency"].upper()
+
+    if conf.get("pkgname"):
+        source = "import %s" % conf.get("pkgname")
+
+    f = tempfile.NamedTemporaryFile(suffix=".py",delete=False)
+    f.write(bytes(source, 'UTF-8'))
+    f.close()
+
+    cmd = "%s %s" % (sys.executable, f.name)
+    output, status = run_command(cmd)
+    makefile_vars["HAVE_PYTHON_%s" % dep] = "y" if status else "n"
+
+type_handlers = {
+    "pkg-config": handle_pkgconfig_check,
+    "ccode": handle_ccode_check,
+    "exec": handle_exec_check,
+    "python": handle_python_check,
 }
 
-header_deps = {
-    "KDBUS": "<systemd/sd-bus.h>",
-    "PTHREAD_H": "<pthread.h>",
-    "RIOTOS": "<riotos/cpu.h>",
-    "DLFCN_H": "<dlfcn.h>",
-}
+def var_str(items):
+    output = ""
+    for k,v in items:
+        if not v: continue
+        output += "%s ?= %s\n" % (k, v)
+    return output
 
-exec_deps = {
-    "VALGRIND": "valgrind",
-    "LCOV": "lcov",
-    "GENHTML": "genhtml",
-}
+def makefile_gen(args):
+    output = ""
+    output += var_str(makefile_vars.items())
+    output += var_str(cfg_cflags.items())
+    output += var_str(cfg_ldflags.items())
+    f = open(args.makefile_output, "w+")
+    f.write(output)
+    f.close()
 
-cfragment_deps = {
-    "ACCEPT4": {"fragment": "accept4(0, 0, 0, 0);", "headers": ["<sys/socket.h>"]},
-    "ISATTY": {"fragment": "isatty(0);", "headers": ["<unistd.h>"]},
-    "PPOLL": {"fragment": "ppoll(0, 0, 0, 0);", "headers": ["<poll.h>"]},
-    "DECL_STRNDUPA": {"fragment": "strndupa(0, 0);", "headers": ["<string.h>"]},
-    "DECL_IFLA_INET6_ADDR_GEN_MODE": {"fragment": "int v = IFLA_INET6_ADDR_GEN_MODE;", \
-                                      "headers": ["<netinet/in.h>", "<netinet/ether.h>", \
-                                                  "<linux/rtnetlink.h>", "<net/if.h>" \
-                                                  "<linux/if_link.h>", "<linux/if_addr.h>"]},
-}
-
-python_pkg_deps = {
-    "PYTHON_JSONSCHEMA" : "jsonschema"
-}
-
-makefile_gen = []
-kconfig_gen = []
-
-compiler = "gcc"
-cflags = ""
-
-def kconfig_add(key, enabled):
-    item = "config {config}\n{indent}bool\n{indent}default {enabled}". \
-           format(config="HAVE_%s" % key, indent="       ", enabled=enabled)
-    kconfig_gen.append(item)
-
-def pkg_config_discover():
-    for k,v in pkg_config_deps.items():
-        cmd = "pkg-config --libs %s --cflags" % v
-        enabled = "n"
-        flags = ""
-        try:
-            flags = subprocess.check_output(cmd, stderr=subprocess.STDOUT,
-                                            shell=True, universal_newlines=True)
-            flags = flags.replace("\n", "")
-            enabled = "y"
-        except subprocess.CalledProcessError as e:
-            flags = None
-
-        if flags is not None:
-            line = "ifeq (y,$(USE_%s))\n" % k
-            line = "%s%s_CFLAGS += %s\n" % (line, k, flags)
-            line = "%sendif\n" % line
-            makefile_gen.append(line)
-
-        kconfig_add(k, enabled)
-
-def python_dep_test():
-    for k,v in python_pkg_deps.items():
-        found = "y"
-        source = "import jsonschema"
-        f = tempfile.NamedTemporaryFile(suffix=".py",delete=False)
-        f.write(bytes(source, 'UTF-8'))
-        f.close()
-
-        try:
-            cmd = "%s %s" % (sys.executable, f.name)
-            subprocess.check_output(cmd, stderr=subprocess.STDOUT,
-                                    shell=True, universal_newlines=True)
-        except subprocess.CalledProcessError as e:
-            found = "n"
-
-        line = "HAVE_%s := %s\n" % (k, found)
-        makefile_gen.append(line)
-        os.unlink(f.name)
-
-def fragment_dep_test():
-    for k,v in cfragment_deps.items():
-        enabled = "y"
-
-        headers = ""
-        for h in v["headers"]:
-            headers = "%s#include %s\n" %(headers, h)
-
-        source = "%s\nint main(int argc, char **argv){\n %s return 0;\n}" % (headers, v["fragment"])
-        f = tempfile.NamedTemporaryFile(suffix=".c",delete=False)
-        f.write(bytes(source, 'UTF-8'))
-        f.close()
-
-        try:
-            output = "%s-bin" % f.name
-            cmd = "{compiler} {cflags} {src} -o {out}".format(compiler=compiler, cflags=cflags,
-                                                              src=f.name, out=output)
-            subprocess.check_output(cmd, stderr=subprocess.STDOUT,
-                                    shell=True, universal_newlines=True)
-            os.unlink(output)
-        except subprocess.CalledProcessError as e:
-            enabled = "n"
-
-        os.unlink(f.name)
-        kconfig_add(k, enabled)
-
-def header_dep_test():
-    for k,v in header_deps.items():
-        enabled = "y"
-        source = "#include %s\nint main(int argc, char **argv){\n    return 0;\n}" % v
-        f = tempfile.NamedTemporaryFile(suffix=".c",delete=False)
-        f.write(bytes(source, 'UTF-8'))
-        f.close()
-
-        try:
-            output = "%s-bin" % f.name
-            cmd = "{compiler} {cflags} {src} -o {out}".format(compiler=compiler, cflags=cflags,
-                                                              src=f.name, out=output)
-            subprocess.check_output(cmd, stderr=subprocess.STDOUT,
-                                    shell=True, universal_newlines=True)
-            os.unlink(output)
-        except subprocess.CalledProcessError as e:
-            enabled = "n"
-
-        os.unlink(f.name)
-        kconfig_add(k, enabled)
-
-def exec_discover():
-    for k,v in exec_deps.items():
-        path = which(v) or ""
-        
-        line = "%s ?= %s\n" % (k, path)
-        makefile_gen.append(line)
+def kconfig_gen(args):
+    output = ""
+    for k,v in cfg_kconfig.items():
+        output += "config {config}\n{indent}bool\n{indent}default {enabled}\n". \
+                  format(config=k, indent="       ", enabled=v)
+    f = open(args.kconfig_output, "w+")
+    f.write(output)
+    f.close()
 
 if __name__ == "__main__":
-    kconfig = "Kconfig.gen"
-    makefile = "Makefile.gen"
-
     parser = argparse.ArgumentParser()
-    parser.add_argument("--compiler", help="The gcc compiler[for headers based tests]", type=str)
-    parser.add_argument("--cflags", help="Additional cflags[for headers based tests]", type=str)
-    parser.add_argument("--kconfig-output", help="The kconfig fragment output file", type=str)
-    parser.add_argument("--makefile-output", help="The makefile fragment output file", type=str)
+    parser.add_argument("--compiler", help="The gcc compiler[for headers based tests]",
+                        type=str, default="gcc")
+    parser.add_argument("--cflags", help="Additional cflags[for headers based tests]",
+                        type=str, default="")
+    parser.add_argument("--kconfig-output", help="The kconfig fragment output file",
+                        type=str, default="Kconfig.gen")
+    parser.add_argument("--makefile-output", help="The makefile fragment output file",
+                        type=str, default="Makefile.gen")
+    parser.add_argument("--dep-config", help="The dependencies config file",
+                        type=argparse.FileType("r"), default="data/jsons/dependencies.json")
 
     args = parser.parse_args()
+    conf = json.loads(args.dep_config.read())
+    dep_checks = conf["dependencies"]
 
-    if (args.compiler):
-        compiler = args.compiler
-
-    if (args.cflags):
-        cflags = args.cflags
-
-    if (args.kconfig_output):
-        kconfig = args.kconfig_output
-
-    pkg_config_discover()
-    header_dep_test()
-    fragment_dep_test()
-    exec_discover()
-    python_dep_test()
-
-    fragment = ""
-    for i in kconfig_gen:
-        fragment += "%s\n" % i
-
-    f = open(kconfig, mode="w+")
-    f.write(fragment)
-    f.close()
-
-    fragment = ""
-    for i in makefile_gen:
-        fragment += "%s\n" % i
-
-    f = open(makefile, mode="w+")
-    f.write(fragment)
-    f.close()
+    for i in dep_checks:
+        handler = type_handlers[i["type"]]
+        if not handler:
+            print("Could not handle type: %s" % i["type"])
+            continue
+        handler(args, i)
+    makefile_gen(args)
+    kconfig_gen(args)

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -53,7 +53,7 @@ endchoice
 
 config PTHREAD
         bool "Pthread"
-        depends on HAVE_PTHREAD && SOL_PLATFORM_LINUX
+        depends on HAVE_PTHREAD_H && SOL_PLATFORM_LINUX
         default y
 
 config LOG

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -26,7 +26,6 @@ config PLATFORM_RIOTOS
 config PLATFORM_SYSTEMD
 	bool "systemd"
 	depends on HAVE_SYSTEMD
-	select USE_SYSTEMD
 	select SOL_PLATFORM_LINUX
 	select KDBUS
 endchoice
@@ -39,7 +38,6 @@ choice
 config MAINLOOP_GLIB
 	bool "glib"
 	depends on SOL_PLATFORM_LINUX && HAVE_GLIB
-	select USE_GLIB
 
 config MAINLOOP_POSIX
 	bool "posix"
@@ -58,7 +56,6 @@ config PTHREAD
 
 config LOG
 	bool "Log"
-	select USE_SYSTEMD
 	default y
 
 choice
@@ -91,7 +88,6 @@ config INSPECTOR
 config KDBUS
 	bool "Kdbus"
 	depends on SOL_PLATFORM_LINUX && HAVE_SYSTEMD && HAVE_KDBUS
-	select USE_GLIB
 	default n
 
 config SOCKET_LINUX

--- a/src/lib/common/Makefile
+++ b/src/lib/common/Makefile
@@ -5,11 +5,14 @@ obj-core-$(CORE)             += sol-platform.o sol-types.o sol-platform-detect.o
 
 obj-core-$(KDBUS)            += sol-bus.o
 obj-core-$(KDBUS)-extra-cflags += $(SYSTEMD_CFLAGS) $(GLIB_CFLAGS)
+obj-core-$(KDBUS)-extra-ldflags += $(SYSTEMD_LDFLAGS) $(GLIB_LDFLAGS)
 
 obj-core-$(MAINLOOP_GLIB)    += sol-mainloop-impl-glib.o
 obj-core-$(MAINLOOP_GLIB)-extra-cflags += $(GLIB_CFLAGS)
+obj-core-$(MAINLOOP_GLIB)-extra-ldflags += $(GLIB_LDFLAGS)
 
 obj-core-$(MAINLOOP_POSIX)   += sol-mainloop-impl-posix.o
+
 obj-core-$(MAINLOOP_RIOTOS)  += sol-mainloop-impl-riot.o
 obj-core-$(PLATFORM_LINUX_MICRO) += sol-platform-impl-linux-micro.o
 obj-core-$(SOCKET_LINUX)     += sol-socket-linux.o
@@ -18,12 +21,15 @@ obj-core-$(PLATFORM_DUMMY)   += sol-platform-impl-dummy.o
 
 obj-core-$(SOL_PLATFORM_LINUX) += sol-platform-linux-common.o sol-log-impl-linux.o
 obj-core-$(SOL_PLATFORM_LINUX)-extra-cflags += $(SYSTEMD_CFLAGS)
+obj-core-$(SOL_PLATFORM_LINUX)-extra-ldflags += $(SYSTEMD_LDFLAGS)
 
 obj-core-$(PLATFORM_SYSTEMD) += sol-platform-impl-systemd.o
 obj-core-$(PLATFORM_SYSTEMD)-extra-cflags += $(SYSTEMD_CFLAGS) $(UDEV_CFLAGS)
+obj-core-$(PLATFORM_SYSTEMD)-extra-ldflags += $(SYSTEMD_LDFLAGS) $(UDEV_LDFLAGS)
 
 ifeq (y,$(PTHREAD))
 obj-core-$(CORE)             += sol-worker-thread.o
 obj-core-$(MAINLOOP_GLIB)    += sol-worker-thread-impl-glib.o
 obj-core-$(MAINLOOP_POSIX)   += sol-worker-thread-impl-posix.o
+obj-core-y-extra-ldflags += $(PTHREAD_H_LDFLAGS)
 endif

--- a/src/lib/common/sol-log-impl-linux.c
+++ b/src/lib/common/sol-log-impl-linux.c
@@ -49,7 +49,7 @@ static pid_t _main_pid;
 static struct sol_str_table *_env_levels = NULL;
 static char *_env_levels_str = NULL;
 
-#ifdef HAVE_PTHREAD_H
+#ifdef PTHREAD
 #include <pthread.h>
 static pthread_t _main_thread;
 static pthread_mutex_t _mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -396,7 +396,7 @@ sol_log_impl_init(void)
     if (_main_pid == 0)
         _main_pid = getpid();
 
-#ifdef HAVE_PTHREAD_H
+#ifdef PTHREAD
     if (_main_thread == 0)
         _main_thread = pthread_self();
 #endif
@@ -447,7 +447,7 @@ sol_log_impl_shutdown(void)
 {
     _env_levels_unload();
     _main_pid = 0;
-#ifdef HAVE_PTHREAD_H
+#ifdef PTHREAD
     _main_thread = 0;
     pthread_mutex_destroy(&_mutex);
 #endif
@@ -456,7 +456,7 @@ sol_log_impl_shutdown(void)
 bool
 sol_log_impl_lock(void)
 {
-#ifdef HAVE_PTHREAD_H
+#ifdef PTHREAD
     int error = pthread_mutex_lock(&_mutex);
     if (!error)
         return true;
@@ -471,7 +471,7 @@ sol_log_impl_lock(void)
 void
 sol_log_impl_unlock(void)
 {
-#ifdef HAVE_PTHREAD_H
+#ifdef PTHREAD
     pthread_mutex_unlock(&_mutex);
 #endif
 }
@@ -501,7 +501,7 @@ sol_log_impl_print_function_stderr(void *data, const struct sol_log_domain *doma
 
     if (_main_pid != getpid())
         fprintf(stderr, "P%u ", getpid());
-#ifdef HAVE_PTHREAD_H
+#ifdef PTHREAD
     if (_main_thread != pthread_self())
         fprintf(stderr, "T%lu ", pthread_self());
 #endif
@@ -576,7 +576,7 @@ sol_log_print_function_file(void *data, const struct sol_log_domain *domain, uin
 
     if (_main_pid != getpid())
         fprintf(fp, "P:%u ", getpid());
-#ifdef HAVE_PTHREAD_H
+#ifdef PTHREAD
     if (_main_thread != pthread_self())
         fprintf(fp, "T:%lu ", pthread_self());
 #endif
@@ -658,7 +658,7 @@ sol_log_print_function_journal(void *data, const struct sol_log_domain *domain, 
     sd_journal_send_with_location(code_file, code_line, function,
         "PRIORITY=%i", sd_level,
         "MESSAGE=%s", msg ? msg : format,
-#ifdef HAVE_PTHREAD_H
+#ifdef PTHREAD
         "THREAD=%" PRIu64, (uint64_t)pthread_self(),
 #endif
         NULL);

--- a/src/lib/common/sol-mainloop-impl-posix.c
+++ b/src/lib/common/sol-mainloop-impl-posix.c
@@ -114,7 +114,7 @@ timeout_compare(const void *data1, const void *data2)
     return sol_util_timespec_compare(&a->expire, &b->expire);
 }
 
-#ifdef HAVE_PTHREAD_H
+#ifdef PTHREAD
 #include <pthread.h>
 
 #define SIGPROCMASK pthread_sigmask
@@ -248,7 +248,7 @@ threads_shutdown(void)
     close(pipe_fds[0]);
 }
 
-#else  /* !HAVE_PTHREAD_H */
+#else  /* !PTHREAD */
 
 #define SIGPROCMASK sigprocmask
 #define MAIN_THREAD_CHECK_RETURN do { } while (0)
@@ -368,7 +368,7 @@ static unsigned char siginfo_storage_used;
 #define SIGINFO_HANDLER_FOREACH(ptr) \
     for (ptr = siginfo_handler; ptr < siginfo_handler + SIGINFO_HANDLER_COUNT; ptr++) if (ptr->sig)
 
-#ifdef HAVE_PTHREAD_H
+#ifdef PTHREAD
 void sol_mainloop_posix_signals_block(void);
 void sol_mainloop_posix_signals_unblock(void);
 

--- a/src/lib/flow/Kconfig
+++ b/src/lib/flow/Kconfig
@@ -4,7 +4,6 @@ config FLOW
 
 config RESOLVER_CONFFILE
 	bool "Resolver conffile"
-	select USE_GLIB
 	default y
 
 config FLOW_RESOLVER

--- a/src/lib/flow/Makefile
+++ b/src/lib/flow/Makefile
@@ -5,4 +5,5 @@ obj-flow-$(FLOW)              += sol-flow-packet.o sol-flow-parser.o sol-flow-st
 
 obj-flow-$(FLOW_RESOLVER)     += sol-flow-resolver-conffile.o
 obj-flow-$(RESOLVER_CONFFILE) += sol-flow-builder.o sol-flow-resolver.o
-obj-flow-$(RESOLVER_CONFFILE)-extra-cflags := $(GLIB_CFLAGS)
+obj-flow-$(RESOLVER_CONFFILE)-extra-cflags += $(GLIB_CFLAGS)
+obj-flow-$(RESOLVER_CONFFILE)-extra-ldflags += $(GLIB_LDFLAGS)

--- a/src/lib/flow/Makefile
+++ b/src/lib/flow/Makefile
@@ -4,6 +4,9 @@ obj-flow-$(FLOW)              := sol-flow.o sol-flow-node-options.o
 obj-flow-$(FLOW)              += sol-flow-packet.o sol-flow-parser.o sol-flow-static.o
 
 obj-flow-$(FLOW_RESOLVER)     += sol-flow-resolver-conffile.o
+obj-flow-$(FLOW_RESOLVER)-extra-cflags += $(GLIB_CFLAGS)
+obj-flow-$(FLOW_RESOLVER)-extra-ldflags += $(GLIB_LDFLAGS)
+
 obj-flow-$(RESOLVER_CONFFILE) += sol-flow-builder.o sol-flow-resolver.o
 obj-flow-$(RESOLVER_CONFFILE)-extra-cflags += $(GLIB_CFLAGS)
 obj-flow-$(RESOLVER_CONFFILE)-extra-ldflags += $(GLIB_LDFLAGS)

--- a/src/modules/flow/gtk/Kconfig
+++ b/src/modules/flow/gtk/Kconfig
@@ -2,4 +2,3 @@ config FLOW_NODE_TYPE_GTK
 	tristate "Node type: gtk"
 	depends on FLOW && HAVE_GTK
 	default m
-	select USE_GTK

--- a/src/modules/flow/gtk/Makefile
+++ b/src/modules/flow/gtk/Makefile
@@ -3,4 +3,5 @@ obj-gtk-$(FLOW_NODE_TYPE_GTK) := gtk.json gtk.o byte-editor.o
 obj-gtk-$(FLOW_NODE_TYPE_GTK) += label.o led.o pushbutton.o pwm-editor.o
 obj-gtk-$(FLOW_NODE_TYPE_GTK) += pwm-viewer.o rgb-editor.o slider.o
 obj-gtk-$(FLOW_NODE_TYPE_GTK) += spinbutton.o toggle.o window.o
-obj-gtk-$(FLOW_NODE_TYPE_GTK)-extra-cflags := $(GTK_CFLAGS)
+obj-gtk-$(FLOW_NODE_TYPE_GTK)-extra-cflags += $(GTK_CFLAGS)
+obj-gtk-$(FLOW_NODE_TYPE_GTK)-extra-ldflags += $(GTK_LDFLAGS)

--- a/src/modules/flow/udev/Kconfig
+++ b/src/modules/flow/udev/Kconfig
@@ -1,5 +1,4 @@
 config FLOW_NODE_TYPE_UDEV
 	tristate "Node type: udev"
 	depends on FLOW
-	select USE_UDEV
 	default m

--- a/src/modules/flow/udev/Makefile
+++ b/src/modules/flow/udev/Makefile
@@ -1,3 +1,4 @@
 obj-$(FLOW_NODE_TYPE_UDEV) += udev.mod
 obj-udev-$(FLOW_NODE_TYPE_UDEV) := udev.json udev.o
-obj-udev-$(FLOW_NODE_TYPE_UDEV)-extra-cflags := $(UDEV_CFLAGS)
+obj-udev-$(FLOW_NODE_TYPE_UDEV)-extra-cflags += $(UDEV_CFLAGS)
+obj-udev-$(FLOW_NODE_TYPE_UDEV)-extra-ldflags += $(UDEV_LDFLAGS)

--- a/src/shared/Makefile
+++ b/src/shared/Makefile
@@ -15,6 +15,7 @@ endif
 ifeq (y,$(MODULES))
 obj-libshared-m += sol-conffile.o
 obj-libshared-m-extra-cflags += $(GLIB_CFLAGS)
+obj-libshared-m-extra-ldflags += $(GLIB_LDFLAGS)
 endif
 
 ifeq (y,$(PLATFORM_GALILEO))

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -28,9 +28,11 @@ test-test-mainloop-linux-$(MAINLOOP_LINUX) := test-mainloop-linux.c
 
 test-$(TEST_MAINLOOP_THREADS) += test-mainloop-threads
 test-test-mainloop-threads-$(TEST_MAINLOOP_THREADS) := test-mainloop-threads.c
+test-test-mainloop-threads-$(TEST_MAINLOOP_THREADS)-extra-ldflags += $(PTHREAD_H_LDFLAGS)
 
 test-$(TEST_MAINLOOP_THREADS_SOL_RUN) += test-mainloop-threads-sol-run
 test-test-mainloop-threads-sol-run-$(TEST_MAINLOOP_THREADS_SOL_RUN) := test-mainloop-threads-sol-run.c
+test-test-mainloop-threads-sol-run-$(TEST_MAINLOOP_THREADS_SOL_RUN)-extra-ldflags += $(PTHREAD_H_LDFLAGS)
 
 test-$(TEST_MONITORS) += test-monitors
 test-test-monitors-$(TEST_MONITORS) := test.c test-monitors.c

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -36,6 +36,7 @@ parse-common-module = \
 	$(call gen-artifact,$(1),$(filter %.json,$(artifacts))) \
 	$(eval mod-objs     := $(filter %.o,$(artifacts))) \
 	$(eval $(1)-cflags  := $(obj-$(1)-$(3)-extra-cflags)) \
+	$(eval $(1)-ldflags := $(obj-$(1)-$(3)-extra-ldflags)) \
 	$(eval $(1)-bs      := $(addprefix $(2),Makefile Kconfig)) \
 	$(eval $(1)-hdrs    := $(filter %.h,$(artifacts))) \
 	$(foreach obj,$(mod-objs), \
@@ -49,6 +50,7 @@ parse-common-module = \
 parse-builtin-module = \
 	$(call parse-common-module,$(1),$(2),y) \
 	$(eval builtin-cflags      += $($(1)-cflags)) \
+	$(eval builtin-ldflags     += $($(1)-ldflags)) \
 	$(eval builtin-objs        += $($(1)-objs)) \
 	$(eval builtin-flows       += $(call flow-type,$(artifacts))) \
 	$(eval builtin-linux-micro += $(call linux-micro-type,$(artifacts))) \
@@ -171,7 +173,7 @@ define make-object
 $(1): $(PRE_GEN) $($(1)-src) $(call find-deps,$(2)) $(find-gen-hdrs)
 	$(Q)echo "      "CC"   "$$@
 	$(Q)$(MKDIR) -p $(dir $(1))
-	$(Q)$(TARGETCC) $(LIB_CFLAGS) $($(1)-src) -c -o $(1) $(3) $(LIB_COVERAGE_FLAGS) $($(2)-cflags)
+	$(Q)$(TARGETCC) $(LIB_CFLAGS) $($(1)-src) -c -o $(1) $(3) $(LIB_COVERAGE_FLAGS) $(sort $($(2)-cflags)) $(sort $($(2)-ldflags))
 endef
 $(foreach mod,$(modules), \
 	$(foreach obj,$($(mod)-objs),$(eval $(call make-object,$(obj),$(mod),$(external-module-flags)))) \
@@ -185,7 +187,7 @@ define make-mod-so
 $($(1)-out): $(SOL_LIB_SO) $(INT_LIB_AR) $(PRE_GEN) $($(1)-objs) $(call find-deps,$(1)) $($(1)-bs)
 	$(Q)echo "     "MOD"   "$$@
 	$(Q)$(MKDIR) -p $(dir $($(1)-out))
-	$(Q)$(TARGETCC) $($(1)-objs) -shared -o $($(1)-out) $(LIB_COVERAGE_FLAGS) $($(1)-cflags)
+	$(Q)$(TARGETCC) $($(1)-objs) -shared -o $($(1)-out) $(LIB_COVERAGE_FLAGS) $(sort $($(1)-cflags)) $(sort $($(1)-ldflags))
 endef
 $(foreach curr,$(mod-so),$(eval $(call make-mod-so,$(curr))))
 
@@ -206,7 +208,7 @@ $(SOL_LIB_SO): $(PRE_GEN) $(SOL_LIB_AR) $(INT_LIB_AR) $(builtin-objs)
 	$(Q)echo "      "LD"   "$(@)
 	$(Q)$(MKDIR) -p $(dir $(SOL_LIB_SO))
 	$(Q)$(TARGETCC) $(builtin-objs) -shared -o $(@).$(VERSION) $(TARGET_LINKFLAGS) \
-		$(LIB_COVERAGE_FLAGS) $(builtin-cflags)
+		$(LIB_COVERAGE_FLAGS) $(sort $(builtin-cflags)) $(sort $(builtin-ldflags))
 	$(Q)$(LN) -fs $(notdir $(@).$(VERSION)) $(@)
 
 $(DEPENDENCY_FILES): $(DEPENDENCY_SCRIPT)


### PR DESCRIPTION
v2:
    + properly set the pthread_h_ldflags;
    + added new patch to set the flow-resolver ldflags;

This patchset changes the dependency-resolver.py to follow what @cmarcelo, @lucasdemarchi and I discussed yesterday, also, adds the missing ldflags support.