### PR TITLE
Change APIs signatures

### DIFF
--- a/src/bin/sol-fbp-runner/inspector.c
+++ b/src/bin/sol-fbp-runner/inspector.c
@@ -86,7 +86,7 @@ inspector_show_in_port(const struct sol_flow_node *node, uint16_t port_idx)
 {
     const struct sol_flow_port_description *port;
 
-    port = sol_flow_node_get_port_in_description(node, port_idx);
+    port = sol_flow_node_get_port_in_description(sol_flow_node_get_type(node), port_idx);
     if (port) {
         if (port->name) {
             inspector_print_port_name(port_idx, port);
@@ -108,7 +108,7 @@ inspector_show_out_port(const struct sol_flow_node *node, uint16_t port_idx)
         return;
     }
 
-    port = sol_flow_node_get_port_out_description(node, port_idx);
+    port = sol_flow_node_get_port_out_description(sol_flow_node_get_type(node), port_idx);
     if (port) {
         if (port->name) {
             inspector_print_port_name(port_idx, port);

--- a/src/lib/flow/sol-flow.c
+++ b/src/lib/flow/sol-flow.c
@@ -474,22 +474,22 @@ sol_flow_node_type_get_port_description(const struct sol_flow_port_description *
 }
 
 SOL_API const struct sol_flow_port_description *
-sol_flow_node_get_port_in_description(const struct sol_flow_node *node, uint16_t port)
+sol_flow_node_get_port_in_description(const struct sol_flow_node_type *type, uint16_t port)
 {
-    SOL_FLOW_NODE_CHECK(node, NULL);
+    SOL_NULL_CHECK(type, NULL);
 
-    SOL_NULL_CHECK(node->type->description, NULL);
-    SOL_NULL_CHECK(node->type->description->ports_in, NULL);
-    return sol_flow_node_type_get_port_description(node->type->description->ports_in, port);
+    SOL_NULL_CHECK(type->description, NULL);
+    SOL_NULL_CHECK(type->description->ports_in, NULL);
+    return sol_flow_node_type_get_port_description(type->description->ports_in, port);
 }
 
 SOL_API const struct sol_flow_port_description *
-sol_flow_node_get_port_out_description(const struct sol_flow_node *node, uint16_t port)
+sol_flow_node_get_port_out_description(const struct sol_flow_node_type *type, uint16_t port)
 {
-    SOL_FLOW_NODE_CHECK(node, NULL);
+    SOL_NULL_CHECK(type, NULL);
 
-    SOL_NULL_CHECK(node->type->description, NULL);
-    SOL_NULL_CHECK(node->type->description->ports_out, NULL);
-    return sol_flow_node_type_get_port_description(node->type->description->ports_out, port);
+    SOL_NULL_CHECK(type->description, NULL);
+    SOL_NULL_CHECK(type->description->ports_out, NULL);
+    return sol_flow_node_type_get_port_description(type->description->ports_out, port);
 }
 #endif

--- a/src/lib/flow/sol-flow.h
+++ b/src/lib/flow/sol-flow.h
@@ -348,20 +348,20 @@ void sol_flow_foreach_builtin_node_type(bool (*cb)(void *data, const struct sol_
 /**
  * Get the port description associated with a given input port index.
  *
- * @param node The node the port belongs to
+ * @param type The node type to get a port description from
  * @param port The port index
  * @return The port description for the given port
  */
-const struct sol_flow_port_description *sol_flow_node_get_port_in_description(const struct sol_flow_node *node, uint16_t port);
+const struct sol_flow_port_description *sol_flow_node_get_port_in_description(const struct sol_flow_node_type *type, uint16_t port);
 
 /**
  * Get the port description associated with a given output port index.
  *
- * @param node The node the port belongs to
+ * @param type The node type to get a port description from
  * @param port The port index
  * @return The port description for the given port
  */
-const struct sol_flow_port_description *sol_flow_node_get_port_out_description(const struct sol_flow_node *node, uint16_t port);
+const struct sol_flow_port_description *sol_flow_node_get_port_out_description(const struct sol_flow_node_type *type, uint16_t port);
 #endif
 
 /* When a node type is a container (i.e. may act as parent of other


### PR DESCRIPTION
Sometimes these APIs can be useful when we have no flow
(sol_flow_node) but we do have a sol_flow_node_type.