### PR TITLE
fbp-generator: add support for DECLARE statement

### DIFF
--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -32,6 +32,7 @@
 
 #include <ctype.h>
 #include <errno.h>
+#include <libgen.h>
 #include <stdio.h>
 #include <unistd.h>
 
@@ -46,17 +47,28 @@
 #include "sol-missing.h"
 #include "type-store.h"
 
+static const char *SYMBOL_PLACEHOLDER_PREFIX = "NULL /* ";
+static const char *SYMBOL_PLACEHOLDER_SUFFIX = " */";
+
 static struct {
-    const char *fbp_file;
     const char *conf_file;
     struct sol_ptr_vector json_files;
+    char *fbp_basename;
+    char *fbp_dirname;
 } args;
 
 static struct sol_arena *str_arena;
 
+struct fbp_data {
+    struct type_description **descriptions;
+    char *filename;
+    char *name;
+    struct sol_fbp_graph graph;
+};
+
 static void
 handle_suboptions(const struct sol_fbp_meta *meta,
-    void (*handle_func)(const struct sol_fbp_meta *meta, char *option, uint16_t index))
+    void (*handle_func)(const struct sol_fbp_meta *meta, char *option, uint16_t index, const char *fbp_file), const char *fbp_file)
 {
     uint16_t i = 0;
     char *p, *remaining;
@@ -69,7 +81,7 @@ handle_suboptions(const struct sol_fbp_meta *meta,
         p = memchr(remaining, '|', strlen(remaining));
         if (p)
             *p = '\0';
-        handle_func(meta, remaining, i);
+        handle_func(meta, remaining, i, fbp_file);
 
         if (!p)
             break;
@@ -81,12 +93,12 @@ handle_suboptions(const struct sol_fbp_meta *meta,
 }
 
 static void
-handle_suboption_with_explicit_fields(const struct sol_fbp_meta *meta, char *option, uint16_t index)
+handle_suboption_with_explicit_fields(const struct sol_fbp_meta *meta, char *option, uint16_t index, const char *fbp_file)
 {
     char *p = memchr(option, ':', strlen(option));
 
     if (!p) {
-        sol_fbp_log_print(args.fbp_file, meta->position.line, meta->position.column, "Wrong suboption format, ignoring"
+        sol_fbp_log_print(fbp_file, meta->position.line, meta->position.column, "Wrong suboption format, ignoring"
             " value '%s'. You cannot mix the formats, choose one 'opt1:val1|opt2:val2...' or 'val1|val2...'", option);
         return;
     }
@@ -96,10 +108,10 @@ handle_suboption_with_explicit_fields(const struct sol_fbp_meta *meta, char *opt
 }
 
 static bool
-check_suboption(char *option, const struct sol_fbp_meta *meta)
+check_suboption(char *option, const struct sol_fbp_meta *meta, const char *fbp_file)
 {
     if (memchr(option, ':', strlen(option))) {
-        sol_fbp_log_print(args.fbp_file, meta->position.line, meta->position.column, "Wrong suboption format, ignoring"
+        sol_fbp_log_print(fbp_file, meta->position.line, meta->position.column, "Wrong suboption format, ignoring"
             "value '%s'. You cannot mix the formats, choose one 'opt1:val1|opt2:val2...' or 'val1|val2...'", option);
         return false;
     }
@@ -108,35 +120,35 @@ check_suboption(char *option, const struct sol_fbp_meta *meta)
 }
 
 static void
-handle_irange_drange_suboption(const struct sol_fbp_meta *meta, char *option, uint16_t index)
+handle_irange_drange_suboption(const struct sol_fbp_meta *meta, char *option, uint16_t index, const char *fbp_file)
 {
     const char *irange_drange_fields[5] = { "val", "min", "max", "step", NULL };
 
-    if (check_suboption(option, meta))
+    if (check_suboption(option, meta, fbp_file))
         printf("            .%s = %s,\n", irange_drange_fields[index], option);
 }
 
 static void
-handle_rgb_suboption(const struct sol_fbp_meta *meta, char *option, uint16_t index)
+handle_rgb_suboption(const struct sol_fbp_meta *meta, char *option, uint16_t index, const char *fbp_file)
 {
     const char *rgb_fields[7] = { "red", "green", "blue",
                                   "red_max", "green_max", "blue_max", NULL };
 
-    if (check_suboption(option, meta))
+    if (check_suboption(option, meta, fbp_file))
         printf("            .%s = %s,\n", rgb_fields[index], option);
 }
 
 static void
-handle_direction_vector_suboption(const struct sol_fbp_meta *meta, char *option, uint16_t index)
+handle_direction_vector_suboption(const struct sol_fbp_meta *meta, char *option, uint16_t index, const char *fbp_file)
 {
     const char *direction_vector_fields[7] = { "x", "y", "z", "min", "max", NULL };
 
-    if (check_suboption(option, meta))
+    if (check_suboption(option, meta, fbp_file))
         printf("            .%s = %s,\n", direction_vector_fields[index], option);
 }
 
 static bool
-handle_options(const struct sol_fbp_meta *meta, struct sol_vector *options)
+handle_options(const struct sol_fbp_meta *meta, struct sol_vector *options, const char *fbp_file)
 {
     struct option_description *o;
     uint16_t i;
@@ -147,19 +159,19 @@ handle_options(const struct sol_fbp_meta *meta, struct sol_vector *options)
 
         if (streq(o->data_type, "int") || streq(o->data_type, "double")) {
             if (memchr(meta->value.data, ':', meta->value.len))
-                handle_suboptions(meta, handle_suboption_with_explicit_fields);
+                handle_suboptions(meta, handle_suboption_with_explicit_fields, fbp_file);
             else
-                handle_suboptions(meta, handle_irange_drange_suboption);
+                handle_suboptions(meta, handle_irange_drange_suboption, fbp_file);
         } else if (streq(o->data_type, "rgb")) {
             if (memchr(meta->value.data, ':', meta->value.len))
-                handle_suboptions(meta, handle_suboption_with_explicit_fields);
+                handle_suboptions(meta, handle_suboption_with_explicit_fields, fbp_file);
             else
-                handle_suboptions(meta, handle_rgb_suboption);
+                handle_suboptions(meta, handle_rgb_suboption, fbp_file);
         } else if (streq(o->data_type, "direction_vector")) {
             if (memchr(meta->value.data, ':', meta->value.len))
-                handle_suboptions(meta, handle_suboption_with_explicit_fields);
+                handle_suboptions(meta, handle_suboption_with_explicit_fields, fbp_file);
             else
-                handle_suboptions(meta, handle_direction_vector_suboption);
+                handle_suboptions(meta, handle_direction_vector_suboption, fbp_file);
         } else if (streq(o->data_type, "string")) {
             if (meta->value.data[0] == '"')
                 printf("        .%.*s = %.*s,\n", (int)meta->key.len, meta->key.data, (int)meta->value.len, meta->value.data);
@@ -173,13 +185,13 @@ handle_options(const struct sol_fbp_meta *meta, struct sol_vector *options)
         return true;
     }
 
-    sol_fbp_log_print(args.fbp_file, meta->position.line, meta->position.column,
+    sol_fbp_log_print(fbp_file, meta->position.line, meta->position.column,
         "Invalid option key '%.*s'", (int)meta->key.len, meta->key.data);
     return false;
 }
 
 static void
-handle_conffile_option(struct sol_fbp_node *n, const char *option)
+handle_conffile_option(struct sol_fbp_node *n, const char *option, const char *fbp_file)
 {
     struct sol_fbp_meta *m;
     struct sol_str_slice key_slice, value_slice;
@@ -194,7 +206,7 @@ handle_conffile_option(struct sol_fbp_node *n, const char *option)
 
     p = memchr(option, '=', strlen(option));
     if (!p) {
-        sol_fbp_log_print(args.fbp_file, n->position.line, n->position.column,
+        sol_fbp_log_print(fbp_file, n->position.line, n->position.column,
             "Couldn't handle '%s' conffile option, ignoring this option...", option);
         return;
     }
@@ -211,26 +223,26 @@ handle_conffile_option(struct sol_fbp_node *n, const char *option)
 }
 
 static const char *
-sol_fbp_generator_resolve_id(struct sol_fbp_node *n, const char *id)
+sol_fbp_generator_resolve_id(struct sol_fbp_node *n, const char *id, const char *fbp_file)
 {
     const char *type_name;
     const char **opts_as_string;
     const char *const *opt;
 
     if (sol_conffile_resolve_path(id, &type_name, &opts_as_string, args.conf_file) < 0) {
-        sol_fbp_log_print(args.fbp_file, n->position.line, n->position.column, "Couldn't resolve type id '%s'", id);
+        sol_fbp_log_print(fbp_file, n->position.line, n->position.column, "Couldn't resolve type id '%s'", id);
         return NULL;
     }
 
     /* Conffile may contain options for this node type */
     for (opt = opts_as_string; *opt != NULL; opt++)
-        handle_conffile_option(n, *opt);
+        handle_conffile_option(n, *opt, fbp_file);
 
     return type_name;
 }
 
 static struct type_description *
-sol_fbp_generator_resolve_type(struct type_store *store, struct sol_fbp_node *n)
+sol_fbp_generator_resolve_type(struct type_store *store, struct sol_fbp_node *n, const char *fbp_file)
 {
     const char *type_name_as_string;
     const char *type_name;
@@ -242,7 +254,7 @@ sol_fbp_generator_resolve_type(struct type_store *store, struct sol_fbp_node *n)
     if (desc)
         return desc;
 
-    type_name = sol_fbp_generator_resolve_id(n, type_name_as_string);
+    type_name = sol_fbp_generator_resolve_id(n, type_name_as_string, fbp_file);
     if (!type_name)
         return NULL;
 
@@ -287,7 +299,7 @@ port_types_compatible(const char *a_type, const char *b_type)
 }
 
 static bool
-handle_port_error(struct sol_vector *ports, struct sol_str_slice *name, struct sol_str_slice *component)
+handle_port_error(struct sol_vector *ports, struct sol_str_slice *name, struct sol_str_slice *component, const char *fbp_file)
 {
     struct sol_fbp_port *p;
     uint16_t i;
@@ -296,7 +308,7 @@ handle_port_error(struct sol_vector *ports, struct sol_str_slice *name, struct s
         if (!sol_str_slice_eq(*name, p->name))
             continue;
 
-        sol_fbp_log_print(args.fbp_file, p->position.line, p->position.column,
+        sol_fbp_log_print(fbp_file, p->position.line, p->position.column,
             "Port '%.*s' doesn't exist for node type '%.*s'",
             (int)name->len, name->data, (int)component->len, component->data);
 
@@ -307,7 +319,7 @@ handle_port_error(struct sol_vector *ports, struct sol_str_slice *name, struct s
 }
 
 static bool
-generate_connections(struct sol_fbp_graph *g, struct type_description **descs)
+generate_connections(const struct fbp_data *data)
 {
     struct sol_fbp_conn *conn;
     struct sol_flow_static_conn_spec *conn_specs;
@@ -315,10 +327,10 @@ generate_connections(struct sol_fbp_graph *g, struct type_description **descs)
 
     /* Build an array of connections then sort it correctly before
      * generating the code. */
-    conn_specs = calloc(g->conns.len, sizeof(struct sol_flow_static_conn_spec));
+    conn_specs = calloc(data->graph.conns.len, sizeof(struct sol_flow_static_conn_spec));
     SOL_NULL_CHECK(conn_specs, false);
 
-    SOL_VECTOR_FOREACH_IDX (&g->conns, conn, i) {
+    SOL_VECTOR_FOREACH_IDX (&data->graph.conns, conn, i) {
         struct sol_flow_static_conn_spec *spec = &conn_specs[i];
         struct type_description *src_desc, *dst_desc;
         struct port_description *src_port_desc, *dst_port_desc;
@@ -328,25 +340,25 @@ generate_connections(struct sol_fbp_graph *g, struct type_description **descs)
         spec->src_port = UINT16_MAX;
         spec->dst_port = UINT16_MAX;
 
-        src_desc = descs[conn->src];
-        dst_desc = descs[conn->dst];
+        src_desc = data->descriptions[conn->src];
+        dst_desc = data->descriptions[conn->dst];
 
         src_port_desc = check_port_existence(&src_desc->out_ports, &conn->src_port, &spec->src_port);
         if (!src_port_desc) {
-            struct sol_fbp_node *n = sol_vector_get(&g->nodes, conn->src);
+            struct sol_fbp_node *n = sol_vector_get(&data->graph.nodes, conn->src);
             free(conn_specs);
-            return handle_port_error(&n->out_ports, &conn->src_port, &n->component);
+            return handle_port_error(&n->out_ports, &conn->src_port, &n->component, data->filename);
         }
 
         dst_port_desc = check_port_existence(&dst_desc->in_ports, &conn->dst_port, &spec->dst_port);
         if (!dst_port_desc) {
-            struct sol_fbp_node *n = sol_vector_get(&g->nodes, conn->dst);
+            struct sol_fbp_node *n = sol_vector_get(&data->graph.nodes, conn->dst);
             free(conn_specs);
-            return handle_port_error(&n->in_ports, &conn->dst_port, &n->component);
+            return handle_port_error(&n->in_ports, &conn->dst_port, &n->component, data->filename);
         }
 
         if (!port_types_compatible(src_port_desc->data_type, dst_port_desc->data_type)) {
-            sol_fbp_log_print(args.fbp_file, conn->position.line, conn->position.column,
+            sol_fbp_log_print(data->filename, conn->position.line, conn->position.column,
                 "Couldn't connect '%s %.*s -> %.*s %s'. Source port type '%s' doesn't match destiny port type '%s'",
                 src_desc->name, (int)conn->src_port.len, conn->src_port.data,
                 (int)conn->dst_port.len, conn->dst_port.data, dst_desc->name,
@@ -356,11 +368,11 @@ generate_connections(struct sol_fbp_graph *g, struct type_description **descs)
         }
     }
 
-    qsort(conn_specs, g->conns.len, sizeof(struct sol_flow_static_conn_spec),
+    qsort(conn_specs, data->graph.conns.len, sizeof(struct sol_flow_static_conn_spec),
         compare_conn_specs);
 
-    printf("static const struct sol_flow_static_conn_spec conns[] = {\n");
-    for (i = 0; i < g->conns.len; i++) {
+    printf("static const struct sol_flow_static_conn_spec conns%s[] = {\n", data->name);
+    for (i = 0; i < data->graph.conns.len; i++) {
         struct sol_flow_static_conn_spec *spec = &conn_specs[i];
         printf("    { %d, %d, %d, %d },\n",
             spec->src, spec->src_port, spec->dst, spec->dst_port);
@@ -373,17 +385,17 @@ generate_connections(struct sol_fbp_graph *g, struct type_description **descs)
 }
 
 static void
-generate_exports(const struct sol_fbp_graph *g)
+generate_exports(const struct fbp_data *data)
 {
     struct sol_fbp_exported_port *e;
     struct sol_fbp_node *n;
     struct sol_fbp_port *p;
     uint16_t i, j;
 
-    if (g->exported_in_ports.len > 0) {
-        printf("const struct sol_flow_static_port_spec exported_in[] = {\n");
-        SOL_VECTOR_FOREACH_IDX (&g->exported_in_ports, e, i) {
-            n = sol_vector_get(&g->nodes, e->node);
+    if (data->graph.exported_in_ports.len > 0) {
+        printf("const struct sol_flow_static_port_spec exported_in%s[] = {\n", data->name);
+        SOL_VECTOR_FOREACH_IDX (&data->graph.exported_in_ports, e, i) {
+            n = sol_vector_get(&data->graph.nodes, e->node);
             SOL_VECTOR_FOREACH_IDX (&n->in_ports, p, j) {
                 if (sol_str_slice_eq(e->port, p->name)) {
                     printf("    { %d, %d },\n", e->node, j);
@@ -395,10 +407,10 @@ generate_exports(const struct sol_fbp_graph *g)
             "};\n\n");
     }
 
-    if (g->exported_out_ports.len > 0) {
-        printf("const struct sol_flow_static_port_spec exported_out[] = {\n");
-        SOL_VECTOR_FOREACH_IDX (&g->exported_out_ports, e, i) {
-            n = sol_vector_get(&g->nodes, e->node);
+    if (data->graph.exported_out_ports.len > 0) {
+        printf("const struct sol_flow_static_port_spec exported_out%s[] = {\n", data->name);
+        SOL_VECTOR_FOREACH_IDX (&data->graph.exported_out_ports, e, i) {
+            n = sol_vector_get(&data->graph.nodes, e->node);
             SOL_VECTOR_FOREACH_IDX (&n->out_ports, p, j) {
                 if (sol_str_slice_eq(e->port, p->name)) {
                     printf("    { %d, %d },\n", e->node, j);
@@ -412,11 +424,14 @@ generate_exports(const struct sol_fbp_graph *g)
 }
 
 static int
-generate(struct sol_fbp_graph *g, struct type_description **descs)
+generate(struct sol_vector *fbp_data_vector)
 {
+    const size_t symbol_placeholder_prefix_size = strlen(SYMBOL_PLACEHOLDER_PREFIX);
+    const size_t symbol_placeholder_suffix_size = strlen(SYMBOL_PLACEHOLDER_SUFFIX);
+    struct fbp_data *data;
     struct sol_fbp_meta *m;
     struct sol_fbp_node *n;
-    uint16_t i, j;
+    uint16_t i, j, k;
 
     printf("#include \"sol-flow.h\"\n"
         "#include \"sol-flow-node-types.h\"\n"
@@ -424,48 +439,66 @@ generate(struct sol_fbp_graph *g, struct type_description **descs)
         "\n"
         "static struct sol_flow_node *flow;\n\n");
 
-    SOL_VECTOR_FOREACH_IDX (&g->nodes, n, i) {
-        if (n->meta.len <= 0)
-            continue;
+    SOL_VECTOR_FOREACH_REVERSE_IDX (fbp_data_vector, data, i) {
+        SOL_VECTOR_FOREACH_IDX (&data->graph.nodes, n, j) {
+            if (n->meta.len <= 0)
+                continue;
 
-        printf("static const struct %s opts%d =\n", descs[i]->options_symbol, i);
-        printf("    %s_OPTIONS_DEFAULTS(\n", descs[i]->symbol);
-        SOL_VECTOR_FOREACH_IDX (&n->meta, m, j) {
-            if (!handle_options(m, &descs[i]->options))
-                return EXIT_FAILURE;
+            printf("static const struct %s opts%s%d =\n", data->descriptions[j]->options_symbol, data->name, j);
+            printf("    %s_OPTIONS_DEFAULTS(\n", data->descriptions[j]->symbol);
+            SOL_VECTOR_FOREACH_IDX (&n->meta, m, k) {
+                if (!handle_options(m, &data->descriptions[j]->options, data->filename))
+                    return EXIT_FAILURE;
+            }
+            printf("    );\n\n");
         }
-        printf("    );\n\n");
+
+        if (!generate_connections(data))
+            return EXIT_FAILURE;
+
+        generate_exports(data);
     }
-
-    if (!generate_connections(g, descs))
-        return EXIT_FAILURE;
-
-    generate_exports(g);
 
     printf("static void\n"
         "startup(void)\n"
         "{\n");
 
-    printf("    const struct sol_flow_node_type *type;\n\n"
-        "    const struct sol_flow_static_node_spec nodes[] = {\n");
-    SOL_VECTOR_FOREACH_IDX (&g->nodes, n, i) {
-        if (n->meta.len <= 0) {
-            printf("        [%d] = {%s, \"%.*s\", NULL},\n",
-                i, descs[i]->symbol, (int)n->name.len, n->name.data);
-        } else {
-            printf("        [%d] = {%s, \"%.*s\", (struct sol_flow_node_options *) &opts%d},\n",
-                i, descs[i]->symbol, (int)n->name.len, n->name.data, i);
+    SOL_VECTOR_FOREACH_REVERSE_IDX (fbp_data_vector, data, i) {
+        printf("    static struct sol_flow_node_type *type%s;\n\n"
+            "    struct sol_flow_static_node_spec nodes%s[] = {\n", data->name, data->name);
+        SOL_VECTOR_FOREACH_IDX (&data->graph.nodes, n, j) {
+            if (n->meta.len <= 0) {
+                printf("        [%d] = {%s, \"%.*s\", NULL},\n",
+                    j, data->descriptions[j]->symbol, (int)n->name.len, n->name.data);
+            } else {
+                printf("        [%d] = {%s, \"%.*s\", (struct sol_flow_node_options *) &opts%s%d},\n",
+                    j, data->descriptions[j]->symbol, (int)n->name.len, n->name.data, data->name, j);
+            }
         }
+        printf("        SOL_FLOW_STATIC_NODE_SPEC_GUARD\n"
+            "    };\n\n");
     }
-    printf("        SOL_FLOW_STATIC_NODE_SPEC_GUARD\n"
-        "    };\n\n");
 
-    printf("    type = sol_flow_static_new_type(nodes, conns, %s, %s, NULL);\n",
-        g->exported_in_ports.len > 0 ? "exported_in" : "NULL",
-        g->exported_out_ports.len > 0 ? "exported_out" : "NULL");
-    printf("    if (!type)\n"
-        "        return;\n\n"
-        "   flow = sol_flow_node_new(NULL, NULL, type, NULL);\n"
+    SOL_VECTOR_FOREACH_REVERSE_IDX (fbp_data_vector, data, i) {
+        for (j = 0; j < data->graph.nodes.len; j++) {
+            if (streqn(data->descriptions[j]->symbol, "NULL", 4)) {
+                size_t type_len = strlen(data->descriptions[j]->symbol) - symbol_placeholder_prefix_size - symbol_placeholder_suffix_size;
+                printf("    nodes%s[%d].type = type%.*s;\n\n", data->name, j, (int)type_len,
+                    data->descriptions[j]->symbol + symbol_placeholder_prefix_size);
+            }
+        }
+
+        printf("    type%s = sol_flow_static_new_type(nodes%s, conns%s, %s%s, %s%s, NULL);\n",
+            data->name, data->name, data->name,
+            data->graph.exported_in_ports.len > 0 ? "exported_in" : "NULL",
+            data->graph.exported_in_ports.len > 0 ? data->name : "",
+            data->graph.exported_out_ports.len > 0 ? "exported_out" : "NULL",
+            data->graph.exported_out_ports.len > 0 ? data->name : "");
+        printf("    if (!type%s)\n"
+            "        return;\n\n", data->name);
+    }
+
+    printf("    flow = sol_flow_node_new(NULL, NULL, type, NULL);\n"
         "}\n\n"
         "static void\n"
         "shutdown(void)\n"
@@ -516,6 +549,7 @@ sol_fbp_generator_type_store_load(struct type_store *store)
 static bool
 sol_fbp_generator_handle_args(int argc, char *argv[])
 {
+    char *filename;
     bool has_json_file = false;
     int opt;
 
@@ -554,40 +588,215 @@ sol_fbp_generator_handle_args(int argc, char *argv[])
         return false;
     }
 
-    args.fbp_file = argv[optind];
+    filename = argv[optind];
+
+    args.fbp_basename = strdup(basename(strdupa(filename)));
+    if (!args.fbp_basename) {
+        SOL_ERR("Couldn't get %s basename.", filename);
+        return false;
+    }
+
+    args.fbp_dirname = strdup(dirname(strdupa(filename)));
+    if (!args.fbp_dirname) {
+        free(args.fbp_basename);
+        SOL_ERR("Couldn't get %s dirname args.", filename);
+        return false;
+    }
+
     return true;
 }
 
-static struct type_description **
-resolve_nodes(const struct sol_fbp_graph *g, struct type_store *store)
+static bool
+add_fbp_type_to_type_store(struct type_store *store, struct fbp_data *data)
+{
+    struct port_description *p, *port;
+    struct sol_fbp_exported_port *e;
+    struct type_description type;
+    bool ret = false;
+    char type_symbol[2048];
+    int r;
+    uint16_t i, j;
+
+    type.name = data->name;
+
+    r = snprintf(type_symbol, sizeof(type_symbol), "%s%s%s",
+        SYMBOL_PLACEHOLDER_PREFIX, data->name, SYMBOL_PLACEHOLDER_SUFFIX);
+    if (r < 0 || r >= (int)sizeof(type_symbol))
+        return false;
+
+    type.symbol = type_symbol;
+
+    /* useless for fbp type */
+    type.options_symbol = type_symbol;
+
+    sol_vector_init(&type.in_ports, sizeof(struct port_description));
+    SOL_VECTOR_FOREACH_IDX (&data->graph.exported_in_ports, e, i) {
+        p = sol_vector_append(&type.in_ports);
+        SOL_NULL_CHECK_GOTO(p, fail_in_ports);
+
+        p->name = strndupa(e->exported_name.data, e->exported_name.len);
+
+        SOL_VECTOR_FOREACH_IDX (&data->descriptions[e->node]->in_ports, port, j) {
+            if (streqn(e->port.data, port->name, e->port.len))
+                p->data_type = strdupa(port->data_type);
+        }
+        SOL_NULL_CHECK_GOTO(p->data_type, fail_in_ports);
+    }
+
+    sol_vector_init(&type.out_ports, sizeof(struct port_description));
+    SOL_VECTOR_FOREACH_IDX (&data->graph.exported_out_ports, e, i) {
+        p = sol_vector_append(&type.out_ports);
+        SOL_NULL_CHECK_GOTO(p, fail_out_ports);
+
+        p->name = strndupa(e->exported_name.data, e->exported_name.len);
+
+        SOL_VECTOR_FOREACH_IDX (&data->descriptions[e->node]->out_ports, port, j) {
+            if (streqn(e->port.data, port->name, e->port.len))
+                p->data_type = strdupa(port->data_type);
+        }
+        SOL_NULL_CHECK_GOTO(p->data_type, fail_out_ports);
+    }
+
+    /* useless for fbp type */
+    sol_vector_init(&type.options, sizeof(struct option_description));
+
+    ret = type_store_add_type(store, &type);
+
+    sol_vector_clear(&type.options);
+fail_out_ports:
+    sol_vector_clear(&type.out_ports);
+fail_in_ports:
+    sol_vector_clear(&type.in_ports);
+
+    return ret;
+}
+
+static bool
+resolve_node(struct fbp_data *data, struct type_store *store)
 {
     struct sol_fbp_node *n;
-    struct type_description **descs;
     uint16_t i;
 
-    descs = calloc(g->nodes.len, sizeof(void *));
-    if (!descs)
-        return NULL;
+    data->descriptions = calloc(data->graph.nodes.len, sizeof(void *));
+    if (!data->descriptions)
+        return false;
 
-    SOL_VECTOR_FOREACH_IDX (&g->nodes, n, i) {
-        descs[i] = sol_fbp_generator_resolve_type(store, n);
-        if (!descs[i]) {
-            free(descs);
-            return NULL;
+    SOL_VECTOR_FOREACH_IDX (&data->graph.nodes, n, i) {
+        data->descriptions[i] = sol_fbp_generator_resolve_type(store, n, data->filename);
+        if (!data->descriptions[i])
+            return false;
+    }
+
+    return true;
+}
+
+static struct fbp_data *
+create_fbp_data(struct sol_vector *fbp_data_vector, struct sol_ptr_vector *file_readers, struct type_store *store, const char *name, const char *fbp_basename)
+{
+    struct fbp_data *data;
+    struct sol_fbp_error *fbp_error;
+    struct sol_file_reader *fr;
+    char filename[2048];
+    int r;
+    uint16_t data_idx;
+
+    r = snprintf(filename, sizeof(filename), "%s/%s", args.fbp_dirname, fbp_basename);
+    if (r < 0 || r >= (int)sizeof(filename)) {
+        SOL_ERR("Couldn't find file '%s': %s\n", filename, sol_util_strerrora(errno));
+        return NULL;
+    }
+
+    fr = sol_file_reader_open(filename);
+    if (!fr) {
+        SOL_ERR("Couldn't open file '%s': %s\n", filename, sol_util_strerrora(errno));
+        return NULL;
+    }
+
+    if (sol_ptr_vector_append(file_readers, fr) < 0) {
+        SOL_ERR("Couldn't handle file '%s': %s\n", filename, sol_util_strerrora(errno));
+        sol_file_reader_close(fr);
+        return NULL;
+    }
+
+    data = sol_vector_append(fbp_data_vector);
+    if (!data) {
+        SOL_ERR("Couldn't create fbp data.");
+        return NULL;
+    }
+
+    if (sol_fbp_graph_init(&data->graph) != 0) {
+        SOL_ERR("Couldn't initialize graph.");
+        return NULL;
+    }
+
+    fbp_error = sol_fbp_parse(sol_file_reader_get_all(fr), &data->graph);
+    if (fbp_error) {
+        sol_fbp_log_print(filename, fbp_error->position.line, fbp_error->position.column, fbp_error->msg);
+        sol_fbp_error_free(fbp_error);
+        return NULL;
+    }
+
+    data->name = strdup(name);
+    if (!data->name) {
+        SOL_ERR("Couldn't create fbp data.");
+        return NULL;
+    }
+
+    data->filename = strdup(filename);
+    if (!data->filename) {
+        SOL_ERR("Couldn't create fbp data.");
+        return NULL;
+    }
+
+    /* Get data index in order to use it after we handle the declarations. */
+    data_idx = fbp_data_vector->len - 1;
+
+    if (data->graph.declarations.len > 0) {
+        struct fbp_data *d;
+        struct sol_fbp_declaration *dec;
+        char *dec_file, *dec_name;
+        uint16_t i;
+
+        SOL_VECTOR_FOREACH_IDX (&data->graph.declarations, dec, i) {
+            if (!sol_str_slice_str_eq(dec->kind, "fbp"))
+                continue;
+
+            dec_file = strndupa(dec->contents.data, dec->contents.len);
+            dec_name = strndupa(dec->name.data, dec->name.len);
+
+            d = create_fbp_data(fbp_data_vector, file_readers, store, dec_name, dec_file);
+            if (!d)
+                return NULL;
+
+            if (!add_fbp_type_to_type_store(store, d)) {
+                SOL_ERR("Couldn't add fbp type to type store");
+                return NULL;
+            }
+
         }
     }
 
-    return descs;
+    /* We need to do this because we may have appended new data to fbp_data_vector,
+     * this changes the position of data pointers since it's a sol_vector. */
+    data = sol_vector_get(fbp_data_vector, data_idx);
+
+    if (!resolve_node(data, store)) {
+        SOL_ERR("Failed to resolve node type.");
+        return NULL;
+    }
+
+    return data;
 }
 
 int
 main(int argc, char *argv[])
 {
-    struct sol_fbp_error *fbp_error;
-    struct sol_file_reader *fr = NULL;
-    struct sol_fbp_graph graph = {};
+    struct fbp_data *data;
+    struct sol_file_reader *fr;
+    struct sol_ptr_vector file_readers;
+    struct sol_vector fbp_data_vector;
     struct type_store *store;
-    struct type_description **descs;
+    uint16_t i;
     uint8_t result = EXIT_FAILURE;
 
     if (sol_init() < 0)
@@ -598,7 +807,7 @@ main(int argc, char *argv[])
 
     if (args.conf_file && access(args.conf_file, R_OK) == -1) {
         SOL_ERR("Couldn't open file '%s': %s", args.conf_file, sol_util_strerrora(errno));
-        goto fail_args;
+        goto fail_access;
     }
 
     store = type_store_new();
@@ -607,50 +816,42 @@ main(int argc, char *argv[])
     if (!sol_fbp_generator_type_store_load(store))
         goto fail_store_load;
 
-    fr = sol_file_reader_open(args.fbp_file);
-    if (!fr) {
-        SOL_ERR("Couldn't open file '%s': %s\n", args.fbp_file, sol_util_strerrora(errno));
-        goto fail_file;
-    }
+    sol_vector_init(&fbp_data_vector, sizeof(struct fbp_data));
 
-    if (sol_fbp_graph_init(&graph) != 0) {
-        SOL_ERR("Couldn't initialize graph");
+    sol_ptr_vector_init(&file_readers);
+
+    if (!create_fbp_data(&fbp_data_vector, &file_readers, store, "", args.fbp_basename))
         goto fail_graph;
-    }
-
-    fbp_error = sol_fbp_parse(sol_file_reader_get_all(fr), &graph);
-    if (fbp_error) {
-        sol_fbp_log_print(args.fbp_file, fbp_error->position.line, fbp_error->position.column, fbp_error->msg);
-        sol_fbp_error_free(fbp_error);
-        goto fail_parse;
-    }
 
     str_arena = sol_arena_new();
     if (!str_arena) {
         SOL_ERR("Couldn't create str arena");
-        goto fail_parse;
+        goto fail_arena;
     }
 
-    descs = resolve_nodes(&graph, store);
-    if (!descs) {
-        SOL_ERR("Failed to resolve node types");
-        goto fail_resolve;
-    }
+    result = generate(&fbp_data_vector);
 
-    result = generate(&graph, descs);
-
-fail_resolve:
-    free(descs);
     sol_arena_del(str_arena);
-fail_parse:
-    sol_fbp_graph_fini(&graph);
+
+fail_arena:
 fail_graph:
-    sol_file_reader_close(fr);
-fail_file:
+    SOL_VECTOR_FOREACH_IDX (&fbp_data_vector, data, i) {
+        free(data->descriptions);
+        sol_fbp_graph_fini(&data->graph);
+        free(data->name);
+        free(data->filename);
+    }
+    sol_vector_clear(&fbp_data_vector);
+    SOL_PTR_VECTOR_FOREACH_IDX (&file_readers, fr, i)
+        sol_file_reader_close(fr);
+    sol_ptr_vector_clear(&file_readers);
 fail_store_load:
     type_store_del(store);
-fail_args:
 fail_store:
+fail_access:
+    free(args.fbp_basename);
+    free(args.fbp_dirname);
+fail_args:
     sol_shutdown();
 end:
     return result;

--- a/src/bin/sol-fbp-generator/type-store.c
+++ b/src/bin/sol-fbp-generator/type-store.c
@@ -34,6 +34,7 @@
 #include <stdio.h>
 
 #include "sol-json.h"
+#include "sol-log.h"
 #include "sol-str-slice.h"
 #include "sol-util.h"
 #include "sol-vector.h"
@@ -782,6 +783,121 @@ type_store_find(struct type_store *store, const char *name)
     }
 
     return NULL;
+}
+
+bool
+type_store_add_type(struct type_store *store, const struct type_description *type)
+{
+    struct option_description *o, *option;
+    struct port_description *p, *port;
+    struct type_description *t;
+    uint16_t i;
+
+    SOL_NULL_CHECK(store, false);
+    SOL_NULL_CHECK(type, false);
+
+    t = sol_vector_append(&store->types);
+    SOL_NULL_CHECK(t, false);
+
+    t->name = strdup(type->name);
+    SOL_NULL_CHECK_GOTO(t->name, fail_name);
+
+    t->symbol = strdup(type->symbol);
+    SOL_NULL_CHECK_GOTO(t->symbol, fail_symbol);
+
+    t->options_symbol = strdup(type->options_symbol);
+    SOL_NULL_CHECK_GOTO(t->options_symbol, fail_options_symbol);
+
+    sol_vector_init(&t->in_ports, sizeof(struct port_description));
+    SOL_VECTOR_FOREACH_IDX (&type->in_ports, p, i) {
+        port = sol_vector_append(&t->in_ports);
+        SOL_NULL_CHECK_GOTO(port, fail_in_ports);
+
+        port->name = strdup(p->name);
+        SOL_NULL_CHECK_GOTO(port->name, fail_in_ports);
+
+        port->data_type = strdup(p->data_type);
+        SOL_NULL_CHECK_GOTO(port->data_type, fail_in_ports);
+    }
+
+    sol_vector_init(&t->out_ports, sizeof(struct port_description));
+    SOL_VECTOR_FOREACH_IDX (&type->out_ports, p, i) {
+        port = sol_vector_append(&t->out_ports);
+        SOL_NULL_CHECK_GOTO(port, fail_out_ports);
+
+        port->name = strdup(p->name);
+        SOL_NULL_CHECK_GOTO(port->name, fail_out_ports);
+
+        port->data_type = strdup(p->data_type);
+        SOL_NULL_CHECK_GOTO(port->data_type, fail_out_ports);
+    }
+
+    sol_vector_init(&t->options, sizeof(struct option_description));
+    SOL_VECTOR_FOREACH_IDX (&type->options, o, i) {
+        option = sol_vector_append(&t->options);
+        SOL_NULL_CHECK_GOTO(option, fail_options);
+
+        option->name = strdup(o->name);
+        SOL_NULL_CHECK_GOTO(option->name, fail_options);
+
+        option->data_type = strdup(o->data_type);
+        SOL_NULL_CHECK_GOTO(option->data_type, fail_options);
+
+        option->default_value_type = o->default_value_type;
+
+        switch (o->default_value_type) {
+        case OPTION_VALUE_TYPE_STRING:
+            option->default_value.string = strdup(o->default_value.string);
+            SOL_NULL_CHECK_GOTO(option->default_value.string, fail_options);
+            break;
+        case OPTION_VALUE_TYPE_RANGE:
+            option->default_value.range = o->default_value.range;
+            break;
+        case OPTION_VALUE_TYPE_RGB:
+            option->default_value.rgb = o->default_value.rgb;
+            break;
+        case OPTION_VALUE_TYPE_DIRECTION_VECTOR:
+            option->default_value.direction_vector = o->default_value.direction_vector;
+            break;
+        case OPTION_VALUE_TYPE_UNPARSED_JSON:
+            option->default_value.token = o->default_value.token;
+            break;
+        case OPTION_VALUE_TYPE_NONE:
+            break;
+        }
+    }
+
+    return true;
+
+fail_options:
+    SOL_VECTOR_FOREACH_IDX (&t->options, o, i) {
+        free(o->name);
+        free(o->data_type);
+
+        if (o->default_value_type == OPTION_VALUE_TYPE_STRING)
+            free(o->default_value.string);
+    }
+    sol_vector_clear(&t->options);
+fail_out_ports:
+    SOL_VECTOR_FOREACH_IDX (&t->out_ports, p, i) {
+        free(p->name);
+        free(p->data_type);
+    }
+    sol_vector_clear(&t->out_ports);
+fail_in_ports:
+    SOL_VECTOR_FOREACH_IDX (&t->in_ports, p, i) {
+        free(p->name);
+        free(p->data_type);
+    }
+    sol_vector_clear(&t->in_ports);
+fail_options_symbol:
+    free(t->symbol);
+fail_symbol:
+    free(t->name);
+fail_name:
+    sol_vector_del(&store->types, store->types.len - 1);
+
+    return false;
 }
 
 void

--- a/src/bin/sol-fbp-generator/type-store.h
+++ b/src/bin/sol-fbp-generator/type-store.h
@@ -108,6 +108,9 @@ bool type_store_read_from_json(struct type_store *store, struct sol_str_slice in
 /* Call after all the types are read. */
 struct type_description *type_store_find(struct type_store *store, const char *name);
 
+/* All the information of this type description will be copied. */
+bool type_store_add_type(struct type_store *store, const struct type_description *type);
+
 void type_store_del(struct type_store *store);
 
 void type_store_print(struct type_store *store);


### PR DESCRIPTION
Now the generator handles the declaration and usage of new types in the FBP itself.

e.g.
    DECLARE=MyType:fbp:my-type.fbp
    my_node(MyType) OUT -> ...

In the generated C code now, we first build the node spec with a placeholder and after
we change this to the proper value, since we need to create this new types in runtime.