### PR TITLE
Make FBPs configurable by allowing them to export options from their sub-nodes.

### DIFF
--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -788,7 +788,7 @@ static const struct %(name_c)s_options %(name_c)s_options_defaults = %(NAME_C)s_
         new_options_func = "%s_new_options_internal" % data["name_c"]
         outfile.write("""
 static struct sol_flow_node_options *
-%(name_func)s(const struct sol_flow_node_options *copy_from)
+%(name_func)s(const struct sol_flow_node_type *type, const struct sol_flow_node_options *copy_from)
 {
     struct %(name_c)s_options *opts;
     const struct %(name_c)s_options *from;
@@ -829,7 +829,7 @@ static struct sol_flow_node_options *
         free_options_func = "%s_free_options_internal" % data["name_c"]
         outfile.write("""
 static void
-%(name_func)s(struct sol_flow_node_options *options)
+%(name_func)s(const struct sol_flow_node_type *type, struct sol_flow_node_options *options)
 {
     struct %(name_c)s_options *opts;
     if (!options) return;

--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -37,6 +37,7 @@
 #include "sol-flow-builder.h"
 #include "sol-flow-internal.h"
 #include "sol-flow-resolver.h"
+#include "sol-str-table.h"
 
 struct sol_flow_builder {
     struct sol_vector nodes;
@@ -55,6 +56,9 @@ struct sol_flow_builder {
     struct sol_ptr_vector ports_in_desc;
     struct sol_ptr_vector ports_out_desc;
 
+    struct sol_vector options_description;
+    size_t options_size;
+
     struct sol_flow_node_type_description type_desc;
 };
 
@@ -62,9 +66,23 @@ struct sol_flow_builder_node_spec {
     struct sol_flow_static_node_spec spec;
     char *name;
 
+    struct sol_vector exported_options;
+
     /* Whether builder owns the options for this node. */
     bool owns_opts;
 };
+
+struct sol_flow_builder_node_exported_option {
+    uint16_t parent_offset, child_offset;
+    uint16_t size;
+    bool is_string;
+};
+
+struct sol_flow_builder_options {
+    struct sol_flow_node_options base;
+};
+
+#define SOL_FLOW_BUILDER_OPTIONS_API_VERSION 1
 
 static void
 sol_flow_builder_init(struct sol_flow_builder *builder)
@@ -75,6 +93,7 @@ sol_flow_builder_init(struct sol_flow_builder *builder)
     sol_vector_init(&builder->exported_out, sizeof(struct sol_flow_static_port_spec));
     sol_ptr_vector_init(&builder->ports_in_desc);
     sol_ptr_vector_init(&builder->ports_out_desc);
+    sol_vector_init(&builder->options_description, sizeof(struct sol_flow_node_options_member_description));
 
     builder->str_arena = sol_arena_new();
     SOL_NULL_CHECK(builder->str_arena);
@@ -126,8 +145,13 @@ sol_flow_builder_del(struct sol_flow_builder *builder)
         if (builder_node_spec->owns_opts && builder_node_spec->spec.opts)
             sol_flow_node_options_del(builder_node_spec->spec.type,
                 (struct sol_flow_node_options *)builder_node_spec->spec.opts);
+        sol_vector_clear(&builder_node_spec->exported_options);
     }
     sol_vector_clear(&builder->nodes);
+
+    sol_vector_clear(&builder->options_description);
+
+    free((void *)builder->type_desc.options);
 
     free(builder->node_spec);
     free(builder->conn_spec);
@@ -352,6 +376,7 @@ sol_flow_builder_add_node(struct sol_flow_builder *builder, const char *name, co
     node_spec->spec.name = node_name;
     node_spec->spec.type = type;
     node_spec->spec.opts = option;
+    sol_vector_init(&node_spec->exported_options, sizeof(struct sol_flow_builder_node_exported_option));
 
     SOL_DBG("Node %s added: type=%p, opts=%p.", name, type, option);
 
@@ -417,6 +442,23 @@ get_node(struct sol_flow_builder *builder, const char *node_name, uint16_t *out_
         SOL_ERR("Failed to find node with name '%s'", node_name);
         return -EINVAL;
     }
+
+    return 0;
+}
+
+static int
+node_spec_add_options_reference(struct sol_flow_builder *builder, uint16_t node, const struct sol_flow_node_options_member_description *parent, const struct sol_flow_node_options_member_description *child)
+{
+    struct sol_flow_builder_node_spec *spec;
+    struct sol_flow_builder_node_exported_option *ref;
+
+    spec = sol_vector_get(&builder->nodes, node);
+    ref = sol_vector_append(&spec->exported_options);
+    SOL_NULL_CHECK(ref, -ENOMEM);
+    ref->parent_offset = parent->offset;
+    ref->child_offset = child->offset;
+    ref->size = parent->size;
+    ref->is_string = streq(parent->data_type, "string");
 
     return 0;
 }
@@ -605,6 +647,31 @@ get_conn_spec(const struct sol_flow_builder *builder)
     return ret_spec;
 }
 
+static struct sol_flow_node_options_description *
+get_options_description(struct sol_flow_builder *builder)
+{
+    struct sol_flow_node_options_description *opts;
+    struct sol_flow_node_options_member_description *member;
+    bool required = false;
+
+    opts = calloc(1, sizeof(*opts));
+    SOL_NULL_CHECK(opts, NULL);
+
+    opts->sub_api = SOL_FLOW_BUILDER_OPTIONS_API_VERSION;
+
+    for (member = builder->options_description.data; member->name; member++) {
+        if (member->required) {
+            required = true;
+            break;
+        }
+    }
+
+    opts->members = builder->options_description.data;
+    opts->required = required;
+
+    return opts;
+}
+
 static struct sol_flow_node_type_description *
 get_type_description(struct sol_flow_builder *builder)
 {
@@ -623,7 +690,19 @@ get_type_description(struct sol_flow_builder *builder)
         builder->type_desc.ports_out = builder->ports_out_desc.base.data;
     }
 
+    if (builder->options_description.len > 0) {
+        struct sol_flow_node_options_member_description *sentinel;
+        sentinel = sol_vector_append(&builder->options_description);
+        SOL_NULL_CHECK(sentinel, NULL);
+        memset(sentinel, 0, sizeof(*sentinel));
+        builder->type_desc.options = get_options_description(builder);
+        SOL_NULL_CHECK_GOTO(builder->type_desc.options, opt_desc_error);
+    }
+
     return &builder->type_desc;
+opt_desc_error:
+    sol_vector_del(&builder->options_description, builder->options_description.len - 1);
+    return NULL;
 }
 
 static int
@@ -655,6 +734,116 @@ get_exported_ports(
             return -ENOMEM;
         *spec = guard;
         *exported_out = builder->exported_out.data;
+    }
+
+    return 0;
+}
+
+static void
+builder_type_free_options(const struct sol_flow_node_type *type, struct sol_flow_node_options *options)
+{
+    struct sol_flow_builder_options *opts = (struct sol_flow_builder_options *)options;
+    const struct sol_flow_node_options_member_description *member;
+
+    SOL_FLOW_NODE_OPTIONS_API_CHECK(options, SOL_FLOW_NODE_OPTIONS_API_VERSION);
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_BUILDER_OPTIONS_API_VERSION);
+
+    for (member = type->description->options->members; member->name; member++) {
+        char **ptr;
+
+        if (!streq(member->data_type, "string"))
+            continue;
+
+        ptr = (char **)((char *)opts + member->offset);
+        free(*ptr);
+    }
+
+    free(opts);
+}
+
+static struct sol_flow_node_options *
+builder_type_new_options(const struct sol_flow_node_type *type, const struct sol_flow_node_options *copy_from)
+{
+    struct sol_flow_builder *builder = (struct sol_flow_builder *)type->type_data;
+    struct sol_flow_builder_options *opts;
+    const struct sol_flow_node_options_member_description *member;
+
+    SOL_NULL_CHECK(builder, NULL);
+
+    if (copy_from) {
+        SOL_FLOW_NODE_OPTIONS_API_CHECK(copy_from, SOL_FLOW_NODE_OPTIONS_API_VERSION, NULL);
+        SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(copy_from, SOL_FLOW_BUILDER_OPTIONS_API_VERSION, NULL);
+    }
+
+    opts = calloc(1, builder->options_size);
+    SOL_NULL_CHECK(opts, NULL);
+
+    opts->base.api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION;
+    opts->base.sub_api = SOL_FLOW_BUILDER_OPTIONS_API_VERSION;
+
+    for (member = type->description->options->members; member->name; member++) {
+        char *dst;
+        const char **src;
+        bool is_string;
+
+        is_string = streq(member->data_type, "string");
+
+        dst = (char *)opts + member->offset;
+        if (copy_from)
+            src = (const char **)((char *)copy_from + member->offset);
+        else
+            src = (const char **)&member->defvalue.ptr;
+
+        if (is_string) {
+            char **s = (char **)dst;
+            free(*s);
+            if (*src) {
+                if (!(*s = strdup(*src))) {
+                    builder_type_free_options(type, &opts->base);
+                    return NULL;
+                }
+            } else
+                *s = NULL;
+        } else
+            memcpy(dst, src, member->size);
+    }
+
+    return &opts->base;
+}
+
+static int
+builder_child_opts_set(const struct sol_flow_node_type *type, uint16_t child, const struct sol_flow_node_options *options, struct sol_flow_node_options *child_opts)
+{
+    struct sol_flow_builder_options *opts = (struct sol_flow_builder_options *)options;
+    struct sol_flow_builder_node_spec *node_spec;
+    struct sol_flow_builder_node_exported_option *opt_ref;
+    const struct sol_flow_builder *builder = type->type_data;
+    uint16_t i;
+
+    SOL_FLOW_NODE_OPTIONS_API_CHECK(options, SOL_FLOW_NODE_OPTIONS_API_VERSION, -EINVAL);
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_BUILDER_OPTIONS_API_VERSION, -EINVAL);
+    SOL_FLOW_NODE_OPTIONS_API_CHECK(child_opts, SOL_FLOW_NODE_OPTIONS_API_VERSION, -EINVAL);
+
+    node_spec = sol_vector_get(&builder->nodes, child);
+    SOL_NULL_CHECK(node_spec, -ECHILD);
+
+    SOL_VECTOR_FOREACH_IDX (&node_spec->exported_options, opt_ref, i) {
+        const char **src;
+        char *dst;
+
+        src = (const char **)((char *)opts + opt_ref->parent_offset);
+        dst = (char *)child_opts + opt_ref->child_offset;
+
+        if (opt_ref->is_string) {
+            char **s = (char **)dst;
+            free(*s);
+            if (*src) {
+                if (!(*s = strdup(*src)))
+                    return -ENOMEM;
+            } else
+                *s = NULL;
+        } else
+            memcpy(dst, src, opt_ref->size);
     }
 
     return 0;
@@ -699,12 +888,18 @@ sol_flow_builder_get_node_type(struct sol_flow_builder *builder)
         builder->conn_spec,
         exported_in,
         exported_out,
-        NULL);
+        desc->options ? builder_child_opts_set : NULL);
     if (!builder->node_type) {
         SOL_WRN("Failed to create new type");
         goto error_node_type;
     }
 
+    if (desc->options) {
+        builder->node_type->new_options = builder_type_new_options;
+        builder->node_type->free_options = builder_type_free_options;
+    }
+
+    builder->node_type->type_data = builder;
     builder->node_type->description = desc;
 
     SOL_DBG("Node type %p created", builder->node_type);
@@ -1037,6 +1232,107 @@ sol_flow_builder_export_out_port(struct sol_flow_builder *builder, const char *n
     if (r < 0) {
         SOL_ERR("Failed to export output port '%s' of node '%s' with exported name '%s': %s",
             port_name, node_name, exported_name, sol_util_strerrora(-r));
+        return r;
+    }
+
+    return 0;
+}
+
+static size_t
+get_member_alignment(const struct sol_flow_node_options_member_description *member)
+{
+    struct sol_str_slice t;
+    static const struct sol_str_table alignments[] = {
+        SOL_STR_TABLE_ITEM("boolean", __alignof__(member->defvalue.b)),
+        SOL_STR_TABLE_ITEM("byte", __alignof__(member->defvalue.byte)),
+        SOL_STR_TABLE_ITEM("float", __alignof__(member->defvalue.f)),
+        SOL_STR_TABLE_ITEM("int", __alignof__(member->defvalue.i)),
+        SOL_STR_TABLE_ITEM("rgb", __alignof__(member->defvalue.rgb)),
+        SOL_STR_TABLE_ITEM("string", __alignof__(member->defvalue.s)),
+    };
+
+    t = SOL_STR_SLICE_STR(member->data_type, strlen(member->data_type));
+    return sol_str_table_lookup_fallback(alignments, t, __alignof__(void *));
+}
+
+SOL_API int
+sol_flow_builder_export_option(struct sol_flow_builder *builder, const char *node_name, const char *option_name, const char *exported_name)
+{
+    struct sol_flow_static_node_spec *node_spec;
+    const struct sol_flow_node_options_member_description *opt;
+    struct sol_flow_node_options_member_description *exported_opt;
+    size_t member_alignment, padding;
+    uint16_t node;
+    int r;
+
+    SOL_NULL_CHECK(builder, -EBADR);
+    SOL_NULL_CHECK(node_name, -EBADR);
+    SOL_NULL_CHECK(option_name, -EBADR);
+    SOL_NULL_CHECK(exported_name, -EBADR);
+
+    if (builder->node_type) {
+        SOL_ERR("Failed to export output port, node type created already");
+        return -EEXIST;
+    }
+
+    r = get_node(builder, node_name, &node, &node_spec);
+    if (r < 0) {
+        SOL_ERR("Failed to find node '%s' to export option member", node_name);
+        return -EINVAL;
+    }
+
+    if (!node_spec->type->description->options || !node_spec->type->description->options->members) {
+        SOL_ERR("Failed to export option member for node '%s', node type has no options", node_name);
+        return -EINVAL;
+    }
+
+    for (opt = node_spec->type->description->options->members; opt->name; opt++) {
+        if (streq(opt->name, option_name))
+            break;
+    }
+
+    if (!opt->name) {
+        SOL_ERR("Failed to find option '%s' from node '%s'", option_name, node_name);
+        return -EINVAL;
+    }
+
+    exported_opt = sol_vector_append(&builder->options_description);
+    if (!exported_opt) {
+        SOL_ERR("Failed to export option '%s' from node '%s'", option_name, node_name);
+        return -ENOMEM;
+    }
+
+    memset(exported_opt, 0, sizeof(*exported_opt));
+    exported_opt->name = sol_arena_strdup(builder->str_arena, exported_name);
+    exported_opt->data_type = opt->data_type;
+    /* Since we can't instantiate a sub-node without its required options
+     * available, we will always have a default for the exported one, which
+     * means there's no point in making them required */
+    exported_opt->required = false;
+    exported_opt->size = opt->size;
+    if (node_spec->opts) {
+        /* The node has options, use whatever we have there as the default
+         * for the exported one.
+         * Since the sub-nodes options is owned by the builder, it's enough to
+         * just reference it here without copying it.
+         */
+        const char **node_opt = (const char **)((char *)node_spec->opts + opt->offset);
+        exported_opt->defvalue.ptr = *node_opt;
+    } else
+        exported_opt->defvalue = opt->defvalue;
+
+    if (!builder->options_size)
+        builder->options_size = sizeof(struct sol_flow_builder_options);
+
+    member_alignment = get_member_alignment(opt);
+    padding = builder->options_size % member_alignment;
+    exported_opt->offset = builder->options_size + padding;
+
+    builder->options_size += exported_opt->size + padding;
+    r = node_spec_add_options_reference(builder, node, exported_opt, opt);
+    if (r < 0) {
+        sol_vector_del(&builder->options_description, builder->options_description.len - 1);
+        SOL_ERR("Failed to export option '%s' from node '%s'", option_name, node_name);
         return r;
     }
 

--- a/src/lib/flow/sol-flow-builder.h
+++ b/src/lib/flow/sol-flow-builder.h
@@ -92,6 +92,8 @@ int sol_flow_builder_connect_by_index(struct sol_flow_builder *builder, const ch
 int sol_flow_builder_export_in_port(struct sol_flow_builder *builder, const char *node_name, const char *port_name, int port_idx, const char *exported_name);
 int sol_flow_builder_export_out_port(struct sol_flow_builder *builder, const char *node_name, const char *port_name, int port_idx, const char *exported_name);
 
+int sol_flow_builder_export_option(struct sol_flow_builder *builder, const char *node_name, const char *option_name, const char *exported_name);
+
 /* Returns the node type generated with the builder. It should be used
  * to create nodes with sol_flow_node_new(). After the type is
  * created, no more nodes or connections can be added.

--- a/src/lib/flow/sol-flow-node-options.c
+++ b/src/lib/flow/sol-flow-node-options.c
@@ -653,10 +653,10 @@ sol_flow_node_options_new_from_strv(const struct sol_flow_node_type *type, const
     SOL_NULL_CHECK(type->description->options, NULL);
     SOL_NULL_CHECK(type->description->options->members, NULL);
     SOL_NULL_CHECK(type->new_options, NULL);
-    opts = type->new_options(NULL);
+    opts = type->new_options(type, NULL);
     SOL_NULL_CHECK(opts, NULL);
     if (!options_from_strv(type->description->options, opts, strv)) {
-        type->free_options(opts);
+        type->free_options(type, opts);
         return NULL;
     }
     return opts;
@@ -677,7 +677,7 @@ sol_flow_node_options_copy(const struct sol_flow_node_type *type, const struct s
     SOL_NULL_CHECK(type->description->options, NULL);
     SOL_NULL_CHECK(type->description->options->members, NULL);
     SOL_NULL_CHECK(type->new_options, NULL);
-    return type->new_options(opts);
+    return type->new_options(type, opts);
 #endif
 }
 
@@ -715,7 +715,7 @@ sol_flow_node_options_del(const struct sol_flow_node_type *type, struct sol_flow
     SOL_NULL_CHECK(type->description->options->members);
     SOL_NULL_CHECK(type->free_options);
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, type->description->options->sub_api);
-    type->free_options(options);
+    type->free_options(type, options);
 #endif
 }
 

--- a/src/lib/flow/sol-flow-parser.c
+++ b/src/lib/flow/sol-flow-parser.c
@@ -228,7 +228,7 @@ sol_flow_parser_del(struct sol_flow_parser *parser)
 
     SOL_NULL_CHECK(parser, -EBADF);
 
-    SOL_PTR_VECTOR_FOREACH_IDX (&parser->builders, b, i)
+    SOL_PTR_VECTOR_FOREACH_REVERSE_IDX (&parser->builders, b, i)
         sol_flow_builder_del(b);
     sol_ptr_vector_clear(&parser->builders);
 

--- a/src/lib/flow/sol-flow-static.c
+++ b/src/lib/flow/sol-flow-static.c
@@ -71,7 +71,8 @@ struct flow_static_type {
     const struct sol_flow_static_port_spec *exported_in_specs;
     const struct sol_flow_static_port_spec *exported_out_specs;
 
-    void (*child_opts_set)(uint16_t child_index,
+    int (*child_opts_set)(const struct sol_flow_node_type *type,
+        uint16_t child_index,
         const struct sol_flow_node_options *opts,
         struct sol_flow_node_options *child_opts);
 
@@ -416,7 +417,7 @@ flow_node_open(struct sol_flow_node *node, void *data, const struct sol_flow_nod
         }
 
         if (type->child_opts_set)
-            type->child_opts_set(i, options, child_opts);
+            type->child_opts_set(node->type, i, options, child_opts);
         r = sol_flow_node_init(child_node, node, spec->name, spec->type,
             child_opts);
         sol_flow_node_free_options(spec->type, child_opts);
@@ -981,7 +982,8 @@ flow_static_type_init(
     const struct sol_flow_static_conn_spec conns[],
     const struct sol_flow_static_port_spec exported_in[],
     const struct sol_flow_static_port_spec exported_out[],
-    void (*child_opts_set)(uint16_t child_index,
+    int (*child_opts_set)(const struct sol_flow_node_type *type,
+        uint16_t child_index,
         const struct sol_flow_node_options *opts,
         struct sol_flow_node_options *child_opts))
 {
@@ -1104,7 +1106,8 @@ sol_flow_static_new_type(
     const struct sol_flow_static_conn_spec conns[],
     const struct sol_flow_static_port_spec exported_in[],
     const struct sol_flow_static_port_spec exported_out[],
-    void (*child_opts_set)(uint16_t child_index,
+    int (*child_opts_set)(const struct sol_flow_node_type *type,
+        uint16_t child_index,
         const struct sol_flow_node_options *opts,
         struct sol_flow_node_options *child_opts))
 {

--- a/src/lib/flow/sol-flow.c
+++ b/src/lib/flow/sol-flow.c
@@ -156,7 +156,7 @@ sol_flow_node_get_options(const struct sol_flow_node_type *type, const struct so
     struct sol_flow_node_options *opts = &empty_defaults;
 
     if (type->new_options)
-        opts = type->new_options(copy_from);
+        opts = type->new_options(type, copy_from);
     return opts;
 }
 
@@ -166,7 +166,7 @@ sol_flow_node_free_options(const struct sol_flow_node_type *type, struct sol_flo
     if (!options || options == &empty_defaults)
         return;
     if (type->free_options)
-        type->free_options(options);
+        type->free_options(type, options);
 }
 
 SOL_API struct sol_flow_node *

--- a/src/lib/flow/sol-flow.h
+++ b/src/lib/flow/sol-flow.h
@@ -297,8 +297,10 @@ struct sol_flow_node_type {
     uint16_t data_size; /**< size of the whole sol_flow_node_type derivate */
     uint16_t flags; /**< @see #sol_flow_node_type_flags */
 
-    struct sol_flow_node_options *(*new_options)(const struct sol_flow_node_options *copy_from); /**< member function to instantiate new options for the node (if @a copy_from is not @c NULL, its members will be copied into the new returned struct */
-    void (*free_options)(struct sol_flow_node_options *opts); /**< member function to delete the node options */
+    const void *type_data; /**< pointer to per-type user data */
+
+    struct sol_flow_node_options *(*new_options)(const struct sol_flow_node_type *type, const struct sol_flow_node_options *copy_from); /**< member function to instantiate new options for the node. If @a copy_from is not @c NULL, its members will be copied into the new returned struct */
+    void (*free_options)(const struct sol_flow_node_type *type, struct sol_flow_node_options *opts); /**< member function to delete the node options */
 
     void (*get_ports_counts)(const struct sol_flow_node_type *type, uint16_t *ports_in_count, uint16_t *ports_out_count); /**< member function to get the number of input/output ports of the node */
     const struct sol_flow_port_type_in *(*get_port_in)(const struct sol_flow_node_type *type, uint16_t port); /**< member function to get the array of the node's input ports */
@@ -502,7 +504,8 @@ struct sol_flow_node_type *sol_flow_static_new_type(
     const struct sol_flow_static_conn_spec conns[],
     const struct sol_flow_static_port_spec exported_in[],
     const struct sol_flow_static_port_spec exported_out[],
-    void (*child_opts_set)(uint16_t child_index,
+    int (*child_opts_set)(const struct sol_flow_node_type *type,
+        uint16_t child_index,
         const struct sol_flow_node_options *opts,
         struct sol_flow_node_options *child_opts));
 

--- a/src/modules/flow/calamari/calamari.c
+++ b/src/modules/flow/calamari/calamari.c
@@ -187,8 +187,9 @@ segments_ctl_close(struct sol_flow_node *node, void *data)
 #define SEG_CLOCK 3
 #define SEG_DATA 4
 
-static void
-calamari_7seg_child_opts_set(uint16_t child_index,
+static int
+calamari_7seg_child_opts_set(const struct sol_flow_node_type *type,
+    uint16_t child_index,
     const struct sol_flow_node_options *opts,
     struct sol_flow_node_options *child_opts)
 {
@@ -206,9 +207,11 @@ calamari_7seg_child_opts_set(uint16_t child_index,
     };
 
     if (child_index == SEG_CTL || child_index > SEG_DATA)
-        return;
+        return 0;
 
     gpio_opts->pin.val = pins[child_index];
+
+    return 0;
 }
 
 static void
@@ -494,8 +497,9 @@ calamari_rgb_led_process_blue(struct sol_flow_node *node, void *data, uint16_t p
 #define RGB_LED_GREEN 2
 #define RGB_LED_BLUE 3
 
-static void
-calamari_rgb_child_opts_set(uint16_t child_index,
+static int
+calamari_rgb_child_opts_set(const struct sol_flow_node_type *type,
+    uint16_t child_index,
     const struct sol_flow_node_options *opts,
     struct sol_flow_node_options *child_opts)
 {
@@ -513,9 +517,11 @@ calamari_rgb_child_opts_set(uint16_t child_index,
 
     // There is nothing to do for node 0, which is rgb-ctl
     if (child_index == RGB_LED_CTL || child_index > RGB_LED_BLUE)
-        return;
+        return 0;
 
     gpio_opts->pin.val = pins[child_index];
+
+    return 0;
 }
 
 static void

--- a/src/modules/flow/grove/grove.c
+++ b/src/modules/flow/grove/grove.c
@@ -54,8 +54,8 @@ struct rotary_converter_data {
     int input_range;
 };
 
-static void
-rotary_child_opts_set(uint16_t child_index, const struct sol_flow_node_options *opts, struct sol_flow_node_options *child_opts)
+static int
+rotary_child_opts_set(const struct sol_flow_node_type *type, uint16_t child_index, const struct sol_flow_node_options *opts, struct sol_flow_node_options *child_opts)
 {
     struct sol_flow_node_type_grove_rotary_sensor_options *container_opts = (struct sol_flow_node_type_grove_rotary_sensor_options *)opts;
 
@@ -70,6 +70,8 @@ rotary_child_opts_set(uint16_t child_index, const struct sol_flow_node_options *
         reader_opts->mask = container_opts->mask;
         reader_opts->poll_timeout = container_opts->poll_timeout;
     }
+
+    return 0;
 }
 
 static void
@@ -165,8 +167,8 @@ struct light_converter_data {
     int input_range;
 };
 
-static void
-light_child_opts_set(uint16_t child_index, const struct sol_flow_node_options *opts, struct sol_flow_node_options *child_opts)
+static int
+light_child_opts_set(const struct sol_flow_node_type *type, uint16_t child_index, const struct sol_flow_node_options *opts, struct sol_flow_node_options *child_opts)
 {
     struct sol_flow_node_type_grove_light_sensor_options *container_opts = (struct sol_flow_node_type_grove_light_sensor_options *)opts;
 
@@ -179,6 +181,8 @@ light_child_opts_set(uint16_t child_index, const struct sol_flow_node_options *o
         reader_opts->mask = container_opts->mask;
         reader_opts->poll_timeout = container_opts->poll_timeout;
     }
+
+    return 0;
 }
 
 static void
@@ -328,8 +332,8 @@ temperature_convert(struct sol_flow_node *node, void *data, uint16_t port, uint1
     return 0;
 }
 
-static void
-temperature_child_opts_set(uint16_t child_index, const struct sol_flow_node_options *opts, struct sol_flow_node_options *child_opts)
+static int
+temperature_child_opts_set(const struct sol_flow_node_type *type, uint16_t child_index, const struct sol_flow_node_options *opts, struct sol_flow_node_options *child_opts)
 {
     struct sol_flow_node_type_grove_temperature_sensor_options *container_opts = (struct sol_flow_node_type_grove_temperature_sensor_options *)opts;
 
@@ -347,6 +351,8 @@ temperature_child_opts_set(uint16_t child_index, const struct sol_flow_node_opti
         reader_opts->mask = container_opts->mask;
         reader_opts->poll_timeout = container_opts->poll_timeout;
     }
+
+    return 0;
 }
 
 static void

--- a/src/shared/sol-fbp-graph.c
+++ b/src/shared/sol-fbp-graph.c
@@ -47,6 +47,7 @@ sol_fbp_graph_init(struct sol_fbp_graph *g)
     sol_vector_init(&g->exported_in_ports, sizeof(struct sol_fbp_exported_port));
     sol_vector_init(&g->exported_out_ports, sizeof(struct sol_fbp_exported_port));
     sol_vector_init(&g->declarations, sizeof(struct sol_fbp_declaration));
+    sol_vector_init(&g->options, sizeof(struct sol_fbp_option));
     g->arena = sol_arena_new();
     return 0;
 }
@@ -70,6 +71,7 @@ sol_fbp_graph_fini(struct sol_fbp_graph *g)
     sol_vector_clear(&g->exported_in_ports);
     sol_vector_clear(&g->exported_out_ports);
     sol_vector_clear(&g->declarations);
+    sol_vector_clear(&g->options);
 
     sol_arena_del(g->arena);
 
@@ -344,5 +346,30 @@ sol_fbp_graph_declare(struct sol_fbp_graph *g,
     dec->kind = kind;
     dec->contents = contents;
     dec->position = position;
+    return i;
+}
+
+int
+sol_fbp_graph_option(struct sol_fbp_graph *g,
+    int node, struct sol_str_slice name, struct sol_str_slice node_opt, struct sol_fbp_position position)
+{
+    struct sol_fbp_option *opt;
+    uint16_t i;
+
+    if (name.len == 0 || node_opt.len == 0)
+        return -EINVAL;
+
+    SOL_VECTOR_FOREACH_IDX (&g->options, opt, i) {
+        if (sol_str_slice_eq(opt->name, name))
+            return -EEXIST;
+    }
+
+    opt = sol_vector_append(&g->options);
+    SOL_NULL_CHECK(opt, -errno);
+
+    opt->name = name;
+    opt->node = node;
+    opt->node_option = node_opt;
+    opt->position = position;
     return i;
 }

--- a/src/shared/sol-fbp-internal-scanner.c
+++ b/src/shared/sol-fbp-internal-scanner.c
@@ -319,10 +319,90 @@ declare_state(struct sol_fbp_scanner *s)
     return declare_equal_state;
 }
 
+static void *
+option_end_state(struct sol_fbp_scanner *s)
+{
+    switch (peek(s)) {
+    case ',':
+    case ' ':
+    case '\n':
+    case '\r':
+    case '\t':
+    case '#':
+    case 0:
+        return default_state;
+
+    default:
+        next(s);
+        return error_state;
+    }
+}
+
+static void *
+option_name_state(struct sol_fbp_scanner *s)
+{
+    while (is_node_ident(peek(s)))
+        next(s);
+    set_token(s, SOL_FBP_TOKEN_IDENTIFIER);
+    return option_end_state;
+}
+
+static void *
+option_second_sep_state(struct sol_fbp_scanner *s)
+{
+    if (next(s) != ':')
+        return error_state;
+    set_token(s, SOL_FBP_TOKEN_COLON);
+    return option_name_state;
+}
+static void *
+option_node_option_state(struct sol_fbp_scanner *s)
+{
+    while (is_node_ident(peek(s)))
+        next(s);
+    set_token(s, SOL_FBP_TOKEN_IDENTIFIER);
+    return option_second_sep_state;
+}
+
+static void *
+option_first_sep_state(struct sol_fbp_scanner *s)
+{
+    if (next(s) != '.')
+        return error_state;
+    set_token(s, SOL_FBP_TOKEN_DOT);
+    return option_node_option_state;
+}
+
+static void *
+option_node_name_state(struct sol_fbp_scanner *s)
+{
+    while (is_node_ident(peek(s)))
+        next(s);
+    set_token(s, SOL_FBP_TOKEN_IDENTIFIER);
+    return option_first_sep_state;
+}
+
+static void *
+option_equal_state(struct sol_fbp_scanner *s)
+{
+    if (next(s) != '=')
+        return error_state;
+    set_token(s, SOL_FBP_TOKEN_EQUAL);
+    return option_node_name_state;
+}
+
+static void *
+option_state(struct sol_fbp_scanner *s)
+{
+    set_token(s, SOL_FBP_TOKEN_OPTION_KEYWORD);
+    return option_equal_state;
+}
+
 static const struct sol_str_table_ptr keyword_table[] = {
     SOL_STR_TABLE_PTR_ITEM("INPORT", inport_state),
     SOL_STR_TABLE_PTR_ITEM("OUTPORT", outport_state),
     SOL_STR_TABLE_PTR_ITEM("DECLARE", declare_state),
+    SOL_STR_TABLE_PTR_ITEM("OPTION", option_state),
     { }
 };
 

--- a/src/shared/sol-fbp-internal-scanner.h
+++ b/src/shared/sol-fbp-internal-scanner.h
@@ -57,7 +57,8 @@
     X(PAREN_OPEN)                                      \
     X(STMT_SEPARATOR)                                  \
     X(STRING)                                          \
-    X(DECLARE_KEYWORD)
+    X(DECLARE_KEYWORD)                                 \
+    X(OPTION_KEYWORD)
 
 #define TOKEN_ENUM(T) SOL_FBP_TOKEN_ ## T,
 

--- a/src/shared/sol-fbp-parser.c
+++ b/src/shared/sol-fbp-parser.c
@@ -371,6 +371,57 @@ parse_declare_stmt(struct sol_fbp_parser *p)
 }
 
 static bool
+parse_option_stmt(struct sol_fbp_parser *p)
+{
+    struct sol_str_slice opt_name, node_name, node_opt, empty = SOL_STR_SLICE_EMPTY;
+    struct sol_fbp_node *err_node;
+    struct sol_fbp_position pos;
+    int node_idx, err;
+
+    assert(next_token(p) == SOL_FBP_TOKEN_OPTION_KEYWORD);
+
+    if (next_token(p) != SOL_FBP_TOKEN_EQUAL)
+        return set_parse_error(p, "Expected '=' after OPTION keyword");
+
+    if (next_token(p) != SOL_FBP_TOKEN_IDENTIFIER)
+        return set_parse_error(p, "Expected node name in option statement");
+
+    node_name = get_token_slice(p);
+    pos = get_token_position(&p->current_token);
+
+    if (next_token(p) != SOL_FBP_TOKEN_DOT)
+        return set_parse_error(p, "Expected '.' after node name in option statement");
+
+    if (next_token(p) != SOL_FBP_TOKEN_IDENTIFIER)
+        return set_parse_error(p, "Expected node option's original name in option statement");
+
+    node_opt = get_token_slice(p);
+
+    if (next_token(p) != SOL_FBP_TOKEN_COLON)
+        return set_parse_error(p, "Expected ':' after option name in option statement");
+
+    if (next_token(p) != SOL_FBP_TOKEN_IDENTIFIER)
+        return set_parse_error(p, "Expected exported option name in option statement");
+
+    opt_name = get_token_slice(p);
+
+    node_idx = sol_fbp_graph_add_node(p->graph, node_name, empty, pos, &err_node);
+    if (node_idx < 0)
+        return handle_node_error(p, &node_name, &pos, node_idx, err_node);
+
+    err = sol_fbp_graph_option(p->graph, node_idx, opt_name, node_opt, pos);
+    if (err == -EEXIST) {
+        p->error_pos = pos;
+        return set_parse_error(p, "Option '%.*s' already declared", SOL_STR_SLICE_PRINT(opt_name));
+    } else if (err == -EINVAL) {
+        p->error_pos = pos;
+        return set_parse_error(p, "Option '%.*s' with invalid values", SOL_STR_SLICE_PRINT(opt_name));
+    }
+
+    return true;
+}
+
+static bool
 parse_meta(struct sol_fbp_parser *p, int node)
 {
     struct sol_str_slice key, value;
@@ -579,6 +630,9 @@ parse_stmt(struct sol_fbp_parser *p)
 
     case SOL_FBP_TOKEN_DECLARE_KEYWORD:
         return parse_declare_stmt(p);
+
+    case SOL_FBP_TOKEN_OPTION_KEYWORD:
+        return parse_option_stmt(p);
 
     case SOL_FBP_TOKEN_IDENTIFIER:
         return parse_conn_stmt(p);

--- a/src/shared/sol-fbp.h
+++ b/src/shared/sol-fbp.h
@@ -88,6 +88,14 @@ struct sol_fbp_declaration {
     struct sol_fbp_position position;
 };
 
+struct sol_fbp_option {
+    struct sol_str_slice name;
+    struct sol_str_slice node_option;
+    int node;
+
+    struct sol_fbp_position position;
+};
+
 struct sol_fbp_graph {
     struct sol_vector nodes;
     struct sol_vector conns;
@@ -95,6 +103,7 @@ struct sol_fbp_graph {
     struct sol_vector exported_in_ports;
     struct sol_vector exported_out_ports;
     struct sol_vector declarations;
+    struct sol_vector options;
 
     struct sol_arena *arena;
 };
@@ -144,6 +153,9 @@ int sol_fbp_graph_add_exported_out_port(struct sol_fbp_graph *g,
 
 int sol_fbp_graph_declare(struct sol_fbp_graph *g,
     struct sol_str_slice name, struct sol_str_slice kind, struct sol_str_slice contents, struct sol_fbp_position);
+
+int sol_fbp_graph_option(struct sol_fbp_graph *g,
+    int node, struct sol_str_slice name, struct sol_str_slice node_opt, struct sol_fbp_position position);
 
 /* Given an input string written using the "FBP file format" described
  * in https://github.com/noflo/fbp/blob/master/README.md, returns a

--- a/src/test-fbp/_adder22.fbp
+++ b/src/test-fbp/_adder22.fbp
@@ -28,9 +28,10 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Takes an irange, add 22 and outputs it.
+# Takes an irange, add 22 (or the value passed in options) and outputs it.
 
 INPORT=adder.IN1:IN
 OUTPORT=adder.OUT:OUT
+OPTION=add_value.value:add_value
 
-_(constant/int:value=22) OUT -> IN0 adder(int/addition)
+add_value(constant/int:value=22) OUT -> IN0 adder(int/addition)

--- a/src/test-fbp/declare.fbp
+++ b/src/test-fbp/declare.fbp
@@ -47,3 +47,11 @@ _(constant/int:value=23) OUT -> IN1 other_equal_sum
 
 other_equal_sum OUT -> RESULT using_other_adder_22_fbp_works(test/result)
 
+# Check thatthe type works with options.
+
+_(constant/int:value=1) OUT -> IN adder_with_opts(MyAdder:add_value=666)
+
+adder_with_opts OUT -> IN0 third_equal(int/equal)
+_(constant/int:value=667) OUT -> IN1 third_equal
+
+third_equal OUT -> RESULT using_adder_22_with_options(test/result)

--- a/src/test/test-fbp-scanner.c
+++ b/src/test/test-fbp-scanner.c
@@ -426,6 +426,19 @@ static struct test_entry scan_tests[] = {
             SOL_FBP_TOKEN_EOF,
         },
     },
+    { /* Export options in FBP files */
+        "OPTION=Subnode.option:MyOption",
+        TOKENS {
+            SOL_FBP_TOKEN_OPTION_KEYWORD,
+            SOL_FBP_TOKEN_EQUAL,
+            SOL_FBP_TOKEN_IDENTIFIER,
+            SOL_FBP_TOKEN_DOT,
+            SOL_FBP_TOKEN_IDENTIFIER,
+            SOL_FBP_TOKEN_COLON,
+            SOL_FBP_TOKEN_IDENTIFIER,
+            SOL_FBP_TOKEN_EOF,
+        },
+    },
 };
 
 #define TOKEN_NAME(T) #T,
@@ -491,6 +504,10 @@ scan_errors(void)
         SOL_STR_SLICE_LITERAL("PORT["),
         SOL_STR_SLICE_LITERAL("PORT]"),
         SOL_STR_SLICE_LITERAL("PORT[NaN]"),
+        SOL_STR_SLICE_LITERAL("OPTION=A"),
+        SOL_STR_SLICE_LITERAL("OPTION=A:B"),
+        SOL_STR_SLICE_LITERAL("OPTION=A.B"),
+        SOL_STR_SLICE_LITERAL("OPTION=A:B.C"),
     };
 
     for (i = 0; i < ARRAY_SIZE(tests); i++) {


### PR DESCRIPTION
An options_description will be created for the type, copying the
option_description_member from the corresponding option of the node,
with default values being taken either from the default in the sub-node's
type, or from the options used to instantiate that specific instance of the
node.

Changes since v1:
 * Fixed 'leaks' for correctness, even though they would be freed when the
   vectors they come from are freed.
 * Return error when strdup() fails while creating options.
 * Killed foosball example changes, added them to the declare test instead.
 * All options related methods receive the type, so we don't need to pass it
   along in the options anymore.