### PR TITLE
Fixes for building external modules

### DIFF
--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -325,7 +325,7 @@ $(PC_GEN): $(PC_GEN_IN)
 $(NODE_TYPE_GEN_SCRIPT): $(NODE_TYPE_GEN_SCRIPT_IN)
 	$(Q)echo "     "GEN"   "$(NODE_TYPE_GEN_SCRIPT)
 	$(Q)$(MKDIR) -p $(dir $(NODE_TYPE_GEN_SCRIPT))
-	$(Q)$(CAT) $(<) | $(SED) 's#@pkgdatadir@#$(DATADIR)#g' > $(@) && $(CHMOD) +x $(@)
+	$(Q)$(CAT) $(<) | $(SED) 's#@pkgdatadir@#$(SOL_DATADIR)#g' > $(@) && $(CHMOD) +x $(@)
 
 $(FLOW_NODE_TYPE_FIND): $(FLOW_NODE_TYPE_FIND_IN)
 	$(Q)echo "     "GEN"   "$(FLOW_NODE_TYPE_FIND)

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -59,6 +59,7 @@ $(foreach bin,$(rpath-bins),$(eval $(call rpath-cleanup,$(bin))))
 
 pre-install: $(PRE_INSTALL)
 	$(Q)echo "     "INSTALLING SYSROOT TO: $(DESTDIR)
+	$(Q)$(MKDIR) -p $(DESTDIR)
 	$(Q)$(CP) -R $(build_sysroot)/* $(DESTDIR)
 
 post-install: pre-install $(addsuffix -rpath-cleanup,$(rpath-bins))


### PR DESCRIPTION
The first one was found when installing Soletta in a non-existant directory.

The second one was found when using the node-type code generator from a external module.

There are still problems when building external modules, that will be fixed in later pull requests.