### PR TITLE
build: check-fbp output should show newlines

### DIFF
--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -4,7 +4,7 @@ check: $(SOL_LIB_SO) $(SOL_LIB_AR) $(tests-out)
 PHONY += check
 
 check-fbp: $(SOL_LIB_SO) $(SOL_LIB_AR) $(bins-out) $(modules-out)
-	$(Q)echo "$(shell SOL_FBP_RUNNER_BIN="$(abspath $(SOL_FBP_RUNNER_BIN))" $(TEST_FBP_SCRIPT))"
+	$(Q)SOL_FBP_RUNNER_BIN="$(abspath $(SOL_FBP_RUNNER_BIN))" $(TEST_FBP_SCRIPT)
 
 PHONY += check-fbp
 


### PR DESCRIPTION
Don't embed the output of the src/test-fbp/run script inside an echo.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>