### PR TITLE
sol-util: Make get_progname fail when execfn is NULL

### DIFF
--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -318,7 +318,10 @@ get_progname(char *out, size_t size)
         return -1;
 
     execfn = (char *)getauxval(AT_EXECFN);
-    if (execfn && execfn[0] == '/')
+    if (!execfn)
+        return -1;
+
+    if (execfn[0] == '/')
         return snprintf(out, size, "%s", execfn);
     else
         return snprintf(out, size, "%s/%s", cwd, execfn);


### PR DESCRIPTION
Signed-off-by: Anselmo L. S. Melo <anselmo.melo@intel.com>