### PR TITLE
Build selective hardware

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -22,6 +22,11 @@ endmenu
 menu "Core library"
 source "src/lib/common/Kconfig"
 source "src/lib/flow/Kconfig"
+
+config NETWORK
+        bool "Network support"
+	default y
+
 source "src/lib/coap/Kconfig"
 source "src/shared/Kconfig"
 endmenu

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -27,7 +27,7 @@
 	    "pkgname": "libudev"
 	},
 	{
-	    "dependency": "kdbus",
+	    "dependency": "sd_bus",
 	    "type": "ccode",
 	    "headers": [
 		"<systemd/sd-bus.h>"

--- a/src/lib/coap/Kconfig
+++ b/src/lib/coap/Kconfig
@@ -1,3 +1,4 @@
 config COAP
 	bool "CoAP"
+	depends on NETWORK
 	default y

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -98,8 +98,13 @@ config HARDWARE_SPI
 	help
           Globaly enables spi hardware support.
 	default y
-endmenu
 
+config HARDWARE_UART
+	bool "uart"
+	help
+          Globaly enables uart hardware support.
+	default y
+endmenu
 
 config SOCKET_LINUX
 	bool "Linux sockets"

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -110,6 +110,12 @@ config HARDWARE_I2C
 	help
           Globaly enables i2c hardware support.
 	default y
+
+config HARDWARE_GPIO
+	bool "gpio"
+	help
+          Globaly enables gpio hardware support.
+	default y
 endmenu
 
 config SOCKET_LINUX

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -86,6 +86,15 @@ config SOL_BUS
 	depends on SOL_PLATFORM_LINUX && HAVE_SYSTEMD && HAVE_SD_BUS
 	default n
 
+menu "Hardware support"
+config HARDWARE_PWM
+	bool "pwm"
+	help
+          Globaly enables pwm hardware support.
+	default y
+endmenu
+
+
 config SOCKET_LINUX
 	bool "Linux sockets"
 	depends on SOL_PLATFORM_LINUX

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -27,7 +27,7 @@ config PLATFORM_SYSTEMD
 	bool "systemd"
 	depends on HAVE_SYSTEMD
 	select SOL_PLATFORM_LINUX
-	select KDBUS
+	select SOL_BUS
 endchoice
 
 choice
@@ -81,9 +81,9 @@ config DEFAULT_LOG_LEVEL_DEBUG
 	bool "debug"
 endchoice
 
-config KDBUS
-	bool "Kdbus"
-	depends on SOL_PLATFORM_LINUX && HAVE_SYSTEMD && HAVE_KDBUS
+config SOL_BUS
+	bool "Sol-bus"
+	depends on SOL_PLATFORM_LINUX && HAVE_SYSTEMD && HAVE_SD_BUS
 	default n
 
 config SOCKET_LINUX

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -92,6 +92,12 @@ config HARDWARE_PWM
 	help
           Globaly enables pwm hardware support.
 	default y
+
+config HARDWARE_SPI
+	bool "spi"
+	help
+          Globaly enables spi hardware support.
+	default y
 endmenu
 
 

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -104,6 +104,12 @@ config HARDWARE_UART
 	help
           Globaly enables uart hardware support.
 	default y
+
+config HARDWARE_I2C
+	bool "i2c"
+	help
+          Globaly enables i2c hardware support.
+	default y
 endmenu
 
 config SOCKET_LINUX

--- a/src/lib/common/Makefile
+++ b/src/lib/common/Makefile
@@ -3,9 +3,9 @@ obj-$(CORE) += core.mod
 obj-core-$(CORE)             := sol-log.o sol-blob.o sol-mainloop.o
 obj-core-$(CORE)             += sol-platform.o sol-types.o sol-platform-detect.o
 
-obj-core-$(KDBUS)            += sol-bus.o
-obj-core-$(KDBUS)-extra-cflags += $(SYSTEMD_CFLAGS) $(GLIB_CFLAGS)
-obj-core-$(KDBUS)-extra-ldflags += $(SYSTEMD_LDFLAGS) $(GLIB_LDFLAGS)
+obj-core-$(SOL_BUS)               += sol-bus.o
+obj-core-$(SOL_BUS)-extra-cflags  += $(SYSTEMD_CFLAGS) $(GLIB_CFLAGS)
+obj-core-$(SOL_BUS)-extra-ldflags += $(SYSTEMD_LDFLAGS) $(GLIB_LDFLAGS)
 
 obj-core-$(MAINLOOP_GLIB)    += sol-mainloop-impl-glib.o
 obj-core-$(MAINLOOP_GLIB)-extra-cflags += $(GLIB_CFLAGS)

--- a/src/lib/common/sol-interrupt_scheduler_riot.c
+++ b/src/lib/common/sol-interrupt_scheduler_riot.c
@@ -40,8 +40,10 @@ static kernel_pid_t pid;
 
 enum interrupt_type {
     GPIO,
+#ifdef HARDWARE_UART
     UART_RX,
     UART_TX
+#endif
 };
 
 struct interrupt_data_base {
@@ -54,6 +56,7 @@ struct interrupt_data {
     void *data;
 };
 
+#ifdef HARDWARE_UART
 struct uart_interrupt_data {
     struct interrupt_data_base base;
     uart_t uart_id;
@@ -66,6 +69,7 @@ struct uart_rx_interrupt_data {
     char char_read;
     struct uart_interrupt_data *uart_int;
 };
+#endif
 
 void
 sol_interrupt_scheduler_set_pid(kernel_pid_t p)
@@ -136,6 +140,7 @@ sol_interrupt_scheduler_gpio_stop(gpio_t dev, void *handler)
 }
 
 /* Run in interrupt context */
+#ifdef HARDWARE_UART
 static void
 uart_rx_cb(void *data, char char_read)
 {
@@ -203,6 +208,7 @@ sol_interrupt_scheduler_uart_stop(uart_t uart, void *handler)
     uart_init_blocking(uart, 9600);
     interrupt_scheduler_handler_free(handler);
 }
+#endif
 
 void
 sol_interrupt_scheduler_process(msg_t *msg)
@@ -216,6 +222,7 @@ sol_interrupt_scheduler_process(msg_t *msg)
         interrupt_data_base_unref(&int_data->base);
         break;
     }
+#ifdef HARDWARE_UART
     case UART_RX: {
         struct uart_rx_interrupt_data *rx_data = (void *)msg->content.ptr;
         uart_rx_cb_t cb = rx_data->uart_int->rx_cb;
@@ -235,5 +242,6 @@ sol_interrupt_scheduler_process(msg_t *msg)
         interrupt_data_base_unref(&int_data->base);
         break;
     }
+#endif
     }
 }

--- a/src/lib/common/sol-interrupt_scheduler_riot.h
+++ b/src/lib/common/sol-interrupt_scheduler_riot.h
@@ -33,14 +33,19 @@
 #include "kernel_types.h"
 #include "msg.h"
 #include "periph/gpio.h"
+
+#ifdef HARDWARE_UART
 #include "periph/uart.h"
+#endif
 
 void sol_interrupt_scheduler_set_pid(kernel_pid_t pid);
 
 int sol_interrupt_scheduler_gpio_init_int(gpio_t dev, gpio_pp_t pullup, gpio_flank_t flank, gpio_cb_t cb, void *arg, void **handler);
 void sol_interrupt_scheduler_gpio_stop(gpio_t dev, void *handler);
 
+#ifdef HARDWARE_UART
 int sol_interrupt_scheduler_uart_init_int(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, uart_tx_cb_t tx_cb, void *arg, void **handler);
 void sol_interrupt_scheduler_uart_stop(uart_t uart, void *handler);
+#endif
 
 void sol_interrupt_scheduler_process(msg_t *msg);

--- a/src/modules/flow/calamari/Kconfig
+++ b/src/modules/flow/calamari/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_CALAMARI
 	tristate "Node type: calamari"
-	depends on FLOW && (FLOW_NODE_TYPE_GPIO = y)
+	depends on FLOW && (FLOW_NODE_TYPE_GPIO = y) && HARDWARE_PWM
 	default m

--- a/src/modules/flow/gpio/Kconfig
+++ b/src/modules/flow/gpio/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_GPIO
 	tristate "Node type: gpio"
-	depends on FLOW
+	depends on FLOW && HARDWARE_GPIO
 	default y

--- a/src/modules/flow/piezo-speaker/Kconfig
+++ b/src/modules/flow/piezo-speaker/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_PIEZO_SPEAKER
 	tristate "Node type: piezo-speaker"
-	depends on FLOW
+	depends on FLOW && HARDWARE_PWM
 	default m

--- a/src/modules/flow/pwm/Kconfig
+++ b/src/modules/flow/pwm/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_PWM
 	tristate "Node type: pwm"
-	depends on FLOW
+	depends on FLOW && HARDWARE_PWM
 	default y

--- a/src/modules/flow/servo-motor/Kconfig
+++ b/src/modules/flow/servo-motor/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_SERVO_MOTOR
 	tristate "Node type: servo-motor"
-	depends on FLOW
+	depends on FLOW && HARDWARE_PWM
 	default m

--- a/src/shared/Makefile
+++ b/src/shared/Makefile
@@ -27,14 +27,23 @@ ifeq (y,$(HARDWARE_PWM))
 obj-libshared-m += sol-pwm-riot.o
 endif
 
+ifeq (y,$(HARDWARE_SPI))
+obj-libshared-m += sol-spi-riot.o
+endif
+
 obj-libshared-m += sol-gpio-riot.o sol-i2c-riot.o
-obj-libshared-m += sol-spi-riot.o sol-uart-riot.o sol-network-riot.o
+obj-libshared-m += sol-uart-riot.o sol-network-riot.o
 endif
 
 ifeq (y,$(SOL_PLATFORM_LINUX))
 ifeq (y,$(HARDWARE_PWM))
 obj-libshared-m += sol-pwm-linux.o
 endif
+
+ifeq (y,$(HARDWARE_SPI))
+obj-libshared-m += sol-spi-linux.o
+endif
+
 obj-libshared-m += sol-file-reader.o sol-gpio-linux.o sol-network-linux.o
-obj-libshared-m += sol-i2c-linux.o sol-spi-linux.o sol-uart-linux.o
+obj-libshared-m += sol-i2c-linux.o sol-uart-linux.o
 endif

--- a/src/shared/Makefile
+++ b/src/shared/Makefile
@@ -5,8 +5,12 @@ obj-libshared-$(INTERNAL_SHARED)   := sol-arena.o sol-fbp-graph.o sol-fbp-intern
 obj-libshared-$(INTERNAL_SHARED)   += sol-fbp-internal-scanner.o sol-util.o
 obj-libshared-$(INTERNAL_SHARED)   += sol-monitors.o sol-str-slice.o sol-str-table.o
 obj-libshared-$(INTERNAL_SHARED)   += sol-vector.o sol-json.o sol-buffer.o
-obj-libshared-$(INTERNAL_SHARED)   += sol-pwm-common.o sol-gpio-common.o
+obj-libshared-$(INTERNAL_SHARED)   += sol-gpio-common.o
 obj-libshared-$(INTERNAL_SHARED)   += sol-i2c-common.o
+
+ifeq (y,$(HARDWARE_PWM))
+obj-libshared-$(INTERNAL_SHARED)   += sol-pwm-common.o
+endif
 
 ifeq (y,$(RESOLVER_CONFFILE))
 obj-libshared-m += sol-fbp-parser.o
@@ -19,11 +23,18 @@ obj-libshared-m-extra-ldflags += $(GLIB_LDFLAGS)
 endif
 
 ifeq (y,$(PLATFORM_RIOTOS))
-obj-libshared-m += sol-gpio-riot.o sol-i2c-riot.o sol-pwm-riot.o
+ifeq (y,$(HARDWARE_PWM))
+obj-libshared-m += sol-pwm-riot.o
+endif
+
+obj-libshared-m += sol-gpio-riot.o sol-i2c-riot.o
 obj-libshared-m += sol-spi-riot.o sol-uart-riot.o sol-network-riot.o
 endif
 
 ifeq (y,$(SOL_PLATFORM_LINUX))
+ifeq (y,$(HARDWARE_PWM))
+obj-libshared-m += sol-pwm-linux.o
+endif
 obj-libshared-m += sol-file-reader.o sol-gpio-linux.o sol-network-linux.o
-obj-libshared-m += sol-pwm-linux.o sol-i2c-linux.o sol-spi-linux.o sol-uart-linux.o
+obj-libshared-m += sol-i2c-linux.o sol-spi-linux.o sol-uart-linux.o
 endif

--- a/src/shared/Makefile
+++ b/src/shared/Makefile
@@ -49,7 +49,9 @@ ifeq (y,$(HARDWARE_GPIO))
 obj-libshared-m += sol-gpio-riot.o
 endif
 
+ifeq (y,$(NETWORK))
 obj-libshared-m += sol-network-riot.o
+endif
 endif
 
 ifeq (y,$(SOL_PLATFORM_LINUX))
@@ -73,5 +75,9 @@ ifeq (y,$(HARDWARE_GPIO))
 obj-libshared-m += sol-gpio-linux.o
 endif
 
-obj-libshared-m += sol-file-reader.o sol-network-linux.o
+ifeq (y,$(NETWORK))
+obj-libshared-m += sol-network-linux.o
+endif
+
+obj-libshared-m += sol-file-reader.o
 endif

--- a/src/shared/Makefile
+++ b/src/shared/Makefile
@@ -5,7 +5,6 @@ obj-libshared-$(INTERNAL_SHARED)   := sol-arena.o sol-fbp-graph.o sol-fbp-intern
 obj-libshared-$(INTERNAL_SHARED)   += sol-fbp-internal-scanner.o sol-util.o
 obj-libshared-$(INTERNAL_SHARED)   += sol-monitors.o sol-str-slice.o sol-str-table.o
 obj-libshared-$(INTERNAL_SHARED)   += sol-vector.o sol-json.o sol-buffer.o
-obj-libshared-$(INTERNAL_SHARED)   += sol-gpio-common.o
 
 ifeq (y,$(HARDWARE_PWM))
 obj-libshared-$(INTERNAL_SHARED)   += sol-pwm-common.o
@@ -13,6 +12,10 @@ endif
 
 ifeq (y,$(HARDWARE_I2C))
 obj-libshared-$(INTERNAL_SHARED)   += sol-i2c-common.o
+endif
+
+ifeq (y,$(HARDWARE_GPIO))
+obj-libshared-$(INTERNAL_SHARED)   += sol-gpio-common.o
 endif
 
 ifeq (y,$(RESOLVER_CONFFILE))
@@ -42,7 +45,10 @@ ifeq (y,$(HARDWARE_I2C))
 obj-libshared-m += sol-i2c-riot.o
 endif
 
+ifeq (y,$(HARDWARE_GPIO))
 obj-libshared-m += sol-gpio-riot.o
+endif
+
 obj-libshared-m += sol-network-riot.o
 endif
 
@@ -63,5 +69,9 @@ ifeq (y,$(HARDWARE_I2C))
 obj-libshared-m += sol-i2c-linux.o
 endif
 
-obj-libshared-m += sol-file-reader.o sol-gpio-linux.o sol-network-linux.o
+ifeq (y,$(HARDWARE_GPIO))
+obj-libshared-m += sol-gpio-linux.o
+endif
+
+obj-libshared-m += sol-file-reader.o sol-network-linux.o
 endif

--- a/src/shared/Makefile
+++ b/src/shared/Makefile
@@ -6,10 +6,13 @@ obj-libshared-$(INTERNAL_SHARED)   += sol-fbp-internal-scanner.o sol-util.o
 obj-libshared-$(INTERNAL_SHARED)   += sol-monitors.o sol-str-slice.o sol-str-table.o
 obj-libshared-$(INTERNAL_SHARED)   += sol-vector.o sol-json.o sol-buffer.o
 obj-libshared-$(INTERNAL_SHARED)   += sol-gpio-common.o
-obj-libshared-$(INTERNAL_SHARED)   += sol-i2c-common.o
 
 ifeq (y,$(HARDWARE_PWM))
 obj-libshared-$(INTERNAL_SHARED)   += sol-pwm-common.o
+endif
+
+ifeq (y,$(HARDWARE_I2C))
+obj-libshared-$(INTERNAL_SHARED)   += sol-i2c-common.o
 endif
 
 ifeq (y,$(RESOLVER_CONFFILE))
@@ -35,7 +38,11 @@ ifeq (y,$(HARDWARE_UART))
 obj-libshared-m += sol-uart-riot.o
 endif
 
-obj-libshared-m += sol-gpio-riot.o sol-i2c-riot.o
+ifeq (y,$(HARDWARE_I2C))
+obj-libshared-m += sol-i2c-riot.o
+endif
+
+obj-libshared-m += sol-gpio-riot.o
 obj-libshared-m += sol-network-riot.o
 endif
 
@@ -52,6 +59,9 @@ ifeq (y,$(HARDWARE_UART))
 obj-libshared-m += sol-uart-linux.o
 endif
 
-obj-libshared-m += sol-file-reader.o sol-gpio-linux.o sol-network-linux.o
+ifeq (y,$(HARDWARE_I2C))
 obj-libshared-m += sol-i2c-linux.o
+endif
+
+obj-libshared-m += sol-file-reader.o sol-gpio-linux.o sol-network-linux.o
 endif

--- a/src/shared/Makefile
+++ b/src/shared/Makefile
@@ -31,8 +31,12 @@ ifeq (y,$(HARDWARE_SPI))
 obj-libshared-m += sol-spi-riot.o
 endif
 
+ifeq (y,$(HARDWARE_UART))
+obj-libshared-m += sol-uart-riot.o
+endif
+
 obj-libshared-m += sol-gpio-riot.o sol-i2c-riot.o
-obj-libshared-m += sol-uart-riot.o sol-network-riot.o
+obj-libshared-m += sol-network-riot.o
 endif
 
 ifeq (y,$(SOL_PLATFORM_LINUX))
@@ -44,6 +48,10 @@ ifeq (y,$(HARDWARE_SPI))
 obj-libshared-m += sol-spi-linux.o
 endif
 
+ifeq (y,$(HARDWARE_UART))
+obj-libshared-m += sol-uart-linux.o
+endif
+
 obj-libshared-m += sol-file-reader.o sol-gpio-linux.o sol-network-linux.o
-obj-libshared-m += sol-i2c-linux.o sol-uart-linux.o
+obj-libshared-m += sol-i2c-linux.o
 endif

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -12,7 +12,7 @@ test-test-fbp-scanner-$(TEST_FBP_SCANNER) := test.c test-fbp-scanner.c
 
 test-$(TEST_FLOW) += test-flow
 test-test-flow-$(TEST_FLOW) := test.c test-flow.c
-test-test-flow-$(TEST_FLOW)-deps := flow-node-type-timer.mod flow-node-type-pwm.mod flow-node-type-console.mod
+test-test-flow-$(TEST_FLOW)-deps := timer.mod pwm.mod console.mod
 
 test-$(TEST_FLOW_BUILDER) += test-flow-builder
 test-test-flow-builder-$(TEST_FLOW_BUILDER) := test.c test-flow-builder.c

--- a/src/test/test-flow.c
+++ b/src/test/test-flow.c
@@ -1125,13 +1125,17 @@ node_options_from_strv(void)
     const char *timer_strv[2] = { "interval=1000", NULL };
     const char *timer_irange_strv[2] = { "interval=50|20|60|2", NULL };
     const char *timer_irange_different_format_strv[2] = { "interval=val:100|min:10|max:200|step:5", NULL };
+#ifdef HARDWARE_PWM
     const char *pwm_strv[6] = { "chip=2", "pin=7", "enabled=true", "period=42", "duty_cycle=88", NULL };
+#endif
     const char *console_strv[4] = { "prefix=console prefix:", "suffix=. suffix!", "output_on_stdout=true", NULL };
     const char *timer_unknown_field_strv[2] = { "this_is_not_a_valid_field=100", NULL };
     const char *timer_wrongly_formatted_strv[2] = { "interval = 1000", NULL };
 
     struct sol_flow_node_type_timer_options *timer_opts;
+#ifdef HARDWARE_PWM
     struct sol_flow_node_type_pwm_options *pwm_opts;
+#endif
     struct sol_flow_node_type_console_options *console_opts;
     struct sol_flow_node_options *opts;
 
@@ -1142,6 +1146,7 @@ node_options_from_strv(void)
     ASSERT_INT_EQ(timer_opts->interval.val, 1000);
     sol_flow_node_options_del(SOL_FLOW_NODE_TYPE_TIMER, (struct sol_flow_node_options *)timer_opts);
 
+#ifdef HARDWARE_PWM
     /* Multiple options */
     pwm_opts = (struct sol_flow_node_type_pwm_options *)
                sol_flow_node_options_new_from_strv(SOL_FLOW_NODE_TYPE_PWM, pwm_strv);
@@ -1152,6 +1157,7 @@ node_options_from_strv(void)
     ASSERT_INT_EQ(pwm_opts->period.val, 42);
     ASSERT_INT_EQ(pwm_opts->duty_cycle.val, 88);
     sol_flow_node_options_del(SOL_FLOW_NODE_TYPE_PWM, (struct sol_flow_node_options *)pwm_opts);
+#endif
 
     /* String options */
     console_opts = (struct sol_flow_node_type_console_options *)


### PR DESCRIPTION
Some boards will not have all the hardware support we offer, with that we should have hardware options to disable our interface and build only what the board or OS supports. A clear example is RIOT on minnow-board which supports only gpio, in that case we should disable spi, pwm etc.

This patch also brings two other non related patches, 1 to fix the issue https://github.com/solettaproject/soletta/issues/119 and one fixes a build dependency for test-flow.