### PR TITLE
Build bring back cheat sheet v2

### DIFF
--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -357,7 +357,7 @@ endef
 
 cleanup-files := $(shell find $(top_srcdir)src/ -name '*.o' -o -name '*.so' -o -name '*.a')
 cleanup-files += $(shell find $(top_srcdir) -name '*.gcda' -o -name '*.gcno')
-cleanup-files += $(CLEANUP_GEN) $(kconfig-clean-objs) $(BUILDDIR)
+cleanup-files += $(CLEANUP_GEN) $(kconfig-clean-objs) $(BUILDDIR) $(CHEAT_SHEET_INDEX_HTML)
 
 clean:
 	$(foreach curr,$(wildcard $(cleanup-files)),$(call clean-resource,$(curr)))

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -47,7 +47,11 @@ endif
 PHONY += run-coverage coverage
 
 PRE_INSTALL := $(PC_GEN) $(SOL_LIB_SO) $(SOL_LIB_AR) $(bins-out) $(modules-out) $(all-mod-descs)
-PRE_INSTALL += $(FLOW_BUILTINS_DESC) $(NODE_TYPE_SCHEMA_DEST) $(PLATFORM_DETECT_DEST) $(GDB_AUTOLOAD_PY_DEST)
+PRE_INSTALL += $(NODE_TYPE_SCHEMA_DEST) $(PLATFORM_DETECT_DEST) $(GDB_AUTOLOAD_PY_DEST)
+
+ifneq (,$(builtin-flows))
+PRE_INSTALL += $(FLOW_BUILTINS_DESC)
+endif
 
 rpath-bins := $(subst $(build_sysroot)/,$(DESTDIR),$(bins-out))
 

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -79,3 +79,11 @@ post-install: pre-install $(all-rpath-bins)
 install: post-install
 
 PHONY += install post-install pre-install
+
+all-desc-jsons = $(all-mod-descs) $(if $(filter $(builtin-flows),$(builtin-flows)),$(FLOW_BUILTINS_DESC))
+
+cheat-sheet: $(CHEAT_SHEET_HTML_SCRIPT) $(CHEAT_SHEET_RESOURCES) $(all-desc-jsons)
+	$(Q)echo "     "GEN"   "$(CHEAT_SHEET_INDEX_HTML)
+	$(Q)$(CHEAT_SHEET_HTML_SCRIPT) $(CHEAT_SHEET_INDEX_HTML_IN) $(CHEAT_SHEET_INDEX_HTML) $(all-desc-jsons)
+
+PHONY += cheat-sheet

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -257,6 +257,16 @@ TEST_VALGRIND_SUPP := $(top_srcdir)src/test/test.supp
 TEST_FBP_SCRIPT := $(top_srcdir)src/test-fbp/run
 SOL_FBP_RUNNER_BIN := $(build_bindir)sol-fbp-runner
 
+CHEAT_SHEET_RESOURCES = \
+	$(wildcard doc/node-types-html/images/*.jpg) \
+	$(wildcard doc/node-types-html/js/*.js) \
+	$(CHEAT_SHEET_INDEX_HTML_IN) \
+	doc/node-types-html/styles.css
+
+CHEAT_SHEET_HTML_SCRIPT := $(SCRIPTDIR)sol-flow-node-type-gen-html.py
+CHEAT_SHEET_INDEX_HTML := doc/node-types-html/index.html
+CHEAT_SHEET_INDEX_HTML_IN := $(addprefix $(top_srcdir),$(addsuffix .in,$(CHEAT_SHEET_INDEX_HTML)))
+
 ## oic flow
 FLOW_OIC_GEN := $(flow-dir)oic/oic.json $(flow-dir)oic/oic.c
 FLOW_OIC_SPEC_DIR := $(top_srcdir)data/oic
@@ -284,5 +294,5 @@ LIB_COVERAGE_FLAGS := -fprofile-arcs -ftest-coverage
 BIN_COVERAGE_FLAGS := --coverage
 endif
 
-warning-targets = all check check-fbp check-valgrind check-fbp-valgrind coverage run-coverage pre-install post-install install: warning
+warning-targets = all check check-fbp check-valgrind check-fbp-valgrind coverage run-coverage pre-install post-install install cheat-sheet: warning
 


### PR DESCRIPTION
v2:
  + introduced a new path to conditionally install builtins.json (install only if we have external modules), this fixes the issue pointed out by @anselmolsm here: https://github.com/solettaproject/soletta/pull/168#issuecomment-117692764

We missed the cheat-sheet target, this patch brings it back.

Signed-off-by: Leandro Dorileo leandro.maciel.dorileo@intel.com