### PR TITLE
log: Fix exposing internal header for external users of node gen script

### DIFF
--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -417,7 +417,37 @@ def generate_header_tail(outfile, data):
     outfile.write("""
 #ifndef SOL_LOG_DOMAIN
 #define SOL_LOG_DOMAIN &_log_domain
-#include "sol-log-internal.h"
+#include "sol-log.h"
+
+#ifdef SOL_LOG_ENABLED
+#define SOL_LOG_INTERNAL_DECLARE(_var, _name) \
+    struct sol_log_domain _var = { \
+        .name = "sol-" _name, \
+        .color = SOL_LOG_COLOR_MAGENTA, \
+        .level = SOL_LOG_LEVEL_WARNING \
+    }
+
+#define SOL_LOG_INTERNAL_DECLARE_STATIC(_var, _name) \
+    static SOL_LOG_INTERNAL_DECLARE(_var, _name)
+
+#define SOL_LOG_INTERNAL_INIT_ONCE \
+    do { \
+        static bool _log_internal_init_once_first = true; \
+        if (_log_internal_init_once_first) { \
+            sol_log_domain_init_level(SOL_LOG_DOMAIN); \
+            _log_internal_init_once_first = false; \
+        } \
+    } while (0)
+#else
+#define SOL_LOG_INTERNAL_DECLARE(_var, _name)
+#define SOL_LOG_INTERNAL_DECLARE_STATIC(_var, _name)
+#define SOL_LOG_INTERNAL_INIT_ONCE
+#ifdef SOL_LOG_DOMAIN
+#undef SOL_LOG_DOMAIN
+#define SOL_LOG_DOMAIN NULL
+#endif // #ifdef SOL_LOG_DOMAIN
+#endif // #ifdef SOL_LOG_ENABLED
+
 SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, \"%(domain)s\");
 
 static void

--- a/src/lib/include/sol-log.h
+++ b/src/lib/include/sol-log.h
@@ -35,7 +35,6 @@
 #include "sol-common-buildopts.h"
 
 #include "sol-macros.h"
-#include "sol_config.h"
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdarg.h>

--- a/src/lib/include/sol-missing.h
+++ b/src/lib/include/sol-missing.h
@@ -32,8 +32,6 @@
 
 #pragma once
 
-#include "sol_config.h"
-
 #if !HAVE_DECL_STRNDUPA
 #include <alloca.h>
 

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -40,7 +40,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include "sol_config.h"
 #include "sol-util.h"
 #include "sol-str-slice.h"
 

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -131,7 +131,6 @@ BSDEPS += $(addprefix $(BSDIR),Makefile.kconfig Makefile.vars Makefile.rules)
 # flags and comp. helpers
 HEADERDIRS := $(addprefix $(top_srcdir),src/shared src/lib/common)
 HEADERDIRS += $(addprefix $(top_srcdir),src/lib/flow src/lib/coap/)
-HEADERDIRS += $(addprefix $(top_srcdir),src/lib/include)
 HEADERDIRS += $(addprefix $(top_srcdir),$(KCONFIG_INCLUDE)generated/)
 HEADERDIRS += $(build_includedir)
 


### PR DESCRIPTION
Also fix double inclusion of some headers that is exposed with this.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>