### PR TITLE
build: -gen.c should be generated inside build_stagedir

### DIFF
--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -29,11 +29,12 @@ all-gen-hdrs = $(foreach gen,$(all-gens),$($(gen)-hdr))
 gen-artifact = \
 	$(foreach json,$(filter %.json,$(2)), \
 		$(eval $(json)-hdr   := $(build_includedir)$(notdir $(subst .json,-gen.h,$(json)))) \
-		$(eval $(json)-src   := $(subst .json,-gen.c,$(json))) \
+		$(eval $(json)-src   := $(subst $(top_srcdir)src,$(build_stagedir),$(subst .json,-gen.c,$(json)))) \
 		$(eval all-gens      += $(json)) \
 		$(eval $(json)-desc  := $(build_descdir)$(1).json) \
 		$(eval all-mod-descs += $($(json)-desc)) \
 		$(eval $(1)-gens     += $(json)) \
+		$(eval $(1)-gen-cflags+= $(addprefix -I,$(dir $($(json)-src)))) \
 	) \
 
 parse-common-module = \
@@ -180,7 +181,7 @@ define make-object
 $(1): $(PRE_GEN) $($(1)-src) $(call find-deps,$(2)) $(find-gen-hdrs)
 	$(Q)echo "      "CC"   "$$@
 	$(Q)$(MKDIR) -p $(dir $(1))
-	$(Q)$(TARGETCC) $(LIB_CFLAGS) $($(1)-src) -c -o $(1) $(3) $(LIB_COVERAGE_FLAGS) $(sort $($(2)-cflags)) $(sort $($(2)-ldflags))
+	$(Q)$(TARGETCC) $(LIB_CFLAGS) $($(2)-gen-cflags) $($(1)-src) -c -o $(1) $(3) $(LIB_COVERAGE_FLAGS) $(sort $($(2)-cflags)) $(sort $($(2)-ldflags))
 endef
 $(foreach mod,$(modules), \
 	$(foreach obj,$($(mod)-objs),$(eval $(call make-object,$(obj),$(mod),$(external-module-flags)))) \
@@ -233,6 +234,7 @@ define make-gen
 $($(1)-hdr) $($(1)-src) $($(1)-desc): $(1) $(NODE_TYPE_GEN_SCRIPT)
 	$(Q)echo "     "GEN"   "$$@
 	$(Q)$(MKDIR) -p $(dir $($(1)-hdr))
+	$(Q)$(MKDIR) -p $(dir $($(1)-src))
 	$(Q)$(MKDIR) -p $(dir $($(1)-desc))
 	$(Q)$(PYTHON) $(NODE_TYPE_GEN_SCRIPT) --prefix=sol-flow-node-type \
 		--genspec-schema=$(NODE_TYPE_SCHEMA) $(1) $($(1)-hdr) $($(1)-src) $($(1)-desc)


### PR DESCRIPTION
v2:
   + properly adjust cflags to out of src generated code location - since it's #include'ed

As far as we understand (and suggested by Ivan) we should be generating
the -gen.c files inside build_stagedir not $(top_srcdir)/src/.../

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>