### PR TITLE
Kbuild v2

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -34,6 +34,14 @@
 	    ]
 	},
 	{
+	    "dependency": "sys_auxv_h",
+	    "type": "ccode",
+	    "headers": [
+		"<sys/auxv.h>"
+	    ],
+	    "fragment": "getauxval(AT_EXECFN);"
+	},
+	{
 	    "dependency": "pthread_h",
 	    "type": "ccode",
 	    "headers": [

--- a/src/lib/common/sol-pin-mux.c
+++ b/src/lib/common/sol-pin-mux.c
@@ -70,7 +70,7 @@ _load_mux(const char *name)
 #ifdef ENABLE_DYNAMIC_MODULES
     int r;
     void *handle;
-    char path[PATH_MAX], install_rootdir[PATH_MAX] = { NULL };
+    char path[PATH_MAX], install_rootdir[PATH_MAX] = { 0 };
     const struct sol_pin_mux *p_sym;
 
     r = sol_util_get_rootdir(install_rootdir, sizeof(install_rootdir));

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -342,7 +342,7 @@ get_progname(char *out, size_t size)
 int
 sol_util_get_rootdir(char *out, size_t size)
 {
-    char progname[PATH_MAX] = { NULL }, *substr, *prefix;
+    char progname[PATH_MAX] = { 0 }, *substr, *prefix;
     int r;
 
     r = get_progname(progname, sizeof(progname));

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -194,7 +194,7 @@ define make-mod-so
 $($(1)-out): $(SOL_LIB_SO) $(INT_LIB_AR) $(PRE_GEN) $($(1)-objs) $(call find-deps,$(1)) $($(1)-bs)
 	$(Q)echo "     "MOD"   "$$@
 	$(Q)$(MKDIR) -p $(dir $($(1)-out))
-	$(Q)$(TARGETCC) $($(1)-objs) -shared -o $($(1)-out) $(LIB_COVERAGE_FLAGS) $(sort $($(1)-cflags)) $(sort $($(1)-ldflags))
+	$(Q)$(TARGETCC) $($(1)-objs) -shared -o $($(1)-out) $(LIB_COVERAGE_FLAGS) $(sort $($(1)-cflags)) $(sort $($(1)-ldflags)) $(COMMON_CFLAGS)
 endef
 $(foreach curr,$(mod-so),$(eval $(call make-mod-so,$(curr))))
 
@@ -214,7 +214,7 @@ $(SOL_LIB_AR): $(PRE_GEN) $(all-objs)
 $(SOL_LIB_SO): $(PRE_GEN) $(SOL_LIB_AR) $(INT_LIB_AR) $(builtin-objs)
 	$(Q)echo "      "LD"   "$(@)
 	$(Q)$(MKDIR) -p $(dir $(SOL_LIB_SO))
-	$(Q)$(TARGETCC) $(builtin-objs) -shared -o $(@).$(VERSION) $(TARGET_LINKFLAGS) \
+	$(Q)$(TARGETCC) $(builtin-objs) -shared -o $(@).$(VERSION) $(TARGET_LINKFLAGS) $(COMMON_CFLAGS) \
 		$(LIB_COVERAGE_FLAGS) $(sort $(builtin-cflags)) $(sort $(builtin-ldflags))
 	$(Q)$(LN) -fs $(notdir $(@).$(VERSION)) $(@)
 


### PR DESCRIPTION
Changes from https://github.com/solettaproject/soletta/pull/164:

 * code fragment for getauxval on dependencies.json
 * readlink("/proc/self/exe", ...) used in the alternate path
 * no more missing.h

With these commits, we're finally able to cross-compile to the Galileo, with
```make CFLAGS="$CFLAGS --sysroot=/extra/galileo-sdk-ii/sysroots/i586-poky-linux-uclibc -m32 -march=i586" TOOLCHAIN_PREFIX="i586-poky-linux-uclibc-" {menuconfig,}``'