### PR TITLE
Make check-valgrind work again

### DIFF
--- a/data/scripts/suite.py
+++ b/data/scripts/suite.py
@@ -91,9 +91,6 @@ def run_valgrind_test(args):
     common_args = "--error-exitcode=1 --num-callers=30"
     valgrind_tools = {
         'memcheck': '--leak-check=full --show-reachable=no',
-        'helgrind': '--history-level=approx',
-        'drd': None,
-        'exp-sgcheck': None,
     }
 
     for k,v in valgrind_tools.items():
@@ -102,7 +99,7 @@ def run_valgrind_test(args):
         threads = []
 
         for i in args.tests.split():
-            cmd = "{valgrind} {test_path} {supp} --tool={tool} {tool_args} {common}". \
+            cmd = "{valgrind} {supp} --tool={tool} {tool_args} {common} {test_path}". \
                   format(valgrind=args.valgrind, test_path=i, supp=args.valgrind_supp, \
                          tool=k, tool_args=v, common=common_args)
             t = Thread(target=run_test_program, args=(cmd, i, stat, log,))

--- a/src/test/test.supp
+++ b/src/test/test.supp
@@ -3,15 +3,9 @@
    Memcheck:Leak
    match-leak-kinds: possible
    fun:calloc
-   fun:allocate_dtv
-   fun:_dl_allocate_tls
-   fun:pthread_create@@GLIBC_2.2.5
-   obj:/usr/lib/libglib-2.0.so.0.4200.1
-   obj:/usr/lib/libglib-2.0.so.0.4200.1
+   ...
    fun:g_thread_new
-   obj:/usr/lib/libglib-2.0.so.0.4200.1
-   obj:/usr/lib/libglib-2.0.so.0.4200.1
-   obj:/usr/lib/libglib-2.0.so.0.4200.1
+   ...
    fun:g_unix_signal_add_full
    fun:sol_mainloop_impl_init
 }

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -11,7 +11,7 @@ PHONY += check-fbp
 ifeq (y,$(HAVE_VALGRIND))
 check-valgrind: $(SOL_LIB_SO) $(SOL_LIB_AR) $(tests-out)
 	$(Q)$(PYTHON) $(TEST_SUITE_RUN_SCRIPT) --tests="$(tests-out)" \
-		--valgrind=$(VALGRIND) --valgrind-supp=$(abpath $(TEST_VALGRIND_SUPP))
+		--valgrind=$(VALGRIND) --valgrind-supp=$(abspath $(TEST_VALGRIND_SUPP))
 
 check-fbp-valgrind: $(SOL_LIB_SO) $(SOL_LIB_AR) $(bins-out) $(modules-out)
 	$(Q)SOL_FBP_RUNNER_BIN="$(abspath $(SOL_FBP_RUNNER_BIN))" \


### PR DESCRIPTION
Fixes some small typos, make the suppression file more flexible so not
depend on specific versions of the library, keep only memcheck tool for
now -- we don't really try to pass on the others. We can readd them
later.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>