### PR TITLE
build: check for required dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,14 @@ include $(top_srcdir)tools/build/Makefile.rules
 # kconfig interface rules
 include $(top_srcdir)tools/build/Makefile.kconfig
 
+ifneq (,$(NOT_FOUND))
+warning:
+	$(Q)echo -e "The following dependencies were not met:\n"
+	$(Q)echo -e $(NOT_FOUND)
+	$(Q)echo -e "If you've just installed it, run: make reconf"
+	$(Q)echo -e "For more information/options, run: make help"
+$(warning-targets)
+else
 ifeq (n,$(HAVE_DEPENDENCY_FILES))
 PRE_GEN += $(DEPENDENCY_FILES)
 endif
@@ -33,16 +41,11 @@ warning:
 	$(Q)echo "For more information/options run: make help"
 $(warning-targets)
 else
-ifeq (n,$(HAVE_PYTHON_JSONSCHEMA))
-warning:
-	$(Q)echo "Cannot proceed, python module \"jsonschema\" was not found in your system..."
-	$(Q)echo "If you've just installed it, run: make reconf"
-$(warning-targets)
-else
 all: $(PRE_GEN) $(SOL_LIB_SO) $(SOL_LIB_AR) $(bins-out) $(modules-out)
 include $(top_srcdir)tools/build/Makefile.targets
-endif # HAVE_PYTHON_JSONSCHEMA
 endif # HAVE_KCONFIG_CONFIG
+endif # NOT_FOUND
 
 .DEFAULT_GOAL = all
 .PHONY = $(PHONY) all
+

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -126,12 +126,14 @@
 	{
 	    "dependency": "chrpath",
 	    "type": "exec",
-	    "exec": "chrpath"
+	    "exec": "chrpath",
+            "required": "true"
 	},
 	{
 	    "dependency": "jsonschema",
 	    "type": "python",
-	    "pkgname": "jsonschema"
+	    "pkgname": "jsonschema",
+            "required": "true"
 	}
     ]
 }

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -218,10 +218,10 @@ $(SOL_LIB_SO): $(PRE_GEN) $(SOL_LIB_AR) $(INT_LIB_AR) $(builtin-objs)
 		$(LIB_COVERAGE_FLAGS) $(sort $(builtin-cflags)) $(sort $(builtin-ldflags))
 	$(Q)$(LN) -fs $(notdir $(@).$(VERSION)) $(@)
 
-$(DEPENDENCY_FILES): $(DEPENDENCY_SCRIPT)
+$(DEPENDENCY_FILES): $(DEPENDENCY_SCRIPT) $(DEPENDENCY_SPEC)
 	$(Q)$(PYTHON) $(DEPENDENCY_SCRIPT) --compiler=$(TARGETCC) --cflags="$(CFLAGS)"
 
-reconf: $(DEPENDENCY_SCRIPT)
+reconf: $(DEPENDENCY_SCRIPT) $(DEPENDENCY_SPEC)
 	$(Q)echo "[re]running dependency-resolver..."
 	$(Q)$(RM) -f $(DEPENDENCY_FILES)
 	$(Q)$(PYTHON) $(DEPENDENCY_SCRIPT) --compiler=$(TARGETCC) --cflags="$(CFLAGS)"

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -121,6 +121,7 @@ SUBDIRS := $(addprefix $(top_srcdir)src/lib/,common coap flow) $(top_srcdir)src/
 SUBDIRS := $(dir $(filter-out $(SUBDIRS),$(shell find $(top_srcdir)src/ -name 'Makefile')))
 
 DEPENDENCY_FILES := Makefile.gen Kconfig.gen
+DEPENDENCY_SPEC := $(top_srcdir)data/jsons/dependencies.json
 DEPENDENCY_SCRIPT := $(SCRIPTDIR)dependency-resolver.py
 HAVE_DEPENDENCY_FILES := $(if $(filter-out $(wildcard $(DEPENDENCY_FILES)),$(DEPENDENCY_FILES)),n,y)
 BSDIR := $(top_srcdir)tools/build/


### PR DESCRIPTION
This patch introduces the required dependencies to dependency-resolver,
so we can check and quit if no such deps are found.

A common use case for this is the absence of chrpath tool and the
users - "silently" - failing to run make install.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>