### PR TITLE
modules: initialize the data for packets sent by generators

### DIFF
--- a/src/modules/flow/test/float-generator.c
+++ b/src/modules/flow/test/float-generator.c
@@ -47,7 +47,7 @@ timer_tick(void *data)
 {
     struct sol_flow_node *node = data;
     struct float_generator_data *mdata = sol_flow_node_get_private_data(node);
-    struct sol_drange output;
+    struct sol_drange output = { };
     double *val;
 
     val = sol_vector_get(&mdata->values, mdata->next_index);

--- a/src/modules/flow/test/int-generator.c
+++ b/src/modules/flow/test/int-generator.c
@@ -48,7 +48,7 @@ timer_tick(void *data)
 {
     struct sol_flow_node *node = data;
     struct int_generator_data *mdata = sol_flow_node_get_private_data(node);
-    struct sol_irange output;
+    struct sol_irange output = { };
     int32_t *val;
 
     val = sol_vector_get(&mdata->values, mdata->next_index);


### PR DESCRIPTION
Fields other than 'val' in {int,float}-generator output were not
initialized, so the packet would contain unitialized data. When another
node used that packet and extracted data from there, it could read
garbage.

This error was flagged by 'make check-fbp-valgrind' in the tests for
filter-repeated.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>