### PR TITLE
sol-flow-builder: Add a check for port description

### DIFF
--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -1055,6 +1055,7 @@ export_port(struct sol_flow_builder *builder, uint16_t node, uint16_t port,
     desc_len = sol_ptr_vector_get_len(desc_vector);
     if (desc_len) {
         port_desc = sol_ptr_vector_get(desc_vector, desc_len - 1);
+        SOL_NULL_CHECK_GOTO(port_desc, error_desc);
         base_port_idx = port_desc->base_port_idx + ((port_desc->array_size) ? : 1);
     }
 


### PR DESCRIPTION
Issue pointed out by KW.

Avoids a possible NULL pointer dereference in the following line.

Signed-off-by: Anselmo L. S. Melo <anselmo.melo@intel.com>