### PR TITLE
builtins.json: we should generate it on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ warning:
 	$(Q)echo "If you've just installed it, run: make reconf"
 $(warning-targets)
 else
-all: $(PRE_GEN) $(SOL_LIB_SO) $(SOL_LIB_AR) $(bins-out) $(modules-out)
 include $(top_srcdir)tools/build/Makefile.targets
+all: $(PRE_GEN) $(SOL_LIB_SO) $(SOL_LIB_AR) $(bins-out) $(modules-out)
 endif # HAVE_PYTHON_JSONSCHEMA
 endif # HAVE_KCONFIG_CONFIG
 

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -50,7 +50,7 @@ PRE_INSTALL := $(PC_GEN) $(SOL_LIB_SO) $(SOL_LIB_AR) $(bins-out) $(modules-out) 
 PRE_INSTALL += $(NODE_TYPE_SCHEMA_DEST) $(PLATFORM_DETECT_DEST) $(GDB_AUTOLOAD_PY_DEST)
 
 ifneq (,$(builtin-flows))
-PRE_INSTALL += $(FLOW_BUILTINS_DESC)
+PRE_GEN += $(FLOW_BUILTINS_DESC)
 endif
 
 rpath-bins := $(subst $(build_sysroot)/,$(DESTDIR),$(bins-out))


### PR DESCRIPTION
The builtins.json file was being generated only on install target,
we must generate it while building.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>