### PR TITLE
build: Reduce eh_frame section size

### DIFF
--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -186,6 +186,9 @@ COMMON_CFLAGS += -DLINUXMICROMODULESDIR=\"$(MODULESDIR)/linux-micro/\"
 COMMON_CFLAGS += -DDATADIR=\"$(SOL_DATADIR)\"
 COMMON_CFLAGS += $(addprefix -I,$(HEADERDIRS))
 
+## Reduce .eh_frame size.
+COMMON_CFLAGS += -fno-asynchronous-unwind-tables
+
 TEST_CFLAGS := $(CHECK_CFLAGS)
 
 LIB_CFLAGS := $(COMMON_CFLAGS)


### PR DESCRIPTION
This section is based on the DWARF format's call frame information (CFI) [1]
and holds information that can be useful for debuggers but also for language
constructs that relies on always having stack unwinding information (i.e. exceptions).
Such constructs, however, are pretty much useless for the C language and are
mainly just used on C++. Furthermore, this section can not be removed by 'strip'
since it is one of the loadable sections of a binary.

When .eh_frame doesn't exist, debuggers can still get the exact same information
they need for unwinding a stack frame and for restoring registers thanks to yet
another section: .debug_frame. This section, however, is 'strippable'. It is
generated by gcc's '-g' options family.

For Soletta, all we need is the debug information we can get from .debug_frame,
so we can clean up eh_frame and rely on debug_frame for debugging. This is done
through gcc's "-fno-asynchronous-unwind-tables" option. The .eh_frame section
stays around but the code size code is heavily reduced.

This is the same approach taken on other C based projects that target small
code size generation [2] [3].

For testing, Soletta was configured and built with:
> make allyesconfig && make -j5

Before patch:
> size -t build/soletta_sysroot/usr/lib/libsoletta.a | tail -n1
 596580  153412     915  750907   b753b (TOTALS)

After patch:
> size -t build/soletta_sysroot/usr/lib/libsoletta.a | tail -n1
 501844  153412     915  656171   a032b (TOTALS)

The first column is .text size. There was a reduction of 94736 bytes.

[1] http://comments.gmane.org/gmane.comp.standards.dwarf/222
[2] https://github.com/gfto/toybox/commit/0d74ad383b8bb8aa82e9cb6449b509ec6d4794a5
[3] http://git.musl-libc.org/cgit/musl/commit/?id=b439c051c7eee4eb4b93fc382f993aa6305ce530

Signed-off-by: Jesus Sanchez-Palencia <jesus.sanchez-palencia@intel.com>