### PR TITLE
build config: Change default log level

### DIFF
--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -60,7 +60,7 @@ config LOG
 
 choice
 	prompt "Maximum allowed log level"
-	default DEFAULT_LOG_LEVEL_ERROR
+	default DEFAULT_LOG_LEVEL_WARNING
 	depends on LOG
 	help
           Maximum log level that will be allowed.


### PR DESCRIPTION
The default log level was set to be ERROR, but it should
be WARNING.

Signed-off-by: Anselmo L. S. Melo <anselmo.melo@intel.com>