### PR TITLE
lib/io: set gpio and pwm config api version on usage

### DIFF
--- a/src/lib/common/sol-pin-mux.c
+++ b/src/lib/common/sol-pin-mux.c
@@ -180,6 +180,7 @@ _set_gpio(int pin, enum sol_gpio_direction dir, int drive, bool val)
     const char *drive_str;
     struct sol_gpio_config gpio_config = { 0 };
 
+    gpio_config.api_version = SOL_GPIO_CONFIG_API_VERSION;
     gpio_config.dir = dir;
     gpio_config.out.value = val;
 

--- a/src/modules/flow/calamari/calamari.c
+++ b/src/modules/flow/calamari/calamari.c
@@ -312,6 +312,7 @@ calamari_led_open(struct sol_flow_node *node, void *data, const struct sol_flow_
     mdata->val = opts->range;
     mdata->node = node;
 
+    pwm_config.api_version = SOL_PWM_CONFIG_API_VERSION;
     pwm_config.period_ns = mdata->period;
     pwm_config.duty_cycle_ns = 0;
     pwm_config.enabled = true;

--- a/src/modules/flow/gpio/gpio.c
+++ b/src/modules/flow/gpio/gpio.c
@@ -82,6 +82,7 @@ gpio_reader_open(struct sol_flow_node *node, void *data, const struct sol_flow_n
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_GPIO_READER_OPTIONS_API_VERSION, -EINVAL);
 
+    gpio_conf.api_version = SOL_GPIO_CONFIG_API_VERSION;
     gpio_conf.dir = SOL_GPIO_DIR_IN;
     gpio_conf.active_low = opts->active_low;
     gpio_conf.in.trigger_mode = mode_lut[opts->edge_rising + 2 * opts->edge_falling];
@@ -127,6 +128,7 @@ gpio_writer_open(struct sol_flow_node *node, void *data, const struct sol_flow_n
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_GPIO_WRITER_OPTIONS_API_VERSION, -EINVAL);
 
+    gpio_conf.api_version = SOL_GPIO_CONFIG_API_VERSION;
     gpio_conf.dir = SOL_GPIO_DIR_OUT;
     gpio_conf.active_low = opts->active_low;
 

--- a/src/modules/flow/piezo-speaker/piezo-speaker.c
+++ b/src/modules/flow/piezo-speaker/piezo-speaker.c
@@ -394,6 +394,7 @@ piezo_speaker_open(struct sol_flow_node *node,
         (const struct sol_flow_node_type_piezo_speaker_sound_options *)options;
     struct sol_pwm_config pwm_config = { 0 };
 
+    pwm_config.api_version = SOL_PWM_CONFIG_API_VERSION;
     pwm_config.period_ns = -1;
     pwm_config.duty_cycle_ns = 0;
 

--- a/src/modules/flow/pwm/pwm.c
+++ b/src/modules/flow/pwm/pwm.c
@@ -110,6 +110,7 @@ pwm_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_opti
         return -EINVAL;
     }
 
+    pwm_config.api_version = SOL_PWM_CONFIG_API_VERSION;
     pwm_config.period_ns = opts->period.val;
     pwm_config.duty_cycle_ns = opts->duty_cycle.val;
     if (opts->inversed_polarity)

--- a/src/modules/flow/servo-motor/servo-motor.c
+++ b/src/modules/flow/servo-motor/servo-motor.c
@@ -66,6 +66,7 @@ servo_motor_open(struct sol_flow_node *node, void *data, const struct sol_flow_n
     mdata->duty_cycle_diff = mdata->duty_cycle_range.max -
                              mdata->duty_cycle_range.min;
 
+    pwm_config.api_version = SOL_PWM_CONFIG_API_VERSION;
     pwm_config.period_ns = opts->period.val * 1000;
     pwm_config.duty_cycle_ns = 0;
 

--- a/src/samples/common/linux-micro-init.c
+++ b/src/samples/common/linux-micro-init.c
@@ -166,6 +166,7 @@ startup(void)
 
     if (pin >= 0) {
         struct sol_gpio_config cfg = {
+            .api_version = SOL_GPIO_CONFIG_API_VERSION,
             .dir = SOL_GPIO_DIR_OUT,
         };
         gpio = sol_gpio_open(pin, &cfg);


### PR DESCRIPTION
They were set to 0 instead of current version.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>