### PR TITLE
Fix samples that should be using array ports

### DIFF
--- a/src/samples/flow/galileo-grove-kit/grove-temperature-sensor.fbp
+++ b/src/samples/flow/galileo-grove-kit/grove-temperature-sensor.fbp
@@ -38,5 +38,5 @@
 const_celsius_symbol(constant/string:value= C)
 
 temperatureSensor(TemperatureSensor) CELSIUS -> IN converter(converter/float-to-string)
-converter OUT -> IN0 concat(string/concatenate)
-const_celsius_symbol OUT -> IN1 concat OUT -> IN screen(LCDString)
+converter OUT -> IN[0] concat(string/concatenate)
+const_celsius_symbol OUT -> IN[1] concat OUT -> IN screen(LCDString)

--- a/src/samples/flow/misc/tickets_queue.fbp
+++ b/src/samples/flow/misc/tickets_queue.fbp
@@ -68,18 +68,18 @@ CallNorm(boolean/and)
 CallNormTicket(int/accumulator:setup_value=0|0)
 CallNormPrinter(console)
 
-CashierBt OUT -> IN0 CallPref
-PrefLess OUT -> IN1 CallPref
+CashierBt OUT -> IN[0] CallPref
+PrefLess OUT -> IN[1] CallPref
 
 CallPref OUT -> IN _(boolean/filter) TRUE -> INC CallPrefTicket
 CallPrefTicket OUT -> IN0 PrefLess
 CallPrefTicket OUT -> IN CallPrefPrinter
 
-CashierBt OUT -> IN0 CouldCallNorm
-PrefLess OUT -> IN _(boolean/not) OUT -> IN1 CouldCallNorm
+CashierBt OUT -> IN[0] CouldCallNorm
+PrefLess OUT -> IN _(boolean/not) OUT -> IN[1] CouldCallNorm
 
-CouldCallNorm OUT -> IN0 CallNorm
-NormLess OUT -> IN1 CallNorm
+CouldCallNorm OUT -> IN[0] CallNorm
+NormLess OUT -> IN[1] CallNorm
 
 CallNorm OUT -> IN _(boolean/filter) TRUE -> INC CallNormTicket
 CallNormTicket OUT -> IN0 NormLess


### PR DESCRIPTION
Fix samples that use boolean/* and string/* node types. Update their code to use array ports.