### PR TITLE
Fix builds without log.

### DIFF
--- a/src/bin/sol-fbp-to-dot/main.c
+++ b/src/bin/sol-fbp-to-dot/main.c
@@ -35,12 +35,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define SOL_LOG_DOMAIN &_log_domain
+#include "sol-log-internal.h"
+
 #include "sol-fbp.h"
 #include "sol-file-reader.h"
 #include "sol-flow-builder.h"
 #include "sol-flow-internal.h"
 #include "sol-flow.h"
-#include "sol-log-internal.h"
 #include "sol-mainloop.h"
 #include "sol-str-slice.h"
 #include "sol-str-table.h"
@@ -305,7 +307,7 @@ main(int argc, char *argv[])
     struct sol_fbp_graph input_graph;
 
     sol_init();
-    sol_log_domain_init_level(&_log_domain);
+    SOL_LOG_INTERNAL_INIT_ONCE;
 
     if (argc == 1) {
         goto usage_error;

--- a/src/bin/sol-flow-node-types/main.c
+++ b/src/bin/sol-flow-node-types/main.c
@@ -37,8 +37,9 @@
 #include <dlfcn.h>
 
 #define SOL_LOG_DOMAIN &_log_domain
-#include "sol-mainloop.h"
 #include "sol-log-internal.h"
+
+#include "sol-mainloop.h"
 #include "sol-flow.h"
 #include "sol-flow-internal.h"
 #include "sol-util.h"
@@ -335,7 +336,7 @@ main(int argc, char *argv[])
     if (sol_init() < 0)
         goto end;
 
-    sol_log_domain_init_level(&_log_domain);
+    SOL_LOG_INTERNAL_INIT_ONCE;
 
     fputs("{\n", stdout);
 

--- a/src/lib/common/Makefile
+++ b/src/lib/common/Makefile
@@ -1,12 +1,18 @@
 obj-$(CORE) += core.mod
 
 obj-core-$(CORE) := \
-    sol-log.o \
     sol-blob.o \
     sol-mainloop.o \
     sol-platform.o \
     sol-types.o \
     sol-platform-detect.o
+
+ifeq (y,$(LOG))
+obj-core-$(CORE) += \
+    sol-log.o
+obj-core-$(SOL_PLATFORM_LINUX) += \
+    sol-log-impl-linux.o
+endif
 
 obj-core-$(KDBUS) += \
     sol-bus.o
@@ -35,8 +41,7 @@ obj-core-$(PLATFORM_DUMMY) += \
     sol-platform-impl-dummy.o
 
 obj-core-$(SOL_PLATFORM_LINUX) += \
-    sol-platform-linux-common.o \
-    sol-log-impl-linux.o
+    sol-platform-linux-common.o
 obj-core-$(SOL_PLATFORM_LINUX)-extra-cflags += $(SYSTEMD_CFLAGS)
 obj-core-$(SOL_PLATFORM_LINUX)-extra-ldflags += $(SYSTEMD_LDFLAGS)
 

--- a/src/lib/common/sol-platform-detect.c
+++ b/src/lib/common/sol-platform-detect.c
@@ -37,7 +37,7 @@
 
 #define SOL_LOG_DOMAIN &_log_domain
 #include "sol-log-internal.h"
-static SOL_LOG_INTERNAL_DECLARE(_log_domain, "platform-detect");
+SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "platform-detect");
 
 #include "sol-file-reader.h"
 #include "sol-json.h"

--- a/src/shared/sol-fbp-internal-log.c
+++ b/src/shared/sol-fbp-internal-log.c
@@ -36,19 +36,14 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include "sol-log-internal.h"
+#define SOL_LOG_DOMAIN &sol_fbp_log_domain
 #include "sol-fbp-internal-log.h"
-#include "sol-util.h"
-
 SOL_LOG_INTERNAL_DECLARE(sol_fbp_log_domain, "fbp");
+
+#include "sol-util.h"
 
 void
 sol_fbp_init_log_domain(void)
 {
-    static bool done = false;
-
-    if (done)
-        return;
-    sol_log_domain_init_level(&sol_fbp_log_domain);
-    done = true;
+    SOL_LOG_INTERNAL_INIT_ONCE;
 }

--- a/src/shared/sol-fbp-internal-log.h
+++ b/src/shared/sol-fbp-internal-log.h
@@ -32,10 +32,9 @@
 
 #pragma once
 
-#include "sol-log.h"
-
 extern struct sol_log_domain sol_fbp_log_domain;
 void sol_fbp_init_log_domain(void);
 
 #undef SOL_LOG_DOMAIN
 #define SOL_LOG_DOMAIN &sol_fbp_log_domain
+#include "sol-log-internal.h"


### PR DESCRIPTION
If we disable logs, then we shouldn't compile sol-log.c or
sol-log-impl-*.c and we better not declare the log domain structure at
all, neither call the functions to touch it.

Signed-off-by: Gustavo Sverzut Barbieri gustavo.barbieri@intel.com