### PR TITLE
build: fix oic generator race condition

### DIFF
--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -290,7 +290,7 @@ FLOW_OIC_SPEC_DIR := $(top_srcdir)data/oic
 PC_GEN := $(build_pcdir)soletta.pc
 PC_GEN_IN := $(top_srcdir)pc/soletta.pc.in
 
-PRE_GEN := $(FLOW_OIC_GEN) $(HEADER_GEN) $(KCONFIG_AUTOHEADER) $(KCONFIG_CONFIG) $(BSDEPS)
+PRE_GEN := $(HEADER_GEN) $(KCONFIG_AUTOHEADER) $(KCONFIG_CONFIG) $(BSDEPS)
 PRE_GEN += $(NODE_TYPE_GEN_SCRIPT)
 
 CLEANUP_GEN := $(FLOW_OIC_GEN) $(HEADER_GEN)


### PR DESCRIPTION
The oic generator targets were in race condition since it's a pre
generation dependency and the modules' itself. Both could have their
execution in clash and break the oic module's source code generation;

This patch removes the pre generation condition and leave it up to
the module to directly depend on it and require its generation up
to their build conditioning.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>