### PR TITLE
code style: fix an old demand of indenting continuation lines properly

### DIFF
--- a/data/schemas/uncrustify.schema
+++ b/data/schemas/uncrustify.schema
@@ -5,6 +5,7 @@
 output_tab_size               = 4 # new tab size
 
 indent_columns                = output_tab_size
+indent_continue               = output_tab_size
 indent_func_call_param        = true # function call parameters one indent level
 indent_func_def_param         = true # function def parameters one indent level
 indent_func_proto_param       = true # function proto parameters one indent level

--- a/src/bin/sol-fbp-runner/main.c
+++ b/src/bin/sol-fbp-runner/main.c
@@ -78,7 +78,7 @@ parse_args(int argc, char *argv[])
     int opt;
     const char known_opts[] = "chs"
 #ifdef SOL_FLOW_INSPECTOR_ENABLED
-                              "D"
+        "D"
 #endif
     ;
 

--- a/src/lib/coap/sol-coap.c
+++ b/src/lib/coap/sol-coap.c
@@ -301,7 +301,7 @@ sol_coap_uri_path_to_buf(const struct sol_str_slice path[],
 }
 
 static int(*find_resource_cb(const struct sol_coap_packet *req,
-        const struct sol_coap_resource *resource)) (
+    const struct sol_coap_resource *resource)) (
     const struct sol_coap_resource *resource,
     struct sol_coap_packet *req,
     const struct sol_network_link_addr *cliaddr, void *data){
@@ -544,8 +544,8 @@ SOL_API int
 sol_coap_send_packet_with_reply(struct sol_coap_server *server, struct sol_coap_packet *pkt,
     const struct sol_network_link_addr *cliaddr,
     int (*reply_cb)(struct sol_coap_packet *req,
-        const struct sol_network_link_addr *cliaddr,
-        void *data),
+    const struct sol_network_link_addr *cliaddr,
+    void *data),
     void *data)
 {
     struct sol_coap_option_value option = {};

--- a/src/lib/coap/sol-coap.h
+++ b/src/lib/coap/sol-coap.h
@@ -179,7 +179,7 @@ int sol_coap_send_packet(struct sol_coap_server *server, struct sol_coap_packet 
 int sol_coap_send_packet_with_reply(struct sol_coap_server *server, struct sol_coap_packet *pkt,
     const struct sol_network_link_addr *cliaddr,
     int (*reply_cb)(struct sol_coap_packet *req,
-        const struct sol_network_link_addr *cliaddr, void *data),
+    const struct sol_network_link_addr *cliaddr, void *data),
     void *data);
 
 int sol_coap_packet_send_notification(struct sol_coap_server *server,

--- a/src/lib/coap/sol-oic-client.c
+++ b/src/lib/coap/sol-oic-client.c
@@ -277,8 +277,8 @@ SOL_API bool
 sol_oic_client_find_resource(struct sol_oic_client *client,
     struct sol_network_link_addr *cliaddr, const char *resource_type,
     void (*resource_found_cb)(struct sol_oic_client *cli,
-        struct sol_oic_resource *res,
-        void *data),
+    struct sol_oic_resource *res,
+    void *data),
     void *data)
 {
     static const char oc_core_uri[] = "/oc/core";
@@ -396,7 +396,7 @@ static bool
 _resource_request(struct sol_oic_client *client, struct sol_oic_resource *res,
     sol_coap_method_t method, uint8_t *payload, size_t payload_len,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-        const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data),
+    const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data),
     void *data, bool observe)
 {
     int (*cb)(struct sol_coap_packet *req, const struct sol_network_link_addr *cliaddr, void *data);
@@ -470,7 +470,7 @@ SOL_API bool
 sol_oic_client_resource_request(struct sol_oic_client *client, struct sol_oic_resource *res,
     sol_coap_method_t method, uint8_t *payload, size_t payload_len,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-        const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data),
+    const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data),
     void *data)
 {
     return _resource_request(client, res, method, payload, payload_len, callback, data, false);
@@ -498,7 +498,7 @@ _poll_resource(void *data)
 static bool
 _observe_with_polling(struct sol_oic_client *client, struct sol_oic_resource *res,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-        const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data),
+    const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data),
     void *data)
 {
     struct resource_request_ctx *ctx = sol_util_memdup(&(struct resource_request_ctx) {
@@ -539,7 +539,7 @@ _stop_observing_with_polling(struct sol_oic_resource *res)
 SOL_API bool
 sol_oic_client_resource_set_observable(struct sol_oic_client *client, struct sol_oic_resource *res,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-        const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data),
+    const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data),
     void *data, bool observe)
 {
     SOL_NULL_CHECK(client, false);

--- a/src/lib/coap/sol-oic-client.h
+++ b/src/lib/coap/sol-oic-client.h
@@ -59,19 +59,19 @@ struct sol_oic_resource {
 bool sol_oic_client_find_resource(struct sol_oic_client *client,
     struct sol_network_link_addr *cliaddr, const char *resource_type,
     void (*resource_found_cb)(struct sol_oic_client *cli,
-        struct sol_oic_resource *res,
-        void *data),
+    struct sol_oic_resource *res,
+    void *data),
     void *data);
 
 bool sol_oic_client_resource_request(struct sol_oic_client *client, struct sol_oic_resource *res,
     sol_coap_method_t method, uint8_t *payload, size_t payload_len,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-        const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data),
+    const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data),
     void *data);
 
 bool sol_oic_client_resource_set_observable(struct sol_oic_client *client, struct sol_oic_resource *res,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-        const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data),
+    const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data),
     void *data, bool observe);
 
 struct sol_oic_resource *sol_oic_resource_ref(struct sol_oic_resource *r);

--- a/src/lib/coap/sol-oic-server.c
+++ b/src/lib/coap/sol-oic-server.c
@@ -681,7 +681,7 @@ out:
 static int
 _sol_oic_resource_type_handle(
     sol_coap_responsecode_t (*handle_fn)(const struct sol_network_link_addr *cliaddr, const void *data,
-        uint8_t *payload, uint16_t *payload_len),
+    uint8_t *payload, uint16_t *payload_len),
     struct sol_coap_packet *req, const struct sol_network_link_addr *cliaddr,
     struct resource_type_data *res, bool expect_payload)
 {

--- a/src/lib/common/include/sol-log.h
+++ b/src/lib/common/include/sol-log.h
@@ -85,27 +85,27 @@ extern "C" {
     __builtin_types_compatible_p(typeof(var), int),                \
     "" # var " (%d) " # exp,                                       \
     __builtin_choose_expr(                                             \
-        __builtin_types_compatible_p(typeof(var), long),               \
-        "" # var " (%ld) " # exp,                                      \
-        __builtin_choose_expr(                                             \
-            __builtin_types_compatible_p(typeof(var), size_t),             \
-            "" # var " (%zu) " # exp,                                      \
-            __builtin_choose_expr(                                             \
-                __builtin_types_compatible_p(typeof(var), unsigned),           \
-                "" # var " (%u) " # exp,                                       \
-                __builtin_choose_expr(                                             \
-                    __builtin_types_compatible_p(typeof(var), uint64_t),           \
-                    "" # var " (%" PRIu64 ") " # exp,                              \
-                    __builtin_choose_expr(                                             \
-                        __builtin_types_compatible_p(typeof(var), uint32_t),           \
-                        "" # var " (%" PRIu32 ") " # exp,                              \
-                        __builtin_choose_expr(                                             \
-                            __builtin_types_compatible_p(typeof(var), uint16_t),           \
-                            "" # var " (%" PRIu16 ") " # exp,                              \
-                            __builtin_choose_expr(                                             \
-                                __builtin_types_compatible_p(typeof(var), uint8_t),            \
-                                "" # var " (%" PRIu8 ") " # exp,                               \
-                                (void)0))))))))
+    __builtin_types_compatible_p(typeof(var), long),               \
+    "" # var " (%ld) " # exp,                                      \
+    __builtin_choose_expr(                                             \
+    __builtin_types_compatible_p(typeof(var), size_t),             \
+    "" # var " (%zu) " # exp,                                      \
+    __builtin_choose_expr(                                             \
+    __builtin_types_compatible_p(typeof(var), unsigned),           \
+    "" # var " (%u) " # exp,                                       \
+    __builtin_choose_expr(                                             \
+    __builtin_types_compatible_p(typeof(var), uint64_t),           \
+    "" # var " (%" PRIu64 ") " # exp,                              \
+    __builtin_choose_expr(                                             \
+    __builtin_types_compatible_p(typeof(var), uint32_t),           \
+    "" # var " (%" PRIu32 ") " # exp,                              \
+    __builtin_choose_expr(                                             \
+    __builtin_types_compatible_p(typeof(var), uint16_t),           \
+    "" # var " (%" PRIu16 ") " # exp,                              \
+    __builtin_choose_expr(                                             \
+    __builtin_types_compatible_p(typeof(var), uint8_t),            \
+    "" # var " (%" PRIu8 ") " # exp,                               \
+    (void)0))))))))
 
 #define SOL_INT_CHECK(var, exp, ...)                     \
     do {                                                \

--- a/src/lib/common/include/sol-missing.h
+++ b/src/lib/common/include/sol-missing.h
@@ -37,11 +37,11 @@
 
 #define __strndupa_internal__(str_, len_, var_)       \
     ({                                                  \
-         size_t var_ ## len = strnlen((str_), (len_));   \
-         char *var_ = alloca((var_ ## len) + 1);         \
-         var_[var_ ## len] = '\0';                       \
-         memcpy(var_, (str_), var_ ## len);              \
-     })
+        size_t var_ ## len = strnlen((str_), (len_));   \
+        char *var_ = alloca((var_ ## len) + 1);         \
+        var_[var_ ## len] = '\0';                       \
+        memcpy(var_, (str_), var_ ## len);              \
+    })
 #define strndupa(str_, len_)     __strndupa_internal__(str_, len_, __tmp__ ## __LINE__)
 #endif
 

--- a/src/lib/common/include/sol-pin-mux-modules.h
+++ b/src/lib/common/include/sol-pin-mux-modules.h
@@ -64,7 +64,7 @@ enum sol_pin_mode {
 
 /* Combinations of the above for convenience */
 #define SOL_PIN_MODE_GPIO_INPUT (SOL_PIN_MODE_GPIO_INPUT_PULLUP | \
-                                 SOL_PIN_MODE_GPIO_INPUT_PULLDOWN | SOL_PIN_MODE_GPIO_INPUT_HIZ)
+    SOL_PIN_MODE_GPIO_INPUT_PULLDOWN | SOL_PIN_MODE_GPIO_INPUT_HIZ)
 #define SOL_PIN_MODE_GPIO (SOL_PIN_MODE_GPIO_INPUT | SOL_PIN_MODE_GPIO_OUTPUT)
 
 struct sol_pin_mux_description {

--- a/src/lib/common/include/sol-platform.h
+++ b/src/lib/common/include/sol-platform.h
@@ -62,10 +62,10 @@ enum sol_platform_state {
 int sol_platform_get_state(void);
 
 int sol_platform_add_state_monitor(void (*cb)(void *data,
-        enum sol_platform_state state),
+    enum sol_platform_state state),
     const void *data);
 int sol_platform_del_state_monitor(void (*cb)(void *data,
-        enum sol_platform_state state),
+    enum sol_platform_state state),
     const void *data);
 
 
@@ -82,11 +82,11 @@ enum sol_platform_service_state {
 enum sol_platform_service_state sol_platform_get_service_state(const char *service);
 
 int sol_platform_add_service_monitor(void (*cb)(void *data, const char *service,
-        enum sol_platform_service_state state),
+    enum sol_platform_service_state state),
     const char *service,
     const void *data);
 int sol_platform_del_service_monitor(void (*cb)(void *data, const char *service,
-        enum sol_platform_service_state state),
+    enum sol_platform_service_state state),
     const char *service,
     const void *data);
 

--- a/src/lib/common/sol-log-impl-linux.c
+++ b/src/lib/common/sol-log-impl-linux.c
@@ -149,14 +149,14 @@ _bool_parse(const char *str, size_t size, bool *storage)
         else
             return false;
     } else if ((size == sizeof("true") - 1 &&
-                strncasecmp(str, "true", size) == 0) ||
-               (size == sizeof("yes") - 1 &&
-                strncasecmp(str, "yes", size) == 0)) {
+        strncasecmp(str, "true", size) == 0) ||
+        (size == sizeof("yes") - 1 &&
+        strncasecmp(str, "yes", size) == 0)) {
         *storage = true;
     } else if ((size == sizeof("false") - 1 &&
-                strncasecmp(str, "false", size) == 0) ||
-               (size == sizeof("no") - 1 &&
-                strncasecmp(str, "no", size) == 0)) {
+        strncasecmp(str, "false", size) == 0) ||
+        (size == sizeof("no") - 1 &&
+        strncasecmp(str, "no", size) == 0)) {
         *storage = false;
     } else
         return false;
@@ -383,13 +383,13 @@ sol_log_impl_init(void)
         const char *term = getenv("TERM");
         if (term) {
             _show_colors = (streq(term, "xterm") ||
-                            streq(term, "xterm-color") ||
-                            streq(term, "xterm-256color") ||
-                            streq(term, "rxvt") ||
-                            streq(term, "rxvt-unicode") ||
-                            streq(term, "rxvt-unicode-256color") ||
-                            streq(term, "gnome") ||
-                            streq(term, "screen"));
+                streq(term, "xterm-color") ||
+                streq(term, "xterm-256color") ||
+                streq(term, "rxvt") ||
+                streq(term, "rxvt-unicode") ||
+                streq(term, "rxvt-unicode-256color") ||
+                streq(term, "gnome") ||
+                streq(term, "screen"));
         }
     }
 #endif

--- a/src/lib/common/sol-platform-impl-linux-micro.c
+++ b/src/lib/common/sol-platform-impl-linux-micro.c
@@ -108,8 +108,8 @@ find_builtin_service_module(const char *name)
     unsigned int i;
 
     for (i = 0, itr = SOL_PLATFORM_LINUX_MICRO_MODULE_ALL;
-         i < SOL_PLATFORM_LINUX_MICRO_MODULE_COUNT;
-         i++, itr++) {
+        i < SOL_PLATFORM_LINUX_MICRO_MODULE_COUNT;
+        i++, itr++) {
         if (streq(name, (*itr)->name)) {
             if (!builtin_init[i]) {
                 if ((*itr)->init) {
@@ -579,8 +579,8 @@ builtins_cleanup(void)
     unsigned int i;
 
     for (i = 0, itr = SOL_PLATFORM_LINUX_MICRO_MODULE_ALL;
-         i < SOL_PLATFORM_LINUX_MICRO_MODULE_COUNT;
-         i++, itr++) {
+        i < SOL_PLATFORM_LINUX_MICRO_MODULE_COUNT;
+        i++, itr++) {
         if (builtin_init[i] && (*itr)->shutdown)
             (*itr)->shutdown((*itr), (*itr)->name);
     }

--- a/src/lib/common/sol-platform.c
+++ b/src/lib/common/sol-platform.c
@@ -117,7 +117,7 @@ sol_platform_get_state(void)
 
 SOL_API int
 sol_platform_add_state_monitor(void (*cb)(void *data,
-        enum sol_platform_state state),
+    enum sol_platform_state state),
     const void *data)
 {
     struct sol_monitors_entry *e;
@@ -132,7 +132,7 @@ sol_platform_add_state_monitor(void (*cb)(void *data,
 
 SOL_API int
 sol_platform_del_state_monitor(void (*cb)(void *data,
-        enum sol_platform_state state),
+    enum sol_platform_state state),
     const void *data)
 {
     int i;
@@ -193,7 +193,7 @@ service_monitor_free(const struct sol_monitors *monitors, const struct sol_monit
 
 SOL_API int
 sol_platform_add_service_monitor(void (*cb)(void *data, const char *service,
-        enum sol_platform_service_state state),
+    enum sol_platform_service_state state),
     const char *service,
     const void *data)
 {
@@ -235,7 +235,7 @@ fail_append:
 
 SOL_API int
 sol_platform_del_service_monitor(void (*cb)(void *data, const char *service,
-        enum sol_platform_service_state state),
+    enum sol_platform_service_state state),
     const char *service,
     const void *data)
 {

--- a/src/lib/datatypes/include/sol-str-table.h
+++ b/src/lib/datatypes/include/sol-str-table.h
@@ -55,11 +55,11 @@ int16_t sol_str_table_lookup_fallback(const struct sol_str_table *table,
 
 #define SOL_STR_TABLE_NOT_FOUND INT16_MAX
 #define sol_str_table_lookup(_table, _key, _pval) ({ \
-    int16_t _v = sol_str_table_lookup_fallback(_table, _key, INT16_MAX); \
-    if (_v != INT16_MAX) \
-        *_pval = _v; \
-    _v != INT16_MAX; \
-})
+        int16_t _v = sol_str_table_lookup_fallback(_table, _key, INT16_MAX); \
+        if (_v != INT16_MAX) \
+            *_pval = _v; \
+        _v != INT16_MAX; \
+    })
 
 
 struct sol_str_table_ptr {
@@ -78,12 +78,12 @@ const void *sol_str_table_ptr_lookup_fallback(const struct sol_str_table_ptr *ta
     const void *fallback) SOL_ATTR_NONNULL(1);
 
 #define sol_str_table_ptr_lookup(_table_ptr, _key, _pval) ({ \
-    const void *_v = sol_str_table_ptr_lookup_fallback(_table_ptr, \
-        _key, NULL); \
-    if (_v != NULL) \
-        *_pval = _v; \
-    _v != NULL; \
-})
+        const void *_v = sol_str_table_ptr_lookup_fallback(_table_ptr, \
+            _key, NULL); \
+        if (_v != NULL) \
+            *_pval = _v; \
+        _v != NULL; \
+    })
 
 #ifdef __cplusplus
 }

--- a/src/lib/datatypes/include/sol-vector.h
+++ b/src/lib/datatypes/include/sol-vector.h
@@ -80,13 +80,13 @@ void sol_vector_clear(struct sol_vector *v);
 
 #define SOL_VECTOR_FOREACH_IDX(vector, itrvar, idx)                      \
     for (idx = 0;                                                       \
-         idx < (vector)->len && (itrvar = sol_vector_get((vector), idx), true); \
-         idx++)
+        idx < (vector)->len && (itrvar = sol_vector_get((vector), idx), true); \
+        idx++)
 
 #define SOL_VECTOR_FOREACH_REVERSE_IDX(vector, itrvar, idx)              \
     for (idx = (vector)->len - 1;                                       \
-         idx != ((typeof(idx)) - 1) && (itrvar = sol_vector_get((vector), idx), true); \
-         idx--)
+        idx != ((typeof(idx)) - 1) && (itrvar = sol_vector_get((vector), idx), true); \
+        idx--)
 
 
 // sol_ptr_vector is like vector but with an API more convenient for storing pointers.
@@ -150,15 +150,15 @@ sol_ptr_vector_clear(struct sol_ptr_vector *pv)
 
 #define SOL_PTR_VECTOR_FOREACH_IDX(vector, itrvar, idx) \
     for (idx = 0; \
-         idx < (vector)->base.len && \
-            ((itrvar = *(((void **)(vector)->base.data) + idx)), true); \
-         idx++)
+        idx < (vector)->base.len && \
+        ((itrvar = *(((void **)(vector)->base.data) + idx)), true); \
+        idx++)
 
 #define SOL_PTR_VECTOR_FOREACH_REVERSE_IDX(vector, itrvar, idx) \
     for (idx = (vector)->base.len - 1; \
-         idx != ((typeof(idx)) - 1) && \
-            (itrvar = *(((void **)(vector)->base.data) + idx), true); \
-         idx--)
+        idx != ((typeof(idx)) - 1) && \
+        (itrvar = *(((void **)(vector)->base.data) + idx), true); \
+        idx--)
 
 #ifdef __cplusplus
 }

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -505,9 +505,9 @@ struct sol_flow_node_type *sol_flow_static_new_type(
     const struct sol_flow_static_port_spec exported_in[],
     const struct sol_flow_static_port_spec exported_out[],
     int (*child_opts_set)(const struct sol_flow_node_type *type,
-        uint16_t child_index,
-        const struct sol_flow_node_options *opts,
-        struct sol_flow_node_options *child_opts));
+    uint16_t child_index,
+    const struct sol_flow_node_options *opts,
+    struct sol_flow_node_options *child_opts));
 
 void sol_flow_static_del_type(struct sol_flow_node_type *type);
 

--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -356,9 +356,9 @@ sol_flow_builder_add_node(struct sol_flow_builder *builder, const char *name, co
     /* check if port names are unique */
     if (type->description &&
         ((type->description->ports_in &&
-          find_duplicated_port_names(type->description->ports_in, false)) ||
-         (type->description->ports_out &&
-          find_duplicated_port_names(type->description->ports_out, true))))
+        find_duplicated_port_names(type->description->ports_in, false)) ||
+        (type->description->ports_out &&
+        find_duplicated_port_names(type->description->ports_out, true))))
         return -EEXIST;
 
     node_name = sol_arena_strdup(builder->str_arena, name);
@@ -410,7 +410,7 @@ conn_spec_add(struct sol_flow_builder *builder, uint16_t src, uint16_t dst, uint
     conn_spec->dst_port = dst_port;
 
     if (sol_ptr_vector_insert_sorted(&builder->conns, conn_spec,
-            compare_conns) < 0) {
+        compare_conns) < 0) {
         free(conn_spec);
         return -ENOMEM;
     }

--- a/src/lib/flow/sol-flow-node-options.c
+++ b/src/lib/flow/sol-flow-node-options.c
@@ -77,8 +77,8 @@ get_member_memory(const struct sol_flow_node_options_member_description *member,
     } while (0)                                 \
 
 #define ASSIGN_LINEAR_VALUES(_parse_func, \
-                             _max_val, _max_str, _max_str_len,          \
-                             _min_val, _min_str, _min_str_len)          \
+        _max_val, _max_str, _max_str_len,          \
+        _min_val, _min_str, _min_str_len)          \
     do {                                                                \
         char *start, *end, backup;                                      \
         int field_cnt_max = ARRAY_SIZE(store_vals); \
@@ -93,11 +93,11 @@ get_member_memory(const struct sol_flow_node_options_member_description *member,
             errno = 0;                                                  \
             if (strlen(start) >= _max_str_len                           \
                 && (strncmp(start, _max_str,                            \
-                        _max_str_len) == 0)) {                      \
+                _max_str_len) == 0)) {                      \
                 is_max = true;                                          \
             } else if (strlen(start) >= _min_str_len                    \
-                       && (strncmp(start, _min_str,                     \
-                               _min_str_len) == 0)) {               \
+                && (strncmp(start, _min_str,                     \
+                _min_str_len) == 0)) {               \
                 is_min = true;                                          \
             }                                                           \
             if (is_max) *store_vals[field_cnt] = _max_val;              \
@@ -123,8 +123,8 @@ get_member_memory(const struct sol_flow_node_options_member_description *member,
     } while (0)
 
 #define ASSIGN_KEY_VAL(_type, _key, _parse_func, _only_not_negative, \
-                       _max_val, _max_str, _max_str_len,        \
-                       _min_val, _min_str, _min_str_len)        \
+        _max_val, _max_str, _max_str_len,        \
+        _min_val, _min_str, _min_str_len)        \
     do {                                                        \
         bool is_max = false, is_min = false;                    \
         _key = strstr(buf, #_key);                              \
@@ -140,11 +140,11 @@ get_member_memory(const struct sol_flow_node_options_member_description *member,
             break;                                              \
         if (strlen(_key) >= _max_str_len                        \
             && (strncmp(_key, _max_str,                         \
-                    _max_str_len) == 0)) {                  \
+            _max_str_len) == 0)) {                  \
             is_max = true;                                      \
         } else if (strlen(_key) >= _min_str_len                 \
-                   && (strncmp(_key, _min_str,                  \
-                           _min_str_len) == 0)) {           \
+            && (strncmp(_key, _min_str,                  \
+            _min_str_len) == 0)) {           \
             is_min = true;                                      \
         }                                                       \
         if (is_max)                                             \
@@ -159,8 +159,8 @@ get_member_memory(const struct sol_flow_node_options_member_description *member,
             char *endptr; \
             _type parsed_val; \
             while (_key ## _end                                 \
-                   && *_key ## _end != '\0'                     \
-                   && *_key ## _end != SUBOPTION_SEPARATOR)     \
+                && *_key ## _end != '\0'                     \
+                && *_key ## _end != SUBOPTION_SEPARATOR)     \
                 _key ## _end++;                                 \
             if (_key ## _end) {                                 \
                 _key ## _backup = *_key ## _end;                \
@@ -193,7 +193,7 @@ irange_parse(const struct sol_flow_node_options_member_description *member,
     bool keys_schema = false;
     char *min, *max, *step, *val;
     bool min_done = false, max_done = false,
-         step_done = false, val_done = false;
+        step_done = false, val_done = false;
     static const char INT_MAX_STR[] = "INT32_MAX";
     static const char INT_MIN_STR[] = "INT32_MIN";
     static const size_t INT_LIMIT_STR_LEN = sizeof(INT_MAX_STR) - 1;
@@ -250,7 +250,7 @@ drange_parse(const struct sol_flow_node_options_member_description *member,
     bool keys_schema = false;
     char *min, *max, *step, *val;
     bool min_done = false, max_done = false,
-         step_done = false, val_done = false;
+        step_done = false, val_done = false;
     static const char DBL_MAX_STR[] = "DBL_MAX";
     static const char DBL_MIN_STR[] = "-DBL_MAX";
     static const size_t DBL_MAX_STR_LEN = sizeof(DBL_MAX_STR) - 1;
@@ -308,7 +308,7 @@ rgb_parse(const struct sol_flow_node_options_member_description *member,
     bool keys_schema = false;
     char *red, *green, *blue, *red_max, *green_max, *blue_max;
     bool red_done = false, green_done = false, blue_done = false,
-         red_max_done = false, green_max_done = false, blue_max_done = false;
+        red_max_done = false, green_max_done = false, blue_max_done = false;
     static const char INT_MAX_STR[] = "INT32_MAX";
     static const char INT_MIN_STR[] = "INT32_MIN";
     static const size_t INT_LIMIT_STR_LEN = sizeof(INT_MAX_STR) - 1;
@@ -402,7 +402,7 @@ direction_vector_parse(const struct sol_flow_node_options_member_description *me
     bool keys_schema = false;
     char *min, *max, *x, *y, *z;
     bool min_done = false, max_done = false,
-         x_done = false, y_done = false, z_done = false;
+        x_done = false, y_done = false, z_done = false;
     static const char DBL_MAX_STR[] = "DBL_MAX";
     static const char DBL_MIN_STR[] = "-DBL_MAX";
     static const size_t DBL_MAX_STR_LEN = sizeof(DBL_MAX_STR) - 1;

--- a/src/lib/flow/sol-flow-parser.c
+++ b/src/lib/flow/sol-flow-parser.c
@@ -290,7 +290,7 @@ get_options_array(struct sol_fbp_node *node, char ***opts_array)
             continue;
 
         if (asprintf(&entry, "%.*s=%.*s", (int)m->key.len, m->key.data,
-                (int)m->value.len, m->value.data) < 0)
+            (int)m->value.len, m->value.data) < 0)
             goto fail;
 
         if (entry[m->key.len + 1] == '"') {

--- a/src/lib/flow/sol-flow-resolver-conffile.c
+++ b/src/lib/flow/sol-flow-resolver-conffile.c
@@ -228,7 +228,7 @@ resolver_conffile_get_strv(const char *id,
     }
 
     *node_type = resolve_module_type_by_component
-                     (type_name, sol_flow_foreach_builtin_node_type);
+            (type_name, sol_flow_foreach_builtin_node_type);
     if (!*node_type) {
         *node_type = _resolver_conffile_get_module(type_name);
         if (!*node_type) {

--- a/src/lib/flow/sol-flow-static.c
+++ b/src/lib/flow/sol-flow-static.c
@@ -983,9 +983,9 @@ flow_static_type_init(
     const struct sol_flow_static_port_spec exported_in[],
     const struct sol_flow_static_port_spec exported_out[],
     int (*child_opts_set)(const struct sol_flow_node_type *type,
-        uint16_t child_index,
-        const struct sol_flow_node_options *opts,
-        struct sol_flow_node_options *child_opts))
+    uint16_t child_index,
+    const struct sol_flow_node_options *opts,
+    struct sol_flow_node_options *child_opts))
 {
     int r;
 
@@ -1107,9 +1107,9 @@ sol_flow_static_new_type(
     const struct sol_flow_static_port_spec exported_in[],
     const struct sol_flow_static_port_spec exported_out[],
     int (*child_opts_set)(const struct sol_flow_node_type *type,
-        uint16_t child_index,
-        const struct sol_flow_node_options *opts,
-        struct sol_flow_node_options *child_opts))
+    uint16_t child_index,
+    const struct sol_flow_node_options *opts,
+    struct sol_flow_node_options *child_opts))
 {
     struct flow_static_type *type;
     int r;

--- a/src/lib/flow/sol-flow.c
+++ b/src/lib/flow/sol-flow.c
@@ -447,8 +447,8 @@ sol_flow_foreach_builtin_node_type(bool (*cb)(void *data, const struct sol_flow_
 
     SOL_NULL_CHECK(cb);
     for (i = 0, itr = SOL_FLOW_BUILTIN_NODE_TYPE_ALL;
-         i <  SOL_FLOW_BUILTIN_NODE_TYPE_COUNT;
-         i++, itr++) {
+        i <  SOL_FLOW_BUILTIN_NODE_TYPE_COUNT;
+        i++, itr++) {
         const struct sol_flow_node_type * (*type_func)(bool (*cb)(void *data, const struct sol_flow_node_type *type), const void *data) = *itr;
         const struct sol_flow_node_type *t = type_func(cb, data);
         if (t && !cb((void *)data, t)) {

--- a/src/lib/io/sol-gpio-linux.c
+++ b/src/lib/io/sol-gpio-linux.c
@@ -293,8 +293,8 @@ sol_gpio_open_raw(int pin, const struct sol_gpio_config *config)
 
     if (unlikely(config->api_version != SOL_GPIO_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open gpio that has unsupported version '%u', "
-                "expected version is '%u'",
-                config->api_version, SOL_GPIO_CONFIG_API_VERSION);
+            "expected version is '%u'",
+            config->api_version, SOL_GPIO_CONFIG_API_VERSION);
         return NULL;
     }
 

--- a/src/lib/io/sol-gpio-riot.c
+++ b/src/lib/io/sol-gpio-riot.c
@@ -78,8 +78,8 @@ sol_gpio_open_raw(int pin, const struct sol_gpio_config *config)
 
     if (unlikely(config->api_version != SOL_GPIO_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open gpio that has unsupported version '%u', "
-                "expected version is '%u'",
-                config->api_version, SOL_GPIO_CONFIG_API_VERSION);
+            "expected version is '%u'",
+            config->api_version, SOL_GPIO_CONFIG_API_VERSION);
         return NULL;
     }
 
@@ -113,8 +113,8 @@ sol_gpio_open_raw(int pin, const struct sol_gpio_config *config)
             gpio->irq.cb = config->in.cb;
             gpio->irq.data = config->in.user_data;
             if (sol_interrupt_scheduler_gpio_init_int(gpio->pin, pull, flank,
-                    gpio_process_cb, gpio,
-                    &gpio->irq.int_handler) < 0)
+                gpio_process_cb, gpio,
+                &gpio->irq.int_handler) < 0)
                 goto error;
         }
     }

--- a/src/lib/io/sol-i2c-linux.c
+++ b/src/lib/io/sol-i2c-linux.c
@@ -300,7 +300,7 @@ sol_i2c_read_register(const struct sol_i2c *i2c, uint8_t command, uint8_t *value
         return sol_i2c_plain_read_register(i2c, command, values, count);
 
     if ((error = _i2c_smbus_ioctl(i2c->dev, I2C_SMBUS_READ, command,
-             count, &data)) < 0) {
+            count, &data)) < 0) {
         SOL_WRN("Unable to perform I2C-SMBus read (byte/word/block) data "
             "(bus = %u, device address = 0x%x, register = 0x%x): %s",
             i2c->bus, i2c->addr, command, sol_util_strerrora(-error));
@@ -439,7 +439,7 @@ sol_i2c_write_register(const struct sol_i2c *i2c, uint8_t command, const uint8_t
     }
 
     if ((error = _i2c_smbus_ioctl(i2c->dev, I2C_SMBUS_WRITE, command, count,
-             &data)) < 0) {
+            &data)) < 0) {
         SOL_WRN("Unable to perform I2C-SMBus write (byte/word/block) data "
             " (bus = %u, device address = 0x%x, register = 0x%x:): %s",
             i2c->bus, i2c->addr, command, sol_util_strerrora(-error));

--- a/src/lib/io/sol-pwm-linux.c
+++ b/src/lib/io/sol-pwm-linux.c
@@ -259,8 +259,8 @@ sol_pwm_open_raw(int device, int channel, const struct sol_pwm_config *config)
 
     if (unlikely(config->api_version != SOL_PWM_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open pwm that has unsupported version '%u', "
-                "expected version is '%u'",
-                config->api_version, SOL_PWM_CONFIG_API_VERSION);
+            "expected version is '%u'",
+            config->api_version, SOL_PWM_CONFIG_API_VERSION);
         return NULL;
     }
 

--- a/src/lib/io/sol-pwm-riot.c
+++ b/src/lib/io/sol-pwm-riot.c
@@ -64,8 +64,8 @@ sol_pwm_open_raw(int device, int channel, const struct sol_pwm_config *config)
 
     if (unlikely(config->api_version != SOL_PWM_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open pwm that has unsupported version '%u', "
-                "expected version is '%u'",
-                config->api_version, SOL_PWM_CONFIG_API_VERSION);
+            "expected version is '%u'",
+            config->api_version, SOL_PWM_CONFIG_API_VERSION);
         return NULL;
     }
 

--- a/src/lib/parsers/include/sol-json.h
+++ b/src/lib/parsers/include/sol-json.h
@@ -76,19 +76,19 @@ enum sol_json_loop_reason {
 
 #define SOL_JSON_SCANNER_ARRAY_LOOP_NEST(scanner_, token_, element_type_, end_reason_) \
     for (end_reason_ = SOL_JSON_LOOP_REASON_OK;  \
-         _sol_json_loop_helper_array(scanner_, token_, &end_reason_, element_type_);)
+        _sol_json_loop_helper_array(scanner_, token_, &end_reason_, element_type_);)
 
 #define SOL_JSON_SCANNER_ARRAY_LOOP(scanner_, token_, element_type_, end_reason_) \
     for (end_reason_ = _sol_json_loop_helper_init(scanner_, token_, SOL_JSON_TYPE_ARRAY_START); \
-         _sol_json_loop_helper_array(scanner_, token_, &end_reason_, element_type_);)
+        _sol_json_loop_helper_array(scanner_, token_, &end_reason_, element_type_);)
 
 #define SOL_JSON_SCANNER_OBJECT_LOOP_NEST(scanner_, token_, key_, value_, end_reason_) \
     for (end_reason_ = SOL_JSON_LOOP_REASON_OK; \
-         _sol_json_loop_helper_object(scanner_, token_, key_, value_, &end_reason_);)
+        _sol_json_loop_helper_object(scanner_, token_, key_, value_, &end_reason_);)
 
 #define SOL_JSON_SCANNER_OBJECT_LOOP(scanner_, token_, key_, value_, end_reason_) \
     for (end_reason_ = _sol_json_loop_helper_init(scanner_, token_, SOL_JSON_TYPE_OBJECT_START); \
-         _sol_json_loop_helper_object(scanner_, token_, key_, value_, &end_reason_);)
+        _sol_json_loop_helper_object(scanner_, token_, key_, value_, &end_reason_);)
 
 static inline void
 sol_json_scanner_init(struct sol_json_scanner *scanner, const void *mem, unsigned int size)

--- a/src/modules/flow/accelerometer/accelerometer.c
+++ b/src/modules/flow/accelerometer/accelerometer.c
@@ -149,7 +149,7 @@ accel_read(struct accelerometer_adxl345_data *mdata)
 #define MAX_EPSILON (10.0f)
 #define EPSILON_CHECK(_axis) \
     if (i > 0 && isgreater(fabs((buffer[i][_axis] * ACCEL_SCALE_M_S) \
-                - mdata->reading[_axis]), MAX_EPSILON)) \
+        - mdata->reading[_axis]), MAX_EPSILON)) \
         break
 
         /* raw readings, with only the sensor-provided filtering */
@@ -248,7 +248,7 @@ accel_init_rate(void *data)
     }
 
     if (accel_timer_resched(mdata, ACCEL_INIT_STEP_TIME,
-            accel_init_stream, mdata) < 0)
+        accel_init_stream, mdata) < 0)
         SOL_WRN("error in scheduling a ADXL345 accel's init command");
 
     return false;
@@ -277,7 +277,7 @@ accel_init_format(void *data)
     }
 
     if (accel_timer_resched(mdata, ACCEL_INIT_STEP_TIME,
-            accel_init_rate, mdata) < 0)
+        accel_init_rate, mdata) < 0)
         SOL_WRN("error in scheduling a ADXL345 accel's init command");
 
     return false;
@@ -311,9 +311,9 @@ accel_init_power(void *data)
         power_done = true;
 
     if (accel_timer_resched(mdata, ACCEL_INIT_STEP_TIME,
-            power_done ?
-            accel_init_format : accel_init_power,
-            mdata) < 0) {
+        power_done ?
+        accel_init_format : accel_init_power,
+        mdata) < 0) {
         SOL_WRN("error in scheduling a ADXL345 accel's init command");
     }
 

--- a/src/modules/flow/boolean/boolean.c
+++ b/src/modules/flow/boolean/boolean.c
@@ -457,7 +457,7 @@ boolean_buffer_open(struct sol_flow_node *node, void *data,
     mdata->n_samples = opts->samples.val;
     mdata->timeout = opts->timeout.val;
     mdata->normalize_cb = sol_str_table_ptr_lookup_fallback
-                              (table, sol_str_slice_from_str(opts->operation), _normalize_all_true);
+            (table, sol_str_slice_from_str(opts->operation), _normalize_all_true);
 
     mdata->input_queue = calloc(mdata->n_samples, sizeof(*mdata->input_queue));
     SOL_NULL_CHECK(mdata->input_queue, -ENOMEM);

--- a/src/modules/flow/calamari/calamari.c
+++ b/src/modules/flow/calamari/calamari.c
@@ -466,6 +466,7 @@ calamari_rgb_led_process_red(struct sol_flow_node *node, void *data, uint16_t po
     bool val;
 
     int r = sol_flow_packet_get_boolean(packet, &val);
+
     SOL_INT_CHECK(r, < 0, r);
     sol_flow_send_boolean_packet(node, SOL_FLOW_NODE_TYPE_CALAMARI_RGB_CTL__OUT__RED, val);
 
@@ -478,6 +479,7 @@ calamari_rgb_led_process_green(struct sol_flow_node *node, void *data, uint16_t 
     bool val;
 
     int r = sol_flow_packet_get_boolean(packet, &val);
+
     SOL_INT_CHECK(r, < 0, r);
     sol_flow_send_boolean_packet(node, SOL_FLOW_NODE_TYPE_CALAMARI_RGB_CTL__OUT__GREEN, val);
 
@@ -490,6 +492,7 @@ calamari_rgb_led_process_blue(struct sol_flow_node *node, void *data, uint16_t p
     bool val;
 
     int r = sol_flow_packet_get_boolean(packet, &val);
+
     SOL_INT_CHECK(r, < 0, r);
     sol_flow_send_boolean_packet(node, SOL_FLOW_NODE_TYPE_CALAMARI_RGB_CTL__OUT__BLUE, val);
 

--- a/src/modules/flow/color/color.c
+++ b/src/modules/flow/color/color.c
@@ -52,7 +52,7 @@ color_luminance_open(struct sol_flow_node *node, void *data, const struct sol_fl
 
     mdata->red = mdata->red > mdata->red_max ? mdata->red_max : mdata->red;
     mdata->green = mdata->green > mdata->green_max ?
-                   mdata->green_max : mdata->green;
+        mdata->green_max : mdata->green;
     mdata->blue = mdata->blue > mdata->blue_max ? mdata->blue_max : mdata->blue;
 
     return 0;

--- a/src/modules/flow/converter/converter.c
+++ b/src/modules/flow/converter/converter.c
@@ -969,7 +969,7 @@ empty_to_string_open(struct sol_flow_node *node, void *data, const struct sol_fl
         SOL_FLOW_NODE_TYPE_CONVERTER_EMPTY_TO_STRING_OPTIONS_API_VERSION,
         -EINVAL);
     opts = (const struct sol_flow_node_type_converter_empty_to_string_options *)
-           options;
+        options;
 
     mdata->string = strdup(opts->output_value);
     if (!mdata->string)
@@ -1072,6 +1072,7 @@ byte_to_bits_convert(struct sol_flow_node *node, void *data, uint16_t port, uint
     unsigned char in_val, last_bit, next_bit;
 
     int r = sol_flow_packet_get_byte(packet, &in_val);
+
     SOL_INT_CHECK(r, < 0, r);
 
     for (i = 0; i <= 7; i++) {
@@ -1283,13 +1284,13 @@ rgb_convert(struct sol_flow_node *node, void *data, uint16_t port, uint32_t val)
     mdata->output_initialized[port] = true;
     if (port == 0)
         mdata->output_value.red = val > mdata->output_value.red_max ?
-                                  mdata->output_value.red_max : val;
+            mdata->output_value.red_max : val;
     else if (port == 1)
         mdata->output_value.green = val > mdata->output_value.green_max ?
-                                    mdata->output_value.green_max : val;
+            mdata->output_value.green_max : val;
     else
         mdata->output_value.blue = val > mdata->output_value.blue_max ?
-                                   mdata->output_value.blue_max : val;
+            mdata->output_value.blue_max : val;
 
     for (i = 0; i < 3; i++) {
         if (!mdata->output_initialized[i])
@@ -1410,20 +1411,20 @@ direction_vector_to_rgb_convert(struct sol_flow_node *node, void *data, uint16_t
     }
 
     val_red = in_val.x *
-              rgb_get_port_max(data, port) / (in_val.max - in_val.min);
+        rgb_get_port_max(data, port) / (in_val.max - in_val.min);
 
     val_green = in_val.y *
-                rgb_get_port_max(data, port) / (in_val.max - in_val.min);
+        rgb_get_port_max(data, port) / (in_val.max - in_val.min);
 
     val_blue = in_val.z *
-               rgb_get_port_max(data, port) / (in_val.max - in_val.min);
+        rgb_get_port_max(data, port) / (in_val.max - in_val.min);
 
     mdata->output_value.red = val_red > mdata->output_value.red_max ?
-                              mdata->output_value.red_max : val_red;
+        mdata->output_value.red_max : val_red;
     mdata->output_value.green = val_green > mdata->output_value.green_max ?
-                                mdata->output_value.green_max : val_green;
+        mdata->output_value.green_max : val_green;
     mdata->output_value.blue = val_blue > mdata->output_value.blue_max ?
-                               mdata->output_value.blue_max : val_blue;
+        mdata->output_value.blue_max : val_blue;
 
     return sol_flow_send_rgb_packet(node, 0, &mdata->output_value);
 }
@@ -1634,8 +1635,8 @@ irange_to_direction_vector_convert(struct sol_flow_node *node, void *data, uint1
     SOL_INT_CHECK(r, < 0, r);
 
     val = in_val.val *
-          (mdata->output_value.max - mdata->output_value.min) /
-          (in_val.max - in_val.min);
+        (mdata->output_value.max - mdata->output_value.min) /
+        (in_val.max - in_val.min);
 
     return direction_vector_convert(node, data, port, val);
 }
@@ -1652,8 +1653,8 @@ drange_to_direction_vector_convert(struct sol_flow_node *node, void *data, uint1
     SOL_INT_CHECK(r, < 0, r);
 
     val = in_val.val *
-          (mdata->output_value.max - mdata->output_value.min) /
-          (in_val.max - in_val.min);
+        (mdata->output_value.max - mdata->output_value.min) /
+        (in_val.max - in_val.min);
 
     return direction_vector_convert(node, data, port, val);
 }
@@ -1852,6 +1853,7 @@ bits_to_byte_convert(struct sol_flow_node *node, void *data, uint16_t port, uint
     bool in_val;
 
     int r = sol_flow_packet_get_boolean(packet, &in_val);
+
     SOL_INT_CHECK(r, < 0, r);
 
     if ((mdata->output_initialized >> idx) & 1) {

--- a/src/modules/flow/evdev/evdev.c
+++ b/src/modules/flow/evdev/evdev.c
@@ -313,7 +313,7 @@ evdev_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_op
     SOL_NULL_CHECK(mdata->handler, -EINVAL);
 
     if (!sol_monitors_append(&mdata->handler->monitors,
-            (sol_monitors_cb_t)evdev_event_handler, node)) {
+        (sol_monitors_cb_t)evdev_event_handler, node)) {
         handler_evdev_close(mdata->handler);
         return -EINVAL;
     }

--- a/src/modules/flow/float/float.c
+++ b/src/modules/flow/float/float.c
@@ -290,7 +290,7 @@ _map(long double in_value, long double in_min, long double in_max, long double o
     long double result;
 
     result = (in_value - in_min) * (out_max - out_min) /
-             (in_max - in_min) + out_min;
+        (in_max - in_min) + out_min;
 
     errno = 0;
     result -= fmodl((result - out_min), out_step);
@@ -835,7 +835,7 @@ wave_generator_trapezoidal_open(struct sol_flow_node *node,
     /* calculating starting val from tick_start */
     t_state->increasing = true;
     mdata->period_in_ticks = mdata->ticks_at_min + mdata->ticks_inc
-                             + mdata->ticks_at_max + mdata->ticks_dec;
+        + mdata->ticks_at_max + mdata->ticks_dec;
 
     tick_start = opts->tick_start.val % mdata->period_in_ticks;
 
@@ -879,7 +879,7 @@ sinusoidal_calc_next(struct drange_wave_generator_sinusoidal_data *mdata)
 
     val->val = sin(s_state->rad_val) * mdata->amplitude;
     val->step = (sin(s_state->rad_val + mdata->rad_step)
-                 * mdata->amplitude) - val->val;
+        * mdata->amplitude) - val->val;
 }
 
 static void

--- a/src/modules/flow/grove/grove.c
+++ b/src/modules/flow/grove/grove.c
@@ -811,7 +811,7 @@ lcd_open(struct sol_flow_node *node,
 
     mdata->display_mode = LCD_ENTRY_MODE_SET | LCD_MODE_SET_LTR;
     mdata->display_control = (LCD_DISPLAY_CONTROL | LCD_DISPLAY_ON)
-                             & (~LCD_BLINK_ON | ~LCD_CURSOR_ON);
+        & (~LCD_BLINK_ON | ~LCD_CURSOR_ON);
 
     return timer_reschedule(mdata, TIME_TO_TURN_ON, setup, mdata);
 }
@@ -861,7 +861,7 @@ cursor_cmd_queue(struct lcd_data *mdata, uint8_t value, bool is_col)
     cmd->chip_addr = DISPLAY_ADDR;
     cmd->data_addr = SEND_COMMAND;
     cmd->value = is_col ? value | ROW_ADDR[mdata->row]
-                 : mdata->col | ROW_ADDR[value];
+        : mdata->col | ROW_ADDR[value];
     cmd->done = false;
 
     return 0;
@@ -1349,7 +1349,7 @@ scroll_display(struct sol_flow_node *node,
     int r;
 
     value |= (port == SOL_FLOW_NODE_TYPE_GROVE_LCD_CHAR__IN__SCROLL_RIGHT ?
-              LCD_MOVE_RIGHT : LCD_MOVE_LEFT);
+        LCD_MOVE_RIGHT : LCD_MOVE_LEFT);
 
     if (mdata->ready) {
         if (!write_display_command(mdata->i2c, value))

--- a/src/modules/flow/gtk/byte-editor.c
+++ b/src/modules/flow/gtk/byte-editor.c
@@ -44,13 +44,13 @@ on_byte_editor_clicked(GtkWidget *widget, gpointer data)
     GList *node;
 
     for (node = gtk_container_get_children(GTK_CONTAINER(mdata->widget));
-         node != NULL; node = node->next) {
+        node != NULL; node = node->next) {
 
         GtkWidget *button = node->data;
         uintptr_t bit = (intptr_t)g_object_get_data(G_OBJECT(button),
             BIT_POSITION_KEY);
         unsigned char v = gtk_toggle_button_get_active
-                              (GTK_TOGGLE_BUTTON(button));
+                (GTK_TOGGLE_BUTTON(button));
         result |= v << bit;
     }
 

--- a/src/modules/flow/gtk/common.h
+++ b/src/modules/flow/gtk/common.h
@@ -52,7 +52,7 @@ struct gtk_common_data {
 int gtk_open(struct sol_flow_node *node,
     void *data,
     int (*setup_cb)(struct gtk_common_data *mdata,
-        const struct sol_flow_node_options *options),
+    const struct sol_flow_node_options *options),
     const struct sol_flow_node_options *options);
 
 void gtk_close(struct sol_flow_node *node, void *data);

--- a/src/modules/flow/gtk/gtk.c
+++ b/src/modules/flow/gtk/gtk.c
@@ -152,7 +152,7 @@ int
 gtk_open(struct sol_flow_node *node,
     void *data,
     int (*setup_cb)(struct gtk_common_data *mdata,
-        const struct sol_flow_node_options *options),
+    const struct sol_flow_node_options *options),
     const struct sol_flow_node_options *options)
 {
     struct gtk_common_data *mdata = data;

--- a/src/modules/flow/gtk/rgb-editor.c
+++ b/src/modules/flow/gtk/rgb-editor.c
@@ -46,14 +46,14 @@ on_value_changed(GtkWidget *widget, gpointer data)
     struct sol_rgb color;
 
     red = gtk_spin_button_get_value_as_int
-              (GTK_SPIN_BUTTON(g_object_get_data
-                      (G_OBJECT(mdata->widget), "spin_r")));
+            (GTK_SPIN_BUTTON(g_object_get_data
+                (G_OBJECT(mdata->widget), "spin_r")));
     green = gtk_spin_button_get_value_as_int
-                (GTK_SPIN_BUTTON(g_object_get_data
-                        (G_OBJECT(mdata->widget), "spin_g")));
+            (GTK_SPIN_BUTTON(g_object_get_data
+                (G_OBJECT(mdata->widget), "spin_g")));
     blue = gtk_spin_button_get_value_as_int
-               (GTK_SPIN_BUTTON(g_object_get_data
-                       (G_OBJECT(mdata->widget), "spin_b")));
+            (GTK_SPIN_BUTTON(g_object_get_data
+                (G_OBJECT(mdata->widget), "spin_b")));
 
     rgba.red = (gdouble)red / COLOR_VALUE_MAX;
     rgba.green = (gdouble)green / COLOR_VALUE_MAX;
@@ -62,7 +62,7 @@ on_value_changed(GtkWidget *widget, gpointer data)
 
     gtk_color_chooser_set_rgba
         (GTK_COLOR_CHOOSER(g_object_get_data(G_OBJECT(mdata->widget),
-                "rgb_button")), &rgba);
+        "rgb_button")), &rgba);
 
     color.red = red;
     color.red_max = COLOR_VALUE_MAX;
@@ -113,7 +113,7 @@ rgb_editor_setup(struct gtk_common_data *mdata,
     g_object_set(grid, "halign", GTK_ALIGN_CENTER, NULL);
 
     red_spin = gtk_spin_button_new_with_range
-                   (COLOR_VALUE_MIN, COLOR_VALUE_MAX, 1);
+            (COLOR_VALUE_MIN, COLOR_VALUE_MAX, 1);
     gtk_grid_attach(GTK_GRID(grid), red_spin, 0, 0, 20, 20);
     g_signal_connect(red_spin, "value-changed",
         G_CALLBACK(on_value_changed), mdata);
@@ -126,7 +126,7 @@ rgb_editor_setup(struct gtk_common_data *mdata,
     gtk_widget_show(red_label);
 
     green_spin = gtk_spin_button_new_with_range
-                     (COLOR_VALUE_MIN, COLOR_VALUE_MAX, 1);
+            (COLOR_VALUE_MIN, COLOR_VALUE_MAX, 1);
     gtk_grid_attach_next_to(GTK_GRID(grid), green_spin, red_spin,
         GTK_POS_RIGHT, 20, 20);
     g_signal_connect(green_spin, "value-changed",
@@ -140,7 +140,7 @@ rgb_editor_setup(struct gtk_common_data *mdata,
     gtk_widget_show(green_label);
 
     blue_spin = gtk_spin_button_new_with_range
-                    (COLOR_VALUE_MIN, COLOR_VALUE_MAX, 1);
+            (COLOR_VALUE_MIN, COLOR_VALUE_MAX, 1);
     gtk_grid_attach_next_to(GTK_GRID(grid), blue_spin, green_spin,
         GTK_POS_RIGHT, 20, 20);
     g_signal_connect(blue_spin, "value-changed",

--- a/src/modules/flow/gtk/slider.c
+++ b/src/modules/flow/gtk/slider.c
@@ -81,7 +81,7 @@ slider_setup(struct gtk_common_data *data,
     }
 
     mdata->widget = gtk_scale_new_with_range
-                        (GTK_ORIENTATION_HORIZONTAL, min, max, step);
+            (GTK_ORIENTATION_HORIZONTAL, min, max, step);
     g_signal_connect(mdata->widget, "value-changed",
         G_CALLBACK(on_slider_changed), mdata);
     g_object_set(mdata->widget, "hexpand", true, NULL);

--- a/src/modules/flow/gyroscope/gyroscope.c
+++ b/src/modules/flow/gyroscope/gyroscope.c
@@ -134,7 +134,7 @@ gyro_read(struct gyroscope_l3g4200d_data *mdata)
         num_samples_available = 0;
     } else {
         num_samples_available = fifo_status
-                                & GYRO_REG_FIFO_SRC_ENTRIES_MASK;
+            & GYRO_REG_FIFO_SRC_ENTRIES_MASK;
     }
 
     if (!num_samples_available) {
@@ -151,7 +151,7 @@ gyro_read(struct gyroscope_l3g4200d_data *mdata)
          */
         int16_t buffer[num_samples_available][3];
         double scale = mdata->use_rad ? GYRO_SCALE_R_S * DEG_TO_RAD
-                       : GYRO_SCALE_R_S;
+            : GYRO_SCALE_R_S;
 
         r = sol_i2c_read_register(mdata->i2c,
             GYRO_REG_XL | GYRO_REG_AUTO_INCREMENT,
@@ -254,7 +254,7 @@ gyro_init_fifo(void *data)
     }
 
     if (gyro_timer_resched(mdata, GYRO_INIT_STEP_TIME,
-            gyro_init_stream, mdata) < 0)
+        gyro_init_stream, mdata) < 0)
         SOL_WRN("error in scheduling a L3G4200D gyro's init command");
 
     return false;
@@ -280,7 +280,7 @@ gyro_init_range(void *data)
     }
 
     if (gyro_timer_resched(mdata, GYRO_INIT_STEP_TIME,
-            gyro_init_fifo, mdata) < 0)
+        gyro_init_fifo, mdata) < 0)
         SOL_WRN("error in scheduling a L3G4200D gyro's init command");
 
     return false;
@@ -312,9 +312,9 @@ gyro_init_sampling(void *data)
     mdata->init_sampling_cnt--;
 
     if (gyro_timer_resched(mdata, GYRO_INIT_STEP_TIME,
-            mdata->init_sampling_cnt ?
-            gyro_init_sampling : gyro_init_range,
-            mdata) < 0) {
+        mdata->init_sampling_cnt ?
+        gyro_init_sampling : gyro_init_range,
+        mdata) < 0) {
         SOL_WRN("error in scheduling a L3G4200D gyro's init command");
     }
 

--- a/src/modules/flow/int/int.c
+++ b/src/modules/flow/int/int.c
@@ -660,7 +660,7 @@ irange_buffer_open(struct sol_flow_node *node, void *data,
     mdata->n_samples = opts->samples.val;
     mdata->timeout = opts->timeout.val;
     mdata->normalize_cb = sol_str_table_ptr_lookup_fallback
-                              (table, sol_str_slice_from_str(opts->operation), _normalize_mean);
+            (table, sol_str_slice_from_str(opts->operation), _normalize_mean);
 
     mdata->input_queue = calloc(mdata->n_samples, sizeof(*mdata->input_queue));
     SOL_NULL_CHECK(mdata->input_queue, -ENOMEM);
@@ -1037,7 +1037,7 @@ _map(int64_t in_value, int64_t in_min, int64_t in_max, int64_t out_min, int64_t 
     }
 
     result = (in_value - in_min) * (out_max - out_min) /
-             (in_max - in_min) + out_min;
+        (in_max - in_min) + out_min;
     result -= (result - out_min) % out_step;
     *out_value = result;
 

--- a/src/modules/flow/network/network.c
+++ b/src/modules/flow/network/network.c
@@ -170,7 +170,7 @@ network_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_
             if (_match_link(mdata, itr)) {
                 sol_ptr_vector_append(&mdata->links, itr);
                 mdata->connected |= (itr->flags & SOL_NETWORK_LINK_RUNNING) &&
-                                    !(itr->flags & SOL_NETWORK_LINK_LOOPBACK);
+                    !(itr->flags & SOL_NETWORK_LINK_LOOPBACK);
             }
         }
     }

--- a/src/modules/flow/random/random.c
+++ b/src/modules/flow/random/random.c
@@ -135,7 +135,7 @@ random_float_generate(struct sol_flow_node *node, void *data, uint16_t port, uin
     fraction = get_random_number(mdata);
 
     out_value.val = value * ((double)(INT32_MAX - 1) / INT32_MAX) +
-                    (double)fraction / INT32_MAX;
+        (double)fraction / INT32_MAX;
 
     return sol_flow_send_drange_packet(node,
         SOL_FLOW_NODE_TYPE_RANDOM_FLOAT__OUT__OUT,

--- a/src/modules/flow/servo-motor/servo-motor.c
+++ b/src/modules/flow/servo-motor/servo-motor.c
@@ -64,7 +64,7 @@ servo_motor_open(struct sol_flow_node *node, void *data, const struct sol_flow_n
     }
 
     mdata->duty_cycle_diff = mdata->duty_cycle_range.max -
-                             mdata->duty_cycle_range.min;
+        mdata->duty_cycle_range.min;
 
     pwm_config.api_version = SOL_PWM_CONFIG_API_VERSION;
     pwm_config.period_ns = opts->period.val * 1000;
@@ -100,7 +100,7 @@ set_pulse_width(struct servo_motor_data *mdata, int32_t pulse_width)
 
     mdata->duty_cycle_range.val = pulse_width;
     if (!sol_pwm_set_duty_cycle(mdata->pwm,
-            mdata->duty_cycle_range.val * 1000)) {
+        mdata->duty_cycle_range.val * 1000)) {
         SOL_WRN("Failed to write duty cycle %" PRId32 "ns.",
             mdata->duty_cycle_range.val * 1000);
         return -1;
@@ -146,7 +146,7 @@ angle_set(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_i
     }
 
     pulse_width = in_value * mdata->duty_cycle_diff / 180 +
-                  mdata->duty_cycle_range.min;
+        mdata->duty_cycle_range.min;
 
     return set_pulse_width(mdata, pulse_width);
 }

--- a/src/modules/flow/test/result.c
+++ b/src/modules/flow/test/result.c
@@ -154,6 +154,7 @@ test_result_process(
     bool passed = false;
 
     int r = sol_flow_packet_get_boolean(packet, &passed);
+
     SOL_INT_CHECK(r, < 0, r);
 
     if (passed)

--- a/src/modules/flow/wallclock/wallclock.c
+++ b/src/modules/flow/wallclock/wallclock.c
@@ -136,7 +136,7 @@ wallclock_schedule_next(struct sol_flow_node *node)
     if (mdata->type == TIMEOUT_SECOND) {
         CLOCK_GETTIME_DO(timeout,
             1000 - ((ts.tv_sec * 1000)
-                    + (ts.tv_nsec / 1000000)) % 1000);
+            + (ts.tv_nsec / 1000000)) % 1000);
         if (time_fail)
             goto err;
     } else {
@@ -167,10 +167,10 @@ wallclock_schedule_next(struct sol_flow_node *node)
             timeout = (SECONDS_IN_MINUTE - local_time.tm_sec);
         } else if (mdata->type == TIMEOUT_HOUR) {
             timeout = (MINUTES_IN_HOUR - local_time.tm_min) * SECONDS_IN_MINUTE
-                      - seconds;
+                - seconds;
         } else { /* TIMEOUT_MONTHDAY or TIMEOUT_WEEKDAY */
             timeout = (HOURS_IN_DAY - local_time.tm_hour) * SECONDS_IN_HOUR
-                      - minutes - seconds;
+                - minutes - seconds;
         }
     }
 

--- a/src/modules/linux-micro/bluetooth/bluetooth.c
+++ b/src/modules/linux-micro/bluetooth/bluetooth.c
@@ -166,7 +166,7 @@ on_dbus_service_state_changed(void *data,
     if (state == SOL_PLATFORM_SERVICE_STATE_ACTIVE)
         fork_run_do();
     else if (state == SOL_PLATFORM_SERVICE_STATE_INACTIVE
-             || state == SOL_PLATFORM_SERVICE_STATE_FAILED)
+        || state == SOL_PLATFORM_SERVICE_STATE_FAILED)
         bluetooth_stop(data, name, true);
 }
 
@@ -184,7 +184,7 @@ bluetooth_start(const struct sol_platform_linux_micro_module *mod,
         return 0;
 
     ret = sol_platform_add_service_monitor
-              (on_dbus_service_state_changed, DBUS, mod);
+            (on_dbus_service_state_changed, DBUS, mod);
     if (ret >= 0)
         goto err;
 

--- a/src/samples/flow/c-api/highlevel.c
+++ b/src/samples/flow/c-api/highlevel.c
@@ -65,12 +65,12 @@ startup(void)
     struct sol_flow_node_type *flow_node_type;
     struct _custom_node_types_reader_options reader_opts =
         _CUSTOM_NODE_TYPES_READER_OPTIONS_DEFAULTS(
-            .intopt.val = 1
-            );
+        .intopt.val = 1
+        );
     struct _custom_node_types_writer_options writer_opts =
         _CUSTOM_NODE_TYPES_WRITER_OPTIONS_DEFAULTS(
-            .prefix = "writer prefix from options"
-            );
+        .prefix = "writer prefix from options"
+        );
 
     builder = sol_flow_builder_new();
 

--- a/src/samples/flow/c-api/lowlevel.c
+++ b/src/samples/flow/c-api/lowlevel.c
@@ -61,12 +61,12 @@ static void log_init(void) SOL_ATTR_UNUSED;
 
 static const struct _custom_node_types_reader_options reader_opts =
     _CUSTOM_NODE_TYPES_READER_OPTIONS_DEFAULTS(
-        .intopt.val = 1
-        );
+    .intopt.val = 1
+    );
 static const struct _custom_node_types_writer_options writer_opts =
     _CUSTOM_NODE_TYPES_WRITER_OPTIONS_DEFAULTS(
-        .prefix = "writer prefix from options"
-        );
+    .prefix = "writer prefix from options"
+    );
 
 /* This array defines the nodes we will use in our flow. It is space
  * efficient and will not be duplicated, a reference of it is kept by

--- a/src/shared/sol-conffile.c
+++ b/src/shared/sol-conffile.c
@@ -158,11 +158,11 @@ sol_conffile_load_keyfile_from_dirs(const char *file, char **full_path)
     /* absolute path */
     if (g_path_is_absolute(file)) {
         if (!g_key_file_load_from_file(keyfile,
-                file, G_KEY_FILE_NONE, &error))
+            file, G_KEY_FILE_NONE, &error))
             goto err;
     } else if (!g_key_file_load_from_dirs(keyfile, file, search_dirs,
-                   full_path, G_KEY_FILE_NONE,
-                   &error))
+        full_path, G_KEY_FILE_NONE,
+        &error))
         goto err;
 
     return keyfile;
@@ -191,7 +191,7 @@ sol_conffile_load_keyfile_from_paths(const char *path,
         splitted_paths = g_strsplit(fallback_paths, ";", -1);
         for (ptr = splitted_paths; *ptr; ptr++) {
             keyfile = sol_conffile_load_keyfile_from_dirs
-                          (*ptr, full_path);
+                    (*ptr, full_path);
             if (keyfile)
                 break;
         }
@@ -235,9 +235,9 @@ sol_conffile_append_to_entry_vector(struct sol_ptr_vector pv)
 
     SOL_PTR_VECTOR_FOREACH_IDX (&pv, pv_entry, i) {
         SOL_PTR_VECTOR_FOREACH_IDX (&sol_conffile_entry_vector,
-                                    sol_conffile_entry_vector_entry, j) {
+            sol_conffile_entry_vector_entry, j) {
             if (streq(pv_entry->id,
-                    sol_conffile_entry_vector_entry->id)) {
+                sol_conffile_entry_vector_entry->id)) {
                 SOL_DBG("Ignoring entry [%s], as it already exists",
                     pv_entry->id);
                 sol_conffile_free_entry_vector(&pv);
@@ -266,7 +266,7 @@ sol_conffile_fill_vector(const char *path, const char *fallback_paths)
     struct sol_ptr_vector pv;
 
     keyfile = sol_conffile_load_keyfile_from_paths
-                  (path, fallback_paths, &full_path);
+            (path, fallback_paths, &full_path);
     if (!keyfile)
         return;
 

--- a/src/shared/sol-fbp-graph.c
+++ b/src/shared/sol-fbp-graph.c
@@ -263,7 +263,7 @@ sol_fbp_graph_add_exported_in_port(struct sol_fbp_graph *g,
             goto end;
         }
         if (ep->node == node && (ep->port_idx == port_idx
-                                 || (ep->port_idx == -1 || port_idx == -1))
+            || (ep->port_idx == -1 || port_idx == -1))
             && sol_str_slice_eq(ep->port, port)) {
             err = -EADDRINUSE;
             goto end;
@@ -301,7 +301,7 @@ sol_fbp_graph_add_exported_out_port(struct sol_fbp_graph *g,
             goto end;
         }
         if (ep->node == node && (ep->port_idx == port_idx
-                                 || (ep->port_idx == -1 || port_idx == -1))
+            || (ep->port_idx == -1 || port_idx == -1))
             && sol_str_slice_eq(ep->port, port)) {
             err = -EADDRINUSE;
             goto end;

--- a/src/shared/sol-monitors.h
+++ b/src/shared/sol-monitors.h
@@ -130,8 +130,8 @@ void sol_monitors_end_walk(struct sol_monitors *ms);
 
 #define __SOL_MONITORS_WALK(ms, itrvar, idx, executed)                    \
     for (bool executed = ({ sol_monitors_begin_walk(ms); false; });      \
-         !executed;                                                     \
-         executed = ({ sol_monitors_end_walk(ms); true; }))              \
+        !executed;                                                     \
+        executed = ({ sol_monitors_end_walk(ms); true; }))              \
         SOL_VECTOR_FOREACH_IDX (&(ms)->entries, itrvar, idx)
 
 #define _SOL_MONITORS_WALK(ms, itrvar, idx, executed) \

--- a/src/shared/sol-network-linux.c
+++ b/src/shared/sol-network-linux.c
@@ -122,10 +122,10 @@ _on_link_event(struct nlmsghdr *header)
     SOL_NULL_CHECK(link);
 
     event = (header->nlmsg_type == RTM_NEWLINK) ? SOL_NETWORK_LINK_ADDED :
-            SOL_NETWORK_LINK_REMOVED;
+        SOL_NETWORK_LINK_REMOVED;
 
     for (rth = IFLA_RTA(ifi), rtl = IFLA_PAYLOAD(header); rtl && RTA_OK(rth, rtl);
-         rth = RTA_NEXT(rth, rtl)) {
+        rth = RTA_NEXT(rth, rtl)) {
         if (rth->rta_type != IFLA_STATS)
             continue;
 
@@ -171,7 +171,7 @@ _on_addr_event(struct nlmsghdr *header)
     SOL_NULL_CHECK(link);
 
     for (rth = IFA_RTA(ifa), rtl = IFA_PAYLOAD(header); rtl && RTA_OK(rth, rtl);
-         rth = RTA_NEXT(rth, rtl)) {
+        rth = RTA_NEXT(rth, rtl)) {
         struct sol_network_link_addr *addr = NULL, *addr_itr;
 
         if (rth->rta_type != IFA_LOCAL && rth->rta_type != IFA_ADDRESS)
@@ -234,7 +234,7 @@ _on_event(void *data, int nl_socket, unsigned int cond)
     }
 
     for (h = (struct nlmsghdr *)buf; NLMSG_OK(h, (unsigned int)status);
-         h = NLMSG_NEXT(h, status)) {
+        h = NLMSG_NEXT(h, status)) {
 
         switch (h->nlmsg_type) {
         case NLMSG_ERROR:
@@ -335,7 +335,7 @@ sol_network_init(void)
     network->nl_addr.nl_groups = RTMGRP_LINK | RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR;
 
     if (bind(network->nl_socket, (struct sockaddr *)&network->nl_addr,
-            sizeof(network->nl_addr)) < 0) {
+        sizeof(network->nl_addr)) < 0) {
         SOL_WRN("Socket bind failed!");
         goto err_bind;
     }
@@ -407,7 +407,7 @@ sol_network_shutdown(void)
 
 bool
 sol_network_subscribe_events(void (*cb)(void *data, const struct sol_network_link *link,
-        enum sol_network_event event),
+    enum sol_network_event event),
     const void *data)
 {
     struct callback *callback;
@@ -426,7 +426,7 @@ sol_network_subscribe_events(void (*cb)(void *data, const struct sol_network_lin
 
 bool
 sol_network_unsubscribe_events(void (*cb)(void *data, const struct sol_network_link *link,
-        enum sol_network_event event),
+    enum sol_network_event event),
     const void *data)
 {
     struct callback *callback;

--- a/src/shared/sol-network-riot.c
+++ b/src/shared/sol-network-riot.c
@@ -116,7 +116,7 @@ sol_network_shutdown(void)
 
 SOL_API bool
 sol_network_subscribe_events(void (*cb)(void *data, const struct sol_network_link *link,
-        enum sol_network_event event),
+    enum sol_network_event event),
     const void *data)
 {
     return false;
@@ -124,7 +124,7 @@ sol_network_subscribe_events(void (*cb)(void *data, const struct sol_network_lin
 
 SOL_API bool
 sol_network_unsubscribe_events(void (*cb)(void *data, const struct sol_network_link *link,
-        enum sol_network_event event),
+    enum sol_network_event event),
     const void *data)
 {
     return false;

--- a/src/shared/sol-network.h
+++ b/src/shared/sol-network.h
@@ -76,10 +76,10 @@ bool sol_network_link_addr_eq(const struct sol_network_link_addr *a,
 bool sol_network_init(void);
 void sol_network_shutdown(void);
 bool sol_network_subscribe_events(void (*cb)(void *data, const struct sol_network_link *link,
-        enum sol_network_event event),
+    enum sol_network_event event),
     const void *data);
 bool sol_network_unsubscribe_events(void (*cb)(void *data, const struct sol_network_link *link,
-        enum sol_network_event event),
+    enum sol_network_event event),
     const void *data);
 
 const struct sol_vector *sol_network_get_available_links(void);

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -314,6 +314,7 @@ static int
 get_progname(char *out, size_t size)
 {
     char cwd[PATH_MAX] = { 0 };
+
 #ifdef HAVE_SYS_AUXV_H
     char *execfn = NULL;
 #else

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -135,9 +135,9 @@ char *sol_util_strerror(int errnum, char *buf, size_t buflen);
 
 #define sol_util_strerrora(errnum) \
     ({ \
-         char buf ## __COUNT__[512]; \
-         sol_util_strerror((errnum), buf ## __COUNT__, sizeof(buf ## __COUNT__)); \
-     })
+        char buf ## __COUNT__[512]; \
+        sol_util_strerror((errnum), buf ## __COUNT__, sizeof(buf ## __COUNT__)); \
+    })
 
 static inline unsigned int
 align_power2(unsigned int u)

--- a/src/test/test-flow-builder.c
+++ b/src/test/test-flow-builder.c
@@ -166,20 +166,20 @@ test_node_get_port_out(const struct sol_flow_node_type *type, uint16_t port)
 static const struct sol_flow_node_type_description test_node_description = {
     .ports_in = (const struct sol_flow_port_description *const []){
         &((const struct sol_flow_port_description){
-              .name = "IN1",
-          }),
+            .name = "IN1",
+        }),
         &((const struct sol_flow_port_description){
-              .name = "IN2",
-          }),
+            .name = "IN2",
+        }),
         NULL
     },
     .ports_out = (const struct sol_flow_port_description *const []){
         &((const struct sol_flow_port_description){
-              .name = "OUT1",
-          }),
+            .name = "OUT1",
+        }),
         &((const struct sol_flow_port_description){
-              .name = "OUT2",
-          }),
+            .name = "OUT2",
+        }),
         NULL
     },
 };
@@ -197,11 +197,11 @@ static const struct sol_flow_node_type test_node_type = {
 static const struct sol_flow_node_type_description test_wrong_out_node_description = {
     .ports_out = (const struct sol_flow_port_description *const []){
         &((const struct sol_flow_port_description){
-              .name = "OUT",
-          }),
+            .name = "OUT",
+        }),
         &((const struct sol_flow_port_description){
-              .name = "OUT",
-          }),
+            .name = "OUT",
+        }),
         NULL
     },
 };
@@ -214,10 +214,10 @@ static const struct sol_flow_node_type test_wrong_out_node_type = {
 static const struct sol_flow_node_type_description test_wrong_out2_node_description = {
     .ports_out = (const struct sol_flow_port_description *const []){
         &((const struct sol_flow_port_description){
-          }),
+        }),
         &((const struct sol_flow_port_description){
-              .name = "OUT",
-          }),
+            .name = "OUT",
+        }),
         NULL
     },
 };
@@ -230,11 +230,11 @@ static const struct sol_flow_node_type test_wrong_out2_node_type = {
 static const struct sol_flow_node_type_description test_wrong_in_node_description = {
     .ports_in = (const struct sol_flow_port_description *const []){
         &((const struct sol_flow_port_description){
-              .name = "IN",
-          }),
+            .name = "IN",
+        }),
         &((const struct sol_flow_port_description){
-              .name = "IN",
-          }),
+            .name = "IN",
+        }),
         NULL
     },
 };
@@ -247,10 +247,10 @@ static const struct sol_flow_node_type test_wrong_in_node_type = {
 static const struct sol_flow_node_type_description test_wrong_in2_node_description = {
     .ports_in = (const struct sol_flow_port_description *const []){
         &((const struct sol_flow_port_description){
-              .name = "IN",
-          }),
+            .name = "IN",
+        }),
         &((const struct sol_flow_port_description){
-          }),
+        }),
         NULL
     },
 };

--- a/src/test/test-flow-parser.c
+++ b/src/test/test-flow-parser.c
@@ -169,46 +169,47 @@ struct test_node_options {
 static const struct sol_flow_node_type_description test_node_description = {
     .ports_in = (const struct sol_flow_port_description *const []){
         &((const struct sol_flow_port_description){
-              .name = "IN1",
-          }),
+            .name = "IN1",
+        }),
         &((const struct sol_flow_port_description){
-              .name = "IN2",
-          }),
+            .name = "IN2",
+        }),
         NULL
     },
     .ports_out = (const struct sol_flow_port_description *const []){
         &((const struct sol_flow_port_description){
-              .name = "OUT1",
-          }),
+            .name = "OUT1",
+        }),
         &((const struct sol_flow_port_description){
-              .name = "OUT2",
-          }),
+            .name = "OUT2",
+        }),
         NULL
     },
     .options = &((const struct sol_flow_node_options_description){
-        .data_size = sizeof(struct test_node_options),
-        .sub_api = 1,
-        .required = false,
-        .members = (const struct sol_flow_node_options_member_description[]){
-                    {
-            .name="opt",
-            .description="An optional option",
-            .data_type="boolean",
-            .required=false,
-            .offset=offsetof(struct test_node_options, opt),
-            .size=sizeof(bool),
-            .defvalue.b = true,
-        },
-            {}
-        }
-    })
+            .data_size = sizeof(struct test_node_options),
+            .sub_api = 1,
+            .required = false,
+            .members = (const struct sol_flow_node_options_member_description[]){
+                {
+                    .name = "opt",
+                    .description = "An optional option",
+                    .data_type = "boolean",
+                    .required = false,
+                    .offset = offsetof(struct test_node_options, opt),
+                    .size = sizeof(bool),
+                    .defvalue.b = true,
+                },
+                {}
+            }
+        })
 };
 
 static struct sol_flow_node_options *
 test_node_type_new_options(const struct sol_flow_node_type *type,
-        const struct sol_flow_node_options *copy_from)
+    const struct sol_flow_node_options *copy_from)
 {
     struct test_node_options *opts, *from = (struct test_node_options *)copy_from;
+
     opts = malloc(sizeof(*opts));
     opts->base.api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION;
     opts->base.sub_api = 1;
@@ -238,11 +239,11 @@ static const struct sol_flow_node_type test_node_type = {
 static const struct sol_flow_node_type_description test_wrong_out_node_description = {
     .ports_out = (const struct sol_flow_port_description *const []){
         &((const struct sol_flow_port_description){
-              .name = "OUT",
-          }),
+            .name = "OUT",
+        }),
         &((const struct sol_flow_port_description){
-              .name = "OUT",
-          }),
+            .name = "OUT",
+        }),
         NULL
     },
 };
@@ -255,10 +256,10 @@ static const struct sol_flow_node_type test_wrong_out_node_type = {
 static const struct sol_flow_node_type_description test_wrong_out2_node_description = {
     .ports_out = (const struct sol_flow_port_description *const []){
         &((const struct sol_flow_port_description){
-          }),
+        }),
         &((const struct sol_flow_port_description){
-              .name = "OUT",
-          }),
+            .name = "OUT",
+        }),
         NULL
     },
 };
@@ -271,11 +272,11 @@ static const struct sol_flow_node_type test_wrong_out2_node_type = {
 static const struct sol_flow_node_type_description test_wrong_in_node_description = {
     .ports_in = (const struct sol_flow_port_description *const []){
         &((const struct sol_flow_port_description){
-              .name = "IN",
-          }),
+            .name = "IN",
+        }),
         &((const struct sol_flow_port_description){
-              .name = "IN",
-          }),
+            .name = "IN",
+        }),
         NULL
     },
 };
@@ -288,10 +289,10 @@ static const struct sol_flow_node_type test_wrong_in_node_type = {
 static const struct sol_flow_node_type_description test_wrong_in2_node_description = {
     .ports_in = (const struct sol_flow_port_description *const []){
         &((const struct sol_flow_port_description){
-              .name = "IN",
-          }),
+            .name = "IN",
+        }),
         &((const struct sol_flow_port_description){
-          }),
+        }),
         NULL
     },
 };

--- a/src/test/test-flow.c
+++ b/src/test/test-flow.c
@@ -1140,14 +1140,14 @@ node_options_from_strv(void)
 
     /* One option */
     timer_opts = (struct sol_flow_node_type_timer_options *)
-                 sol_flow_node_options_new_from_strv(SOL_FLOW_NODE_TYPE_TIMER, timer_strv);
+        sol_flow_node_options_new_from_strv(SOL_FLOW_NODE_TYPE_TIMER, timer_strv);
     ASSERT(timer_opts);
     ASSERT_INT_EQ(timer_opts->interval.val, 1000);
     sol_flow_node_options_del(SOL_FLOW_NODE_TYPE_TIMER, (struct sol_flow_node_options *)timer_opts);
 
     /* Multiple options */
     pwm_opts = (struct sol_flow_node_type_pwm_options *)
-               sol_flow_node_options_new_from_strv(SOL_FLOW_NODE_TYPE_PWM, pwm_strv);
+        sol_flow_node_options_new_from_strv(SOL_FLOW_NODE_TYPE_PWM, pwm_strv);
     ASSERT(pwm_opts);
     ASSERT_INT_EQ(pwm_opts->chip.val, 2);
     ASSERT_INT_EQ(pwm_opts->pin.val, 7);
@@ -1158,7 +1158,7 @@ node_options_from_strv(void)
 
     /* String options */
     console_opts = (struct sol_flow_node_type_console_options *)
-                   sol_flow_node_options_new_from_strv(SOL_FLOW_NODE_TYPE_CONSOLE, console_strv);
+        sol_flow_node_options_new_from_strv(SOL_FLOW_NODE_TYPE_CONSOLE, console_strv);
     ASSERT(console_opts);
     ASSERT(streq(console_opts->prefix, "console prefix:"));
     ASSERT(streq(console_opts->suffix, ". suffix!"));
@@ -1167,7 +1167,7 @@ node_options_from_strv(void)
 
     /* Irange options */
     timer_opts = (struct sol_flow_node_type_timer_options *)
-                 sol_flow_node_options_new_from_strv(SOL_FLOW_NODE_TYPE_TIMER, timer_irange_strv);
+        sol_flow_node_options_new_from_strv(SOL_FLOW_NODE_TYPE_TIMER, timer_irange_strv);
     ASSERT(timer_opts);
     ASSERT_INT_EQ(timer_opts->interval.val, 50);
     ASSERT_INT_EQ(timer_opts->interval.step, 2);
@@ -1177,7 +1177,7 @@ node_options_from_strv(void)
 
     /* Irange different format options */
     timer_opts = (struct sol_flow_node_type_timer_options *)
-                 sol_flow_node_options_new_from_strv(SOL_FLOW_NODE_TYPE_TIMER, timer_irange_different_format_strv);
+        sol_flow_node_options_new_from_strv(SOL_FLOW_NODE_TYPE_TIMER, timer_irange_different_format_strv);
     ASSERT(timer_opts);
     ASSERT_INT_EQ(timer_opts->interval.val, 100);
     ASSERT_INT_EQ(timer_opts->interval.step, 5);
@@ -1217,7 +1217,7 @@ merge_options(void)
     };
 
     opts = (struct sol_flow_node_type_console_options *)
-           sol_flow_node_options_new_from_strv(SOL_FLOW_NODE_TYPE_CONSOLE, original_strv);
+        sol_flow_node_options_new_from_strv(SOL_FLOW_NODE_TYPE_CONSOLE, original_strv);
     ASSERT(opts);
 
     ASSERT(streq(opts->prefix, "original_prefix"));
@@ -1250,7 +1250,7 @@ copy_options(void)
     opts.flush = false;
 
     copied_opts = (struct sol_flow_node_type_console_options *)
-                  sol_flow_node_options_copy(SOL_FLOW_NODE_TYPE_CONSOLE, &opts.base);
+        sol_flow_node_options_copy(SOL_FLOW_NODE_TYPE_CONSOLE, &opts.base);
     ASSERT(copied_opts);
 
     /* Will touch some of the values after the copy. */

--- a/src/test/test-json.c
+++ b/src/test/test-json.c
@@ -157,7 +157,7 @@ test_json(void)
         output = scan_tests[i].output;
 
         for (j = 0; j < scan_tests[i].expected_elements; j++) {
-            if(!sol_json_scanner_next(&scanner, &input)) {
+            if (!sol_json_scanner_next(&scanner, &input)) {
                 SOL_WRN("Error: Unexpected end of file.");
                 ASSERT(false);
             }


### PR DESCRIPTION
Like function headers, function invocations, macro declarations, etc.
We always indent to a fixed size, now.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>