### PR TITLE
parser: use sol_util_strerrora() instead of strerror()

### DIFF
--- a/src/shared/sol-fbp-parser.c
+++ b/src/shared/sol-fbp-parser.c
@@ -693,7 +693,7 @@ sol_fbp_log_print(const char *file, unsigned int line, unsigned int column, cons
 
     va_start(ap, format);
     if (vasprintf(&msg, format, ap) == -1) {
-        SOL_WRN("Unable to parse error message %s", strerror(errno));
+        SOL_WRN("Unable to parse error message %s", sol_util_strerrora(errno));
         va_end(ap);
         return;
     }


### PR DESCRIPTION
strerror() should never be used in Soletta.

sol_util_strerrora() is a wrapper for that that's always
threadsafe, regardless of implementation details.

Signed-off-by: Ricardo de Almeida Gonzaga <ricardo.gonzaga@intel.com>