### PR TITLE
lib: changes versioned structs regarding api_version

### DIFF
--- a/src/lib/common/include/sol-pin-mux-modules.h
+++ b/src/lib/common/include/sol-pin-mux-modules.h
@@ -86,9 +86,10 @@ struct sol_pin_mux_controller {
  * Structure containing the recipes (lists of rules) that should be used
  * to multiplex the pins of a given platform
  */
-#define SOL_PIN_MUX_API_VERSION (1UL)
+#define SOL_PIN_MUX_API_VERSION (1)
 struct sol_pin_mux {
-    unsigned long int api_version; /**< API version */
+    uint16_t api_version; /**< API version */
+    uint16_t reserved; /* save this hole for a future field */
     const char *plat_name; /**< Name this multiplexer target platform */
 
     struct sol_pin_mux_controller gpio;

--- a/src/lib/flow/include/sol-flow-parser.h
+++ b/src/lib/flow/include/sol-flow-parser.h
@@ -51,8 +51,9 @@ extern "C" {
 struct sol_flow_parser;
 
 struct sol_flow_parser_client {
-#define SOL_FLOW_PARSER_CLIENT_API_VERSION (1UL)
-    unsigned long api_version;
+#define SOL_FLOW_PARSER_CLIENT_API_VERSION (1)
+    uint16_t api_version; /**< API version */
+    uint16_t reserved; /* save this hole for a future field */
     void *data;
 
     /* Called by parser to load declared types, buf should be valid

--- a/src/lib/flow/include/sol-flow-resolver.h
+++ b/src/lib/flow/include/sol-flow-resolver.h
@@ -49,8 +49,9 @@ extern "C" {
  */
 
 struct sol_flow_resolver {
-#define SOL_FLOW_RESOLVER_API_VERSION (1UL)
-    unsigned long api_version;
+#define SOL_FLOW_RESOLVER_API_VERSION (1)
+    uint16_t api_version; /**< API version */
+    uint16_t reserved; /* save this hole for a future field */
     const char *name;
     void *data;
 

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -266,7 +266,8 @@ struct sol_flow_node_type_description {
      * incremented.
      */
 #define SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION (1)
-    unsigned long api_version;
+    uint16_t api_version; /**< API version */
+    uint16_t reserved; /* save this hole for a future field */
     const char *name; /**< mandatory, the user-visible name */
     const char *category; /**< mandatory, convention is: category/subcategory/..., such as input/hw/sensor for a pressure sensor or input/sw/oic/switch for an OIC compliant on/off switch */
     const char *symbol; /**< the symbol that exports this type, useful to code that generates C code.  */

--- a/src/lib/io/include/sol-gpio.h
+++ b/src/lib/io/include/sol-gpio.h
@@ -64,7 +64,6 @@ struct sol_gpio_config {
 #define SOL_GPIO_CONFIG_API_VERSION (1)
     uint16_t api_version;
     enum sol_gpio_direction dir;
-    bool active_low;
     enum sol_gpio_drive drive_mode;
     union {
         struct {
@@ -77,6 +76,7 @@ struct sol_gpio_config {
             bool value;
         } out;
     };
+    bool active_low;
 };
 
 struct sol_gpio *sol_gpio_open(int pin, const struct sol_gpio_config *config) SOL_ATTR_WARN_UNUSED_RESULT;

--- a/src/lib/io/include/sol-pwm.h
+++ b/src/lib/io/include/sol-pwm.h
@@ -57,6 +57,7 @@ enum sol_pwm_polarity {
 struct sol_pwm_config {
 #define SOL_PWM_CONFIG_API_VERSION (1)
     uint16_t api_version;
+    uint16_t reserved; /* save this hole for a future field */
     int32_t period_ns; /* if == -1, won't set */
     int32_t duty_cycle_ns; /* if == -1, won't set, but if period is set, duty cycle is zeroed */
     enum sol_pwm_alignment alignment;


### PR DESCRIPTION
Use uint16_t for api_version (most structs were using it
already).
In some cases, it leads to a hole, so a "reserved" field was
placed.
In some cases struct was changed a bit to reduce holes.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>