### PR TITLE
sol-flow: Add an API to help the creation of complex nodes

### DIFF
--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -509,6 +509,17 @@ struct sol_flow_node_type *sol_flow_static_new_type(
     const struct sol_flow_node_options *opts,
     struct sol_flow_node_options *child_opts));
 
+struct sol_flow_node_type *sol_flow_static_new_container_node_type(
+    const struct sol_flow_node_type **base,
+    const struct sol_flow_static_node_spec nodes[],
+    const struct sol_flow_static_conn_spec conns[],
+    const struct sol_flow_static_port_spec exported_in[],
+    const struct sol_flow_static_port_spec exported_out[],
+    int (*child_opts_set)(const struct sol_flow_node_type *type,
+        uint16_t child_index,
+        const struct sol_flow_node_options *opts,
+        struct sol_flow_node_options *child_opts));
+
 void sol_flow_static_del_type(struct sol_flow_node_type *type);
 
 #ifdef __cplusplus

--- a/src/lib/flow/sol-flow-static.c
+++ b/src/lib/flow/sol-flow-static.c
@@ -1127,6 +1127,33 @@ sol_flow_static_new_type(
     return &type->base.base;
 }
 
+SOL_API struct sol_flow_node_type *
+sol_flow_static_new_container_node_type(
+    const struct sol_flow_node_type **base,
+    const struct sol_flow_static_node_spec nodes[],
+    const struct sol_flow_static_conn_spec conns[],
+    const struct sol_flow_static_port_spec exported_in[],
+    const struct sol_flow_static_port_spec exported_out[],
+    int (*child_opts_set)(const struct sol_flow_node_type *type,
+        uint16_t child_index,
+        const struct sol_flow_node_options *opts,
+        struct sol_flow_node_options *child_opts))
+{
+    struct sol_flow_node_type *type;
+
+    type = sol_flow_static_new_type(nodes, conns, exported_in, exported_out, child_opts_set);
+    SOL_NULL_CHECK(type, NULL);
+
+    type->new_options = (*base)->new_options;
+    type->free_options = (*base)->free_options;
+
+#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
+    type->description = (*base)->description;
+#endif
+
+    return type;
+}
+
 SOL_API void
 sol_flow_static_del_type(struct sol_flow_node_type *type)
 {

--- a/src/modules/flow/calamari/calamari.c
+++ b/src/modules/flow/calamari/calamari.c
@@ -245,14 +245,7 @@ calamari_7seg_new_type(const struct sol_flow_node_type **current)
     nodes[SEG_CTL].type = SOL_FLOW_NODE_TYPE_CALAMARI_SEGMENTS_CTL;
     nodes[SEG_CLEAR].type = nodes[SEG_LATCH].type = nodes[SEG_CLOCK].type = nodes[SEG_DATA].type = SOL_FLOW_NODE_TYPE_GPIO_WRITER;
 
-    type = sol_flow_static_new_type(nodes, conns, exported_in, NULL, calamari_7seg_child_opts_set);
-    SOL_NULL_CHECK(type);
-#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
-    type->description = (*current)->description;
-#endif
-    type->new_options = (*current)->new_options;
-    type->free_options = (*current)->free_options;
-    *current = type;
+    *current = sol_flow_static_new_container_node_type(current, nodes, conns, exported_in, NULL, calamari_7seg_child_opts_set);
 }
 
 #undef SEG_CTL
@@ -561,14 +554,7 @@ calamari_rgb_led_new_type(const struct sol_flow_node_type **current)
     nodes[RGB_LED_CTL].type = SOL_FLOW_NODE_TYPE_CALAMARI_RGB_CTL;
     nodes[RGB_LED_RED].type = nodes[RGB_LED_GREEN].type = nodes[RGB_LED_BLUE].type = SOL_FLOW_NODE_TYPE_GPIO_WRITER;
 
-    type = sol_flow_static_new_type(nodes, conns, exported_in, NULL, calamari_rgb_child_opts_set);
-    SOL_NULL_CHECK(type);
-#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
-    type->description = (*current)->description;
-#endif
-    type->new_options = (*current)->new_options;
-    type->free_options = (*current)->free_options;
-    *current = type;
+    *current =  sol_flow_static_new_container_node_type(current, nodes, conns, exported_in, NULL, calamari_rgb_child_opts_set);
 }
 
 #undef RGB_LED_CTL

--- a/src/modules/flow/grove/grove.c
+++ b/src/modules/flow/grove/grove.c
@@ -100,14 +100,7 @@ grove_rotary_sensor_new_type(const struct sol_flow_node_type **current)
     nodes[0].type = SOL_FLOW_NODE_TYPE_GROVE_ROTARY_CONVERTER;
     nodes[1].type = SOL_FLOW_NODE_TYPE_AIO_READER;
 
-    type = sol_flow_static_new_type(nodes, conns, NULL, exported_out, &rotary_child_opts_set);
-    SOL_NULL_CHECK(type);
-#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
-    type->description = (*current)->description;
-#endif
-    type->new_options = (*current)->new_options;
-    type->free_options = (*current)->free_options;
-    *current = type;
+    *current =  sol_flow_static_new_container_node_type(current, nodes, conns, NULL, exported_out, rotary_child_opts_set);
 }
 
 static void
@@ -210,14 +203,8 @@ grove_light_sensor_new_type(const struct sol_flow_node_type **current)
     nodes[0].type = SOL_FLOW_NODE_TYPE_GROVE_LIGHT_CONVERTER;
     nodes[1].type = SOL_FLOW_NODE_TYPE_AIO_READER;
 
-    type = sol_flow_static_new_type(nodes, conns, NULL, exported_out, &light_child_opts_set);
-    SOL_NULL_CHECK(type);
-#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
-    type->description = (*current)->description;
-#endif
-    type->new_options = (*current)->new_options;
-    type->free_options = (*current)->free_options;
-    *current = type;
+    *current = sol_flow_static_new_container_node_type(current, nodes, conns, NULL, exported_out, light_child_opts_set);
+
 }
 
 static void
@@ -382,14 +369,7 @@ grove_temperature_sensor_new_type(const struct sol_flow_node_type **current)
     nodes[0].type = SOL_FLOW_NODE_TYPE_GROVE_TEMPERATURE_CONVERTER;
     nodes[1].type = SOL_FLOW_NODE_TYPE_AIO_READER;
 
-    type = sol_flow_static_new_type(nodes, conns, NULL, exported_out, &temperature_child_opts_set);
-    SOL_NULL_CHECK(type);
-#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
-    type->description = (*current)->description;
-#endif
-    type->new_options = (*current)->new_options;
-    type->free_options = (*current)->free_options;
-    *current = type;
+    *current = sol_flow_static_new_container_node_type(current, nodes, conns, NULL, exported_out, temperature_child_opts_set);
 }
 
 static void


### PR DESCRIPTION
The current complex nodes we have - the ones with subflows -
required more than a call to sol_flow_static_new_type. This
patch introduces an auxiliar funcion that does the steps
required to create such nodes.

Signed-off-by: Anselmo L. S. Melo <anselmo.melo@intel.com>