### PR TITLE
build: Fix the build of external modules

### DIFF
--- a/src/lib/flow/sol-flow-buildopts.h.in
+++ b/src/lib/flow/sol-flow-buildopts.h.in
@@ -32,14 +32,12 @@
 
 #pragma once
 
-#include "sol_config.h"
-
 @SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED@
 @SOL_FLOW_INSPECTOR_ENABLED@
 
 @SOL_BUILD_FLOW_MODULE_RESOLVER_CONFFILE@
 
-#ifdef NODE_DESCRIPTION
+#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
 #ifdef SOL_BUILD_FLOW_MODULE_RESOLVER_CONFFILE
 extern const struct sol_flow_resolver *sol_flow_resolver_conffile;
 #else


### PR DESCRIPTION
It was depending of a header that is not installed.