### PR TITLE
runner: Don't use LOG if sol_init() fails

### DIFF
--- a/src/bin/sol-fbp-runner/main.c
+++ b/src/bin/sol-fbp-runner/main.c
@@ -162,7 +162,7 @@ main(int argc, char *argv[])
     }
 
     if (sol_init() < 0) {
-        SOL_CRI("Cannot initialize soletta.");
+        fprintf(stderr, "Cannot initialize soletta.\n");
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
It fix the following problem:

CRITICAL:./src/lib/common/sol-log.c:127:sol_log_vprint() SOL_LOG used
before initialization. domain=0x7fd54b40e300,
file=./src/bin/sol-fbp-runner/main.c, function=main, line=168,
fomart=Cannot initialize soletta.
[2]    25976 abort (core dumped) build/soletta_sysroot/tmp/soletta/bin/sol-fbp-runner

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>