### PR TITLE
check: allow disabling colors [v2]

### DIFF
--- a/data/scripts/suite.py
+++ b/data/scripts/suite.py
@@ -34,6 +34,7 @@ from multiprocessing import Manager
 from threading import Thread
 import argparse
 import subprocess
+import sys
 
 WARN = '\033[93m'
 PASS = '\033[92m'
@@ -139,9 +140,24 @@ if __name__ == "__main__":
     parser.add_argument("--valgrind", help="Path to valgrind, if provided " \
                         "the tests are run with it", type=str)
     parser.add_argument("--valgrind-supp", help="Path to valgrind's suppression file", type=str)
+    parser.add_argument("--color", metavar="WHEN", type=str,
+                        help="Use colors. WHEN can be always, auto and never.")
+    parser.set_defaults(color="auto")
 
     args = parser.parse_args()
     if args.valgrind_supp:
         args.valgrind_supp = "--suppressions=%s" % args.valgrind_supp
+    if args.color == "auto":
+        if sys.stdout.isatty():
+            args.color = "always"
+        else:
+            args.color = "never"
+
+    if args.color == "never":
+        WARN = ''
+        PASS = ''
+        FAIL = ''
+        ENDC = ''
+        STATUS_COLOR = ['', '']
 
     run_suite(args)

--- a/tools/check-style.py
+++ b/tools/check-style.py
@@ -125,7 +125,7 @@ def run_check(args, uncrustify):
             gen = unified_diff(fromlines, tolines, f, unc_file)
             for ln in gen:
                 passed = False
-                if sys.stdout.isatty() and not args.no_colors:
+                if args.color == "always":
                     out = re.sub("^\@", "%s@" % DIFF_REF_COLOR, \
                                  re.sub("^\-", "%s-" % DIFF_REM_COLOR, \
                                  re.sub("$", END_COLOR, \
@@ -146,8 +146,9 @@ if __name__ == "__main__":
                        type=str, metavar="<base-commit>")
     group.add_argument("-r", help="Use a refspec instead of a base commit",
                        dest="refspec", type=str, metavar="<refspec>")
-    parser.add_argument("--no-colors", help="Don't display colorized diffs",
-                        action="store_true")
+    parser.add_argument("--color", metavar="WHEN", type=str, \
+                        help="Use colors. WHEN can be always, auto and never.")
+    parser.set_defaults(color="auto")
 
     args = parser.parse_args()
     if args.base_commit:
@@ -156,6 +157,12 @@ if __name__ == "__main__":
         args.target_refspec = args.refspec
     else:
         args.target_refspec = "HEAD~1"
+
+    if args.color == "auto":
+        if sys.stdout.isatty():
+            args.color = "always"
+        else:
+            args.color = "never"
 
     uncrustify = check_uncrustify()
     if not uncrustify:


### PR DESCRIPTION
Replaces #239.

Changes from version 1:
- Use a single option modelled after git-diff and Leandro suggestion.
- Change `check-style.py` to work the same way.