### PR TITLE
shared-linux: Use SOL_ATTR_WARN_UNUSED_RESULT in all functions

### DIFF
--- a/src/shared/sol-util-linux.h
+++ b/src/shared/sol-util-linux.h
@@ -44,7 +44,7 @@ int sol_util_write_file(const char *path, const char *fmt, ...) SOL_ATTR_PRINTF(
 int sol_util_vwrite_file(const char *path, const char *fmt, va_list args) SOL_ATTR_PRINTF(2, 0);
 int sol_util_read_file(const char *path, const char *fmt, ...) SOL_ATTR_SCANF(2, 3);
 int sol_util_vread_file(const char *path, const char *fmt, va_list args) SOL_ATTR_SCANF(2, 0);
-void *sol_util_load_file_raw(const int fd, size_t *size);
-char *sol_util_load_file_string(const char *filename, size_t *size);
-int sol_util_get_rootdir(char *out, size_t size);
-int sol_util_fd_set_flag(int fd, int flag);
+void *sol_util_load_file_raw(const int fd, size_t *size) SOL_ATTR_WARN_UNUSED_RESULT;
+char *sol_util_load_file_string(const char *filename, size_t *size) SOL_ATTR_WARN_UNUSED_RESULT;
+int sol_util_get_rootdir(char *out, size_t size) SOL_ATTR_WARN_UNUSED_RESULT;
+int sol_util_fd_set_flag(int fd, int flag) SOL_ATTR_WARN_UNUSED_RESULT;


### PR DESCRIPTION
None of these functions should have their return values ignored.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>