### PR TITLE
Add 'samples' target

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -60,6 +60,11 @@ menu "Networking"
 source "src/lib/comms/Kconfig"
 endmenu
 
+menu "Samples"
+source "src/samples/coap/Kconfig"
+source "src/samples/common/Kconfig"
+endmenu
+
 menu "Tools"
 source "src/bin/sol-fbp-generator/Kconfig"
 source "src/bin/sol-fbp-runner/Kconfig"

--- a/src/samples/coap/.gitignore
+++ b/src/samples/coap/.gitignore
@@ -1,4 +1,4 @@
-/oic-client
-/oic-server
-/simple-client
-/simple-server
+/oic-sample-client
+/oic-sample-server
+/coap-sample-client
+/coap-sample-server

--- a/src/samples/coap/Kconfig
+++ b/src/samples/coap/Kconfig
@@ -1,0 +1,9 @@
+config COAP_SAMPLES
+	bool "CoAP samples"
+	depends on COAP
+	default n
+
+config OIC_SAMPLES
+	bool "OIC samples"
+	depends on OIC
+	default n

--- a/src/samples/coap/Makefile
+++ b/src/samples/coap/Makefile
@@ -1,0 +1,7 @@
+sample-$(COAP_SAMPLES) += coap-sample-client coap-sample-server
+sample-coap-sample-client-$(COAP_SAMPLES) := simple-client.c
+sample-coap-sample-server-$(COAP_SAMPLES) := simple-server.c
+
+sample-$(OIC_SAMPLES) += oic-sample-client oic-sample-server
+sample-oic-sample-client-$(OIC_SAMPLES) := oic-client.c
+sample-oic-sample-server-$(OIC_SAMPLES) := oic-server.c

--- a/src/samples/common/.gitignore
+++ b/src/samples/common/.gitignore
@@ -1,3 +1,3 @@
 linux-micro-init
 platform-simple
-uart
+uart-sample

--- a/src/samples/common/Kconfig
+++ b/src/samples/common/Kconfig
@@ -1,0 +1,13 @@
+config LINUX_MICRO_INIT_SAMPLE
+	bool "Linux Micro Init"
+	depends on PLATFORM_LINUX_MICRO
+	default n
+
+config PLATFORM_SIMPLE_SAMPLE
+	bool "Platform Simple"
+	default n
+
+config UART_SAMPLE
+	bool "UART"
+	default n
+

--- a/src/samples/common/Makefile
+++ b/src/samples/common/Makefile
@@ -1,0 +1,8 @@
+sample-$(LINUX_MICRO_INIT_SAMPLE) += linux-micro-init
+sample-linux-micro-init-$(LINUX_MICRO_INIT_SAMPLE) := linux-micro-init.c
+
+sample-$(PLATFORM_SIMPLE_SAMPLE) += platform-simple
+sample-platform-simple-$(PLATFORM_SIMPLE_SAMPLE) := platform-simple.c
+
+sample-$(UART_SAMPLE) += uart-sample
+sample-uart-sample-$(UART_SAMPLE) := uart.c

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -93,7 +93,13 @@ parse-test = \
 	$(eval $(1)-deps      := $(subst .mod,,$(test-$(1)-y-deps))) \
 	$(eval tests-out      += $(test-$(1)-out)) \
 
-clean-control = $(eval obj-y:=) $(eval obj-m:=) $(eval bin-y:=) $(eval test-y:=)
+parse-sample = \
+	$(eval sample-$(1)-srcs := $(addprefix $(2),$(sample-$(1)-y))) \
+	$(eval sample-$(1)-out  := $(addprefix $(2),$(1))) \
+	$(eval $(1)-deps      := $(subst .mod,,$(sample-$(1)-y-deps))) \
+	$(eval samples-out      += $(sample-$(1)-out)) \
+
+clean-control = $(eval obj-y:=) $(eval obj-m:=) $(eval bin-y:=) $(eval test-y:=) $(eval sample-y:=)
 
 inc-subdirs = \
 	$(foreach subdir,$(SUBDIRS), $(clean-control) \
@@ -116,6 +122,10 @@ inc-subdirs = \
 		$(eval tests += $(test-y)) \
 		$(foreach test,$(test-y), \
 			$(call parse-test,$(test),$(subdir)) \
+		) \
+		$(eval samples += $(sample-y)) \
+		$(foreach sample,$(sample-y), \
+			$(call parse-sample,$(sample),$(subdir)) \
 		) \
 		$(clean-control) \
 	)
@@ -166,6 +176,14 @@ $(bin-$(1)-out): $(PRE_GEN) $(SOL_LIB_SO) $(INT_LIB_AR) $(bin-$(1)-srcs) $(call 
 	$(Q)$(TARGETCC) $(filter-out %.h,$(bin-$(1)-srcs)) -o $(bin-$(1)-out) $(LIB_COVERAGE_FLAGS) $(BIN_CFLAGS)
 endef
 $(foreach curr,$(bins),$(eval $(call make-bin,$(curr))))
+
+define make-sample
+$(sample-$(1)-out): $(PRE_GEN) $(SOL_LIB_SO) $(sample-$(1)-srcs) $(call find-deps,$(1))
+	$(Q)echo "     "SMP"   "$$@
+	$(Q)$(TARGETCC) $(filter-out %.h,$(sample-$(1)-srcs)) -o $$@ \
+		$(BIN_CFLAGS) $(SAMPLE_CFLAGS) $(call find-deps,$(1)) $(LIB_COVERAGE_FLAGS)
+endef
+$(foreach sample,$(samples),$(eval $(call make-sample,$(sample))))
 
 define make-test
 $(test-$(1)-out): $(PRE_GEN) $(SOL_LIB_SO) $(test-$(1)-srcs) $(call find-deps,$(1))

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -46,6 +46,10 @@ endif
 
 PHONY += run-coverage coverage
 
+samples: $(SOL_LIB_SO) $(SOL_LIB_AR) $(samples-out)
+
+PHONY += samples
+
 PRE_INSTALL := $(PC_GEN) $(SOL_LIB_SO) $(SOL_LIB_AR) $(bins-out) $(modules-out) $(all-mod-descs)
 PRE_INSTALL += $(NODE_TYPE_SCHEMA_DEST) $(PLATFORM_DETECT_DEST) $(GDB_AUTOLOAD_PY_DEST)
 

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -7,6 +7,7 @@ obj-y :=
 obj-m :=
 bin-y :=
 test-y :=
+sample-y :=
 
 # builtin objects, deps and configs lookup variables
 builtins :=
@@ -32,6 +33,9 @@ bins-out :=
 # test suite lookup variables
 tests :=
 tests-out :=
+
+samples :=
+samples-out :=
 
 all-gens :=
 all-objs :=
@@ -215,6 +219,8 @@ BIN_CFLAGS += $(addprefix -L,$(LIB_OUTPUTDIR))
 BIN_CFLAGS += -lsoletta -ldl
 BIN_CFLAGS += -Wl,-R$(abspath $(build_libdir))
 BIN_CFLAGS += -lm
+
+SAMPLE_CFLAGS :=
 
 TARGET_LINKFLAGS := $(addprefix -L,$(INT_LIBDIR))
 TARGET_LINKFLAGS += -Wl,--whole-archive -lshared -Wl,-no-whole-archive -ldl


### PR DESCRIPTION
Allow CoAP and common samples to be built using the 'make samples'
target.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>