### PR TITLE
flow: provide a generic function for deleting node types

### DIFF
--- a/src/lib/flow/include/sol-flow-static.h
+++ b/src/lib/flow/include/sol-flow-static.h
@@ -172,8 +172,6 @@ struct sol_flow_node *sol_flow_static_get_node(struct sol_flow_node *node, uint1
 struct sol_flow_node_type *sol_flow_static_new_type(
     const struct sol_flow_static_spec *spec);
 
-void sol_flow_static_del_type(struct sol_flow_node_type *type);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -321,6 +321,10 @@ struct sol_flow_node_type {
 
     void (*init_type)(void); /**< member function called at least once for each node type, that allows initialization of node-specific data (packet types, logging domains, etc) */
 
+    /** Called as part of sol_flow_node_type_del() to dispose any
+     * extra resources associated with the node type. */
+    void (*dispose_type)(struct sol_flow_node_type *type);
+
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
     const struct sol_flow_node_type_description *description; /**< pointer to node's description */
 #endif
@@ -345,6 +349,12 @@ const struct sol_flow_port_type_in *sol_flow_node_type_get_port_in(const struct 
  *
  */
 const struct sol_flow_port_type_out *sol_flow_node_type_get_port_out(const struct sol_flow_node_type *type, uint16_t port);
+
+/**
+ * Delete a node type. It should be used only for types dynamically
+ * created and returned by functions like sol_flow_static_new_type().
+ */
+void sol_flow_node_type_del(struct sol_flow_node_type *type);
 
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
 /**

--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -158,7 +158,7 @@ sol_flow_builder_del(struct sol_flow_builder *builder)
     free(builder->conn_spec);
 
     if (builder->node_type)
-        sol_flow_static_del_type(builder->node_type);
+        sol_flow_node_type_del(builder->node_type);
 
     sol_arena_del(builder->str_arena);
 

--- a/src/lib/flow/sol-flow-static.c
+++ b/src/lib/flow/sol-flow-static.c
@@ -505,7 +505,7 @@ flow_node_close(struct sol_flow_node *node, void *data)
     free(fsd->nodes);
 
     if (type->owned_by_node)
-        sol_flow_static_del_type(&type->base.base);
+        sol_flow_node_type_del(&type->base.base);
 }
 
 static bool
@@ -976,6 +976,15 @@ fail_nomem:
     return -ENOMEM;
 }
 
+static void
+flow_dispose_type(struct sol_flow_node_type *type)
+{
+    struct flow_static_type *fst = (struct flow_static_type *)type;
+
+    flow_static_type_fini(fst);
+    free(fst);
+}
+
 static int
 flow_static_type_init(
     struct flow_static_type *type,
@@ -994,6 +1003,7 @@ flow_static_type_init(
                 .get_ports_counts = flow_get_ports_counts,
                 .get_port_in = flow_get_port_in,
                 .get_port_out = flow_get_port_out,
+                .dispose_type = flow_dispose_type,
             },
             .send = flow_send,
         },
@@ -1057,7 +1067,7 @@ sol_flow_static_new(struct sol_flow_node *parent, const struct sol_flow_static_n
         NULL);
 
     if (!node)
-        sol_flow_static_del_type(&type->base.base);
+        sol_flow_node_type_del(&type->base.base);
 
     return node;
 }
@@ -1127,16 +1137,4 @@ sol_flow_static_new_type(
     }
 
     return &type->base.base;
-}
-
-SOL_API void
-sol_flow_static_del_type(struct sol_flow_node_type *type)
-{
-    struct flow_static_type *fst;
-
-    SOL_FLOW_STATIC_TYPE_CHECK(type);
-
-    fst = (struct flow_static_type *)type;
-    flow_static_type_fini(fst);
-    free(fst);
 }

--- a/src/lib/flow/sol-flow.c
+++ b/src/lib/flow/sol-flow.c
@@ -435,6 +435,14 @@ sol_flow_node_type_get_port_out(const struct sol_flow_node_type *type, uint16_t 
     return type->get_port_out(type, port);
 }
 
+SOL_API void
+sol_flow_node_type_del(struct sol_flow_node_type *type)
+{
+    if (!type || !type->dispose_type)
+        return;
+    type->dispose_type(type);
+}
+
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
 #include "sol-flow-builtins-gen.h"
 

--- a/src/test/test-flow.c
+++ b/src/test/test-flow.c
@@ -304,7 +304,7 @@ test_flow_new_type(void)
 static void
 test_flow_del_type(struct sol_flow_node_type *type)
 {
-    sol_flow_static_del_type(type);
+    sol_flow_node_type_del(type);
 }
 
 #define ASSERT_EVENT_COUNT(node, event, count) \
@@ -774,7 +774,7 @@ test_other_flow_new_type(void)
 static void
 test_other_flow_del_type(struct sol_flow_node_type *type)
 {
-    sol_flow_static_del_type(type);
+    sol_flow_node_type_del(type);
 }
 
 


### PR DESCRIPTION
Some node *types* are created in runtime, and need to be later deleted
and have extra resources disposed. Types created with
sol_flow_static_new_type() are one example, others might be added later.

This patch provide a generic function for deleting those types, so code
that contains collections of node types doesn't need to track which
specific delete function to call. We'll use that as part of
sol-flow-resolver, for the declared types, that might have different
sources.

There's a callback function to handle the per type behavior in the type
structure. Uses of sol_flow_static_del_type() were replace with
sol_flow_node_type_del().

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>