### PR TITLE
tests: fix warnings on two fbp tests

### DIFF
--- a/src/test-fbp/converter-error-expected.txt
+++ b/src/test-fbp/converter-error-expected.txt
@@ -1,0 +1,1 @@
+WRN: ./src/lib/common/sol-types.c:242 sol_irange_division() Division by zero: 10, 0

--- a/src/test-fbp/hub-expected.txt
+++ b/src/test-fbp/hub-expected.txt
@@ -1,0 +1,1 @@
+WRN: ./src/lib/common/sol-types.c:242 sol_irange_division() Division by zero: 10, 0


### PR DESCRIPTION
Division by 0 was expected on these tests.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>