### PR TITLE
platform-detect: Sanitize platform name

### DIFF
--- a/src/lib/common/sol-platform-detect.c
+++ b/src/lib/common/sol-platform-detect.c
@@ -266,3 +266,24 @@ end:
     sol_file_reader_close(json_doc);
     return platform;
 }
+
+bool
+sol_platform_invalid_name(const char *name)
+{
+    unsigned int i;
+
+    if (name[0] == '\0')
+        return true;
+
+    for (i = 0; name[i] != '\0'; i++) {
+        // https://xkcd.com/276/
+        if ((name[i] >= 'A' && name[i] <= 'Z') ||
+            (name[i] >= 'a' && name[i] <= 'z') ||
+            (name[i] == '_' || name[i] == '-'))
+            continue;
+
+        return true;
+    }
+
+    return false;
+}

--- a/src/lib/common/sol-platform-detect.h
+++ b/src/lib/common/sol-platform-detect.h
@@ -32,4 +32,7 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 char *sol_platform_detect(void);
+bool sol_platform_invalid_name(const char *name);

--- a/src/lib/common/sol-platform.c
+++ b/src/lib/common/sol-platform.c
@@ -99,6 +99,11 @@ sol_platform_get_name(void)
         platform_name = strdup(platform_name);
     else
         platform_name = sol_platform_detect();
+
+    if (platform_name && sol_platform_invalid_name(platform_name)) {
+        free(platform_name);
+        platform_name = NULL;
+    }
 #endif
 
 #ifdef PLATFORM_NAME


### PR DESCRIPTION
Version "regexless". This should fix coverity bug 122264.

Related to #266

@anselmolsm @barbieri