### PR TITLE
Let type outlive builder

### DIFF
--- a/src/bin/sol-fbp-runner/runner.c
+++ b/src/bin/sol-fbp-runner/runner.c
@@ -329,10 +329,12 @@ runner_del(struct runner *r)
 {
     if (r->root)
         sol_flow_node_del(r->root);
+    if (r->builder) {
+        sol_flow_node_type_del(r->root_type);
+        sol_flow_builder_del(r->builder);
+    }
     if (r->parser)
         sol_flow_parser_del(r->parser);
-    if (r->builder)
-        sol_flow_builder_del(r->builder);
     free(r->dirname);
     free(r->basename);
     free(r);

--- a/src/lib/datatypes/include/sol-vector.h
+++ b/src/lib/datatypes/include/sol-vector.h
@@ -91,6 +91,16 @@ int sol_vector_del(struct sol_vector *v, uint16_t i);
 
 void sol_vector_clear(struct sol_vector *v);
 
+static inline void *
+sol_vector_take_all(struct sol_vector *v)
+{
+    void *data = v->data;
+
+    v->data = NULL;
+    v->len = 0;
+    return data;
+}
+
 #define SOL_VECTOR_FOREACH_IDX(vector, itrvar, idx)                      \
     for (idx = 0;                                                       \
         idx < (vector)->len && (itrvar = sol_vector_get((vector), idx), true); \
@@ -160,6 +170,11 @@ sol_ptr_vector_clear(struct sol_ptr_vector *pv)
     sol_vector_clear(&pv->base);
 }
 
+static inline void *
+sol_ptr_vector_take_all(struct sol_ptr_vector *pv)
+{
+    return sol_vector_take_all(&pv->base);
+}
 
 #define SOL_PTR_VECTOR_FOREACH_IDX(vector, itrvar, idx) \
     for (idx = 0; \

--- a/src/lib/flow/include/sol-flow-builder.h
+++ b/src/lib/flow/include/sol-flow-builder.h
@@ -91,9 +91,8 @@ int sol_flow_builder_export_option(struct sol_flow_builder *builder, const char 
 
 /* Returns the node type generated with the builder. It should be used
  * to create nodes with sol_flow_node_new(). After the type is
- * created, no more nodes or connections can be added.
- * This node type will be freed by the builder when the builder
- * itself is deleted.
+ * created, no more nodes or connections can be added. This node type
+ * must be deleted using sol_flow_node_type_del().
  */
 struct sol_flow_node_type *sol_flow_builder_get_node_type(struct sol_flow_builder *builder);
 

--- a/src/lib/flow/include/sol-flow-static.h
+++ b/src/lib/flow/include/sol-flow-static.h
@@ -115,6 +115,11 @@ struct sol_flow_static_spec {
         uint16_t child_index,
         const struct sol_flow_node_options *opts,
         struct sol_flow_node_options *child_opts);
+
+    /** Function called after the static type is disposed. The user is
+     * passed the type_data pointer, that can be used to store
+     * reference to extra resources to be disposed. */
+    void (*dispose)(const void *type_data);
 };
 
 /**

--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -176,9 +176,16 @@ sol_flow_builder_set_resolver(struct sol_flow_builder *builder,
     builder->resolver = resolver;
 }
 
+static struct sol_arena *
+get_arena(struct sol_flow_builder *builder)
+{
+    return builder->str_arena;
+}
+
 static bool
 set_type_description_symbols(struct sol_flow_builder *builder, const char *name)
 {
+    struct sol_flow_node_type_description *desc = &builder->type_desc;
     char *n;
     char buf[4096];
     int r;
@@ -191,8 +198,8 @@ set_type_description_symbols(struct sol_flow_builder *builder, const char *name)
     if (r < 0 || r >= (int)sizeof(buf))
         return false;
 
-    builder->type_desc.symbol = sol_arena_strdup(builder->str_arena, buf);
-    SOL_NULL_CHECK(builder->type_desc.symbol, false);
+    desc->symbol = sol_arena_strdup(get_arena(builder), buf);
+    SOL_NULL_CHECK(desc->symbol, false);
 
     n = strdupa(name);
     for (char *p = n; *p; p++)
@@ -202,8 +209,8 @@ set_type_description_symbols(struct sol_flow_builder *builder, const char *name)
     if (r < 0 || r >= (int)sizeof(buf))
         return false;
 
-    builder->type_desc.options_symbol = sol_arena_strdup(builder->str_arena, buf);
-    SOL_NULL_CHECK(builder->type_desc.options_symbol, false);
+    desc->options_symbol = sol_arena_strdup(get_arena(builder), buf);
+    SOL_NULL_CHECK(desc->options_symbol, false);
 
     return true;
 }
@@ -212,6 +219,8 @@ SOL_API int
 sol_flow_builder_set_type_description(struct sol_flow_builder *builder, const char *name, const char *category,
     const char *description, const char *author, const char *url, const char *license, const char *version)
 {
+    struct sol_flow_node_type_description *desc;
+
     SOL_NULL_CHECK(builder, -EINVAL);
 
     if (builder->node_type) {
@@ -224,26 +233,28 @@ sol_flow_builder_set_type_description(struct sol_flow_builder *builder, const ch
         return -EINVAL;
     }
 
-    builder->type_desc.name = sol_arena_strdup(builder->str_arena, name);
-    SOL_NULL_CHECK_GOTO(builder->type_desc.name, failure);
+    desc = &builder->type_desc;
 
-    builder->type_desc.category = sol_arena_strdup(builder->str_arena, category);
-    SOL_NULL_CHECK_GOTO(builder->type_desc.category, failure);
+    desc->name = sol_arena_strdup(get_arena(builder), name);
+    SOL_NULL_CHECK_GOTO(desc->name, failure);
 
-    builder->type_desc.description = sol_arena_strdup(builder->str_arena, description);
-    SOL_NULL_CHECK_GOTO(builder->type_desc.description, failure);
+    desc->category = sol_arena_strdup(get_arena(builder), category);
+    SOL_NULL_CHECK_GOTO(desc->category, failure);
 
-    builder->type_desc.author = sol_arena_strdup(builder->str_arena, author);
-    SOL_NULL_CHECK_GOTO(builder->type_desc.author, failure);
+    desc->description = sol_arena_strdup(get_arena(builder), description);
+    SOL_NULL_CHECK_GOTO(desc->description, failure);
 
-    builder->type_desc.url = sol_arena_strdup(builder->str_arena, url);
-    SOL_NULL_CHECK_GOTO(builder->type_desc.url, failure);
+    desc->author = sol_arena_strdup(get_arena(builder), author);
+    SOL_NULL_CHECK_GOTO(desc->author, failure);
 
-    builder->type_desc.license = sol_arena_strdup(builder->str_arena, license);
-    SOL_NULL_CHECK_GOTO(builder->type_desc.license, failure);
+    desc->url = sol_arena_strdup(get_arena(builder), url);
+    SOL_NULL_CHECK_GOTO(desc->url, failure);
 
-    builder->type_desc.version = sol_arena_strdup(builder->str_arena, version);
-    SOL_NULL_CHECK_GOTO(builder->type_desc.version, failure);
+    desc->license = sol_arena_strdup(get_arena(builder), license);
+    SOL_NULL_CHECK_GOTO(desc->license, failure);
+
+    desc->version = sol_arena_strdup(get_arena(builder), version);
+    SOL_NULL_CHECK_GOTO(desc->version, failure);
 
     if (!set_type_description_symbols(builder, name))
         goto failure;
@@ -362,7 +373,7 @@ sol_flow_builder_add_node(struct sol_flow_builder *builder, const char *name, co
         find_duplicated_port_names(type->description->ports_out, true))))
         return -EEXIST;
 
-    node_name = sol_arena_strdup(builder->str_arena, name);
+    node_name = sol_arena_strdup(get_arena(builder), name);
     if (!node_name)
         return -errno;
 
@@ -1052,7 +1063,7 @@ export_port(struct sol_flow_builder *builder, uint16_t node, uint16_t port,
     int i = 0, r;
     uint16_t desc_len, base_port_idx = 0;
 
-    name = sol_arena_strdup(builder->str_arena, exported_name);
+    name = sol_arena_strdup(get_arena(builder), exported_name);
     SOL_NULL_CHECK_GOTO(name, error_name);
 
     desc_len = sol_ptr_vector_get_len(desc_vector);
@@ -1280,7 +1291,7 @@ sol_flow_builder_export_option(struct sol_flow_builder *builder, const char *nod
     }
 
     memset(exported_opt, 0, sizeof(*exported_opt));
-    exported_opt->name = sol_arena_strdup(builder->str_arena, exported_name);
+    exported_opt->name = sol_arena_strdup(get_arena(builder), exported_name);
     exported_opt->data_type = opt->data_type;
     /* Since we can't instantiate a sub-node without its required options
      * available, we will always have a default for the exported one, which

--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -211,6 +211,8 @@ dispose_builder_type(const void *data)
     free(type_data->node_extras);
 
     sol_arena_del(type_data->arena);
+
+    free(type_data);
 }
 
 SOL_API int
@@ -222,10 +224,8 @@ sol_flow_builder_del(struct sol_flow_builder *builder)
 
     SOL_NULL_CHECK(builder, -EBADR);
 
-    if (builder->node_type) {
-        sol_flow_node_type_del(builder->node_type);
+    if (builder->node_type)
         goto end;
-    }
 
     SOL_PTR_VECTOR_FOREACH_IDX (&builder->ports_in_desc, port_desc, i)
         free(port_desc);
@@ -255,9 +255,9 @@ sol_flow_builder_del(struct sol_flow_builder *builder)
     sol_vector_clear(&builder->exported_out);
 
     sol_arena_del(builder->type_data->arena);
+    free(builder->type_data);
 
 end:
-    free(builder->type_data);
     free(builder);
     return 0;
 }

--- a/src/lib/flow/sol-flow-static.c
+++ b/src/lib/flow/sol-flow-static.c
@@ -77,6 +77,8 @@ struct flow_static_type {
         const struct sol_flow_node_options *opts,
         struct sol_flow_node_options *child_opts);
 
+    void (*dispose)(const void *type_data);
+
     struct sol_flow_port_type_in *ports_in;
     struct sol_flow_port_type_out *ports_out;
 
@@ -980,8 +982,11 @@ static void
 flow_dispose_type(struct sol_flow_node_type *type)
 {
     struct flow_static_type *fst = (struct flow_static_type *)type;
+    const void *type_data = type->type_data;
 
     flow_static_type_fini(fst);
+    if (fst->dispose)
+        fst->dispose(type_data);
     free(fst);
 }
 
@@ -1011,7 +1016,8 @@ flow_static_type_init(
         .conn_specs = spec->conns,
         .exported_in_specs = spec->exported_in,
         .exported_out_specs = spec->exported_out,
-        .child_opts_set = spec->child_opts_set
+        .child_opts_set = spec->child_opts_set,
+        .dispose = spec->dispose,
     };
 
     r = setup_node_specs(type);

--- a/src/samples/flow/c-api/highlevel.c
+++ b/src/samples/flow/c-api/highlevel.c
@@ -56,13 +56,13 @@ static void log_init(void) SOL_ATTR_UNUSED;
  * node type descriptions.
  */
 
+static struct sol_flow_node_type *flow_node_type;
 static struct sol_flow_node *flow;
-static struct sol_flow_builder *builder;
 
 static void
 startup(void)
 {
-    struct sol_flow_node_type *flow_node_type;
+    struct sol_flow_builder *builder;
     struct _custom_node_types_reader_options reader_opts =
         _CUSTOM_NODE_TYPES_READER_OPTIONS_DEFAULTS(
         .intopt.val = 1
@@ -99,13 +99,15 @@ startup(void)
     sol_flow_builder_connect(builder, "logic", "OUT", 0, "console", "IN", 0);
 
     /* this creates a static flow using the low-level API that will
-     * actually run the flow. Note that its memory is bound to
-     * builder, then keep builder alive.
+     * actually run the flow.
      */
     flow_node_type = sol_flow_builder_get_node_type(builder);
 
     /* create and run the flow */
     flow = sol_flow_node_new(NULL, "highlevel", flow_node_type, NULL);
+
+    /* builder is not necessary anymore, so delete it */
+    sol_flow_builder_del(builder);
 }
 
 static void
@@ -113,8 +115,8 @@ shutdown(void)
 {
     /* stop the flow, disconnect ports and close children nodes */
     sol_flow_node_del(flow);
-    /* free the builder and its internal node type */
-    sol_flow_builder_del(builder);
+    /* delete the node type we've created with builder */
+    sol_flow_builder_del(flow_node_type);
 }
 
 SOL_MAIN_DEFAULT(startup, shutdown);

--- a/src/test/test-flow-builder.c
+++ b/src/test/test-flow-builder.c
@@ -281,6 +281,7 @@ connect_two_nodes(void)
     sol_flow_builder_connect(builder, "node2", "OUT2", -1, "node1", "IN1", -1);
 
     node_type = sol_flow_builder_get_node_type(builder);
+    sol_flow_builder_del(builder);
 
     flow = sol_flow_node_new(NULL, "simple_and", node_type, NULL);
     ASSERT(flow);
@@ -294,7 +295,7 @@ connect_two_nodes(void)
     ASSERT_EVENT_COUNT(node_in, EVENT_PORT_DISCONNECT, 0);
 
     sol_flow_node_del(flow);
-    sol_flow_builder_del(builder);
+    sol_flow_node_type_del(node_type);
 
     ASSERT_EVENT_COUNT(node_out, EVENT_PORT_CONNECT, 4);
     ASSERT_EVENT_COUNT(node_out, EVENT_PORT_DISCONNECT, 4);
@@ -321,6 +322,7 @@ connections_nodes_are_ordered(void)
     sol_flow_builder_connect(builder, "node1", "OUT1", -1, "node2", "IN1", -1);
 
     node_type = sol_flow_builder_get_node_type(builder);
+    sol_flow_builder_del(builder);
 
     /* if connections are out of order flow won't be created */
     flow = sol_flow_node_new(NULL, "simple_and", node_type, NULL);
@@ -328,7 +330,7 @@ connections_nodes_are_ordered(void)
     ASSERT(flow);
 
     sol_flow_node_del(flow);
-    sol_flow_builder_del(builder);
+    sol_flow_node_type_del(node_type);
 }
 
 DEFINE_TEST(connections_ports_are_ordered);
@@ -350,13 +352,14 @@ connections_ports_are_ordered(void)
     sol_flow_builder_connect(builder, "node1", "OUT1", -1, "node2", "IN2", -1);
 
     node_type = sol_flow_builder_get_node_type(builder);
+    sol_flow_builder_del(builder);
 
     /* if connections are out of order flow won't be created */
     flow = sol_flow_node_new(NULL, "simple_and", node_type, NULL);
     ASSERT(flow);
 
     sol_flow_node_del(flow);
-    sol_flow_builder_del(builder);
+    sol_flow_node_type_del(node_type);
 }
 
 DEFINE_TEST(nodes_must_have_unique_names);
@@ -446,6 +449,7 @@ ports_can_be_exported(void)
     ASSERT(streq(type->description->ports_in[0]->name, in_name));
     ASSERT(streq(type->description->ports_out[0]->name, out_name));
 
+    sol_flow_node_type_del(type);
     sol_flow_builder_del(builder);
 }
 
@@ -547,6 +551,7 @@ add_type_descriptions(void)
 
     type = sol_flow_builder_get_node_type(builder);
     ASSERT(type);
+    sol_flow_builder_del(builder);
 
     ASSERT(streq(type->description->name, "MyName"));
     ASSERT(streq(type->description->category, "MyCategory"));
@@ -558,7 +563,7 @@ add_type_descriptions(void)
     ASSERT(streq(type->description->symbol, "SOL_FLOW_NODE_TYPE_BUILDER_MYNAME"));
     ASSERT(streq(type->description->options_symbol, "sol_flow_node_type_builder_myname_options"));
 
-    sol_flow_builder_del(builder);
+    sol_flow_node_type_del(type);
 }
 
 TEST_MAIN_WITH_RESET_FUNC(clear_events);

--- a/src/test/test-vector.c
+++ b/src/test/test-vector.c
@@ -238,5 +238,43 @@ vector_iterates_correctly_using_void_as_iterator(void)
     sol_vector_clear(v);
 }
 
+DEFINE_TEST(vector_take_all);
+
+static void
+vector_take_all(void)
+{
+    struct sol_vector v_ = SOL_VECTOR_INIT(int), *v = &v_;
+    int *elem, *taken;
+    uint16_t i;
+
+    for (i = 0; i < 16; i++) {
+        elem = sol_vector_append(v);
+        *elem = i;
+    }
+
+    ASSERT_INT_EQ(v->len, 16);
+
+    taken = sol_vector_take_all(v);
+
+    ASSERT(taken);
+    ASSERT_INT_EQ(v->len, 0);
+
+    for (i = 0; i < 16; i++)
+        ASSERT_INT_EQ(taken[i], i);
+
+    for (i = 0; i < 16; i++) {
+        elem = sol_vector_append(v);
+        *elem = -1;
+    }
+
+    ASSERT_INT_EQ(v->len, 16);
+
+    for (i = 0; i < 16; i++)
+        ASSERT_INT_EQ(taken[i], i);
+
+    sol_vector_clear(v);
+    free(taken);
+}
+
 
 TEST_MAIN();


### PR DESCRIPTION
The goal of this series is to make a simple change: let the type created by the builder be deleted using the now existing `sol_flow_node_type_del()`.

This is useful because the code handling different "kinds" of node types (from FBP, from scripting), can be also generic, and don't care about where the type came from to delete it afterwards.