### PR TITLE
generator: Fix not adding the API version to node specs

### DIFF
--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -591,11 +591,13 @@ generate_create_type_function(struct fbp_data *data)
 
     dprintf(fd, "\n"
         "    struct sol_flow_static_spec spec = {\n"
+        "        .api_version = %u,\n"
         "        .nodes = nodes,\n"
         "        .conns = conns,\n"
         "        .exported_in = %s,\n"
         "        .exported_out = %s,\n"
         "    };\n",
+        SOL_FLOW_STATIC_API_VERSION,
         data->graph.exported_in_ports.len > 0 ? "exported_in" : "NULL",
         data->graph.exported_out_ports.len > 0 ? "exported_out" : "NULL");
 


### PR DESCRIPTION
When the sol_flow_static_spec structure was introduced, along with it
came the verification for the API version. The generator was not update
to take this into account.

Signed-off-by: Vinicius Costa Gomes <vinicius.gomes@intel.com>