### PR TITLE
build: check for required dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,14 @@ include $(top_srcdir)tools/build/Makefile.rules
 # kconfig interface rules
 include $(top_srcdir)tools/build/Makefile.kconfig
 
+ifneq (,$(NOT_FOUND))
+warning:
+	$(Q)echo -e "The following (required) dependencies were not met:\n"
+	$(Q)echo -e "$(NOT_FOUND)"
+	$(Q)echo -e "If you've just installed it, run: make reconf"
+	$(Q)echo -e "For more information/options, run: make help"
+$(warning-targets)
+else
 ifeq ($(HAVE_KCONFIG_CONFIG),)
 warning: $(KCONFIG_GEN)
 	$(Q)echo "You need a config file first. Please run a config target, e.g.: make menuconfig"
@@ -31,16 +39,10 @@ warning: $(KCONFIG_GEN)
 	$(Q)echo "For more information/options run: make help"
 $(warning-targets)
 else
-ifeq (n,$(HAVE_PYTHON_JSONSCHEMA))
-warning:
-	$(Q)echo "Cannot proceed, python module \"jsonschema\" was not found in your system..."
-	$(Q)echo "If you've just installed it, run: make reconf"
-$(warning-targets)
-else
 include $(top_srcdir)tools/build/Makefile.targets
 all: $(PRE_GEN) $(SOL_LIB_SO) $(SOL_LIB_AR) $(bins-out) $(modules-out)
-endif # HAVE_PYTHON_JSONSCHEMA
 endif # HAVE_KCONFIG_CONFIG
+endif # NOT_FOUND
 
 $(KCONFIG_CONFIG): $(KCONFIG_GEN)
 

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -236,12 +236,14 @@
 	{
 	    "dependency": "chrpath",
 	    "type": "exec",
-	    "exec": "chrpath"
+	    "exec": "chrpath",
+	    "required": true
 	},
 	{
 	    "dependency": "jsonschema",
 	    "type": "python",
-	    "pkgname": "jsonschema"
+	    "pkgname": "jsonschema",
+	    "required": true
 	}
     ]
 }


### PR DESCRIPTION
v2:
   + new approach on the dep-resolver side - given all the changed happened on it;


This patch introduces the required dependencies to dependency-resolver,
so we can check and quit if no such deps are found.

A common use case for this is the absence of chrpath tool and the
users - "silently" - failing to run make install.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>