### PR TITLE
Initial Contiki port V2

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -152,6 +152,13 @@
 	    ]
 	},
 	{
+	    "dependency": "contiki",
+	    "type": "ccode",
+	    "headers": [
+		"<contiki.h>"
+	    ]
+	},
+	{
 	    "dependency": "dlfcn_h",
 	    "type": "ccode",
 	    "headers": [

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -121,6 +121,19 @@ config PLATFORM_RIOTOS
             Soletta will do its best to offer the same experience on
             all platforms, including RIOt.
 
+config PLATFORM_CONTIKI
+	bool "contiki"
+	depends on HAVE_CONTIKI
+	help
+            This platform is to be used with Contiki Small OS.
+
+            Contiki (http://contiki-os.org/) is an open source operating
+            system for the Internet of Things. Contiki connects tiny low-cost,
+            low-power microcontrollers to the Internet.
+
+            Soletta will do its best to offer the same experience on
+            all platforms, including Contiki.
+
 endchoice
 
 source "src/modules/linux-micro/Kconfig"
@@ -194,6 +207,12 @@ config MAINLOOP_RIOTOS
 	depends on PLATFORM_RIOTOS && HAVE_RIOTOS
 	help
             The mainloop to be used in RIOT platform.
+
+config MAINLOOP_CONTIKI
+	bool "contiki"
+	depends on PLATFORM_CONTIKI && HAVE_CONTIKI
+	help
+            The mainloop to be used in Contiki platform.
 
 endchoice
 

--- a/src/lib/common/Makefile
+++ b/src/lib/common/Makefile
@@ -4,8 +4,7 @@ obj-core-$(CORE) := \
     sol-blob.o \
     sol-mainloop.o \
     sol-platform.o \
-    sol-types.o \
-    sol-platform-detect.o
+    sol-types.o
 
 ifeq (y,$(LOG))
 obj-core-$(CORE) += \
@@ -44,7 +43,8 @@ obj-core-$(PLATFORM_DUMMY) += \
     sol-platform-impl-dummy.o
 
 obj-core-$(SOL_PLATFORM_LINUX) += \
-    sol-platform-linux-common.o
+    sol-platform-linux-common.o \
+    sol-platform-detect.o
 obj-core-$(SOL_PLATFORM_LINUX)-extra-cflags += $(SYSTEMD_CFLAGS)
 obj-core-$(SOL_PLATFORM_LINUX)-extra-ldflags += $(SYSTEMD_LDFLAGS)
 

--- a/src/lib/common/Makefile
+++ b/src/lib/common/Makefile
@@ -13,6 +13,8 @@ obj-core-$(SOL_PLATFORM_LINUX) += \
     sol-log-impl-linux.o
 obj-core-$(PLATFORM_RIOTOS) += \
     sol-log-impl-riot.o
+obj-core-$(PLATFORM_CONTIKI) += \
+    sol-log-impl-contiki.o
 endif
 
 obj-core-$(KDBUS) += \
@@ -33,6 +35,11 @@ obj-core-$(MAINLOOP_RIOTOS) += \
     sol-interrupt_scheduler_riot.o  \
     sol-mainloop-common.o \
     sol-mainloop-impl-riot.o
+
+obj-core-$(MAINLOOP_CONTIKI) += \
+    sol-mainloop-common.o \
+    sol-mainloop-impl-contiki.o
+
 obj-core-$(PLATFORM_LINUX_MICRO) += \
     sol-platform-impl-linux-micro.o
 obj-core-$(SOCKET_LINUX) += \
@@ -41,6 +48,8 @@ obj-core-$(PLATFORM_RIOTOS) += \
     sol-platform-impl-riot.o
 obj-core-$(PLATFORM_DUMMY) += \
     sol-platform-impl-dummy.o
+obj-core-$(PLATFORM_CONTIKI) += \
+    sol-platform-impl-contiki.o
 
 obj-core-$(SOL_PLATFORM_LINUX) += \
     sol-mainloop-linux.o \
@@ -80,3 +89,6 @@ headers-$(HAVE_PIN_MUX) += \
 
 headers-$(SOL_PLATFORM_LINUX) += \
     include/sol-mainloop-linux.h \
+
+headers-$(MAINLOOP_CONTIKI) += \
+    include/sol-mainloop-contiki.h

--- a/src/lib/common/Makefile
+++ b/src/lib/common/Makefile
@@ -43,6 +43,7 @@ obj-core-$(PLATFORM_DUMMY) += \
     sol-platform-impl-dummy.o
 
 obj-core-$(SOL_PLATFORM_LINUX) += \
+    sol-mainloop-linux.o \
     sol-platform-linux-common.o \
     sol-platform-detect.o
 obj-core-$(SOL_PLATFORM_LINUX)-extra-cflags += $(SYSTEMD_CFLAGS)
@@ -76,3 +77,6 @@ headers-y := \
 
 headers-$(HAVE_PIN_MUX) += \
     include/sol-pin-mux-modules.h
+
+headers-$(SOL_PLATFORM_LINUX) += \
+    include/sol-mainloop-linux.h \

--- a/src/lib/common/include/sol-mainloop-contiki.h
+++ b/src/lib/common/include/sol-mainloop-contiki.h
@@ -32,12 +32,16 @@
 
 #pragma once
 
-{{
-st.on_value("SOL_PLATFORM_LINUX", "y", "#define SOL_PLATFORM_LINUX 1", "")
-st.on_value("PLATFORM_RIOTOS", "y", "#define SOL_PLATFORM_RIOT 1", "")
-st.on_value("PLATFORM_CONTIKI", "y", "#define SOL_PLATFORM_CONTIKI 1", "")
-}}
+#include <contiki.h>
+#include <stdbool.h>
 
-{{
-st.on_value("LOG", "y", "#define SOL_LOG_ENABLED 1", "")
-}}
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void sol_mainloop_contiki_event_set(process_event_t ev, process_data_t data);
+bool sol_mainloop_contiki_iter(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/lib/common/include/sol-mainloop-linux.h
+++ b/src/lib/common/include/sol-mainloop-linux.h
@@ -32,24 +32,28 @@
 
 #pragma once
 
-/* implement these functions for your own system so soletta will work */
-
-#define SOL_LOG_DOMAIN &_sol_mainloop_log_domain
-extern struct sol_log_domain _sol_mainloop_log_domain;
-#include "sol-log-internal.h"
-#include "sol-mainloop.h"
-#ifdef SOL_PLATFORM_LINUX
-#include "sol-mainloop-impl-linux.h"
+#ifdef __cplusplus
+extern "C" {
 #endif
 
-int sol_mainloop_impl_init(void);
-void sol_mainloop_impl_run(void);
-void sol_mainloop_impl_quit(void);
-void sol_mainloop_impl_shutdown(void);
+enum sol_fd_flags {
+    SOL_FD_FLAGS_NONE = 0,
+    SOL_FD_FLAGS_IN   = (1 << 0),
+    SOL_FD_FLAGS_OUT  = (1 << 1),
+    SOL_FD_FLAGS_PRI  = (1 << 2),
+    SOL_FD_FLAGS_ERR  = (1 << 3),
+    SOL_FD_FLAGS_HUP  = (1 << 4),
+    SOL_FD_FLAGS_NVAL = (1 << 5)
+};
 
-void *sol_mainloop_impl_timeout_add(unsigned int timeout_ms, bool (*cb)(void *data), const void *data);
-bool sol_mainloop_impl_timeout_del(void *handle);
+struct sol_fd;
+struct sol_fd *sol_fd_add(int fd, unsigned int flags, bool (*cb)(void *data, int fd, unsigned int active_flags), const void *data);
+bool sol_fd_del(struct sol_fd *handle);
 
-void *sol_mainloop_impl_idle_add(bool (*cb)(void *data), const void *data);
-bool sol_mainloop_impl_idle_del(void *handle);
+struct sol_child_watch;
+struct sol_child_watch *sol_child_watch_add(uint64_t pid, void (*cb)(void *data, uint64_t pid, int status), const void *data);
+bool sol_child_watch_del(struct sol_child_watch *handle);
 
+#ifdef __cplusplus
+}
+#endif

--- a/src/lib/common/include/sol-mainloop.h
+++ b/src/lib/common/include/sol-mainloop.h
@@ -126,27 +126,13 @@ struct sol_idle;
 struct sol_idle *sol_idle_add(bool (*cb)(void *data), const void *data);
 bool sol_idle_del(struct sol_idle *handle);
 
-enum sol_fd_flags {
-    SOL_FD_FLAGS_NONE = 0,
-    SOL_FD_FLAGS_IN   = (1 << 0),
-    SOL_FD_FLAGS_OUT  = (1 << 1),
-    SOL_FD_FLAGS_PRI  = (1 << 2),
-    SOL_FD_FLAGS_ERR  = (1 << 3),
-    SOL_FD_FLAGS_HUP  = (1 << 4),
-    SOL_FD_FLAGS_NVAL = (1 << 5)
-};
-
-struct sol_fd;
-struct sol_fd *sol_fd_add(int fd, unsigned int flags, bool (*cb)(void *data, int fd, unsigned int active_flags), const void *data);
-bool sol_fd_del(struct sol_fd *handle);
-
-struct sol_child_watch;
-struct sol_child_watch *sol_child_watch_add(uint64_t pid, void (*cb)(void *data, uint64_t pid, int status), const void *data);
-bool sol_child_watch_del(struct sol_child_watch *handle);
-
 int sol_argc(void);
 char **sol_argv(void);
 void sol_args_set(int argc, char *argv[]);
+
+#ifdef SOL_PLATFORM_LINUX
+#include "sol-mainloop-linux.h"
+#endif
 
 struct sol_main_callbacks {
 #define SOL_MAIN_CALLBACKS_API_VERSION (1)

--- a/src/lib/common/include/sol-mainloop.h
+++ b/src/lib/common/include/sol-mainloop.h
@@ -32,6 +32,8 @@
 
 #pragma once
 
+#include "sol-common-buildopts.h"
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -142,6 +144,27 @@ struct sol_main_callbacks {
     void (*shutdown)(void);
 };
 
+#ifdef SOL_PLATFORM_CONTIKI
+#include "sol-mainloop-contiki.h"
+
+#define SOL_MAIN_DEFAULT(STARTUP, SHUTDOWN)               \
+    PROCESS(soletta_app_process, "soletta app process");  \
+    AUTOSTART_PROCESSES(&soletta_app_process);            \
+    PROCESS_THREAD(soletta_app_process, ev, data)         \
+    {                                                     \
+        sol_mainloop_contiki_event_set(ev, data);         \
+        PROCESS_BEGIN();                                  \
+        if (sol_init() < 0)                               \
+            return EXIT_FAILURE;                          \
+        STARTUP();                                        \
+        sol_run();                                        \
+        while (sol_mainloop_contiki_iter())               \
+            PROCESS_WAIT_EVENT();                         \
+        SHUTDOWN();                                       \
+        sol_shutdown();                                   \
+        PROCESS_END();                                    \
+    }
+#else
 #define SOL_MAIN(CALLBACKS)                                          \
     int main(int argc, char *argv[]) {                              \
         return sol_mainloop_default_main(&(CALLBACKS), argc, argv);  \
@@ -154,6 +177,7 @@ struct sol_main_callbacks {
         .shutdown = (SHUTDOWN),                                         \
     };                                                                  \
     SOL_MAIN(sol_main_callbacks_instance)
+#endif
 
 /* Internal. */
 int sol_mainloop_default_main(const struct sol_main_callbacks *callbacks, int argc, char *argv[]);

--- a/src/lib/common/sol-event-handler-contiki.h
+++ b/src/lib/common/sol-event-handler-contiki.h
@@ -30,54 +30,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdint.h>
-#include <stdlib.h>
+#pragma once
 
-#include "sol-pwm.h"
+#include <stdbool.h>
 
-struct sol_pwm *
-sol_pwm_open_raw(int device, int channel, const struct sol_pwm_config *config)
-{
-    return NULL;
-}
+#include <contiki.h>
 
-void
-sol_pwm_close(struct sol_pwm *pwm)
-{
-}
-
-bool
-sol_pwm_set_enabled(struct sol_pwm *pwm, bool enable)
-{
-    return false;
-}
-
-bool
-sol_pwm_get_enabled(const struct sol_pwm *pwm)
-{
-    return false;
-}
-
-bool
-sol_pwm_set_period(struct sol_pwm *pwm, uint32_t period_ns)
-{
-    return false;
-}
-
-int32_t
-sol_pwm_get_period(const struct sol_pwm *pwm)
-{
-    return -1;
-}
-
-bool
-sol_pwm_set_duty_cycle(struct sol_pwm *pwm, uint32_t duty_cycle_ns)
-{
-    return false;
-}
-
-int32_t
-sol_pwm_get_duty_cycle(const struct sol_pwm *pwm)
-{
-    return -1;
-}
+bool sol_mainloop_contiki_event_handler_add(const process_event_t *ev, const process_data_t ev_data, void (*cb)(void *user_data, process_event_t ev, process_data_t ev_data), const void *data);
+bool sol_mainloop_contiki_event_handler_del(const process_event_t *ev, const process_data_t ev_data, void (*cb)(void *user_data, process_event_t ev, process_data_t ev_data), const void *data);

--- a/src/lib/common/sol-log-impl-contiki.c
+++ b/src/lib/common/sol-log-impl-contiki.c
@@ -30,14 +30,75 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
 
-{{
-st.on_value("SOL_PLATFORM_LINUX", "y", "#define SOL_PLATFORM_LINUX 1", "")
-st.on_value("PLATFORM_RIOTOS", "y", "#define SOL_PLATFORM_RIOT 1", "")
-st.on_value("PLATFORM_CONTIKI", "y", "#define SOL_PLATFORM_CONTIKI 1", "")
-}}
+#include "sol-log-impl.h"
 
-{{
-st.on_value("LOG", "y", "#define SOL_LOG_ENABLED 1", "")
-}}
+int
+sol_log_impl_init(void)
+{
+    return 0;
+}
+
+void
+sol_log_impl_shutdown(void)
+{
+}
+
+bool
+sol_log_impl_lock(void)
+{
+    return true;
+}
+
+void
+sol_log_impl_unlock(void)
+{
+}
+
+void
+sol_log_impl_domain_init_level(struct sol_log_domain *domain)
+{
+    domain->level = _global_domain.level;
+}
+
+void
+sol_log_impl_print_function_stderr(void *data, const struct sol_log_domain *domain, uint8_t message_level, const char *file, const char *function, int line, const char *format, va_list args)
+{
+    const char *name = domain->name ? domain->name : "";
+    char level_str[4];
+    size_t len;
+    int errno_bkp = errno;
+
+    sol_log_level_to_str(message_level, level_str, sizeof(level_str));
+
+    if (_show_file && _show_function && _show_line) {
+        fprintf(stderr, "%s:%s %s:%d %s() ",
+            level_str, name, file, line, function);
+    } else {
+        fprintf(stderr, "%s:%s ", level_str, name);
+
+        if (_show_file)
+            fputs(file, stderr);
+        if (_show_file && _show_line)
+            fputc(':', stderr);
+        if (_show_line)
+            fprintf(stderr, "%d", line);
+
+        if (_show_file || _show_line)
+            fputc(' ', stderr);
+
+        if (_show_function)
+            fprintf(stderr, "%s() ", function);
+    }
+
+    errno = errno_bkp;
+    vfprintf(stderr, format, args);
+
+    len = strlen(format);
+    if (len > 0 && format[len - 1] != '\n')
+        fputc('\n', stderr);
+    fflush(stderr);
+}

--- a/src/lib/common/sol-mainloop-common.c
+++ b/src/lib/common/sol-mainloop-common.c
@@ -294,6 +294,7 @@ sol_mainloop_common_idler_first(void)
     return NULL;
 }
 
+#ifndef SOL_PLATFORM_CONTIKI
 void
 sol_mainloop_impl_run(void)
 {
@@ -306,6 +307,7 @@ sol_mainloop_impl_run(void)
     while (sol_mainloop_common_loop_check())
         sol_mainloop_impl_iter();
 }
+#endif
 
 void
 sol_mainloop_impl_quit(void)

--- a/src/lib/common/sol-mainloop-impl-contiki.c
+++ b/src/lib/common/sol-mainloop-impl-contiki.c
@@ -1,0 +1,141 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <contiki.h>
+#include <lib/sensors.h>
+
+#include "sol-mainloop-common.h"
+#include "sol-mainloop-contiki.h"
+#include "sol-mainloop-impl.h"
+#include "sol-vector.h"
+
+#define DEFAULT_USLEEP_TIME 10000
+#define DEFAULT_USLEEP_TIME_TICKS (CLOCK_SECOND * DEFAULT_USLEEP_TIME) / NSEC_PER_SEC
+
+static process_event_t event;
+static process_data_t event_data;
+static struct etimer et;
+
+void
+sol_mainloop_impl_lock(void)
+{
+}
+
+void
+sol_mainloop_impl_unlock(void)
+{
+}
+
+bool
+sol_mainloop_impl_main_thread_check(void)
+{
+    return true;
+}
+
+void
+sol_mainloop_impl_main_thread_notify(void)
+{
+}
+
+int
+sol_mainloop_impl_init(void)
+{
+    sol_mainloop_common_init();
+    return 0;
+}
+
+void
+sol_mainloop_impl_shutdown(void)
+{
+    sol_mainloop_common_shutdown();
+}
+
+static inline clock_time_t
+ticks_until_next_timeout(void)
+{
+    struct sol_timeout_common *timeout;
+    struct timespec now, diff;
+
+    timeout = sol_mainloop_common_timeout_first();
+    if (!timeout)
+        return DEFAULT_USLEEP_TIME_TICKS;
+
+    now = sol_util_timespec_get_current();
+    sol_util_timespec_sub(&timeout->expire, &now, &diff);
+
+    if (diff.tv_sec < 0)
+        return 0;
+
+    return diff.tv_sec * CLOCK_SECOND +
+                (CLOCK_SECOND / NSEC_PER_SEC) * diff.tv_nsec;
+}
+
+void
+sol_mainloop_impl_run(void)
+{
+    if (!sol_mainloop_impl_main_thread_check()) {
+        SOL_ERR("sol_run() called on different thread than sol_init()");
+        return;
+    }
+
+    sol_mainloop_common_loop_set(true);
+}
+
+bool
+sol_mainloop_contiki_iter(void)
+{
+    // Another event could make process wakeup
+    etimer_stop(&et);
+
+    // TODO: check event
+
+    sol_mainloop_common_timeout_process();
+    sol_mainloop_common_idler_process();
+    sol_mainloop_common_timeout_process();
+
+    if (!sol_mainloop_common_loop_check())
+        return false;
+
+    etimer_set(&et, ticks_until_next_timeout());
+    return true;
+}
+
+void
+sol_mainloop_impl_iter(void)
+{
+    // empty
+}
+
+void
+sol_mainloop_contiki_event_set(process_event_t ev, process_data_t data)
+{
+}

--- a/src/lib/common/sol-mainloop-impl-linux.h
+++ b/src/lib/common/sol-mainloop-impl-linux.h
@@ -32,24 +32,8 @@
 
 #pragma once
 
-/* implement these functions for your own system so soletta will work */
+void *sol_mainloop_impl_fd_add(int fd, unsigned int flags, bool (*cb)(void *data, int fd, unsigned int active_flags), const void *data);
+bool sol_mainloop_impl_fd_del(void *handle);
 
-#define SOL_LOG_DOMAIN &_sol_mainloop_log_domain
-extern struct sol_log_domain _sol_mainloop_log_domain;
-#include "sol-log-internal.h"
-#include "sol-mainloop.h"
-#ifdef SOL_PLATFORM_LINUX
-#include "sol-mainloop-impl-linux.h"
-#endif
-
-int sol_mainloop_impl_init(void);
-void sol_mainloop_impl_run(void);
-void sol_mainloop_impl_quit(void);
-void sol_mainloop_impl_shutdown(void);
-
-void *sol_mainloop_impl_timeout_add(unsigned int timeout_ms, bool (*cb)(void *data), const void *data);
-bool sol_mainloop_impl_timeout_del(void *handle);
-
-void *sol_mainloop_impl_idle_add(bool (*cb)(void *data), const void *data);
-bool sol_mainloop_impl_idle_del(void *handle);
-
+void *sol_mainloop_impl_child_watch_add(uint64_t pid, void (*cb)(void *data, uint64_t pid, int status), const void *data);
+bool sol_mainloop_impl_child_watch_del(void *handle);

--- a/src/lib/common/sol-mainloop-impl-riot.c
+++ b/src/lib/common/sol-mainloop-impl-riot.c
@@ -126,31 +126,3 @@ sol_mainloop_impl_iter(void)
     if (vtimer_msg_receive_timeout(&msg, timex) > 0)
         sol_interrupt_scheduler_process(&msg);
 }
-
-void *
-sol_mainloop_impl_fd_add(int fd, unsigned int flags, bool (*cb)(void *data, int fd, unsigned int active_flags), const void *data)
-{
-    SOL_CRI("Unsupported");
-    return NULL;
-}
-
-bool
-sol_mainloop_impl_fd_del(void *handle)
-{
-    SOL_CRI("Unsupported");
-    return true;
-}
-
-void *
-sol_mainloop_impl_child_watch_add(uint64_t pid, void (*cb)(void *data, uint64_t pid, int status), const void *data)
-{
-    SOL_CRI("Unsupported");
-    return NULL;
-}
-
-bool
-sol_mainloop_impl_child_watch_del(void *handle)
-{
-    SOL_CRI("Unsupported");
-    return true;
-}

--- a/src/lib/common/sol-mainloop-linux.c
+++ b/src/lib/common/sol-mainloop-linux.c
@@ -30,26 +30,34 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-/* implement these functions for your own system so soletta will work */
-
-#define SOL_LOG_DOMAIN &_sol_mainloop_log_domain
-extern struct sol_log_domain _sol_mainloop_log_domain;
-#include "sol-log-internal.h"
 #include "sol-mainloop.h"
-#ifdef SOL_PLATFORM_LINUX
-#include "sol-mainloop-impl-linux.h"
-#endif
+#include "sol-mainloop-impl.h"
 
-int sol_mainloop_impl_init(void);
-void sol_mainloop_impl_run(void);
-void sol_mainloop_impl_quit(void);
-void sol_mainloop_impl_shutdown(void);
+SOL_API struct sol_fd *
+sol_fd_add(int fd, unsigned int flags, bool (*cb)(void *data, int fd, unsigned int active_flags), const void *data)
+{
+    SOL_NULL_CHECK(cb, NULL);
+    return sol_mainloop_impl_fd_add(fd, flags, cb, data);
+}
 
-void *sol_mainloop_impl_timeout_add(unsigned int timeout_ms, bool (*cb)(void *data), const void *data);
-bool sol_mainloop_impl_timeout_del(void *handle);
+SOL_API bool
+sol_fd_del(struct sol_fd *handle)
+{
+    SOL_NULL_CHECK(handle, false);
+    return sol_mainloop_impl_fd_del(handle);
+}
 
-void *sol_mainloop_impl_idle_add(bool (*cb)(void *data), const void *data);
-bool sol_mainloop_impl_idle_del(void *handle);
+SOL_API struct sol_child_watch *
+sol_child_watch_add(uint64_t pid, void (*cb)(void *data, uint64_t pid, int status), const void *data)
+{
+    SOL_INT_CHECK(pid, < 1, NULL);
+    SOL_NULL_CHECK(cb, NULL);
+    return sol_mainloop_impl_child_watch_add(pid, cb, data);
+}
 
+SOL_API bool
+sol_child_watch_del(struct sol_child_watch *handle)
+{
+    SOL_NULL_CHECK(handle, false);
+    return sol_mainloop_impl_child_watch_del(handle);
+}

--- a/src/lib/common/sol-mainloop.c
+++ b/src/lib/common/sol-mainloop.c
@@ -231,35 +231,6 @@ sol_idle_del(struct sol_idle *handle)
     return sol_mainloop_impl_idle_del(handle);
 }
 
-SOL_API struct sol_fd *
-sol_fd_add(int fd, unsigned int flags, bool (*cb)(void *data, int fd, unsigned int active_flags), const void *data)
-{
-    SOL_NULL_CHECK(cb, NULL);
-    return sol_mainloop_impl_fd_add(fd, flags, cb, data);
-}
-
-SOL_API bool
-sol_fd_del(struct sol_fd *handle)
-{
-    SOL_NULL_CHECK(handle, false);
-    return sol_mainloop_impl_fd_del(handle);
-}
-
-SOL_API struct sol_child_watch *
-sol_child_watch_add(uint64_t pid, void (*cb)(void *data, uint64_t pid, int status), const void *data)
-{
-    SOL_INT_CHECK(pid, < 1, NULL);
-    SOL_NULL_CHECK(cb, NULL);
-    return sol_mainloop_impl_child_watch_add(pid, cb, data);
-}
-
-SOL_API bool
-sol_child_watch_del(struct sol_child_watch *handle)
-{
-    SOL_NULL_CHECK(handle, false);
-    return sol_mainloop_impl_child_watch_del(handle);
-}
-
 SOL_API int
 sol_argc(void)
 {

--- a/src/lib/common/sol-platform-impl-contiki.c
+++ b/src/lib/common/sol-platform-impl-contiki.c
@@ -30,14 +30,68 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include <errno.h>
+#include <stdlib.h>
 
-{{
-st.on_value("SOL_PLATFORM_LINUX", "y", "#define SOL_PLATFORM_LINUX 1", "")
-st.on_value("PLATFORM_RIOTOS", "y", "#define SOL_PLATFORM_RIOT 1", "")
-st.on_value("PLATFORM_CONTIKI", "y", "#define SOL_PLATFORM_CONTIKI 1", "")
-}}
+#include "sol-platform.h"
+#include "sol-platform-impl.h"
 
-{{
-st.on_value("LOG", "y", "#define SOL_LOG_ENABLED 1", "")
-}}
+int
+sol_platform_impl_init(void)
+{
+    return 0;
+}
+
+void
+sol_platform_impl_shutdown(void)
+{
+}
+
+int
+sol_platform_impl_get_state(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_impl_add_service_monitor(const char *service)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_impl_del_service_monitor(const char *service)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_impl_start_service(const char *service)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_impl_stop_service(const char *service)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_impl_restart_service(const char *service)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_impl_set_target(const char *target)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}

--- a/src/lib/common/sol-platform.c
+++ b/src/lib/common/sol-platform.c
@@ -39,7 +39,9 @@
 #include "sol-log-internal.h"
 #include "sol-macros.h"
 #include "sol-monitors.h"
+#ifdef SOL_PLATFORM_LINUX
 #include "sol-platform-detect.h"
+#endif
 #include "sol-platform.h"
 #include "sol-util.h"
 

--- a/src/lib/io/Makefile
+++ b/src/lib/io/Makefile
@@ -14,6 +14,11 @@ obj-io-$(IO) += \
     sol-uart-riot.o
 endif
 
+ifeq (y,$(PLATFORM_CONTIKI))
+obj-io-$(IO) += \
+    sol-missing-contiki.o
+endif
+
 ifeq (y,$(SOL_PLATFORM_LINUX))
 obj-io-$(IO) += \
     sol-gpio-linux.o \

--- a/src/lib/io/Makefile
+++ b/src/lib/io/Makefile
@@ -16,6 +16,7 @@ endif
 
 ifeq (y,$(PLATFORM_CONTIKI))
 obj-io-$(IO) += \
+    sol-gpio-contiki.o \
     sol-missing-contiki.o
 endif
 

--- a/src/lib/io/sol-gpio-contiki.c
+++ b/src/lib/io/sol-gpio-contiki.c
@@ -1,0 +1,135 @@
+#include <errno.h>
+#include <stdlib.h>
+
+#include <contiki.h>
+#include <dev/button-sensor.h>
+#include <dev/leds.h>
+#include <lib/sensors.h>
+
+#define SOL_LOG_DOMAIN &_log_domain
+#include "sol-log-internal.h"
+#include "sol-gpio.h"
+#include "sol-mainloop.h"
+#include "sol-util.h"
+#include "sol-event-handler-contiki.h"
+
+static SOL_LOG_INTERNAL_DECLARE(_log_domain, "gpio");
+
+struct sol_gpio
+{
+    int pin;
+    struct sensors_sensor *button_sensor;
+    bool active_low;
+    struct {
+        void (*cb)(void *data, struct sol_gpio *gpio);
+        void *data;
+    } irq;
+};
+
+static void
+event_handler_cb(void *user_data, process_event_t ev, process_data_t ev_data)
+{
+    struct sol_gpio *gpio = user_data;
+    gpio->irq.cb(gpio->irq.data, gpio);
+}
+
+struct sol_gpio *
+sol_gpio_open_raw(int pin, const struct sol_gpio_config *config)
+{
+    struct sol_gpio *gpio;
+    struct sensors_sensor *found = NULL;
+
+    SOL_LOG_INTERNAL_INIT_ONCE;
+
+    process_start(&sensors_process, NULL);
+
+    if (config->drive_mode != SOL_GPIO_DRIVE_NONE) {
+        SOL_ERR("Unable to set pull resistor on pin=%d", pin);
+        return NULL;
+    }
+
+    if (config->dir == SOL_GPIO_DIR_IN) {
+        const struct sensors_sensor *sensor = sensors_first();
+        int i = 0;
+
+        while (sensor) {
+            if (strcmp(sensor->type, BUTTON_SENSOR)) {
+                sensor = sensors_next(sensor);
+                continue;
+            }
+            if (i == pin) {
+                found = (struct sensors_sensor *) sensor;
+                break;
+            }
+            sensor = sensors_next(sensor);
+            i++;
+        }
+
+        if (!found) {
+            SOL_ERR("GPIO pin=%d not found.", pin);
+            return NULL;
+        }
+    } else {
+        if (pin < 0 || pin > 7) {
+            SOL_ERR("GPIO pin=%d not found.", pin);
+            return NULL;
+        }
+    }
+
+    gpio = malloc(sizeof(struct sol_gpio));
+    SOL_NULL_CHECK(gpio, NULL);
+
+    gpio->pin = pin;
+    gpio->button_sensor = found;
+    gpio->active_low = config->active_low;
+
+    if (config->dir == SOL_GPIO_DIR_IN) {
+        gpio->irq.cb = config->in.cb;
+        gpio->irq.data = (void *) config->in.user_data;
+        if (config->in.cb)
+            sol_mainloop_contiki_event_handler_add(&sensors_event, found,
+                                                   event_handler_cb, gpio);
+    } else
+        sol_gpio_write(gpio, config->out.value);
+
+    return gpio;
+}
+
+void
+sol_gpio_close(struct sol_gpio *gpio)
+{
+    SOL_NULL_CHECK(gpio);
+    if (gpio->irq.cb)
+        sol_mainloop_contiki_event_handler_del(&sensors_event,
+                                               gpio->button_sensor,
+                                               event_handler_cb, gpio);
+    free(gpio);
+}
+
+bool
+sol_gpio_write(struct sol_gpio *gpio, bool value)
+{
+    SOL_NULL_CHECK(gpio, false);
+
+    if (gpio->button_sensor)
+        return false;
+
+    value = gpio->active_low ^ value;
+
+    if (value)
+        leds_set(leds_get() | (1 << gpio->pin));
+    else
+        leds_set(leds_get() & (~(1 << gpio->pin)));
+    return true;
+}
+
+int
+sol_gpio_read(struct sol_gpio *gpio)
+{
+    SOL_NULL_CHECK(gpio, -EINVAL);
+
+    if (gpio->button_sensor)
+        return gpio->active_low ^ !!gpio->button_sensor->value(0);
+
+    return gpio->active_low ^ !!(leds_get() & (1 << gpio->pin));
+}

--- a/src/lib/io/sol-missing-contiki.c
+++ b/src/lib/io/sol-missing-contiki.c
@@ -30,14 +30,78 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include <stdint.h>
+#include <stdlib.h>
 
-{{
-st.on_value("SOL_PLATFORM_LINUX", "y", "#define SOL_PLATFORM_LINUX 1", "")
-st.on_value("PLATFORM_RIOTOS", "y", "#define SOL_PLATFORM_RIOT 1", "")
-st.on_value("PLATFORM_CONTIKI", "y", "#define SOL_PLATFORM_CONTIKI 1", "")
-}}
+#include "sol-gpio.h"
+#include "sol-pwm.h"
 
-{{
-st.on_value("LOG", "y", "#define SOL_LOG_ENABLED 1", "")
-}}
+struct sol_gpio *
+sol_gpio_open(int pin, const struct sol_gpio_config *config)
+{
+    return NULL;
+}
+
+void
+sol_gpio_close(struct sol_gpio *gpio)
+{
+}
+
+bool
+sol_gpio_write(struct sol_gpio *gpio, bool value)
+{
+    return false;
+}
+
+int
+sol_gpio_read(struct sol_gpio *gpio)
+{
+    return -1;
+}
+
+struct sol_pwm *
+sol_pwm_open_raw(int device, int channel, const struct sol_pwm_config *config)
+{
+    return NULL;
+}
+
+void
+sol_pwm_close(struct sol_pwm *pwm)
+{
+}
+
+bool
+sol_pwm_set_enabled(struct sol_pwm *pwm, bool enable)
+{
+    return false;
+}
+
+bool
+sol_pwm_get_enabled(const struct sol_pwm *pwm)
+{
+    return false;
+}
+
+bool
+sol_pwm_set_period(struct sol_pwm *pwm, uint32_t period_ns)
+{
+    return false;
+}
+
+int32_t
+sol_pwm_get_period(const struct sol_pwm *pwm)
+{
+    return -1;
+}
+
+bool
+sol_pwm_set_duty_cycle(struct sol_pwm *pwm, uint32_t duty_cycle_ns)
+{
+    return false;
+}
+
+int32_t
+sol_pwm_get_duty_cycle(const struct sol_pwm *pwm)
+{
+    return -1;
+}

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -50,6 +50,22 @@ sol_util_memdup(const void *data, size_t len)
     return ptr;
 }
 
+#ifdef SOL_PLATFORM_CONTIKI
+#include <contiki.h>
+
+struct timespec
+sol_util_timespec_get_current(void)
+{
+    struct timespec ret;
+    clock_time_t ticks;
+
+    ticks = clock_time();
+    ret.tv_sec = ticks / CLOCK_SECOND;
+    ticks -= ret.tv_sec * CLOCK_SECOND;
+    ret.tv_nsec = (ticks * NSEC_PER_SEC) / CLOCK_SECOND;
+    return ret;
+}
+#else
 struct timespec
 sol_util_timespec_get_current(void)
 {
@@ -58,6 +74,7 @@ sol_util_timespec_get_current(void)
     clock_gettime(CLOCK_MONOTONIC, &t);
     return t;
 }
+#endif
 
 char *
 sol_util_strerror(int errnum, char *buf, size_t buflen)

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -171,6 +171,9 @@ endif
 ifeq (y,$(PLATFORM_RIOTOS))
 PLATFORM_NAME = riotos
 endif
+ifeq (y,$(PLATFORM_CONTIKI))
+PLATFORM_NAME = contiki
+endif
 endif #!PLATFORM_NAME
 
 ifneq (,$(PLATFORM_NAME))


### PR DESCRIPTION
For now only a limited version of GPIO is supported.

To test you will need my patches on Contiki side that are in this repository https://github.com/zehortigoza/contiki/commits/soletta-port
To compile just go to examples/soletta-gpio-example and make, this way it will compile to native platform.

Changes from V1:
- including sol-mainloop-contiki.h to the exported headers on lib/common/Makefile like others files on the same directory.
- added check HAVE_CONTIKI to kconfig
- changed order of parameters of contiki-event callback to follow other callbacks
- moved Contiki version of SOL_MAIN_DEFAULT to sol-mainloop.h
- added patch to remove sol_mainloop_impl_fd_add/del and sol_mainloop_impl_child_watch_add/del stub implementation from Small Os

