### PR TITLE
build: check for required dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,14 @@ include $(top_srcdir)tools/build/Makefile.rules
 # kconfig interface rules
 include $(top_srcdir)tools/build/Makefile.kconfig
 
+ifneq (,$(NOT_FOUND))
+warning:
+	$(Q)echo -e "The following (required) dependencies were not met:\n"
+	$(Q)echo -e "$(NOT_FOUND)"
+	$(Q)echo -e "If you've just installed it, run: make reconf"
+	$(Q)echo -e "For more information/options, run: make help"
+$(warning-targets)
+else
 ifeq ($(HAVE_KCONFIG_CONFIG),)
 warning: $(KCONFIG_GEN)
 	$(Q)echo "You need a config file first. Please run a config target, e.g.: make menuconfig"
@@ -31,16 +39,10 @@ warning: $(KCONFIG_GEN)
 	$(Q)echo "For more information/options run: make help"
 $(warning-targets)
 else
-ifeq (n,$(HAVE_PYTHON_JSONSCHEMA))
-warning:
-	$(Q)echo "Cannot proceed, python module \"jsonschema\" was not found in your system..."
-	$(Q)echo "If you've just installed it, run: make reconf"
-$(warning-targets)
-else
 include $(top_srcdir)tools/build/Makefile.targets
 all: $(PRE_GEN) $(SOL_LIB_SO) $(SOL_LIB_AR) $(bins-out) $(modules-out)
-endif # HAVE_PYTHON_JSONSCHEMA
 endif # HAVE_KCONFIG_CONFIG
+endif # NOT_FOUND
 
 $(KCONFIG_CONFIG): $(KCONFIG_GEN)
 

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -236,12 +236,14 @@
 	{
 	    "dependency": "chrpath",
 	    "type": "exec",
-	    "exec": "chrpath"
+	    "exec": "chrpath",
+	    "required": true
 	},
 	{
 	    "dependency": "jsonschema",
 	    "type": "python",
-	    "pkgname": "jsonschema"
+	    "pkgname": "jsonschema",
+	    "required": true
 	}
     ]
 }

--- a/data/scripts/dependency-resolver.py
+++ b/data/scripts/dependency-resolver.py
@@ -191,16 +191,33 @@ def handle_ccode_check(args, conf, context):
         context.add_kconfig("HAVE_%s" % dep, "bool", "n")
 
 def handle_exec_check(args, conf, context):
-    dep = conf["dependency"].upper()
-    path = which(conf["exec"]) or None
+    dep = conf.get("dependency")
+    exe = conf.get("exec")
 
-    context.add_cond_makefile_var(dep, path)
+    if not exe:
+        print("Could not parse dependency: %s, no exec was specified.")
+        exit(1)
+
+    path = which(exe)
+    required = conf.get("required")
+
+    if required and not path:
+        req_label = context.find_makefile_var("NOT_FOUND")
+        req_label += "executable: %s\\n" % exe
+        context.add_append_makefile_var("NOT_FOUND", req_label, True)
+
+    context.add_cond_makefile_var(dep.upper(), path)
 
 def handle_python_check(args, conf, context):
-    dep = conf["dependency"].upper()
+    dep = conf.get("dependency")
+    required = conf.get("required", False)
+    pkgname = conf.get("pkgname")
 
-    if conf.get("pkgname"):
-        source = "import %s" % conf.get("pkgname")
+    if not pkgname:
+        print("Could not parse dependency: %s, no pkgname specified.")
+        exit(1)
+
+    source = "import %s" % pkgname
 
     f = tempfile.NamedTemporaryFile(suffix=".py",delete=False)
     f.write(bytes(source, 'UTF-8'))
@@ -208,7 +225,13 @@ def handle_python_check(args, conf, context):
 
     cmd = "%s %s" % (sys.executable, f.name)
     output, status = run_command(cmd)
-    context.add_cond_makefile_var("HAVE_PYTHON_%s" % dep, "y" if status else "n")
+
+    if required and not status:
+        req_label = context.find_makefile_var("NOT_FOUND")
+        req_label += "python module: %s\\n" % pkgname
+        context.add_append_makefile_var("NOT_FOUND", req_label, True)
+
+    context.add_cond_makefile_var("HAVE_PYTHON_%s" % dep.upper(), "y" if status else "n")
 
 def handle_cflags_check(args, conf, context):
     check_cflags = conf.get("cflags")


### PR DESCRIPTION
v2:
   + new approach on the dep-resolver side - given all the changed happened on it;

v3:
   + fixed minor stylish issues pointed by @lpereira;

This patch introduces the required dependencies to dependency-resolver,
so we can check and quit if no such deps are found.

A common use case for this is the absence of chrpath tool and the
users - "silently" - failing to run make install.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>