### PR TITLE
tests: fix warnings on two fbp tests

### DIFF
--- a/src/test-fbp/README
+++ b/src/test-fbp/README
@@ -16,8 +16,14 @@ For example
     my-test.fbp
     my-test-expected.txt OR my-test-expected-fail.txt
 
-Don't depend on output messages from SOL_WRN and friends on the
-expected files since they contain implementation information (line,
+It also supports regular expressions variants. Its syntax
+is described at https://docs.python.org/3/library/re.html.
+In such cases, files must be named with extension '.re.txt'
+instead of just '.txt'. So it will look for an expression match.
+
+If output messages from SOL_WRN and friends are expected on the
+expected files, using regular expressions is required,
+since they contain implementation information (line,
 column, file name in the source) that might change as the code
 evolves.
 

--- a/src/test-fbp/converter-error-expected.re.txt
+++ b/src/test-fbp/converter-error-expected.re.txt
@@ -1,0 +1,1 @@
+WRN: ./src/lib/common/sol-types.c:.*? sol_irange_division\(\) Division by zero: 10, 0

--- a/src/test-fbp/hub-expected.re.txt
+++ b/src/test-fbp/hub-expected.re.txt
@@ -1,0 +1,1 @@
+WRN: ./src/lib/common/sol-types.c:.*? sol_irange_division\(\) Division by zero: 10, 0

--- a/tools/generate-svg-from-all-fbps
+++ b/tools/generate-svg-from-all-fbps
@@ -46,7 +46,8 @@ function die() {
 [ -e $FBP_TO_DOT ] || die "Couldn't find sol-fbp-to-dot."
 
 for f in $(find src/ -name \*.fbp); do
-    if [ -f ${f/.fbp/-expected-fail.txt} ]; then
+    if [ -f ${f/.fbp/-expected-fail.txt} ] ||
+       [ -f ${f/.fbp/-expected-fail.re.txt} ]; then
 	continue
     fi
     dir=$(dirname $f)

--- a/tools/run-fbp-tests
+++ b/tools/run-fbp-tests
@@ -33,6 +33,7 @@
 import argparse
 import difflib
 import os
+import re
 import subprocess
 import sys
 
@@ -75,19 +76,33 @@ def collect_tests(tests):
 def get_expected(t):
     code = 0
     out = None
+    is_re = False
+    filename = None
+
     no_ext = os.path.splitext(t)[0]
     success_file = no_ext + "-expected.txt"
+    success_file_re = no_ext + "-expected.re.txt"
     fail_file = no_ext + "-expected-fail.txt"
+    fail_file_re = no_ext + "-expected-fail.re.txt"
 
     if os.path.isfile(success_file):
-        with open(success_file) as f:
-            out = f.read()
+        filename = success_file
+    elif os.path.isfile(success_file_re):
+        filename = success_file_re
+        is_re = True
     elif os.path.isfile(fail_file):
-        with open(fail_file) as f:
-            out = f.read()
+        filename = fail_file
         code = 1
+    elif os.path.isfile(fail_file_re):
+        filename = fail_file_re
+        code = 1
+        is_re = True
 
-    return out, code
+    if filename:
+        with open(filename) as f:
+            out = f.read()
+
+    return out, code, is_re
 
 if __name__ == "__main__":
     cmd_prefix = []
@@ -131,21 +146,34 @@ if __name__ == "__main__":
     for t in tests:
         dir = os.path.dirname(t)
         file = os.path.basename(t)
-        expected_out, expected_code = get_expected(t)
+
+        expected_out, expected_code, is_re = get_expected(t)
         out, code = sh(cmd_prefix + [runner, file], cwd=dir)
-        if expected_out is not None and out != expected_out:
-            failures += 1
-            print("FAILED running %s: wrong output" % t)
-            for line in difflib.unified_diff(out.splitlines(True), expected_out.splitlines(True)):
-                sys.stdout.write(line)
-            print()
-            continue
+
+        if expected_out:
+            if is_re:
+                if not re.match(expected_out, out):
+                    failures += 1
+                    print("FAILED running %s: wrong output" % t)
+                    print("Expected expression:")
+                    print(expected_out)
+                    print("Output:")
+                    print(out)
+                    print()
+                    continue
+            elif out != expected_out:
+                failures += 1
+                print("FAILED running %s: wrong output" % t)
+                for line in difflib.unified_diff(out.splitlines(True), expected_out.splitlines(True)):
+                    sys.stdout.write(line)
+                print()
+                continue
         if expected_code != code:
             failures += 1
             print("FAILED running %s: wrong exit code, got %d but expected %d" % (t, code, expected_code))
             print()
             continue
-        if expected_out is None and len(out) > 0:
+        if not expected_out and len(out) > 0:
             print("IGNORING unexpected output from", t)
             print(out)
 


### PR DESCRIPTION
v2 changelog:
  * use regular expressions instead of hardcoded loc

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>