### PR TITLE
coverage: fix 'make coverage' v2

### DIFF
--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -140,6 +140,7 @@ GDB_AUTOLOAD_PY_DEST := $(build_gdbautoload)libsoletta.so.$(VERSION)-gdb.py
 GDB_AUTOLOAD_PY := $(top_srcdir)data/gdb/libsoletta.so-gdb.py
 
 COMMON_CFLAGS += $(CFLAGS)
+COMMON_LDFLAGS += $(LDFLAGS)
 
 ifeq (y,$(LOG))
 ifeq (y,$(MAXIMUM_LOG_LEVEL_CRITICAL))
@@ -183,6 +184,7 @@ endif
 
 ifneq (,$(filter %coverage,$(MAKECMDGOALS)))
 COMMON_CFLAGS += -fprofile-arcs -ftest-coverage
+COMMON_LDFLAGS += -lgcov
 endif
 
 DEP_RESOLVER_CFLAGS := $(CFLAGS) -Werror=implicit-function-declaration


### PR DESCRIPTION
Differences from v1:
     - lgcov passed to COMMON_LDFLAGS instead.

@dorileo asked me to also include 'COMMON_LDFLAGS += $(LDFLAGS)' to
this file since the build system wasn't considering flags passed by the user.

Signed-off-by: Ricardo de Almeida Gonzaga <ricardo.gonzaga@intel.com>