### PR TITLE
build: Remove unnecessary flags when compiling tests

### DIFF
--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -196,7 +196,7 @@ $(foreach sample,$(samples),$(eval $(call make-sample,$(sample))))
 define make-test
 $(test-$(1)-out): $(PRE_GEN) $(SOL_LIB_SO) $(test-$(1)-srcs) $(call find-deps,$(1))
 	$(Q)echo "     "TST"   "$$@
-	$(Q)$(TARGETCC) $(TEST_CFLAGS) $(all-cflags) $(test-$(1)-cflags) $(filter-out %.h,$(test-$(1)-srcs)) $(builtin-objs) $(call find-deps,$(1)) -o $$@ $(sort $(builtin-ldflags)) $(TEST_LDFLAGS) $(test-$(1)-ldflags) $(all-ldflags)
+	$(Q)$(TARGETCC) $(TEST_CFLAGS) $(test-$(1)-cflags) $(filter-out %.h,$(test-$(1)-srcs)) $(builtin-objs) $(call find-deps,$(1)) -o $$@ $(sort $(builtin-ldflags)) $(TEST_LDFLAGS) $(test-$(1)-ldflags)
 
 endef
 $(foreach curr,$(tests),$(eval $(call make-test,$(curr))))


### PR DESCRIPTION
When compiling the tests, we were adding more flags than needed, in
particular all-ldflags and all-cflags, that have all the flags that were
encountered.

After:
molly soletta > ldd ./src/test/test-vector
	linux-vdso.so.1 (0x00007ffe519c2000)
	libglib-2.0.so.0 => /usr/x86_64-pc-linux-gnu/lib/libglib-2.0.so.0 (0x00007f4c7e445000)
	libpthread.so.0 => /usr/x86_64-pc-linux-gnu/lib/libpthread.so.0 (0x00007f4c7e228000)
	libm.so.6 => /usr/x86_64-pc-linux-gnu/lib/libm.so.6 (0x00007f4c7df2b000)
	libdl.so.2 => /usr/x86_64-pc-linux-gnu/lib/libdl.so.2 (0x00007f4c7dd27000)
	libc.so.6 => /usr/x86_64-pc-linux-gnu/lib/libc.so.6 (0x00007f4c7d984000)
	/usr/x86_64-pc-linux-gnu/lib/ld-linux-x86-64.so.2 (0x00007f4c7e77c000)

Before:
molly soletta > ldd ./src/test/test-vector
	linux-vdso.so.1 (0x00007ffd7ebf5000)
	libglib-2.0.so.0 => /usr/x86_64-pc-linux-gnu/lib/libglib-2.0.so.0 (0x00007f7370e17000)
	libpthread.so.0 => /usr/x86_64-pc-linux-gnu/lib/libpthread.so.0 (0x00007f7370bfa000)
	libudev.so.1 => /usr/x86_64-pc-linux-gnu/lib/libudev.so.1 (0x00007f737132e000)
	libgtk-3.so.0 => /usr/x86_64-pc-linux-gnu/lib/libgtk-3.so.0 (0x00007f737031e000)
	libgdk-3.so.0 => /usr/x86_64-pc-linux-gnu/lib/libgdk-3.so.0 (0x00007f737007d000)
	libpangocairo-1.0.so.0 => /usr/x86_64-pc-linux-gnu/lib/libpangocairo-1.0.so.0 (0x00007f736fe70000)
	libpango-1.0.so.0 => /usr/x86_64-pc-linux-gnu/lib/libpango-1.0.so.0 (0x00007f736fc25000)
	libatk-1.0.so.0 => /usr/x86_64-pc-linux-gnu/lib/libatk-1.0.so.0 (0x00007f736f9ff000)
	libcairo-gobject.so.2 => /usr/x86_64-pc-linux-gnu/lib/libcairo-gobject.so.2 (0x00007f736f7f7000)
	libcairo.so.2 => /usr/x86_64-pc-linux-gnu/lib/libcairo.so.2 (0x00007f736f4cf000)
	libgdk_pixbuf-2.0.so.0 => /usr/x86_64-pc-linux-gnu/lib/libgdk_pixbuf-2.0.so.0 (0x00007f736f2ad000)
	libgio-2.0.so.0 => /usr/x86_64-pc-linux-gnu/lib/libgio-2.0.so.0 (0x00007f736ef32000)
	libgobject-2.0.so.0 => /usr/x86_64-pc-linux-gnu/lib/libgobject-2.0.so.0 (0x00007f736ece1000)
	libm.so.6 => /usr/x86_64-pc-linux-gnu/lib/libm.so.6 (0x00007f736e9e4000)
	libdl.so.2 => /usr/x86_64-pc-linux-gnu/lib/libdl.so.2 (0x00007f736e7e0000)
	libc.so.6 => /usr/x86_64-pc-linux-gnu/lib/libc.so.6 (0x00007f736e43d000)
	/usr/x86_64-pc-linux-gnu/lib/ld-linux-x86-64.so.2 (0x00007f737114e000)
	librt.so.1 => /usr/x86_64-pc-linux-gnu/lib/librt.so.1 (0x00007f736e235000)
	libcap.so.2 => /usr/x86_64-pc-linux-gnu/lib/libcap.so.2 (0x00007f736e030000)
	libdw.so.1 => /usr/x86_64-pc-linux-gnu/lib/libdw.so.1 (0x00007f736dde9000)
	libXinerama.so.1 => /usr/x86_64-pc-linux-gnu/lib/libXinerama.so.1 (0x00007f736dbe7000)
	libXrandr.so.2 => /usr/x86_64-pc-linux-gnu/lib/libXrandr.so.2 (0x00007f736d9dd000)
	libXcursor.so.1 => /usr/x86_64-pc-linux-gnu/lib/libXcursor.so.1 (0x00007f736d7d3000)
	libharfbuzz.so.0 => /usr/x86_64-pc-linux-gnu/lib/libharfbuzz.so.0 (0x00007f736d57c000)
	libXi.so.6 => /usr/x86_64-pc-linux-gnu/lib/libXi.so.6 (0x00007f736d36d000)
	libXcomposite.so.1 => /usr/x86_64-pc-linux-gnu/lib/libXcomposite.so.1 (0x00007f736d16b000)
	libpixman-1.so.0 => /usr/x86_64-pc-linux-gnu/lib/libpixman-1.so.0 (0x00007f736cec6000)
	libEGL.so.1 => /usr/x86_64-pc-linux-gnu/lib/libEGL.so.1 (0x00007f736cbce000)
	libgbm.so.1 => /usr/x86_64-pc-linux-gnu/lib/libgbm.so.1 (0x00007f736c9c3000)
	libxcb-shm.so.0 => /usr/x86_64-pc-linux-gnu/lib/libxcb-shm.so.0 (0x00007f736c7c1000)
	libXrender.so.1 => /usr/x86_64-pc-linux-gnu/lib/libXrender.so.1 (0x00007f736c5b8000)
	libGL.so.1 => /usr/x86_64-pc-linux-gnu/lib/libGL.so.1 (0x00007f736c289000)
	libglapi.so.0 => /usr/x86_64-pc-linux-gnu/lib/libglapi.so.0 (0x00007f736c035000)
	libXdamage.so.1 => /usr/x86_64-pc-linux-gnu/lib/libXdamage.so.1 (0x00007f736be33000)
	libXfixes.so.3 => /usr/x86_64-pc-linux-gnu/lib/libXfixes.so.3 (0x00007f736bc2e000)
	libX11-xcb.so.1 => /usr/x86_64-pc-linux-gnu/lib/libX11-xcb.so.1 (0x00007f736ba2d000)
	libxcb-glx.so.0 => /usr/x86_64-pc-linux-gnu/lib/libxcb-glx.so.0 (0x00007f736b817000)
	libxcb-dri2.so.0 => /usr/x86_64-pc-linux-gnu/lib/libxcb-dri2.so.0 (0x00007f736b613000)
	libxcb-dri3.so.0 => /usr/x86_64-pc-linux-gnu/lib/libxcb-dri3.so.0 (0x00007f736b411000)
	libxcb-present.so.0 => /usr/x86_64-pc-linux-gnu/lib/libxcb-present.so.0 (0x00007f736b20f000)
	libxcb-randr.so.0 => /usr/x86_64-pc-linux-gnu/lib/libxcb-randr.so.0 (0x00007f736b003000)
	libxcb-xfixes.so.0 => /usr/x86_64-pc-linux-gnu/lib/libxcb-xfixes.so.0 (0x00007f736adfd000)
	libxcb-render.so.0 => /usr/x86_64-pc-linux-gnu/lib/libxcb-render.so.0 (0x00007f736abf4000)
	libxcb-shape.so.0 => /usr/x86_64-pc-linux-gnu/lib/libxcb-shape.so.0 (0x00007f736a9f1000)
	libxcb-sync.so.1 => /usr/x86_64-pc-linux-gnu/lib/libxcb-sync.so.1 (0x00007f736a7ec000)
	libxshmfence.so.1 => /usr/x86_64-pc-linux-gnu/lib/libxshmfence.so.1 (0x00007f736a5ea000)
	libXxf86vm.so.1 => /usr/x86_64-pc-linux-gnu/lib/libXxf86vm.so.1 (0x00007f736a3e5000)
	libXext.so.6 => /usr/x86_64-pc-linux-gnu/lib/libXext.so.6 (0x00007f736a1d3000)
	libX11.so.6 => /usr/x86_64-pc-linux-gnu/lib/libX11.so.6 (0x00007f7369e97000)
	libxcb.so.1 => /usr/x86_64-pc-linux-gnu/lib/libxcb.so.1 (0x00007f7369c79000)
	libXau.so.6 => /usr/x86_64-pc-linux-gnu/lib/libXau.so.6 (0x00007f7369a76000)
	libXdmcp.so.6 => /usr/x86_64-pc-linux-gnu/lib/libXdmcp.so.6 (0x00007f7369871000)
	libdrm.so.2 => /usr/x86_64-pc-linux-gnu/lib/libdrm.so.2 (0x00007f7369664000)
	libatk-bridge-2.0.so.0 => /usr/x86_64-pc-linux-gnu/lib/libatk-bridge-2.0.so.0 (0x00007f7369436000)
	libatspi.so.0 => /usr/x86_64-pc-linux-gnu/lib/libatspi.so.0 (0x00007f7369206000)
	libdbus-1.so.3 => /usr/x86_64-pc-linux-gnu/lib/libdbus-1.so.3 (0x00007f7368fb8000)
	libsystemd.so.0 => /usr/x86_64-pc-linux-gnu/lib/libsystemd.so.0 (0x00007f737129a000)
	liblzma.so.5 => /usr/x86_64-pc-linux-gnu/lib/liblzma.so.5 (0x00007f7368d93000)
	libepoxy.so.0 => /usr/x86_64-pc-linux-gnu/lib/libepoxy.so.0 (0x00007f7368ab0000)
	libpangoft2-1.0.so.0 => /usr/x86_64-pc-linux-gnu/lib/libpangoft2-1.0.so.0 (0x00007f736889c000)
	libgthread-2.0.so.0 => /usr/x86_64-pc-linux-gnu/lib/libgthread-2.0.so.0 (0x00007f736869b000)
	libfontconfig.so.1 => /usr/x86_64-pc-linux-gnu/lib/libfontconfig.so.1 (0x00007f736845e000)
	libexpat.so.1 => /usr/x86_64-pc-linux-gnu/lib/libexpat.so.1 (0x00007f7368235000)
	libfreetype.so.6 => /usr/x86_64-pc-linux-gnu/lib/libfreetype.so.6 (0x00007f7367f9e000)
	libbz2.so.1.0 => /usr/x86_64-pc-linux-gnu/lib/libbz2.so.1.0 (0x00007f7367d8e000)
	libpng16.so.16 => /usr/x86_64-pc-linux-gnu/lib/libpng16.so.16 (0x00007f7367b5d000)
	libgmodule-2.0.so.0 => /usr/x86_64-pc-linux-gnu/lib/libgmodule-2.0.so.0 (0x00007f736795a000)
	libz.so.1 => /usr/x86_64-pc-linux-gnu/lib/libz.so.1 (0x00007f7367745000)
	libresolv.so.2 => /usr/x86_64-pc-linux-gnu/lib/libresolv.so.2 (0x00007f736752e000)
	libffi.so.6 => /usr/x86_64-pc-linux-gnu/lib/libffi.so.6 (0x00007f7367326000)
	libattr.so.1 => /usr/x86_64-pc-linux-gnu/lib/libattr.so.1 (0x00007f7367122000)
	libelf.so.1 => /usr/x86_64-pc-linux-gnu/lib/libelf.so.1 (0x00007f7366f0b000)
	libnvidia-glsi.so.352.21 => /usr/x86_64-pc-linux-gnu/lib/libnvidia-glsi.so.352.21 (0x00007f7366c87000)
	libnvidia-tls.so.352.21 => /usr/x86_64-pc-linux-gnu/lib/tls/libnvidia-tls.so.352.21 (0x00007f7366a84000)
	libnvidia-glcore.so.352.21 => /usr/x86_64-pc-linux-gnu/lib/libnvidia-glcore.so.352.21 (0x00007f7363ff3000)

Signed-off-by: Vinicius Costa Gomes <vinicius.gomes@intel.com>