### PR TITLE
More robust way to get the rootdir

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -128,6 +128,20 @@
 	    "fragment": "getauxval(AT_EXECFN);"
 	},
 	{
+	    "dependency": "decl_dladdr",
+	    "type": "ccode",
+	    "defines": [
+		"_GNU_SOURCE"
+	    ],
+	    "headers": [
+		"<dlfcn.h>"
+	    ],
+	    "fragment": "dladdr(0, 0);",
+	    "ldflags": {
+		"value": "-ldl"
+	    }
+	},
+	{
 	    "dependency": "pthread_h",
 	    "type": "ccode",
 	    "headers": [

--- a/src/shared/sol-util-linux.c
+++ b/src/shared/sol-util-linux.c
@@ -285,10 +285,34 @@ get_libname(char *out, size_t size)
     return -ENOSYS;
 }
 
+static const char *
+strrstr(const char *haystack, const char *needle)
+{
+    const char *r = NULL;
+
+    if (!haystack || !needle)
+        return NULL;
+
+    if (strlen(needle) == 0)
+        return haystack + strlen(haystack);
+
+    while (1) {
+        const char *p = strstr(haystack, needle);
+        if (!p)
+            return r;
+
+        r = p;
+        haystack = p + 1;
+    }
+
+    return r;
+}
+
 int
 sol_util_get_rootdir(char *out, size_t size)
 {
-    char progname[PATH_MAX] = { 0 }, *substr, *prefix;
+    char progname[PATH_MAX] = { 0 }, *prefix;
+    const char *substr;
     int r;
 
     r = get_libname(progname, sizeof(progname));
@@ -298,7 +322,7 @@ sol_util_get_rootdir(char *out, size_t size)
             return r;
     }
 
-    substr = strstr(progname, PREFIX);
+    substr = strrstr(progname, PREFIX);
     if (!substr) {
         return -1;
     }


### PR DESCRIPTION
Instead of using paths relative to the binary that is being run, this series proposes a way to find the path relative to the libsoletta.so library. This solves the problem when running the binaries under gdb, sudo, and so on.