### PR TITLE
build: split internal tests

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -1,8 +1,8 @@
 test-$(TEST_ARENA) += test-arena
 test-test-arena-$(TEST_ARENA) := test.c test-arena.c
 
-test-$(TEST_COAP) += test-coap
-test-test-coap-$(TEST_COAP) := test.c test-coap.c
+test-internal-$(TEST_COAP) += test-coap
+test-internal-test-coap-$(TEST_COAP) := test.c test-coap.c
 
 test-$(TEST_FBP) += test-fbp
 test-test-fbp-$(TEST_FBP) := test.c test-fbp.c

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -101,11 +101,11 @@ parse-bin = \
 	$(eval bins-out      += $(bin-$(1)-out)) \
 
 parse-test = \
-	$(eval test-$(1)-srcs := $(addprefix $(2),$(test-$(1)-y))) \
+	$(eval test-$(1)-srcs := $(addprefix $(2),$($(3)-$(1)-y))) \
 	$(eval test-$(1)-out  := $(addprefix $(2),$(1))) \
-	$(eval test-$(1)-cflags := $(test-$(1)-y-extra-cflags)) \
-	$(eval test-$(1)-ldflags := $(test-$(1)-y-extra-ldflags)) \
-	$(eval $(1)-deps      := $(subst .mod,,$(test-$(1)-y-deps))) \
+	$(eval test-$(1)-cflags := $($(3)-$(1)-y-extra-cflags)) \
+	$(eval test-$(1)-ldflags := $($(3)-$(1)-y-extra-ldflags)) \
+	$(eval $(1)-deps      := $(subst .mod,,$($(3)-$(1)-y-deps))) \
 	$(eval tests-out      += $(test-$(1)-out)) \
 
 parse-sample = \
@@ -114,7 +114,8 @@ parse-sample = \
 	$(eval $(1)-deps        := $(subst .mod,,$(sample-$(1)-y-deps))) \
 	$(eval samples-out      += $(sample-$(1)-out)) \
 
-clean-control = $(eval headers-y:=) $(eval obj-y:=) $(eval obj-m:=) $(eval bin-y:=) $(eval test-y:=) $(eval sample-y:=)
+clean-control = $(eval headers-y:=) $(eval obj-y:=) $(eval obj-m:=) $(eval bin-y:=) \
+		$(eval test-y:=) $(eval test-internal-y:=) $(eval sample-y:=)
 
 inc-subdirs = \
 	$(foreach subdir,$(SUBDIRS), $(clean-control) \
@@ -137,7 +138,11 @@ inc-subdirs = \
 		) \
 		$(eval tests += $(test-y)) \
 		$(foreach test,$(test-y), \
-			$(call parse-test,$(test),$(subdir)) \
+			$(call parse-test,$(test),$(subdir),test) \
+		) \
+		$(eval tests-internal += $(test-internal-y)) \
+		$(foreach test,$(test-internal-y), \
+			$(call parse-test,$(test),$(subdir),test-internal) \
 		) \
 		$(eval samples += $(sample-y)) \
 		$(foreach sample,$(sample-y), \
@@ -196,10 +201,18 @@ $(foreach sample,$(samples),$(eval $(call make-sample,$(sample))))
 define make-test
 $(test-$(1)-out): $(PRE_GEN) $(SOL_LIB_SO) $(test-$(1)-srcs) $(call find-deps,$(1))
 	$(Q)echo "     "TST"   "$$@
-	$(Q)$(TARGETCC) $(TEST_CFLAGS) $(test-$(1)-cflags) $(filter-out %.h,$(test-$(1)-srcs)) $(builtin-objs) $(call find-deps,$(1)) -o $$@ $(sort $(builtin-ldflags)) $(TEST_LDFLAGS) $(test-$(1)-ldflags)
-
+	$(Q)$(TARGETCC) $(TEST_CFLAGS) $(test-$(1)-cflags) $(filter-out %.h,$(test-$(1)-srcs)) \
+	$(call find-deps,$(1)) -o $$@ $(TEST_LDFLAGS) $(test-$(1)-ldflags)
 endef
 $(foreach curr,$(tests),$(eval $(call make-test,$(curr))))
+
+define make-test-internal
+$(test-$(1)-out): $(PRE_GEN) $(SOL_LIB_SO) $(test-$(1)-srcs) $(call find-deps,$(1))
+	$(Q)echo "     "TST"   "$$@
+	$(Q)$(TARGETCC) $(TEST_INT_CFLAGS) $(test-$(1)-cflags) $(filter-out %.h,$(test-$(1)-srcs)) \
+	$(builtin-objs) $(call find-deps,$(1)) -o $$@ $(sort $(builtin-ldflags)) $(TEST_INT_LDFLAGS) $(test-$(1)-ldflags)
+endef
+$(foreach curr,$(tests-internal),$(eval $(call make-test-internal,$(curr))))
 
 find-gen-hdrs = $(foreach gen,$($(2)-gens),$($(gen)-hdr))
 external-module-flags = -DSOL_FLOW_NODE_TYPE_MODULE_EXTERNAL=1 -DSOL_PLATFORM_LINUX_MICRO_MODULE_EXTERNAL=1 -DSOL_PIN_MUX_MODULE_EXTERNAL=1

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -27,6 +27,7 @@ bins-out :=
 
 # test suite lookup variables
 tests :=
+tests-internal :=
 tests-out :=
 
 samples :=
@@ -210,18 +211,23 @@ EXEC_LDFLAGS += -ldl
 LIB_LDFLAGS += -ldl
 endif
 
+LINKED_OBJS_LDFLAGS := $(addprefix -L,$(LIB_OUTPUTDIR))
+LINKED_OBJS_LDFLAGS += -lsoletta
+LINKED_OBJS_LDFLAGS += -Wl,-R$(abspath $(build_libdir))
+
 OBJ_CFLAGS := $(COMMON_CFLAGS) $(COVERAGE_CFLAGS)
 OBJ_LDFLAGS += $(addprefix -L,$(LIB_OUTPUTDIR))
 
 MOD_CFLAGS := $(COMMON_CFLAGS) $(COVERAGE_CFLAGS)
+
+TEST_INT_CFLAGS := $(COMMON_CFLAGS) $(CHECK_CFLAGS)
+TEST_INT_LDFLAGS := $(EXEC_LDFLAGS)
+
 TEST_CFLAGS := $(COMMON_CFLAGS) $(CHECK_CFLAGS)
-TEST_LDFLAGS := $(EXEC_LDFLAGS)
+TEST_LDFLAGS := $(EXEC_LDFLAGS) $(LINKED_OBJS_LDFLAGS)
 
 BIN_CFLAGS := $(COMMON_CFLAGS)
-BIN_LDFLAGS := $(EXEC_LDFLAGS)
-BIN_LDFLAGS += $(addprefix -L,$(LIB_OUTPUTDIR))
-BIN_LDFLAGS += -lsoletta
-BIN_LDFLAGS += -Wl,-R$(abspath $(build_libdir))
+BIN_LDFLAGS := $(EXEC_LDFLAGS) $(LINKED_OBJS_LDFLAGS)
 
 SAMPLE_CFLAGS := $(BIN_CFLAGS)
 SAMPLE_LDFLAGS := $(BIN_LDFLAGS)


### PR DESCRIPTION
We have 2 categories of tests, one testing the public exported API's
and those testing the "internal API's", the current only internal test
implementation is test-coap.

This patch introduces a differentiation for the mentioned categories.
Tests using the public API are now linked to libsoletta.so and uses
only objects exported there, the internal ones have access to any part
of internal symbols, so they can test any part of it.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>