### PR TITLE
build: generate svg on cheat-sheet rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@
 *.gcda
 *.gcno
 /coverage
-/svg
 *.uncrustify
 .config*
 Makefile.gen

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,3 +1,4 @@
 doxygen/html
 doxygen/latex
 doxygen/man
+svg

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -102,8 +102,11 @@ endif
 
 PHONY += doc
 
+ifeq (y,$(FBP_TO_DOT))
 cheat-sheet: $(CHEAT_SHEET_HTML_SCRIPT) $(CHEAT_SHEET_RESOURCES) $(all-desc-jsons)
 	$(Q)echo "     "GEN"   "$(CHEAT_SHEET_INDEX_HTML)
 	$(Q)$(CHEAT_SHEET_HTML_SCRIPT) $(CHEAT_SHEET_INDEX_HTML_IN) $(CHEAT_SHEET_INDEX_HTML) $(all-desc-jsons)
+	$(Q)$(GEN_SVG_SCRIPT) "$(abspath $(SOL_FBP_TO_DOT_BIN))" $(SVG_OUTPUT_DIR)
+endif
 
 PHONY += cheat-sheet

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -296,6 +296,10 @@ CHEAT_SHEET_HTML_SCRIPT := $(SCRIPTDIR)sol-flow-node-type-gen-html.py
 CHEAT_SHEET_INDEX_HTML := doc/node-types-html/index.html
 CHEAT_SHEET_INDEX_HTML_IN := $(addprefix $(top_srcdir),$(addsuffix .in,$(CHEAT_SHEET_INDEX_HTML)))
 
+GEN_SVG_SCRIPT := $(top_srcdir)tools/generate-svg-from-all-fbps
+SOL_FBP_TO_DOT_BIN := $(build_bindir)sol-fbp-to-dot
+SVG_OUTPUT_DIR := doc/svg
+
 DOXYGEN_GENERATED = \
 	doc/doxygen/html \
 	doc/doxygen/latex \

--- a/tools/generate-svg-from-all-fbps
+++ b/tools/generate-svg-from-all-fbps
@@ -31,11 +31,21 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # Generate SVG representations of all FBP files in the repository.
+# ./generate-svg-from-all-fbps path/to/sol-fbp-to-dot path/to/output_dir
 
 set -e
 
-OUTPUT=$PWD/svg
+# Default paths
+OUTPUT=$PWD/doc/svg
 FBP_TO_DOT=$PWD/build/soletta_sysroot/usr/bin/sol-fbp-to-dot
+
+if [[ ! -z "$1" ]]; then
+    FBP_TO_DOT=$1
+fi
+
+if [[ ! -z "$2" ]]; then
+    OUTPUT=$2
+fi
 
 function die() {
     echo "ERROR: $1"


### PR DESCRIPTION
v2 changelog:
  * keep make doc dependency on cheat sheet
  * check if sol-fbp-to-dot was built

Also support parameters on script to set output and fbp-to-dot
paths

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>