### PR TITLE
stub-gen: Macro and struct names wrong

### DIFF
--- a/data/scripts/sol-flow-node-type-stub-gen.py
+++ b/data/scripts/sol-flow-node-type-stub-gen.py
@@ -335,11 +335,11 @@ static int
         print_data_struct(outfile, struct)
         if "options" in data:
             outfile.write("""\
-    const struct %(name_c)s_options *opts;
+    const struct sol_flow_node_type_%(name_c)s_options *opts;
 
-    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, %(NAME_C)s_OPTIONS_API_VERSION,
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_%(NAME_C)s_OPTIONS_API_VERSION,
                                        -EINVAL);
-    opts = (const struct %(name_c)s_options *)options;
+    opts = (const struct sol_flow_node_type_%(name_c)s_options *)options;
 
 """ % {
     "name_c": data["name_c"],


### PR DESCRIPTION
Generated files struct name and functions changed over time, but
sol-flow-node-type-stub-gen.py has not been updated to reflect this new
naming.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>