### PR TITLE
build: doc targets

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -265,6 +265,11 @@
 	    "type": "python",
 	    "pkgname": "jsonschema",
 	    "required": true
+	},
+	{
+	    "dependency": "graphviz",
+	    "type": "exec",
+	    "exec": "dot"
 	}
     ]
 }

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -82,10 +82,8 @@ install: post-install
 
 PHONY += install post-install pre-install
 
-all-desc-jsons = $(all-mod-descs) $(if $(filter $(builtin-flows),$(builtin-flows)),$(FLOW_BUILTINS_DESC))
-
 ifeq (yyy,$(HAVE_DOXYGEN)$(HAVE_BZIP2)$(HAVE_TAR))
-doc: $(DOXYGEN_RESOURCES) cheat-sheet
+doxygen: $(DOXYGEN_RESOURCES) cheat-sheet
 	$(Q)$(RM) -rf $(DOXYGEN_GENERATED)
 	$(Q)$(DOXYGEN) doc/doxygen/Doxyfile
 	$(Q)$(RM) -rf $(PACKAGE_DOCNAME).tar*
@@ -96,17 +94,25 @@ doc: $(DOXYGEN_RESOURCES) cheat-sheet
 	$(Q)$(RM) -rf $(PACKAGE_DOCNAME)/
 	$(Q)$(MV) $(PACKAGE_DOCNAME).tar.bz2 $(top_builddir)
 else
-doc:
+doxygen:
 	$(Q)echo "     "ERROR: Make sure to have bzip2, tar and doxygen installed and reconfigure
 endif
 
+PHONY += doxygen
+
+doc: cheat-sheet doxygen
+
 PHONY += doc
 
-ifeq (y,$(FBP_TO_DOT))
-cheat-sheet: $(CHEAT_SHEET_HTML_SCRIPT) $(CHEAT_SHEET_RESOURCES) $(SOL_FBP_TO_DOT_BIN) $(all-desc-jsons)
+ifeq (yy,$(FBP_TO_DOT)$(HAVE_GRAPHVIZ))
+cheat-sheet: $(CHEAT_SHEET_HTML_SCRIPT) $(CHEAT_SHEET_RESOURCES) $(SOL_FBP_TO_DOT_BIN) $(all-mod-descs)
 	$(Q)echo "     "GEN"   "$(CHEAT_SHEET_INDEX_HTML)
-	$(Q)$(CHEAT_SHEET_HTML_SCRIPT) $(CHEAT_SHEET_INDEX_HTML_IN) $(CHEAT_SHEET_INDEX_HTML) $(all-desc-jsons)
+	$(Q)$(CHEAT_SHEET_HTML_SCRIPT) $(CHEAT_SHEET_INDEX_HTML_IN) $(CHEAT_SHEET_INDEX_HTML) $(all-mod-descs)
 	$(Q)$(GEN_SVG_SCRIPT) "$(abspath $(SOL_FBP_TO_DOT_BIN))" $(SVG_OUTPUT_DIR)
+else
+cheat-sheet:
+	$(Q)echo "     "Either no sol-fbp-to-dot built, or dot graphviz installed in the host system
+	$(Q)echo "     "If you're lacking graphviz after installing it run, make reconf
 endif
 
 PHONY += cheat-sheet

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -78,6 +78,7 @@ HAVE_VALGRIND := $(if $(filter-out $(wildcard $(VALGRIND)),$(VALGRIND)),n,y)
 HAVE_DOXYGEN := $(if $(filter-out $(wildcard $(DOXYGEN)),$(DOXYGEN)),n,y)
 HAVE_TAR := $(if $(filter-out $(wildcard $(TAR)),$(TAR)),n,y)
 HAVE_BZIP2 := $(if $(filter-out $(wildcard $(BZIP2)),$(BZIP2)),n,y)
+HAVE_GRAPHVIZ := $(if $(filter $(GRAPHVIZ),$(GRAPHVIZ)),n,y)
 
 # installation
 PREFIX := $(patsubst "%",%,$(PREFIX))
@@ -328,6 +329,7 @@ EXTRA_HEADERS := $(COMMON_BUILDOPTS_H) $(FLOW_BUILDOPTS_H)
 EXTRA_BINS := $(FLOW_NODE_TYPE_FIND)
 EXTRA_BINS += $(addprefix $(SCRIPTDIR),sol-flow-node-type-gen.py sol-flow-node-type-validate.py)
 
-warning-targets = all check check-fbp check-valgrind check-fbp-valgrind coverage run-coverage pre-install post-install install doc cheat-sheet samples: warning
+warning-targets = all check check-fbp check-valgrind check-fbp-valgrind coverage run-coverage \
+		pre-install post-install install doc cheat-sheet samples doxygen: warning
 
 PACKAGE_DOCNAME := "soletta"-$(VERSION)-doc


### PR DESCRIPTION
Created a new target specific to doxygen, the former doc target now
remains aggregating all the docs targets (i.e doxygen, cheat-sheet).

Removed the builtins.json dependency since we don't need it to generate
the cheat-sheet.

Added a fallback rule for cheat-sheet if solettas is configured without
FBP_TO_DOT.

Also added graphviz dependency to dep-resolver once it's required to run
the svg generator script.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>