### PR TITLE
flow: introduce simplectype type creator.

### DIFF
--- a/src/lib/common/include/sol-macros.h
+++ b/src/lib/common/include/sol-macros.h
@@ -54,6 +54,7 @@
 #define SOL_ATTR_SECTION(secname) __attribute__((section(secname)))
 #define SOL_ATTR_USED __attribute__((__used__))
 #define SOL_ATTR_UNUSED __attribute__((__unused__))
+#define SOL_ATTR_SENTINEL __attribute__((sentinel))
 #else
 #define SOL_API
 #define SOL_ATTR_WARN_UNUSED_RESULT
@@ -64,6 +65,7 @@
 #define SOL_ATTR_NONNULL(...)
 #define SOL_ATTR_SECTION(secname)
 #define SOL_ATTR_USED
+#define SOL_ATTR_SENTINEL
 #endif
 
 /**

--- a/src/lib/common/include/sol-types.h
+++ b/src/lib/common/include/sol-types.h
@@ -46,6 +46,69 @@ extern "C" {
  */
 
 /**
+ * @defgroup Type_Checking Type Checking
+ *
+ * @{
+ */
+
+/**
+ * @def _SOL_TYPE_CHECK(type, var, value)
+ *
+ * Internal macro to check type of given value. It does so by creating
+ * a block with a new variable called @a var of the given @a type,
+ * assigning the @a value to it and then returning the variable.
+ *
+ * The compiler should issue compile-time type errors if the value
+ * doesn't match the type of variable.
+ *
+ * @see SOL_TYPE_CHECK()
+ * @internal
+ */
+#define _SOL_TYPE_CHECK(type, var, value) \
+    ({ type var = (value); var; })
+
+/**
+ * @def SOL_TYPE_CHECK(type, value)
+ *
+ * Macro to check @a type of given @a value.
+ *
+ * The compiler should issue compile-time type errors if the value
+ * doesn't match the type.
+ *
+ * It is often used with macros that ends into types such as 'void*'
+ * or even variable-arguments (varargs).
+ *
+ * Example: set mystruct to hold a string, checking type:
+ * @code
+ * struct mystruct {
+ *    int type;
+ *    void *value;
+ * };
+ *
+ * #define mystruct_set_string(st, x) \
+ *    do { \
+ *       st->type = mystruct_type_string; \
+ *       st->value = SOL_TYPE_CHECK(const char *, x); \
+ *    } while (0)
+ * @endcode
+ *
+ * Example: a free that checks if argument is a string
+ * @code
+ * #define free_str(x) free(SOL_TYPE_CHECK(char *, x))
+ * @endcode
+ *
+ * @param type the desired type to check.
+ * @param value the value to check, it's returned by the macro.
+ * @return the given value
+ */
+#define SOL_TYPE_CHECK(type, value) \
+    _SOL_TYPE_CHECK(type, __dummy_ ## __COUNTER__, (value))
+
+/**
+ * @}
+ */
+
+/**
  * @defgroup Types Types
  *
  * @{

--- a/src/lib/flow/Makefile
+++ b/src/lib/flow/Makefile
@@ -3,6 +3,7 @@ obj-$(FLOW) += flow.mod
 obj-flow-$(FLOW) := \
     sol-flow-node-options.o \
     sol-flow-packet.o \
+    sol-flow-simplectype.o \
     sol-flow-static.o \
     sol-flow.o
 
@@ -31,4 +32,5 @@ headers-$(FLOW) := \
     include/sol-flow-packet.h \
     include/sol-flow-parser.h \
     include/sol-flow-resolver.h \
+    include/sol-flow-simplectype.h \
     include/sol-flow-static.h

--- a/src/lib/flow/include/sol-flow-simplectype.h
+++ b/src/lib/flow/include/sol-flow-simplectype.h
@@ -1,0 +1,187 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "sol-flow.h"
+#include "sol-macros.h"
+
+struct sol_flow_simplectype_event {
+    enum sol_flow_simplectype_event_type {
+        SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_OPEN, /**< the node is being opened (instantiated) */
+        SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_CLOSE, /**< the node is being closed (deleted) */
+        SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_IN_CONNECT, /**< the input port defined by @c port index and @c port_name name is being connected */
+        SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_IN_DISCONNECT, /**< the input port defined by @c port index and @c port_name name is being disconnected */
+        SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_IN_PROCESS, /**< the input port defined by @c port index and @c port_name name received an incoming @c packet */
+        SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_OUT_CONNECT,  /**< the output port defined by @c port index and @c port_name name is being connected */
+        SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_OUT_DISCONNECT,  /**< the output port defined by @c port index and @c port_name name is being disconnected */
+    } type; /**< the type defining this event, use it before accessing the other members of this structure */
+    uint16_t port; /**< if type is one of SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_* events, the reference port index */
+    uint16_t conn_id; /**< if type is one of SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_* events, the reference connection identifier */
+    const char *port_name; /* if type is one of SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_* events, the port name (copy of the string given to sol_flow_simplectype_new_full() */
+    const struct sol_flow_node_options *options; /* if type is SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_OPEN, the given options */
+    const struct sol_flow_packet *packet; /* if type is SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_IN_PROCESS, the incoming packet */
+};
+
+
+#define SOL_FLOW_SIMPLECTYPE_PORT_TYPE_IN 1
+#define SOL_FLOW_SIMPLECTYPE_PORT_TYPE_OUT 2
+
+#define SOL_FLOW_SIMPLECTYPE_PORT_IN(name, type) \
+    SOL_TYPE_CHECK(const char *, name), \
+    SOL_TYPE_CHECK(const struct sol_flow_packet_type *, type), \
+    SOL_FLOW_SIMPLECTYPE_PORT_TYPE_IN
+
+#define SOL_FLOW_SIMPLECTYPE_PORT_OUT(name, type) \
+    SOL_TYPE_CHECK(const char *, name), \
+    SOL_TYPE_CHECK(const struct sol_flow_packet_type *, type), \
+    SOL_FLOW_SIMPLECTYPE_PORT_TYPE_OUT
+
+/**
+ * Creates a flow node type using a simple C function.
+ *
+ * This is a helper to ease development of custom nodes where the full
+ * power of node type is not needed. Instead a single function is used
+ * and given the node, the node private data and the event.
+ *
+ * Each node will have a context (private) data of size declared to
+ * sol_flow_simplectype_new_full(). This is given as the last
+ * argument to the callback @a func as well as can be retrieved with
+ * sol_flow_node_get_private_data(). An example:
+ * @code
+ * static int
+ * mytype_func(struct sol_flow_node *node,
+ *             const struct sol_flow_simplectype_event *ev,
+ *             void *data)
+ * {
+ *    struct my_context *ctx = data;
+ *    if (ev->type == SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_OPEN) {
+ *       ctx->my_value = initial_value;
+ *       ctx->my_string = strdup("inital_string");
+ *    } else if (ev->type == SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_CLOSE) {
+ *       free(ctx->my_string);
+ *       // do not free(ctx), it's automatically deleted
+ *    } else {
+ *       printf("value=%d, string=%s\n", ctx->my_value, ctx->my_string);
+ *    }
+ * }
+ * @endcode
+ *
+ * The newly returned type should be freed calling its
+ * 'dispose_type()' callback.
+ *
+ * The ports of the given type should be specified using the
+ * NULL-terminated variable arguments, each port takes a triple name,
+ * packet_type and direction. Name is the string and direction is
+ * either #SOL_FLOW_SIMPLECTYPE_PORT_TYPE_IN or
+ * #SOL_FLOW_SIMPLECTYPE_PORT_TYPE_OUT. Consider using the macros
+ * #SOL_FLOW_SIMPLECTYPE_PORT_IN() and
+ * #SOL_FLOW_SIMPLECTYPE_PORT_OUT() to make it clear and future-proof.
+ *
+ * @param name the type name, will be used in debug. Often this is the
+ *        name of the function you're using.
+ * @param private_data_size the amount of bytes to store for each node
+ *        instance. This memory can be retrieved from a node with
+ *        sol_flow_node_get_private_data() and is given to @a func as
+ *        the last argument. If zero is given, then this node
+ *        shouldn't store per-instance information and data shouldn't
+ *        be used.
+ * @param func the function to call for all events of this node such
+ *        as opening (creating), closing (destroying), ports being
+ *        connected or disconnected as well as incoming packets on
+ *        input ports.
+ *
+ * @return newly created node type, free using its
+ *         sol_flow_node_type_del().
+ *
+ * @see sol_flow_simplectype_new()
+ * @see sol_flow_simplectype_new_nocontext()
+ * @see sol_flow_node_type_del()
+ */
+struct sol_flow_node_type *sol_flow_simplectype_new_full(const char *name, size_t context_data_size, int (*func)(struct sol_flow_node *node, const struct sol_flow_simplectype_event *ev, void *data), ...) SOL_ATTR_SENTINEL;
+
+/**
+ * @def sol_flow_simplectype_new(context_data_type, cb, ...)
+ *
+ * This macro will simplify usage of sol_flow_simplectype_new_full()
+ * by taking only a context data type and the callback, as well as the
+ * port information. It will transform the callback (func) into the
+ * name of the simplectype as well as doing the
+ * sizeof(context_data_type) to specify the data size.
+ *
+ * @see sol_flow_simplectype_new_full()
+ * @see sol_flow_simplectype_new_nocontext()
+ */
+#define sol_flow_simplectype_new(context_data_type, cb, ...) sol_flow_simplectype_new_full(#cb, sizeof(context_data_type), cb, ## __VA_ARGS__, NULL)
+
+/**
+ * @def sol_flow_simplectype_new_nocontext(cb, ...)
+ *
+ * This macro will simplify usage of sol_flow_simplectype_new_full()
+ * by taking only the callback as well as the port information. It
+ * will transform the callback (func) into the name of the simplectype
+ * and use context_data_size as 0.
+ *
+ * @see sol_flow_simplectype_new_full()
+ * @see sol_flow_simplectype_new()
+ */
+#define sol_flow_simplectype_new_nocontext(cb, ...) sol_flow_simplectype_new_full(#cb, 0, cb, ## __VA_ARGS__, NULL)
+
+/**
+ * Helper to retrieve the output port index from its name.
+ *
+ * While the port index is defined by the declaration order given to
+ * sol_flow_simplectype_new_full(), sometimes it is desirable to find
+ * out the index given the string.
+ *
+ * Note that this needs a lookup, so avoid doing it in hot paths.
+ *
+ * @param type the type to search the port index given its name.
+ * @param port_out_name the output port name to retrieve the index.
+ * @return UINT16_MAX if not found, the index if found.
+ */
+uint16_t sol_flow_simplectype_get_port_out_index(const struct sol_flow_node_type *type, const char *port_out_name);
+
+/**
+ * Helper to retrieve the input port index from its name.
+ *
+ * While the port index is defined by the declaration order given to
+ * sol_flow_simplectype_new_full(), sometimes it is desirable to find
+ * in the index given the string.
+ *
+ * Note that this needs a lookup, so avoid doing it in hot paths.
+ *
+ * @param type the type to search the port index given its name.
+ * @param port_in_name the input port name to retrieve the index.
+ * @return UINT16_MAX if not found, the index if found.
+ */
+uint16_t sol_flow_simplectype_get_port_in_index(const struct sol_flow_node_type *type, const char *port_in_name);

--- a/src/lib/flow/sol-flow-simplectype.c
+++ b/src/lib/flow/sol-flow-simplectype.c
@@ -1,0 +1,484 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#include "sol-flow-internal.h"
+#include "sol-flow-simplectype.h"
+
+struct simplectype_port_in {
+    struct sol_flow_port_type_in base;
+    char *name;
+};
+
+struct simplectype_port_out {
+    struct sol_flow_port_type_out base;
+    char *name;
+};
+
+struct simplectype_type_data {
+    int (*func)(struct sol_flow_node *node, const struct sol_flow_simplectype_event *ev, void *data);
+    struct sol_vector ports_in, ports_out;
+};
+
+#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
+static bool
+simplectype_create_description_ports_in(const struct simplectype_type_data *type_data, struct sol_flow_node_type_description *desc)
+{
+    struct sol_flow_port_description **ports_in;
+    struct simplectype_port_in *port;
+    uint16_t idx;
+
+    ports_in = calloc(type_data->ports_in.len + 1,
+        sizeof(struct sol_flow_port_description *));
+    SOL_NULL_CHECK(ports_in, false);
+    desc->ports_in = (const struct sol_flow_port_description *const *)ports_in;
+
+    SOL_VECTOR_FOREACH_IDX (&(type_data->ports_in), port, idx) {
+        struct sol_flow_port_description *pd;
+
+        pd = calloc(1, sizeof(*pd));
+        SOL_NULL_CHECK_GOTO(pd, error_port);
+
+        pd->name = port->name;
+        pd->array_size = 0;
+        pd->base_port_idx = idx;
+        ports_in[idx] = pd;
+    }
+    return true;
+
+error_port:
+    while (idx > 0) {
+        idx--;
+        free(ports_in[idx]);
+    }
+    free(ports_in);
+    desc->ports_in = NULL;
+    return false;
+}
+
+static bool
+simplectype_create_description_ports_out(const struct simplectype_type_data *type_data, struct sol_flow_node_type_description *desc)
+{
+    struct sol_flow_port_description **ports_out;
+    struct simplectype_port_out *port;
+    uint16_t idx;
+
+    ports_out = calloc(type_data->ports_out.len + 1,
+        sizeof(struct sol_flow_port_description *));
+    SOL_NULL_CHECK(ports_out, false);
+    desc->ports_out = (const struct sol_flow_port_description *const *)ports_out;
+
+    SOL_VECTOR_FOREACH_IDX (&(type_data->ports_out), port, idx) {
+        struct sol_flow_port_description *pd;
+
+        pd = calloc(1, sizeof(*pd));
+        SOL_NULL_CHECK_GOTO(pd, error_port);
+
+        pd->name = port->name;
+        ports_out[idx] = pd;
+    }
+    return true;
+
+error_port:
+    while (idx > 0) {
+        idx--;
+        free(ports_out[idx]);
+    }
+    free(ports_out);
+    desc->ports_out = NULL;
+    return false;
+}
+#endif
+
+static bool
+simplectype_create_description(struct sol_flow_node_type *type, const char *name)
+{
+#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
+    struct sol_flow_node_type_description *desc;
+    const struct simplectype_type_data *type_data = type->type_data;
+
+    type->description = desc = calloc(1, sizeof(*desc));
+    SOL_NULL_CHECK(type->description, false);
+
+    desc->api_version = SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION;
+
+    desc->name = strdup(name);
+    SOL_NULL_CHECK_GOTO(desc->name, error);
+
+    if (!simplectype_create_description_ports_in(type_data, desc))
+        goto error;
+
+    if (!simplectype_create_description_ports_out(type_data, desc))
+        goto error;
+
+    return true;
+
+error:
+    free((void *)desc->name);
+    free((void *)desc->ports_in);
+    free((void *)desc->ports_out);
+    return false;
+
+#else
+    return true;
+#endif
+}
+
+static void
+simplectype_destroy_description(struct sol_flow_node_type *type)
+{
+#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
+    const struct sol_flow_node_type_description *desc = type->description;
+
+    SOL_NULL_CHECK(desc);
+
+    if (desc->ports_in) {
+        struct sol_flow_port_description **ports;
+
+        ports = (struct sol_flow_port_description **)desc->ports_in;
+        for (; *ports != NULL; ports++)
+            free(*ports);
+        free((void *)desc->ports_in);
+    }
+
+    if (desc->ports_out) {
+        struct sol_flow_port_description **ports;
+
+        ports = (struct sol_flow_port_description **)desc->ports_out;
+        for (; *ports != NULL; ports++)
+            free(*ports);
+        free((void *)desc->ports_out);
+    }
+
+    free((void *)desc->name);
+    free((void *)desc);
+#endif
+}
+
+static void
+simplectype_get_ports_counts(const struct sol_flow_node_type *type, uint16_t *ports_in_count, uint16_t *ports_out_count)
+{
+    const struct simplectype_type_data *type_data = type->type_data;
+
+    if (ports_in_count)
+        *ports_in_count = type_data->ports_in.len;
+    if (ports_out_count)
+        *ports_out_count = type_data->ports_out.len;
+}
+
+static const struct sol_flow_port_type_in *
+simplectype_get_port_in(const struct sol_flow_node_type *type, uint16_t port)
+{
+    const struct simplectype_type_data *type_data = type->type_data;
+
+    return sol_vector_get(&(type_data->ports_in), port);
+}
+
+static const struct sol_flow_port_type_out *
+simplectype_get_port_out(const struct sol_flow_node_type *type, uint16_t port)
+{
+    const struct simplectype_type_data *type_data = type->type_data;
+
+    return sol_vector_get(&(type_data->ports_out), port);
+}
+
+static int
+simplectype_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
+{
+    const struct simplectype_type_data *type_data = node->type->type_data;
+    struct sol_flow_simplectype_event ev = {
+        .type = SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_OPEN,
+        .options = options,
+    };
+
+    return type_data->func(node, &ev, data);
+}
+
+static void
+simplectype_close(struct sol_flow_node *node, void *data)
+{
+    const struct simplectype_type_data *type_data = node->type->type_data;
+    struct sol_flow_simplectype_event ev = {
+        .type = SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_CLOSE,
+    };
+
+    type_data->func(node, &ev, data);
+}
+
+static void
+simplectype_dispose(struct sol_flow_node_type *type)
+{
+    struct simplectype_type_data *type_data = (void *)type->type_data;
+    struct simplectype_port_in *port_in;
+    struct simplectype_port_out *port_out;
+    uint16_t idx;
+
+    simplectype_destroy_description(type);
+
+    SOL_VECTOR_FOREACH_IDX (&(type_data->ports_in), port_in, idx) {
+        free(port_in->name);
+    }
+    sol_vector_clear(&(type_data->ports_in));
+
+    SOL_VECTOR_FOREACH_IDX (&(type_data->ports_out), port_out, idx) {
+        free(port_out->name);
+    }
+    sol_vector_clear(&(type_data->ports_out));
+
+    free(type_data);
+    free(type);
+}
+
+static int
+simplectype_port_in_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    const struct simplectype_type_data *type_data = node->type->type_data;
+    struct simplectype_port_in *p = sol_vector_get(&(type_data->ports_in), port);
+    struct sol_flow_simplectype_event ev = {
+        .type = SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_IN_PROCESS,
+        .port = port,
+        .conn_id = conn_id,
+        .port_name = p->name,
+        .packet = packet,
+    };
+
+    return type_data->func(node, &ev, data);
+}
+
+static int
+simplectype_port_in_connect(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id)
+{
+    const struct simplectype_type_data *type_data = node->type->type_data;
+    struct simplectype_port_in *p = sol_vector_get(&(type_data->ports_in), port);
+    struct sol_flow_simplectype_event ev = {
+        .type = SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_IN_CONNECT,
+        .port = port,
+        .conn_id = conn_id,
+        .port_name = p->name,
+    };
+
+    return type_data->func(node, &ev, data);
+}
+
+static int
+simplectype_port_in_disconnect(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id)
+{
+    const struct simplectype_type_data *type_data = node->type->type_data;
+    struct simplectype_port_in *p = sol_vector_get(&(type_data->ports_in), port);
+    struct sol_flow_simplectype_event ev = {
+        .type = SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_IN_DISCONNECT,
+        .port = port,
+        .conn_id = conn_id,
+        .port_name = p->name,
+    };
+
+    return type_data->func(node, &ev, data);
+}
+
+static int
+simplectype_port_out_connect(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id)
+{
+    const struct simplectype_type_data *type_data = node->type->type_data;
+    struct simplectype_port_out *p = sol_vector_get(&(type_data->ports_out), port);
+    struct sol_flow_simplectype_event ev = {
+        .type = SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_OUT_CONNECT,
+        .port = port,
+        .conn_id = conn_id,
+        .port_name = p->name,
+    };
+
+    return type_data->func(node, &ev, data);
+}
+
+static int
+simplectype_port_out_disconnect(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id)
+{
+    const struct simplectype_type_data *type_data = node->type->type_data;
+    struct simplectype_port_out *p = sol_vector_get(&(type_data->ports_out), port);
+    struct sol_flow_simplectype_event ev = {
+        .type = SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_OUT_DISCONNECT,
+        .port = port,
+        .conn_id = conn_id,
+        .port_name = p->name,
+    };
+
+    return type_data->func(node, &ev, data);
+}
+
+SOL_API struct sol_flow_node_type *
+sol_flow_simplectype_new_full(const char *name, size_t private_data_size, int (*func)(struct sol_flow_node *node, const struct sol_flow_simplectype_event *ev, void *data), ...)
+{
+    struct sol_vector ports_in = SOL_VECTOR_INIT(struct simplectype_port_in);
+    struct sol_vector ports_out = SOL_VECTOR_INIT(struct simplectype_port_out);
+    struct sol_flow_node_type *type;
+    struct simplectype_type_data *type_data;
+    struct simplectype_port_in *port_in;
+    struct simplectype_port_out *port_out;
+    const char *port_name;
+    uint16_t idx;
+    va_list ap;
+    bool ok = true;
+
+    SOL_NULL_CHECK(func, NULL);
+
+    va_start(ap, func);
+    while ((port_name = va_arg(ap, const char *)) != NULL) {
+        const struct sol_flow_packet_type *pt = va_arg(ap, void *);
+        int direction = va_arg(ap, int);
+
+        SOL_NULL_CHECK_GOTO(pt, error);
+        SOL_INT_CHECK_GOTO(pt->api_version,
+            != SOL_FLOW_PACKET_TYPE_API_VERSION, error);
+
+        if (direction == SOL_FLOW_SIMPLECTYPE_PORT_TYPE_IN) {
+            port_in = sol_vector_append(&ports_in);
+            SOL_NULL_CHECK_GOTO(port_in, error);
+
+            port_in->name = strdup(port_name);
+            SOL_NULL_CHECK_GOTO(port_in->name, error);
+
+            port_in->base.api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION;
+            port_in->base.packet_type = pt;
+            port_in->base.connect = simplectype_port_in_connect;
+            port_in->base.disconnect = simplectype_port_in_disconnect;
+            port_in->base.process = simplectype_port_in_process;
+        } else if (direction == SOL_FLOW_SIMPLECTYPE_PORT_TYPE_OUT) {
+            port_out = sol_vector_append(&ports_out);
+            SOL_NULL_CHECK_GOTO(port_out, error);
+
+            port_out->name = strdup(port_name);
+            SOL_NULL_CHECK_GOTO(port_out->name, error);
+
+            port_out->base.api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION;
+            port_out->base.packet_type = pt;
+            port_out->base.connect = simplectype_port_out_connect;
+            port_out->base.disconnect = simplectype_port_out_disconnect;
+        } else {
+            SOL_WRN("'%s' port '%s' (type %p %s) unexpected direction %d",
+                name, port_name, pt, pt->name ? pt->name : "?", direction);
+            goto error;
+        }
+    }
+    va_end(ap);
+
+    if (!ok)
+        goto error;
+
+    if (ports_in.len == 0 && ports_out.len == 0) {
+        SOL_WRN("cannot create node type %s without ports for func=%p",
+            name, func);
+        return NULL;
+    }
+
+    type = calloc(1, sizeof(*type));
+    SOL_NULL_CHECK_GOTO(type, error);
+
+    type->api_version = SOL_FLOW_NODE_TYPE_API_VERSION;
+    type->data_size = private_data_size;
+
+    type->type_data = type_data = calloc(1, sizeof(*type_data));
+    SOL_NULL_CHECK_GOTO(type->type_data, error_type_data);
+    type_data->func = func;
+    type_data->ports_in = ports_in;
+    type_data->ports_out = ports_out;
+
+    type->get_ports_counts = simplectype_get_ports_counts;
+    type->get_port_in = simplectype_get_port_in;
+    type->get_port_out = simplectype_get_port_out;
+    type->open = simplectype_open;
+    type->close = simplectype_close;
+    type->dispose_type = simplectype_dispose;
+
+    if (!simplectype_create_description(type, name))
+        goto error_desc;
+
+    return type;
+
+error_desc:
+    free(type_data);
+error_type_data:
+    free(type);
+error:
+
+    SOL_VECTOR_FOREACH_IDX (&ports_in, port_in, idx) {
+        free(port_in->name);
+    }
+    sol_vector_clear(&ports_in);
+
+    SOL_VECTOR_FOREACH_IDX (&ports_out, port_out, idx) {
+        free(port_out->name);
+    }
+    sol_vector_clear(&ports_out);
+    return NULL;
+}
+
+SOL_API uint16_t
+sol_flow_simplectype_get_port_out_index(const struct sol_flow_node_type *type, const char *port_out_name)
+{
+    const struct simplectype_type_data *type_data;
+    struct simplectype_port_out *port;
+    uint16_t idx;
+
+    SOL_NULL_CHECK(type, UINT16_MAX);
+    SOL_NULL_CHECK(port_out_name, UINT16_MAX);
+
+    type_data = type->type_data;
+    SOL_VECTOR_FOREACH_IDX (&(type_data->ports_out), port, idx) {
+        if (streq(port->name, port_out_name))
+            return idx;
+    }
+
+    return UINT16_MAX;
+}
+
+SOL_API uint16_t
+sol_flow_simplectype_get_port_in_index(const struct sol_flow_node_type *type, const char *port_in_name)
+{
+    const struct simplectype_type_data *type_data;
+    struct simplectype_port_in *port;
+    uint16_t idx;
+
+    SOL_NULL_CHECK(type, UINT16_MAX);
+    SOL_NULL_CHECK(port_in_name, UINT16_MAX);
+
+    type_data = type->type_data;
+    SOL_VECTOR_FOREACH_IDX (&(type_data->ports_in), port, idx) {
+        if (streq(port->name, port_in_name))
+            return idx;
+    }
+
+    return UINT16_MAX;
+}
+

--- a/src/samples/flow/c-api/simplectype.c
+++ b/src/samples/flow/c-api/simplectype.c
@@ -1,0 +1,323 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+#include "sol-flow-builder.h"
+#include "sol-flow-simplectype.h"
+#include "sol-log.h"
+#include "sol-mainloop.h"
+
+/**
+ * @file simplectype.c
+ *
+ * Example how to create and use a simple C node type and the
+ * high-level API. To understand how to use the high-level C API with
+ * existing or custom C types using the generator from JSON
+ * (recommended), take a look at @ref highlevel.c
+ *
+ * Note that this sample's 'mytype*' uses all features of simplectype,
+ * usually some options will not be used in most applications, such as
+ * port connections and disconnection events or context. One example
+ * of the simplistic version is the 'isodd' that checks if if the
+ * given number is odd or even.
+ */
+
+static struct sol_flow_node *flow;
+static struct sol_flow_builder *builder;
+static struct sol_flow_node_type *flow_node_type;
+static struct sol_flow_node_type *isoddtype;
+static struct sol_flow_node_type *mytype;
+
+/*
+ * isodd is a very simplistic type, it only handle a single event and
+ * has no storage/context. All it does is get an integer and send a
+ * boolean true if that number is odd, sending false if it's even.
+ */
+static int
+isodd(struct sol_flow_node *node, const struct sol_flow_simplectype_event *ev, void *data)
+{
+    int32_t val;
+    int r;
+
+    /* we only handle events for port input. */
+    if (ev->type != SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_IN_PROCESS)
+        return 0;
+
+    /* get the integer value from irange and check if it worked */
+    r = sol_flow_packet_get_irange_value(ev->packet, &val);
+    if (r < 0)
+        return r;
+
+    /* we use port index '0' here, after all we have a single port */
+    return sol_flow_send_boolean_packet(node, 0, (val % 2 != 0));
+}
+
+/*
+ * mytype is an extensive example of simplectype capabilities.
+ *
+ * It will take options at node open, keep context and handle all
+ * events.
+ *
+ * It stores an integer and a boolean, initially set throught options
+ * and then modified via input ports, then from time to time (every
+ * 500ms) it will create a string with both values and send on its
+ * output port.
+ *
+ */
+struct mytype_options {
+#define MYTYPE_OPTIONS_SUB_API 0x1234
+    struct sol_flow_node_options base;
+    int someint;
+    bool somebool;
+};
+
+struct mytype_context {
+    struct sol_timeout *timer;
+    int someint;
+    bool somebool;
+};
+
+static bool
+on_timeout(void *data)
+{
+    struct sol_flow_node *node = data;
+    struct mytype_context *ctx = sol_flow_node_get_private_data(node);
+    uint16_t port_idx;
+    char buf[256];
+
+    printf("mytype tick... send packet. ctx=%p someint=%d, somebool=%d\n",
+        ctx, ctx->someint, ctx->somebool);
+
+    snprintf(buf, sizeof(buf), "%d/%s",
+        ctx->someint,
+        ctx->somebool ? "true" : "false");
+
+    /* this is to demo the discovery from name, but one could/should use the
+     * port index for efficiency matters.
+     */
+    port_idx = sol_flow_simplectype_get_port_out_index(mytype, "STRING");
+    sol_flow_send_string_packet(node, port_idx, buf);
+
+    return true;
+}
+
+static int
+mytype_func(struct sol_flow_node *node, const struct sol_flow_simplectype_event *ev, void *data)
+{
+    struct mytype_context *ctx = data;
+
+    switch (ev->type) {
+    case SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_OPEN: {
+        if (ev->options && ev->options->sub_api == MYTYPE_OPTIONS_SUB_API) {
+            struct mytype_options *opt = (struct mytype_options *)ev->options;
+            ctx->someint = opt->someint;
+            ctx->somebool = opt->somebool;
+        }
+        /* every 500ms send out a string representing our someint + somebool */
+        ctx->timer = sol_timeout_add(500, on_timeout, node);
+        if (!ctx->timer)
+            return -ENOMEM;
+        printf("simplectype opened ctx=%p, someint=%d, somebool=%d\n",
+            ctx, ctx->someint, ctx->somebool);
+        return 0;
+    }
+    case SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_CLOSE: {
+        printf("simplectype closed ctx=%p\n", ctx);
+        sol_timeout_del(ctx->timer);
+        return 0;
+    }
+    case SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_IN_PROCESS: {
+        /* this is to show the port names, ideally one would keep the
+         * indexes and use them here, doing integer comparisons
+         * instead of strcmp()
+         */
+        if (strcmp(ev->port_name, "IRANGE") == 0) {
+            int32_t val;
+            if (sol_flow_packet_get_irange_value(ev->packet, &val) == 0) {
+                printf("simplectype updated integer from %d to %d\n",
+                    ctx->someint, val);
+                ctx->someint = val;
+                return 0;
+            }
+        } else if (strcmp(ev->port_name, "BOOLEAN") == 0) {
+            bool val;
+            if (sol_flow_packet_get_boolean(ev->packet, &val) == 0) {
+                printf("simplectype updated boolean from %d to %d\n",
+                    ctx->somebool, val);
+                ctx->somebool = val;
+                return 0;
+            }
+        }
+        printf("simplectype port '%s' got unexpected data!\n", ev->port_name);
+        return -EINVAL;
+    }
+    case SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_IN_CONNECT:
+        printf("simplectype port IN '%s' id=%d conn=%d connected ctx=%p\n",
+            ev->port_name, ev->port, ev->conn_id, ctx);
+        return 0;
+    case SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_IN_DISCONNECT:
+        printf("simplectype port IN '%s' id=%d conn=%d disconnected ctx=%p\n",
+            ev->port_name, ev->port, ev->conn_id, ctx);
+        return 0;
+    case SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_OUT_CONNECT:
+        printf("simplectype port OUT '%s' id=%d conn=%d connected ctx=%p\n",
+            ev->port_name, ev->port, ev->conn_id, ctx);
+        return 0;
+    case SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_PORT_OUT_DISCONNECT:
+        printf("simplectype port OUT '%s' id=%d conn=%d disconnected ctx=%p\n",
+            ev->port_name, ev->port, ev->conn_id, ctx);
+        return 0;
+    }
+
+    return -EINVAL;
+}
+
+static void
+startup(void)
+{
+    /* you can give your simplectype custom arguments, just give it
+     * the struct and remember to fill its "base" with the API fields.
+     * the 'api_version' is checked by sol-flow calls, while sub_api
+     * is checked at mytype_func when handling the
+     * SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_OPEN.
+     */
+    struct mytype_options mystuff_opts = {
+        .base = {
+            .api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION,
+            .sub_api = MYTYPE_OPTIONS_SUB_API,
+        },
+        .someint = 12,
+        .somebool = true,
+    };
+
+    builder = sol_flow_builder_new();
+
+    /* declare 'isodd' without private data and with ports:
+     * input: IN (index: 0)
+     * output: OUT (index: 0)
+     */
+    isoddtype = sol_flow_simplectype_new_nocontext(
+        isodd,
+        SOL_FLOW_SIMPLECTYPE_PORT_IN("IN", SOL_FLOW_PACKET_TYPE_IRANGE),
+        SOL_FLOW_SIMPLECTYPE_PORT_OUT("OUT", SOL_FLOW_PACKET_TYPE_BOOLEAN),
+        NULL);
+
+    /* declare mytype with 'struct mytype_context' private data and with ports:
+     * input: IRANGE (index: 0), BOOLEAN (index: 1)
+     * output: STRING (index: 0, as input and output have separate arrays)
+     */
+    mytype = sol_flow_simplectype_new(
+        struct mytype_context, mytype_func,
+        SOL_FLOW_SIMPLECTYPE_PORT_IN("IRANGE", SOL_FLOW_PACKET_TYPE_IRANGE),
+        SOL_FLOW_SIMPLECTYPE_PORT_IN("BOOLEAN", SOL_FLOW_PACKET_TYPE_BOOLEAN),
+        SOL_FLOW_SIMPLECTYPE_PORT_OUT("STRING", SOL_FLOW_PACKET_TYPE_STRING),
+        NULL);
+
+    /* for types declared as builtin or external modules, add by type name */
+    sol_flow_builder_add_node_by_type(builder, "timer",
+        "timer", NULL);
+    sol_flow_builder_add_node_by_type(builder, "booltoggle",
+        "boolean/toggle", NULL);
+    sol_flow_builder_add_node_by_type(builder, "intacc",
+        "int/accumulator", NULL);
+    sol_flow_builder_add_node_by_type(builder, "debug",
+        "console", NULL);
+    sol_flow_builder_add_node_by_type(builder, "console_mystuff",
+        "console", NULL);
+    sol_flow_builder_add_node_by_type(builder, "console_isodd",
+        "console", NULL);
+
+    /* use our types as we'd use any custom type: given its handle */
+    sol_flow_builder_add_node(builder, "isodd", isoddtype, NULL);
+    sol_flow_builder_add_node(builder, "mystuff", mytype, &mystuff_opts.base);
+
+    /* setup connections */
+    sol_flow_builder_connect(builder, "timer", "OUT", -1,
+        "booltoggle", "IN", -1);
+    sol_flow_builder_connect(builder, "timer", "OUT", -1,
+        "intacc", "INC", -1);
+
+    /* intacc OUT -> IN isodd OUT -> IN console_isodd */
+    sol_flow_builder_connect(builder, "intacc", "OUT", -1,
+        "isodd", "IN", -1);
+    sol_flow_builder_connect(builder, "isodd", "OUT", -1,
+        "console_isodd", "IN", -1);
+
+    /* booltoggle OUT -> BOOLEAN mystuff
+     * intacc OUT -> IRANGE mystuff
+     * mystuff STRING -> IN console_mystuff
+     */
+    sol_flow_builder_connect(builder, "booltoggle", "OUT", -1,
+        "mystuff", "BOOLEAN", -1);
+    sol_flow_builder_connect(builder, "intacc", "OUT", -1,
+        "mystuff", "IRANGE", -1);
+    sol_flow_builder_connect(builder, "mystuff", "STRING", -1,
+        "console_mystuff", "IN", -1);
+
+    /* also print out values from boolean toggle and integer
+     * accumulator so we can double check the results.
+     */
+    sol_flow_builder_connect(builder, "booltoggle", "OUT", -1,
+        "debug", "IN", -1);
+    sol_flow_builder_connect(builder, "intacc", "OUT", -1,
+        "debug", "IN", -1);
+
+    /* this creates a static flow using the low-level API that will
+     * actually run the flow. Note that its memory is bound to
+     * builder, then keep builder alive.
+     */
+    flow_node_type = sol_flow_builder_get_node_type(builder);
+
+    /* create and run the flow */
+    flow = sol_flow_node_new(NULL, "simplectype", flow_node_type, NULL);
+}
+
+static void
+shutdown(void)
+{
+    /* stop the flow, disconnect ports and close children nodes */
+    sol_flow_node_del(flow);
+
+    /* delete types */
+    sol_flow_node_type_del(isoddtype);
+    sol_flow_node_type_del(mytype);
+    sol_flow_node_type_del(flow_node_type);
+
+    /* delete the builder */
+    sol_flow_builder_del(builder);
+}
+
+SOL_MAIN_DEFAULT(startup, shutdown);


### PR DESCRIPTION
Changes since v1:
 - "samples/flow: fix API so they compile and run" was merged to master.
 - removed type checking functions, added a `SOL_TYPE_CHECK()` macro instead
 - fixed style issues (forgot to run check-style.py)