### PR TITLE
Generate subflow code using sol-fbp-generator

### DIFF
--- a/src/modules/flow/calamari/calamari-7seg.c
+++ b/src/modules/flow/calamari/calamari-7seg.c
@@ -1,0 +1,72 @@
+static const struct sol_flow_node_type *
+create_0_root_type(void)
+{
+    static const struct sol_flow_node_type_gpio_writer_options opts1 =
+        SOL_FLOW_NODE_TYPE_GPIO_WRITER_OPTIONS_DEFAULTS(
+            .pin = {
+                .val = 473,
+            },
+        );
+
+    static const struct sol_flow_node_type_gpio_writer_options opts2 =
+        SOL_FLOW_NODE_TYPE_GPIO_WRITER_OPTIONS_DEFAULTS(
+            .pin = {
+                .val = 475,
+            },
+        );
+
+    static const struct sol_flow_node_type_gpio_writer_options opts3 =
+        SOL_FLOW_NODE_TYPE_GPIO_WRITER_OPTIONS_DEFAULTS(
+            .pin = {
+                .val = 340,
+            },
+        );
+
+    static const struct sol_flow_node_type_gpio_writer_options opts4 =
+        SOL_FLOW_NODE_TYPE_GPIO_WRITER_OPTIONS_DEFAULTS(
+            .pin = {
+                .val = 474,
+            },
+        );
+
+    static const struct sol_flow_static_conn_spec conns[] = {
+        { 0, 0, 1, 0 },
+        { 0, 1, 2, 0 },
+        { 0, 2, 3, 0 },
+        { 0, 3, 4, 0 },
+        SOL_FLOW_STATIC_CONN_SPEC_GUARD
+    };
+
+    static const struct sol_flow_static_port_spec exported_in[] = {
+        { 0, 0 },
+        { 0, 1 },
+        SOL_FLOW_STATIC_PORT_SPEC_GUARD
+    };
+
+
+    static struct sol_flow_static_node_spec nodes[] = {
+        [0] = {NULL, "ctl", NULL},
+        [1] = {NULL, "clear", (struct sol_flow_node_options *) &opts1},
+        [2] = {NULL, "latch", (struct sol_flow_node_options *) &opts2},
+        [3] = {NULL, "clock", (struct sol_flow_node_options *) &opts3},
+        [4] = {NULL, "data", (struct sol_flow_node_options *) &opts4},
+        SOL_FLOW_STATIC_NODE_SPEC_GUARD
+    };
+
+    struct sol_flow_static_spec spec = {
+        .api_version = 1,
+        .nodes = nodes,
+        .conns = conns,
+        .exported_in = exported_in,
+        .exported_out = NULL,
+    };
+
+    nodes[0].type = SOL_FLOW_NODE_TYPE_CALAMARI_SEGMENTS_CTL;
+    nodes[1].type = SOL_FLOW_NODE_TYPE_GPIO_WRITER;
+    nodes[2].type = SOL_FLOW_NODE_TYPE_GPIO_WRITER;
+    nodes[3].type = SOL_FLOW_NODE_TYPE_GPIO_WRITER;
+    nodes[4].type = SOL_FLOW_NODE_TYPE_GPIO_WRITER;
+
+    return sol_flow_static_new_type(&spec);
+}
+

--- a/src/modules/flow/calamari/calamari-7seg.fbp
+++ b/src/modules/flow/calamari/calamari-7seg.fbp
@@ -1,0 +1,7 @@
+INPORT=ctl.SEGMENTS:SEGMENTS
+INPORT=ctl.VALUE:VALUE
+
+ctl(calamari/segments-ctl) CLEAR -> IN clear(gpio/writer:pin=473)
+ctl LATCH -> IN latch(gpio/writer:pin=475)
+ctl CLOCK -> IN clock(gpio/writer:pin=340)
+ctl DATA -> IN data(gpio/writer:pin=474)

--- a/src/modules/flow/calamari/calamari.c
+++ b/src/modules/flow/calamari/calamari.c
@@ -215,46 +215,14 @@ calamari_7seg_child_opts_set(const struct sol_flow_node_type *type,
     return 0;
 }
 
+#include "calamari-7seg.c"
+
 static void
 calamari_7seg_new_type(const struct sol_flow_node_type **current)
 {
     struct sol_flow_node_type *type;
 
-    static struct sol_flow_static_node_spec nodes[] = {
-        [SEG_CTL] = { NULL, "segments-ctl", NULL },
-        [SEG_CLEAR] = { NULL, "gpio-clear", NULL },
-        [SEG_LATCH] = { NULL, "gpio-latch", NULL },
-        [SEG_CLOCK] = { NULL, "gpio-clock", NULL },
-        [SEG_DATA] = { NULL, "gpio-data", NULL },
-        SOL_FLOW_STATIC_NODE_SPEC_GUARD
-    };
-
-    static const struct sol_flow_static_conn_spec conns[] = {
-        { SEG_CTL, SOL_FLOW_NODE_TYPE_CALAMARI_SEGMENTS_CTL__OUT__CLEAR, SEG_CLEAR, SOL_FLOW_NODE_TYPE_GPIO_WRITER__IN__IN },
-        { SEG_CTL, SOL_FLOW_NODE_TYPE_CALAMARI_SEGMENTS_CTL__OUT__LATCH, SEG_LATCH, SOL_FLOW_NODE_TYPE_GPIO_WRITER__IN__IN },
-        { SEG_CTL, SOL_FLOW_NODE_TYPE_CALAMARI_SEGMENTS_CTL__OUT__CLOCK, SEG_CLOCK, SOL_FLOW_NODE_TYPE_GPIO_WRITER__IN__IN },
-        { SEG_CTL, SOL_FLOW_NODE_TYPE_CALAMARI_SEGMENTS_CTL__OUT__DATA, SEG_DATA, SOL_FLOW_NODE_TYPE_GPIO_WRITER__IN__IN },
-        SOL_FLOW_STATIC_CONN_SPEC_GUARD
-    };
-
-    static const struct sol_flow_static_port_spec exported_in[] = {
-        { SEG_CTL, SOL_FLOW_NODE_TYPE_CALAMARI_SEGMENTS_CTL__IN__SEGMENTS },
-        { SEG_CTL, SOL_FLOW_NODE_TYPE_CALAMARI_SEGMENTS_CTL__IN__VALUE },
-        SOL_FLOW_STATIC_PORT_SPEC_GUARD
-    };
-
-    static const struct sol_flow_static_spec spec = {
-        .api_version = SOL_FLOW_STATIC_API_VERSION,
-        .nodes = nodes,
-        .conns = conns,
-        .exported_in = exported_in,
-        .child_opts_set = calamari_7seg_child_opts_set,
-    };
-
-    nodes[SEG_CTL].type = SOL_FLOW_NODE_TYPE_CALAMARI_SEGMENTS_CTL;
-    nodes[SEG_CLEAR].type = nodes[SEG_LATCH].type = nodes[SEG_CLOCK].type = nodes[SEG_DATA].type = SOL_FLOW_NODE_TYPE_GPIO_WRITER;
-
-    type = sol_flow_static_new_type(&spec);
+    type = create_0_root_type();
     SOL_NULL_CHECK(type);
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
     type->description = (*current)->description;

--- a/src/modules/flow/calamari/calamari.json
+++ b/src/modules/flow/calamari/calamari.json
@@ -166,7 +166,7 @@
       ]
     },
     {
-      "category": "internal",
+      "category": "output/hw",
       "description": "",
       "in_ports": [
         {

--- a/tools/run-fbp-generator
+++ b/tools/run-fbp-generator
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import difflib
+import os
+import re
+import subprocess
+import sys
+
+def sh(cmd, cwd=None):
+    try:
+        out = subprocess.check_output(cmd, stderr=subprocess.STDOUT, cwd=cwd).decode('utf-8')
+        return out, 0
+    except subprocess.CalledProcessError as err:
+        return err.output.decode('utf-8'), err.returncode
+
+def is_valid_fbp(f):
+    return os.path.splitext(f)[1] == ".fbp"
+
+def collect_fbps_dir(dir, result):
+    for root, subdirs, files in os.walk(dir):
+        for f in files:
+            if is_valid_fbp(f):
+                result.append(os.path.join(root, f))
+        for d in subdirs:
+            collect_fbps_dir(d, result)
+
+
+def collect_fbps(fbps):
+    result = []
+
+    for t in args.fbps:
+        t = os.path.abspath(t)
+        if not os.path.exists(t):
+            print("Ignoring non-existent fbp file or directory", t)
+            continue
+
+        if os.path.isdir(t):
+            collect_fbps_dir(t, result)
+        elif is_valid_fbp(t):
+            result.append(t)
+
+    return result
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--generator", default="../build/soletta_sysroot/usr/bin/sol-fbp-generator", type=str)
+    parser.add_argument("--json_dir", default="../build/soletta_sysroot/usr/share/soletta/flow/descriptions", type=str)
+    parser.add_argument("fbps", nargs='*', default=["../src/modules/flow/"])
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.generator):
+        sys.exit("Couldn't find generator program at %s" % generator)
+
+    fbps = collect_fbps(args.fbps)
+
+    for f in fbps:
+        dir = os.path.dirname(f)
+        file = os.path.basename(f)
+        dst_filename = os.path.splitext(file)[0]
+        dst_filename += "-gen.c"
+
+        out, code = sh([os.path.abspath(args.generator), '-s', '-j', os.path.abspath(args.json_dir), file, dst_filename], cwd=dir)
+
+        if code != 0:
+           print("run-fbp-generator failed! sol-fbp-generator status: %s" % out)


### PR DESCRIPTION
This commit is the first step to achieve automatic code
generation for modules that depend on subflows. Calamari's
7-segments type is an abstraction for four GPIO nodes and
a controller (calamari/segments-ctl). Instead of specifying
this subflow by hand using the C api, we can now rely on
sol-fbp-generator to do the dirty work for us, by merely
writing an fbp file describing the subflow.

As soon as the build system starts calling the run-fbp-generator,
calamari-7seg.c will be gone and a calamari-7seg-gen.c will take
its place. Also, future patches for sol-fbp-generator must provide
a way to set the 'child_opts_set' callback. To overcome this
limitation, calamari-7seg.fbp enforces the GPIO node options,
which means that conffiles won't work and samples for
calamari/7seg must be run on kernels >= 3.18 to work properly.

Signed-off-by: Luiz Ywata <luizg.ywata@intel.com>