### PR TITLE
Soletta meets JS v3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "src/thirdparty/duktape"]
+	path = src/thirdparty/duktape
+	url = https://github.com/svaarala/duktape-releases.git
+	branch = v1.2.2
+	sparsecheckout = true
+	sparserules = src/ LICENSE.txt

--- a/data/scripts/git-init-submodules.py
+++ b/data/scripts/git-init-submodules.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import configparser
+import os
+import subprocess
+import sys
+
+def run_command(cmd):
+    try:
+        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT,
+                                         shell=True, universal_newlines=True)
+        return output.replace("\n", "").strip(), True
+    except subprocess.CalledProcessError as e:
+        return e.output, False
+
+def submodule_clone(name, path, url, branch, depth, dest, sparserules):
+    if os.path.exists(dest):
+        return None, True
+
+    print("GIT: cloning submodule %s ..." % name, end="")
+    sys.stdout.flush()
+    out, status = run_command("git clone {url} {branch} {depth} --bare {dest}".format(
+        url=url, branch=branch, depth=depth, dest=dest))
+
+    if sparserules:
+        submodule_config = "%s/config" % dest
+        rules_dir = "%s/info" % dest
+
+        if not os.path.exists(rules_dir):
+            os.makedirs(rules_dir)
+
+        rules_file = "%s/info/sparse-checkout" % dest
+
+        config = configparser.ConfigParser()
+        config.read(submodule_config)
+        config.set("core", "sparsecheckout", 'true')
+        config.set("core", "bare", 'false')
+        with open(submodule_config, "w") as fd:
+            config.write(fd)
+
+        content = ""
+        for ln in sparserules.split():
+            content += "%s\n" % ln
+
+        with open(rules_file, "w") as fd:
+            fd.write(content)
+
+    run_command("git submodule init " + path)
+
+    print("[done]")
+    return out, status
+
+def submodule_checkout(name, submodule_git, path):
+    git_link = "%s/.git" % path
+
+    if os.path.exists(git_link):
+        os.remove(git_link)
+
+    ddepth = len(path.split("/"))
+    with open(git_link, "w") as git:
+        git.write("gitdir: %s%s" % ("../" * ddepth, submodule_git))
+
+    out, status = run_command("cd {path} && git checkout -f".format(path=path))
+
+if __name__ == "__main__":
+    gitmodules = ".gitmodules"
+    
+    if not os.path.exists(gitmodules):
+        exit(0)
+
+    config = configparser.ConfigParser()
+    config["DEFAULT"] = {"sparsecheckout": False, "sparserules": "", "branch": ""}
+    config.read(gitmodules)
+
+    for k,v in config.items():
+        if not k.startswith("submodule"):
+            continue
+
+        name = k.replace("submodule ", "").replace("\"", "")
+        path = config.get(k, "path")
+        url = config.get(k, "url")
+        sparsecheckout = config.get(k, "sparsecheckout")
+        sparserules = config.get(k, "sparserules")
+        branch = config.get(k, "branch")
+
+        if not name and not path:
+            print("ERROR: Can't initialize submodule: %d, missing either name or path." % name)
+            exit(1)
+
+        submodule_git = ".git/modules/%s" % name
+        depth = "--depth 1" if sparsecheckout else ""
+        branch_arg = "-b %s" % branch if branch else ""
+        out, status = submodule_clone(name, path, url, branch_arg, depth, submodule_git, sparserules)
+
+        if not status:
+            print("ERROR: Failed to clone submodule: %s" % name)
+            print("ERROR: %s" % out)
+            exit(1)
+
+        submodule_checkout(name, submodule_git, path)

--- a/src/lib/flow/Kconfig
+++ b/src/lib/flow/Kconfig
@@ -2,6 +2,11 @@ config FLOW
 	bool "Flow support"
 	default y
 
+config JAVASCRIPT
+	bool "Javascript support"
+	depends on FLOW
+	default y
+
 config NODE_DESCRIPTION
 	bool "Node description support"
 	depends on FLOW

--- a/src/lib/flow/Makefile
+++ b/src/lib/flow/Makefile
@@ -11,6 +11,9 @@ obj-flow-$(NODE_DESCRIPTION) += \
     sol-flow-resolver.o \
     sol-flow-builder.o
 
+obj-flow-$(JAVASCRIPT) += \
+	sol-flow-js.o
+
 ifeq (y,$(RESOLVER_CONFFILE))
 def-resolver-flag = -Dsol_flow_default_resolver=sol_flow_resolver_conffile
 else
@@ -28,6 +31,7 @@ headers-$(FLOW) := \
     include/sol-flow-builder.h \
     include/sol-flow.h \
     include/sol-flow-inspector.h \
+    include/sol-flow-js.h \
     include/sol-flow-packet.h \
     include/sol-flow-parser.h \
     include/sol-flow-resolver.h \

--- a/src/lib/flow/include/sol-flow-js.h
+++ b/src/lib/flow/include/sol-flow-js.h
@@ -1,0 +1,85 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "sol-flow.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * JS node allows the usage of Javascript language to create new and
+ * customizable node types.
+ *
+ * A JS node type is specified with one object containing each
+ * input and output port declarations (name and type) and its
+ * callback functions that will be trigged on the occurrence
+ * of certain events like input/output ports processes, open/close
+ * processes, so forth and so on.
+ */
+
+/**
+ * Creates a new "JS node" type.
+ *
+ * The Javascript code must contain an object:
+ *
+ *     - 'node': This object will be used to declare input and output ports
+ *               and its callback functions that will be trigged on the occurence
+ *               of certain events like input/output ports processes, open/close
+ *               processes, so forth and so on.
+ *
+ * e.g.  var node = {
+ *           in: [
+ *               {
+ *                   name: 'IN',
+ *                   type: 'int',
+ *                   process: function(v) {
+ *                       sendPacket("OUT", 42);
+ *                   }
+ *               }
+ *           ],
+ *           out: [ { name: 'OUT', type: 'int' } ]
+ *       };
+ *
+ * @param buf A buffer containing the Javascript code in which will be used
+ *            in this new JS node type.
+ * @param len The size of the buffer.
+ *
+ * @return A new JS node type on success, otherwise @c NULL.
+ */
+struct sol_flow_node_type *sol_flow_js_new_type(const char *buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/lib/flow/sol-flow-js.c
+++ b/src/lib/flow/sol-flow-js.c
@@ -1,0 +1,1336 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <float.h>
+#include <stdio.h>
+
+#include "duktape.h"
+#include "sol-arena.h"
+#include "sol-flow-internal.h"
+#include "sol-flow-js.h"
+#include "sol-str-table.h"
+
+/* Contains information specific to a type based on JS. */
+struct flow_js_type {
+    struct sol_flow_node_type base;
+
+    struct sol_vector ports_in;
+    struct sol_vector ports_out;
+
+    struct sol_arena *str_arena;
+
+    char *js_content_buf;
+    size_t js_content_buf_len;
+};
+
+struct flow_js_port_in {
+    struct sol_flow_port_type_in type;
+    char *name;
+    char *type_name;
+};
+
+struct flow_js_port_out {
+    struct sol_flow_port_type_out type;
+    char *name;
+    char *type_name;
+};
+
+/* Contains information specific to a node of a JS node type. */
+struct flow_js_data {
+    /* Each node keeps its own JavaScript context and global object. */
+    struct duk_context *duk_ctx;
+};
+
+enum {
+    PORTS_IN_CONNECT_INDEX,
+    PORTS_IN_DISCONNECT_INDEX,
+    PORTS_IN_PROCESS_INDEX,
+    PORTS_IN_METHODS_LENGTH,
+};
+
+enum {
+    PORTS_OUT_CONNECT_INDEX,
+    PORTS_OUT_DISCONNECT_INDEX,
+    PORTS_OUT_METHODS_LENGTH,
+};
+
+static const char *
+get_in_port_name(const struct flow_js_type *type, uint16_t port)
+{
+    const struct flow_js_port_in *p;
+
+    p = sol_vector_get(&type->ports_in, port);
+    if (!p) {
+        SOL_WRN("Couldn't get input port %d name.", port);
+        return "";
+    }
+
+    return p->name;
+}
+
+static const char *
+get_out_port_name(const struct flow_js_type *type, uint16_t port)
+{
+    const struct flow_js_port_out *p;
+
+    p = sol_vector_get(&type->ports_out, port);
+    if (!p) {
+        SOL_WRN("Couldn't get output port %d name.", port);
+        return "";
+    }
+
+    return p->name;
+}
+
+static duk_ret_t
+send_boolean_packet(struct sol_flow_node *node, uint16_t port, duk_context *ctx)
+{
+    bool value;
+    int r;
+
+    value = duk_require_boolean(ctx, 1);
+
+    r = sol_flow_send_boolean_packet(node, port, value);
+    if (r < 0) {
+        duk_error(ctx, DUK_ERR_ERROR, "Couldn't send boolean packet on '%s' port.",
+            get_out_port_name((struct flow_js_type *)node->type, port));
+    }
+
+    return r;
+}
+
+static duk_ret_t
+send_byte_packet(struct sol_flow_node *node, uint16_t port, duk_context *ctx)
+{
+    unsigned char value;
+    int r;
+
+    value = duk_require_int(ctx, 1);
+
+    r = sol_flow_send_byte_packet(node, port, value);
+    if (r < 0) {
+        duk_error(ctx, DUK_ERR_ERROR, "Couldn't send byte packet on '%s' port.",
+            get_out_port_name((struct flow_js_type *)node->type, port));
+    }
+
+    return r;
+}
+
+static duk_ret_t
+send_float_packet(struct sol_flow_node *node, uint16_t port, duk_context *ctx)
+{
+    struct sol_drange value;
+    int r;
+
+    if (duk_is_number(ctx, 1)) {
+        value.val = duk_require_number(ctx, 1);
+
+        value.min = -DBL_MAX;
+        value.max = DBL_MAX;
+        value.step = DBL_MIN;
+    } else {
+        duk_require_object_coercible(ctx, 1);
+
+        duk_get_prop_string(ctx, -1, "val");
+        duk_get_prop_string(ctx, -2, "min");
+        duk_get_prop_string(ctx, -3, "max");
+        duk_get_prop_string(ctx, -4, "step");
+
+        value.val = duk_require_number(ctx, -4);
+        value.min = duk_require_number(ctx, -3);
+        value.max = duk_require_number(ctx, -2);
+        value.step = duk_require_number(ctx, -1);
+
+        duk_pop_n(ctx, 4); /* step, max, min, val values */
+    }
+
+    r = sol_flow_send_drange_packet(node, port, &value);
+    if (r < 0) {
+        duk_error(ctx, DUK_ERR_ERROR, "Couldn't send float packet on '%s' port.",
+            get_out_port_name((struct flow_js_type *)node->type, port));
+    }
+
+    return r;
+}
+
+static duk_ret_t
+send_int_packet(struct sol_flow_node *node, uint16_t port, duk_context *ctx)
+{
+    struct sol_irange value;
+    int r;
+
+    if (duk_is_number(ctx, 1)) {
+        value.val = duk_require_int(ctx, 1);
+
+        value.min = INT32_MIN;
+        value.max = INT32_MAX;
+        value.step = 1;
+    } else {
+        duk_require_object_coercible(ctx, 1);
+
+        duk_get_prop_string(ctx, -1, "val");
+        duk_get_prop_string(ctx, -2, "min");
+        duk_get_prop_string(ctx, -3, "max");
+        duk_get_prop_string(ctx, -4, "step");
+
+        value.val = duk_require_int(ctx, -4);
+        value.min = duk_require_int(ctx, -3);
+        value.max = duk_require_int(ctx, -2);
+        value.step = duk_require_int(ctx, -1);
+
+        duk_pop_n(ctx, 4); /* step, max, min, val values */
+    }
+
+    r = sol_flow_send_irange_packet(node, port, &value);
+    if (r < 0) {
+        duk_error(ctx, DUK_ERR_ERROR, "Couldn't send int packet on '%s' port.",
+            get_out_port_name((struct flow_js_type *)node->type, port));
+    }
+
+    return r;
+}
+
+static duk_ret_t
+send_rgb_packet(struct sol_flow_node *node, uint16_t port, duk_context *ctx)
+{
+    struct sol_rgb value;
+    int r;
+
+    duk_require_object_coercible(ctx, 1);
+
+    duk_get_prop_string(ctx, -1, "red");
+    duk_get_prop_string(ctx, -2, "green");
+    duk_get_prop_string(ctx, -3, "blue");
+    duk_get_prop_string(ctx, -4, "red_max");
+    duk_get_prop_string(ctx, -5, "green_max");
+    duk_get_prop_string(ctx, -6, "blue_max");
+
+    value.red = duk_require_int(ctx, -6);
+    value.green = duk_require_int(ctx, -5);
+    value.blue = duk_require_int(ctx, -4);
+    value.red_max = duk_require_int(ctx, -3);
+    value.green_max = duk_require_int(ctx, -2);
+    value.blue_max = duk_require_int(ctx, -1);
+
+    duk_pop_n(ctx, 6); /* blue_max, green_max, red_max, blue, green, red values */
+
+    r = sol_flow_send_rgb_packet(node, port, &value);
+    if (r < 0) {
+        duk_error(ctx, DUK_ERR_ERROR, "Couldn't send rgb packet on '%s' port.",
+            get_out_port_name((struct flow_js_type *)node->type, port));
+    }
+
+    return r;
+}
+
+static duk_ret_t
+send_string_packet(struct sol_flow_node *node, uint16_t port, duk_context *ctx)
+{
+    const char *value;
+    int r;
+
+    value = duk_require_string(ctx, 1);
+
+    r = sol_flow_send_string_packet(node, port, value);
+    if (r < 0) {
+        duk_error(ctx, DUK_ERR_ERROR, "Couldn't send string packet on '%s' port.",
+            get_out_port_name((struct flow_js_type *)node->type, port));
+    }
+
+    return r;
+}
+
+static struct sol_flow_node *
+get_node_from_duk_ctx(duk_context *ctx)
+{
+    struct sol_flow_node *n;
+
+    duk_push_global_object(ctx);
+
+    duk_get_prop_string(ctx, -1, "\xFF" "Soletta_node_pointer");
+    n = duk_require_pointer(ctx, -1);
+
+    duk_pop_2(ctx); /* Soletta_node_pointer, global object values */
+
+    return n;
+}
+
+static int
+get_output_port_number(const struct flow_js_type *type, const char *port_name)
+{
+    struct flow_js_port_out *p;
+    uint16_t i;
+
+    SOL_VECTOR_FOREACH_IDX (&type->ports_out, p, i) {
+        if (streq(p->name, port_name))
+            return i;
+    }
+
+    return -EINVAL;
+}
+
+/* sendPacket() on Javascript may throw exceptions. */
+static duk_ret_t
+send_packet(duk_context *ctx)
+{
+    const struct flow_js_port_out *port;
+    const struct flow_js_type *type;
+    const char *port_name;
+    struct sol_flow_node *node;
+    int port_number;
+
+    port_name = duk_require_string(ctx, 0);
+
+    node = get_node_from_duk_ctx(ctx);
+    type = (struct flow_js_type *)node->type;
+    if (!node || !type) {
+        duk_error(ctx, DUK_ERR_ERROR, "Couldn't send packet to '%s' port.", port_name);
+        return 0;
+    }
+
+    /* TODO: Check a cheaper way to do this, if we had hashes we could
+     * use them here. */
+
+    port_number = get_output_port_number(type, port_name);
+    if (port_number < 0) {
+        duk_error(ctx, DUK_ERR_ERROR, "'%s' invalid port name.", port_name);
+        return 0;
+    }
+
+    port = sol_vector_get(&type->ports_out, port_number);
+    if (!port) {
+        duk_error(ctx, DUK_ERR_ERROR, "'%s' invalid port name.", port_name);
+        return 0;
+    }
+
+    if (port->type.packet_type == SOL_FLOW_PACKET_TYPE_BOOLEAN)
+        return send_boolean_packet(node, port_number, ctx);
+    if (port->type.packet_type == SOL_FLOW_PACKET_TYPE_BYTE)
+        return send_byte_packet(node, port_number, ctx);
+    if (port->type.packet_type == SOL_FLOW_PACKET_TYPE_DRANGE)
+        return send_float_packet(node, port_number, ctx);
+    if (port->type.packet_type == SOL_FLOW_PACKET_TYPE_IRANGE)
+        return send_int_packet(node, port_number, ctx);
+    if (port->type.packet_type == SOL_FLOW_PACKET_TYPE_RGB)
+        return send_rgb_packet(node, port_number, ctx);
+    if (port->type.packet_type == SOL_FLOW_PACKET_TYPE_STRING)
+        return send_string_packet(node, port_number, ctx);
+
+    /* TODO: Create a way to let the user define custom packets. Maybe we could
+     * use the same techniques we do for option parsing, and provide an object
+     * with an array of fields, offsets and values in basic C types. */
+
+    duk_error(ctx, DUK_ERR_ERROR, "Couldn't handle unknown port type %s.", port->type_name);
+
+    return 0;
+}
+
+/* sendErrorPacket() on Javascript may throw exceptions. */
+static duk_ret_t
+send_error_packet(duk_context *ctx)
+{
+    const char *value_msg = NULL;
+    struct sol_flow_node *node;
+    int value_code, r;
+
+    value_code = duk_require_int(ctx, 0);
+
+    if (duk_is_string(ctx, 1))
+        value_msg = duk_require_string(ctx, 1);
+
+    node = get_node_from_duk_ctx(ctx);
+    if (!node) {
+        duk_error(ctx, DUK_ERR_ERROR, "Couldn't send error packet.");
+        return 0;
+    }
+
+    r = sol_flow_send_error_packet(node, value_code, value_msg);
+    if (r < 0)
+        duk_error(ctx, DUK_ERR_ERROR, "Couldn't send error packet.");
+
+    return r;
+}
+
+static bool
+setup_ports_in_methods(struct duk_context *duk_ctx, uint16_t ports_in_len, uint16_t base)
+{
+    uint16_t i;
+
+    if (ports_in_len == 0)
+        return true;
+
+    duk_get_prop_string(duk_ctx, -1, "in");
+
+    if (!duk_is_array(duk_ctx, -1)) {
+        SOL_ERR("'in' property of object 'node' should be an array.");
+        return false;
+    }
+
+    duk_push_global_stash(duk_ctx);
+
+    for (i = 0; i < ports_in_len; i++) {
+        if (!duk_get_prop_index(duk_ctx, -2, i)) {
+            SOL_ERR("Couldn't get input port information from 'ports.in[%d]'.", i);
+            return false;
+        }
+
+        /* This is in order to get port methods references in one call.
+         *
+         * We have 3 methods for each input port. We put all in the stash,
+         * even with 'undefined' values, if the method is not implemented on JS.
+         *
+         * We calculate the index by the following:
+         *
+         * base + input_port_index * ports_in_methods_length + method_index
+         *
+         * base - where should it start, for input ports it should be 0.
+         * input_port_index - the index of the JS 'in' array entry.
+         * method_index - the index of the method for input ports.
+         */
+
+        duk_get_prop_string(duk_ctx, -1, "connect");
+        duk_put_prop_index(duk_ctx, -3, base + i * PORTS_IN_METHODS_LENGTH + PORTS_IN_CONNECT_INDEX);
+
+        duk_get_prop_string(duk_ctx, -1, "disconnect");
+        duk_put_prop_index(duk_ctx, -3, base + i * PORTS_IN_METHODS_LENGTH + PORTS_IN_DISCONNECT_INDEX);
+
+        duk_get_prop_string(duk_ctx, -1, "process");
+        duk_put_prop_index(duk_ctx, -3, base + i * PORTS_IN_METHODS_LENGTH + PORTS_IN_PROCESS_INDEX);
+
+        duk_pop(duk_ctx); /* array entry */
+    }
+
+    duk_pop_2(duk_ctx); /* in array and global_stash value */
+
+    return true;
+}
+
+static bool
+setup_ports_out_methods(struct duk_context *duk_ctx, uint16_t ports_out_len, uint16_t base)
+{
+    uint16_t i;
+
+    if (ports_out_len == 0)
+        return true;
+
+    duk_get_prop_string(duk_ctx, -1, "out");
+
+    if (!duk_is_array(duk_ctx, -1)) {
+        SOL_ERR("'out' property of object 'node' should be an array.");
+        return false;
+    }
+
+    duk_push_global_stash(duk_ctx);
+
+    for (i = 0; i < ports_out_len; i++) {
+        if (!duk_get_prop_index(duk_ctx, -2, i)) {
+            SOL_ERR("Couldn't get output port information from 'ports.out[%d]'.", i);
+            return false;
+        }
+
+        /* This is in order to get port methods references in one call.
+         *
+         * We have 2 methods for each output port. We put all in the stash,
+         * even with 'undefined' values, if the method is not implemented on JS.
+         *
+         * We calculate the index by the following:
+         *
+         * base + output_port_index * ports_out_methods_length + method_index
+         *
+         * base - where should it start, for output ports it should be the size of input ports * number of input methods.
+         * input_port_index - the index of the JS 'in' array entry.
+         * method_index - the index of the method for output ports.
+         */
+
+        duk_get_prop_string(duk_ctx, -1, "connect");
+        duk_put_prop_index(duk_ctx, -3, base + i * PORTS_OUT_METHODS_LENGTH + PORTS_OUT_CONNECT_INDEX);
+
+        duk_get_prop_string(duk_ctx, -1, "disconnect");
+        duk_put_prop_index(duk_ctx, -3, base + i * PORTS_OUT_METHODS_LENGTH + PORTS_OUT_DISCONNECT_INDEX);
+
+        duk_pop(duk_ctx); /* array entry */
+    }
+
+    duk_pop_2(duk_ctx); /* out array and global_stash value */
+
+    return true;
+}
+
+static bool
+setup_ports_methods(duk_context *duk_ctx, uint16_t ports_in_len, uint16_t ports_out_len)
+{
+    /* We're using duktape global stash to keep reference to some JS
+     * port methods: connect(), disconnect() and process() in order
+     * to call it directly when receive a port number.
+     */
+
+    if (!setup_ports_in_methods(duk_ctx, ports_in_len, 0))
+        return false;
+
+    if (!setup_ports_out_methods(duk_ctx, ports_out_len, ports_in_len * PORTS_IN_METHODS_LENGTH))
+        return false;
+
+    return true;
+}
+
+/* open() method on JS may throw exceptions. */
+static int
+flow_js_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
+{
+    const struct flow_js_type *type = (struct flow_js_type *)node->type;
+    struct flow_js_data *mdata = data;
+
+    mdata->duk_ctx = duk_create_heap_default();
+    if (!mdata->duk_ctx) {
+        SOL_ERR("Failed to create a Duktape heap");
+        return -1;
+    }
+
+    /* TODO: Check if there's a "already parsed" representation that we can use. */
+    if (duk_peval_lstring(mdata->duk_ctx, type->js_content_buf, type->js_content_buf_len) != 0) {
+        SOL_ERR("Failed to read from javascript content buffer: %s", duk_safe_to_string(mdata->duk_ctx, -1));
+        duk_destroy_heap(mdata->duk_ctx);
+        return -1;
+    }
+    duk_pop(mdata->duk_ctx); /* duk_peval_lstring() result */
+
+    duk_push_global_object(mdata->duk_ctx);
+
+    /* "Soletta_node_pointer" is a hidden property. \xFF is used to give one extra level of hiding */
+    duk_push_string(mdata->duk_ctx, "\xFF" "Soletta_node_pointer");
+    duk_push_pointer(mdata->duk_ctx, node);
+    duk_def_prop(mdata->duk_ctx, -3,
+        DUK_DEFPROP_HAVE_VALUE |
+        DUK_DEFPROP_HAVE_WRITABLE |
+        DUK_DEFPROP_HAVE_ENUMERABLE |
+        DUK_DEFPROP_HAVE_CONFIGURABLE);
+
+    duk_push_c_function(mdata->duk_ctx, send_packet, 2);
+    duk_put_prop_string(mdata->duk_ctx, -2, "sendPacket");
+
+    duk_push_c_function(mdata->duk_ctx, send_error_packet, 2);
+    duk_put_prop_string(mdata->duk_ctx, -2, "sendErrorPacket");
+
+    /* From this point node JS object is always in the top of the stack. */
+    duk_get_prop_string(mdata->duk_ctx, -1, "node");
+
+    if (!setup_ports_methods(mdata->duk_ctx, type->ports_in.len, type->ports_out.len)) {
+        SOL_ERR("Failed to handle ports methods: %s", duk_safe_to_string(mdata->duk_ctx, -1));
+        duk_destroy_heap(mdata->duk_ctx);
+        return -1;
+    }
+
+    if (!duk_has_prop_string(mdata->duk_ctx, -1, "open"))
+        return 0;
+
+    duk_push_string(mdata->duk_ctx, "open");
+    if (duk_pcall_prop(mdata->duk_ctx, -2, 0) != DUK_EXEC_SUCCESS) {
+        duk_error(mdata->duk_ctx, DUK_ERR_ERROR, "Javascript open() function error: %s\n",
+            duk_safe_to_string(mdata->duk_ctx, -1));
+    }
+
+    duk_pop(mdata->duk_ctx); /* open() result */
+
+    return 0;
+}
+
+/* close() method on JS may throw exceptions. */
+static void
+flow_js_close(struct sol_flow_node *node, void *data)
+{
+    const struct flow_js_data *mdata = (struct flow_js_data *)data;
+
+    if (duk_has_prop_string(mdata->duk_ctx, -1, "close")) {
+        duk_push_string(mdata->duk_ctx, "close");
+
+        if (duk_pcall_prop(mdata->duk_ctx, -2, 0) != DUK_EXEC_SUCCESS) {
+            duk_error(mdata->duk_ctx, DUK_ERR_ERROR, "Javascript close() function error: %s\n",
+                duk_safe_to_string(mdata->duk_ctx, -1));
+        }
+
+        duk_pop(mdata->duk_ctx); /* close() result */
+    }
+
+    duk_destroy_heap(mdata->duk_ctx);
+}
+
+static int
+process_boilerplate_pre(duk_context *ctx, struct sol_flow_node *node, uint16_t port)
+{
+    duk_push_global_stash(ctx);
+
+    if (!duk_get_prop_index(ctx, -1, port * PORTS_IN_METHODS_LENGTH + PORTS_IN_PROCESS_INDEX)) {
+        SOL_ERR("Couldn't handle '%s' process().", get_in_port_name((struct flow_js_type *)node->type, port));
+        duk_pop_2(ctx); /* get_prop() value and global_stash */
+        return -1;
+    }
+
+    if (duk_is_null_or_undefined(ctx, -1)) {
+        SOL_WRN("'%s' process() callback not implemented in javascript, ignoring incoming packets for this port",
+            get_in_port_name((struct flow_js_type *)node->type, port));
+        duk_pop_2(ctx); /* get_prop() value and global_stash */
+        return 0;
+    }
+
+    /* In order to use 'node' object as 'this' binding. */
+    duk_dup(ctx, -3);
+
+    return 1;
+}
+
+static int
+process_boilerplate_post(duk_context *ctx, struct sol_flow_node *node, uint16_t port, uint16_t js_method_nargs)
+{
+    if (duk_pcall_method(ctx, js_method_nargs) != DUK_EXEC_SUCCESS) {
+        duk_error(ctx, DUK_ERR_ERROR, "Javascript %s process() function error: %s\n",
+            get_in_port_name((struct flow_js_type *)node->type, port), duk_safe_to_string(ctx, -1));
+        duk_pop_2(ctx); /* process() result and global_stash */
+        return -1;
+    }
+
+    duk_pop_2(ctx); /* process() result and global_stash */
+
+    return 0;
+}
+
+static int
+boolean_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    const struct flow_js_data *mdata = (struct flow_js_data *)data;
+    bool value;
+    int r;
+
+    r = sol_flow_packet_get_boolean(packet, &value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    r = process_boilerplate_pre(mdata->duk_ctx, node, port);
+    SOL_INT_CHECK(r, <= 0, r);
+
+    duk_push_boolean(mdata->duk_ctx, value);
+
+    return process_boilerplate_post(mdata->duk_ctx, node, port, 1);
+}
+
+static int
+byte_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    const struct flow_js_data *mdata = (struct flow_js_data *)data;
+    unsigned char value;
+    int r;
+
+    r = sol_flow_packet_get_byte(packet, &value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    r = process_boilerplate_pre(mdata->duk_ctx, node, port);
+    SOL_INT_CHECK(r, <= 0, r);
+
+    duk_push_int(mdata->duk_ctx, value);
+
+    return process_boilerplate_post(mdata->duk_ctx, node, port, 1);
+}
+
+static int
+error_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    const struct flow_js_data *mdata = (struct flow_js_data *)data;
+    const char *value_msg;
+    int r, value_code;
+
+    r = sol_flow_packet_get_error(packet, &value_code, &value_msg);
+    SOL_INT_CHECK(r, < 0, r);
+
+    r = process_boilerplate_pre(mdata->duk_ctx, node, port);
+    SOL_INT_CHECK(r, <= 0, r);
+
+    duk_push_int(mdata->duk_ctx, value_code);
+    duk_push_string(mdata->duk_ctx, value_msg);
+
+    return process_boilerplate_post(mdata->duk_ctx, node, port, 2);
+}
+
+static int
+float_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    const struct flow_js_data *mdata = (struct flow_js_data *)data;
+    struct sol_drange value;
+    duk_idx_t obj_idx;
+    int r;
+
+    r = sol_flow_packet_get_drange(packet, &value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    r = process_boilerplate_pre(mdata->duk_ctx, node, port);
+    SOL_INT_CHECK(r, <= 0, r);
+
+    obj_idx = duk_push_object(mdata->duk_ctx);
+    duk_push_number(mdata->duk_ctx, value.val);
+    duk_put_prop_string(mdata->duk_ctx, obj_idx, "val");
+    duk_push_number(mdata->duk_ctx, value.min);
+    duk_put_prop_string(mdata->duk_ctx, obj_idx, "min");
+    duk_push_number(mdata->duk_ctx, value.max);
+    duk_put_prop_string(mdata->duk_ctx, obj_idx, "max");
+    duk_push_number(mdata->duk_ctx, value.step);
+    duk_put_prop_string(mdata->duk_ctx, obj_idx, "step");
+
+    return process_boilerplate_post(mdata->duk_ctx, node, port, 1);
+}
+
+static int
+int_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    const struct flow_js_data *mdata = (struct flow_js_data *)data;
+    struct sol_irange value;
+    duk_idx_t obj_idx;
+    int r;
+
+    r = sol_flow_packet_get_irange(packet, &value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    r = process_boilerplate_pre(mdata->duk_ctx, node, port);
+    SOL_INT_CHECK(r, <= 0, r);
+
+    obj_idx = duk_push_object(mdata->duk_ctx);
+    duk_push_int(mdata->duk_ctx, value.val);
+    duk_put_prop_string(mdata->duk_ctx, obj_idx, "val");
+    duk_push_int(mdata->duk_ctx, value.min);
+    duk_put_prop_string(mdata->duk_ctx, obj_idx, "min");
+    duk_push_int(mdata->duk_ctx, value.max);
+    duk_put_prop_string(mdata->duk_ctx, obj_idx, "max");
+    duk_push_int(mdata->duk_ctx, value.step);
+    duk_put_prop_string(mdata->duk_ctx, obj_idx, "step");
+
+    return process_boilerplate_post(mdata->duk_ctx, node, port, 1);
+}
+
+static int
+rgb_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id,
+    const struct sol_flow_packet *packet)
+{
+    const struct flow_js_data *mdata = (struct flow_js_data *)data;
+    struct sol_rgb value;
+    duk_idx_t obj_idx;
+    int r;
+
+    r = sol_flow_packet_get_rgb(packet, &value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    r = process_boilerplate_pre(mdata->duk_ctx, node, port);
+    SOL_INT_CHECK(r, <= 0, r);
+
+    obj_idx = duk_push_object(mdata->duk_ctx);
+    duk_push_int(mdata->duk_ctx, value.red);
+    duk_put_prop_string(mdata->duk_ctx, obj_idx, "red");
+    duk_push_int(mdata->duk_ctx, value.green);
+    duk_put_prop_string(mdata->duk_ctx, obj_idx, "green");
+    duk_push_int(mdata->duk_ctx, value.blue);
+    duk_put_prop_string(mdata->duk_ctx, obj_idx, "blue");
+    duk_push_int(mdata->duk_ctx, value.red_max);
+    duk_put_prop_string(mdata->duk_ctx, obj_idx, "red_max");
+    duk_push_int(mdata->duk_ctx, value.green_max);
+    duk_put_prop_string(mdata->duk_ctx, obj_idx, "green_max");
+    duk_push_int(mdata->duk_ctx, value.blue_max);
+    duk_put_prop_string(mdata->duk_ctx, obj_idx, "blue_max");
+
+    return process_boilerplate_post(mdata->duk_ctx, node, port, 1);
+}
+
+static int
+string_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    const struct flow_js_data *mdata = (struct flow_js_data *)data;
+    const char *value;
+    int r;
+
+    r = sol_flow_packet_get_string(packet, &value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    r = process_boilerplate_pre(mdata->duk_ctx, node, port);
+    SOL_INT_CHECK(r, <= 0, r);
+
+    duk_push_string(mdata->duk_ctx, value);
+
+    return process_boilerplate_post(mdata->duk_ctx, node, port, 1);
+}
+
+/* process() methods on JS may throw exceptions. */
+static int
+flow_js_port_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id,
+    const struct sol_flow_packet *packet)
+{
+    const struct sol_flow_packet_type *packet_type;
+
+    packet_type = sol_flow_packet_get_type(packet);
+    if (packet_type == SOL_FLOW_PACKET_TYPE_BOOLEAN)
+        return boolean_process(node, data, port, conn_id, packet);
+    if (packet_type == SOL_FLOW_PACKET_TYPE_BYTE)
+        return byte_process(node, data, port, conn_id, packet);
+    if (packet_type == SOL_FLOW_PACKET_TYPE_ERROR)
+        return error_process(node, data, port, conn_id, packet);
+    if (packet_type == SOL_FLOW_PACKET_TYPE_DRANGE)
+        return float_process(node, data, port, conn_id, packet);
+    if (packet_type == SOL_FLOW_PACKET_TYPE_IRANGE)
+        return int_process(node, data, port, conn_id, packet);
+    if (packet_type == SOL_FLOW_PACKET_TYPE_RGB)
+        return rgb_process(node, data, port, conn_id, packet);
+    if (packet_type == SOL_FLOW_PACKET_TYPE_STRING)
+        return string_process(node, data, port, conn_id, packet);
+
+    return 0;
+}
+
+/* connect() and disconnect() port methods on JS may throw exceptions. */
+static int
+handle_js_port_activity(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id,
+    uint16_t base, uint16_t methods_length, uint16_t method_index)
+{
+    const struct flow_js_data *mdata = (struct flow_js_data *)data;
+
+    duk_push_global_stash(mdata->duk_ctx);
+
+    if (!duk_get_prop_index(mdata->duk_ctx, -1, base + port * methods_length + method_index)) {
+        duk_error(mdata->duk_ctx, DUK_ERR_ERROR, "Couldn't handle '%s' %s().",
+            get_in_port_name((struct flow_js_type *)node->type, port),
+            method_index == PORTS_IN_CONNECT_INDEX ? "connect" : "disconnect");
+        duk_pop_2(mdata->duk_ctx); /* get_prop() value and global_stash */
+        return -1;
+    }
+
+    if (duk_is_null_or_undefined(mdata->duk_ctx, -1)) {
+        duk_pop_2(mdata->duk_ctx); /* get_prop() value and global_stash */
+        return 0;
+    }
+
+    if (duk_pcall(mdata->duk_ctx, 0) != DUK_EXEC_SUCCESS) {
+        duk_error(mdata->duk_ctx, DUK_ERR_ERROR, "Javascript function error: %s\n",
+            duk_safe_to_string(mdata->duk_ctx, -1));
+        duk_pop_2(mdata->duk_ctx); /* method() result and global_stash */
+        return -1;
+    }
+
+    duk_pop_2(mdata->duk_ctx); /* method() result and global_stash */
+
+    return 0;
+}
+
+static int
+flow_js_port_in_connect(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id)
+{
+    return handle_js_port_activity(node, data, port, conn_id, 0, PORTS_IN_METHODS_LENGTH, PORTS_IN_CONNECT_INDEX);
+}
+
+static int
+flow_js_port_in_disconnect(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id)
+{
+    return handle_js_port_activity(node, data, port, conn_id, 0, PORTS_IN_METHODS_LENGTH, PORTS_IN_DISCONNECT_INDEX);
+}
+
+static int
+flow_js_port_out_connect(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id)
+{
+    const struct flow_js_type *type = (struct flow_js_type *)node->type;
+
+    return handle_js_port_activity(node, data, port, conn_id,
+        type->ports_in.len * PORTS_IN_METHODS_LENGTH, PORTS_OUT_METHODS_LENGTH, PORTS_OUT_CONNECT_INDEX);
+}
+
+static int
+flow_js_port_out_disconnect(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id)
+{
+    const struct flow_js_type *type = (struct flow_js_type *)node->type;
+
+    return handle_js_port_activity(node, data, port, conn_id,
+        type->ports_in.len * PORTS_IN_METHODS_LENGTH, PORTS_OUT_METHODS_LENGTH, PORTS_OUT_DISCONNECT_INDEX);
+}
+
+static void
+flow_js_get_ports_counts(const struct sol_flow_node_type *type, uint16_t *ports_in_count, uint16_t *ports_out_count)
+{
+    const struct flow_js_type *js_type = (struct flow_js_type *)type;
+
+    if (ports_in_count)
+        *ports_in_count = js_type->ports_in.len;
+    if (ports_out_count)
+        *ports_out_count = js_type->ports_out.len;
+}
+
+static const struct sol_flow_port_type_in *
+flow_js_get_port_in(const struct sol_flow_node_type *type, uint16_t port)
+{
+    const struct flow_js_type *js_type = (struct flow_js_type *)type;
+    const struct flow_js_port_in *p = sol_vector_get(&js_type->ports_in, port);
+
+    return p ? &p->type : NULL;
+}
+
+static const struct sol_flow_port_type_out *
+flow_js_get_port_out(const struct sol_flow_node_type *type, uint16_t port)
+{
+    const struct flow_js_type *js_type = (struct flow_js_type *)type;
+    const struct flow_js_port_out *p = sol_vector_get(&js_type->ports_out, port);
+
+    return p ? &p->type : NULL;
+}
+
+#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
+static const struct sol_flow_node_type_description sol_flow_node_type_js_description = {
+    .api_version = SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION,
+    .name = "js",
+    .category = "js",
+    .symbol = "SOL_FLOW_NODE_TYPE_JS",
+    .options_symbol = "sol_flow_node_type_js_options",
+    .version = NULL,
+    /* TODO: Add a way for the user specify description, author, url and license. */
+};
+
+static int
+setup_description(struct flow_js_type *type)
+{
+    struct sol_flow_node_type_description *desc;
+    struct sol_flow_port_description **p;
+    struct flow_js_port_in *port_type_in;
+    struct flow_js_port_out *port_type_out;
+    int i, j;
+
+    type->base.description = calloc(1, sizeof(struct sol_flow_node_type_description));
+    SOL_NULL_CHECK(type->base.description, -ENOMEM);
+
+    type->base.description = memcpy((struct sol_flow_node_type_description *)type->base.description,
+        &sol_flow_node_type_js_description, sizeof(struct sol_flow_node_type_description));
+
+    desc = (struct sol_flow_node_type_description *)type->base.description;
+
+    /* Extra slot for NULL sentinel at the end. */
+    desc->ports_in = calloc(type->ports_in.len + 1, sizeof(struct sol_flow_port_description *));
+    SOL_NULL_CHECK_GOTO(desc->ports_in, fail_ports_in);
+
+    p = (struct sol_flow_port_description **)desc->ports_in;
+    for (i = 0; i < type->ports_in.len; i++) {
+        p[i] = calloc(1, sizeof(struct sol_flow_port_description));
+        SOL_NULL_CHECK_GOTO(p[i], fail_ports_in_desc);
+
+        port_type_in = sol_vector_get(&type->ports_in, i);
+
+        p[i]->name = port_type_in->name;
+        p[i]->description = "Input port";
+        p[i]->data_type = port_type_in->type_name;
+        p[i]->array_size = 0;
+        p[i]->base_port_idx = i;
+        p[i]->required = false;
+    }
+
+    /* Extra slot for NULL sentinel at the end. */
+    desc->ports_out = calloc(type->ports_out.len + 1, sizeof(struct sol_flow_port_description *));
+    SOL_NULL_CHECK_GOTO(desc->ports_out, fail_ports_in_desc);
+
+    p = (struct sol_flow_port_description **)desc->ports_out;
+    for (j = 0; j < type->ports_out.len; j++) {
+        p[j] = calloc(1, sizeof(struct sol_flow_port_description));
+        SOL_NULL_CHECK_GOTO(p[j], fail_ports_out_desc);
+
+        port_type_out = sol_vector_get(&type->ports_out, j);
+
+        p[j]->name = port_type_out->name;
+        p[j]->description = "Output port";
+        p[j]->data_type = port_type_out->type_name;
+        p[j]->array_size = 0;
+        p[j]->base_port_idx = j;
+        p[j]->required = false;
+    }
+
+    return 0;
+
+fail_ports_out_desc:
+    if (j > 0) {
+        for (; j >= 0; j--) {
+            free((struct sol_flow_port_description *)desc->ports_out[j]);
+        }
+    }
+    free((struct sol_flow_port_description **)desc->ports_out);
+fail_ports_in_desc:
+    if (i > 0) {
+        for (; i >= 0; i--) {
+            free((struct sol_flow_port_description *)desc->ports_in[i]);
+        }
+    }
+    free((struct sol_flow_port_description **)desc->ports_in);
+fail_ports_in:
+    free(desc);
+    return -ENOMEM;
+}
+
+static void
+free_description(struct flow_js_type *type)
+{
+    struct sol_flow_node_type_description *desc;
+    uint16_t i;
+
+    desc = (struct sol_flow_node_type_description *)type->base.description;
+
+    for (i = 0; i < type->ports_in.len; i++)
+        free((struct sol_flow_port_description *)desc->ports_in[i]);
+    free((struct sol_flow_port_description **)desc->ports_in);
+
+    for (i = 0; i < type->ports_out.len; i++)
+        free((struct sol_flow_port_description *)desc->ports_out[i]);
+    free((struct sol_flow_port_description **)desc->ports_out);
+
+    free(desc);
+}
+#endif
+
+static const struct sol_flow_packet_type *
+get_packet_type(const char *type)
+{
+    /* We're using 'if statements' instead of 'sol_str_table_ptr' because we couldn't create the table
+     * as 'const static' since the packet types are declared in another file (found only in linkage time),
+     * and creating the table all the time would give us a bigger overhead than 'if statements' */
+
+    if (!strcasecmp(type, "boolean"))
+        return SOL_FLOW_PACKET_TYPE_BOOLEAN;
+    if (!strcasecmp(type, "byte"))
+        return SOL_FLOW_PACKET_TYPE_BYTE;
+    if (!strcasecmp(type, "drange") || !strcasecmp(type, "float"))
+        return SOL_FLOW_PACKET_TYPE_DRANGE;
+    if (!strcasecmp(type, "error"))
+        return SOL_FLOW_PACKET_TYPE_ERROR;
+    if (!strcasecmp(type, "irange") || !strcasecmp(type, "int"))
+        return SOL_FLOW_PACKET_TYPE_IRANGE;
+    if (!strcasecmp(type, "rgb"))
+        return SOL_FLOW_PACKET_TYPE_RGB;
+    if (!strcasecmp(type, "string"))
+        return SOL_FLOW_PACKET_TYPE_STRING;
+
+    return NULL;
+}
+
+static bool
+setup_ports_in(struct duk_context *duk_ctx, struct sol_arena *str_arena, struct sol_vector *ports_in)
+{
+    const char *name, *type_name;
+    const struct sol_flow_packet_type *packet_type;
+    struct flow_js_port_in *port_type;
+    uint16_t array_len, i;
+
+    if (!duk_has_prop_string(duk_ctx, -1, "in"))
+        return true;
+
+    duk_get_prop_string(duk_ctx, -1, "in");
+
+    if (!duk_is_array(duk_ctx, -1)) {
+        SOL_ERR("'in' property of variable 'ports' should be an array.");
+        return false;
+    }
+
+    if (!duk_get_prop_string(duk_ctx, -1, "length")) {
+        SOL_ERR("Couldn't get 'in' length from 'ports' variable.");
+        return false;
+    }
+
+    array_len = duk_require_int(duk_ctx, -1);
+    duk_pop(duk_ctx); /* length value */
+
+    if (array_len == 0)
+        return true;
+
+    sol_vector_init(ports_in, sizeof(struct flow_js_port_in));
+
+    for (i = 0; i < array_len; i++) {
+        if (!duk_get_prop_index(duk_ctx, -1, i)) {
+            SOL_WRN("Couldn't get input port information from 'ports.in[%d]', ignoring this port creation...", i);
+            duk_pop(duk_ctx);
+            continue;
+        }
+
+        if (!duk_get_prop_string(duk_ctx, -1, "name")) {
+            SOL_WRN("Input port 'name' property is missing on 'ports.in[%d]', ignoring this port creation... "
+                "e.g. '{ name:'IN', type:'boolean' }'", i);
+            duk_pop_2(duk_ctx);
+            continue;
+        }
+
+        if (!duk_get_prop_string(duk_ctx, -2, "type")) {
+            SOL_WRN("Input port 'type' property is missing on 'ports.in[%d]', ignoring this port creation... "
+                "e.g. '{ name:'IN', type:'boolean' }'", i);
+            duk_pop_3(duk_ctx);
+            continue;
+        }
+
+        name = duk_require_string(duk_ctx, -2);
+        type_name = duk_require_string(duk_ctx, -1);
+
+        packet_type = get_packet_type(type_name);
+        if (!packet_type) {
+            SOL_WRN("Input port type '%s' is an invalid packet type on 'ports.in[%d]', ignoring this port creation...", type_name, i);
+            duk_pop_3(duk_ctx);
+            continue;
+        }
+
+        port_type = sol_vector_append(ports_in);
+        SOL_NULL_CHECK(port_type, false);
+
+        port_type->type.api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION;
+        port_type->type.packet_type = packet_type;
+        port_type->type.process = flow_js_port_process;
+        port_type->type.connect = flow_js_port_in_connect;
+        port_type->type.disconnect = flow_js_port_in_disconnect;
+
+        port_type->name = sol_arena_strdup(str_arena, name);
+        SOL_NULL_CHECK(port_type->name, false);
+
+        port_type->type_name = sol_arena_strdup(str_arena, type_name);
+        SOL_NULL_CHECK(port_type->type_name, false);
+
+        duk_pop_3(duk_ctx);
+    }
+
+    duk_pop(duk_ctx); /* in value */
+
+    return true;
+}
+
+static bool
+setup_ports_out(struct duk_context *duk_ctx, struct sol_arena *str_arena, struct sol_vector *ports_out)
+{
+    const char *name, *type_name;
+    const struct sol_flow_packet_type *packet_type;
+    struct flow_js_port_out *port_type;
+    uint16_t array_len, i;
+
+    if (!duk_has_prop_string(duk_ctx, -1, "out"))
+        return true;
+
+    duk_get_prop_string(duk_ctx, -1, "out");
+
+    if (!duk_is_array(duk_ctx, -1)) {
+        SOL_ERR("'out' property of variable 'ports' should be an array.");
+        return false;
+    }
+
+    if (!duk_get_prop_string(duk_ctx, -1, "length")) {
+        SOL_ERR("Couldn't get 'out' length from 'ports' variable.");
+        return false;
+    }
+
+    array_len = duk_require_int(duk_ctx, -1);
+    duk_pop(duk_ctx); /* length value */
+
+    if (array_len == 0)
+        return true;
+
+    sol_vector_init(ports_out, sizeof(struct flow_js_port_out));
+
+    for (i = 0; i < array_len; i++) {
+        if (!duk_get_prop_index(duk_ctx, -1, i)) {
+            SOL_WRN("Couldn't get output port information from 'ports.out[%d]', ignoring this port creation...", i);
+            duk_pop(duk_ctx);
+            continue;
+        }
+
+        if (!duk_get_prop_string(duk_ctx, -1, "name")) {
+            SOL_WRN("Output port 'name' property is missing on 'ports.out[%d]', ignoring this port creation... "
+                "e.g. '{ name:'OUT', type:'boolean' }'", i);
+            duk_pop_2(duk_ctx);
+            continue;
+        }
+
+        if (!duk_get_prop_string(duk_ctx, -2, "type")) {
+            SOL_WRN("Output port 'type' property is missing on 'ports.out[%d]', ignoring this port creation... "
+                "e.g. '{ name:'OUT', type:'boolean' }'", i);
+            duk_pop_3(duk_ctx);
+            continue;
+        }
+
+        name = duk_require_string(duk_ctx, -2);
+        type_name = duk_require_string(duk_ctx, -1);
+
+        packet_type = get_packet_type(type_name);
+        if (!packet_type) {
+            SOL_WRN("Output port type '%s' is an invalid packet type on 'ports.out[%d]', ignoring this port creation...", type_name, i);
+            duk_pop_3(duk_ctx);
+            continue;
+        }
+
+        port_type = sol_vector_append(ports_out);
+        SOL_NULL_CHECK(port_type, false);
+
+        port_type->type.api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION;
+        port_type->type.packet_type = packet_type;
+        port_type->type.connect = flow_js_port_out_connect;
+        port_type->type.disconnect = flow_js_port_out_disconnect;
+
+        port_type->name = sol_arena_strdup(str_arena, name);
+        SOL_NULL_CHECK(port_type->name, false);
+
+        port_type->type_name = sol_arena_strdup(str_arena, type_name);
+        SOL_NULL_CHECK(port_type->type_name, false);
+
+        duk_pop_3(duk_ctx);
+    }
+
+    duk_pop(duk_ctx); /* out value */
+
+    return true;
+}
+
+static bool
+setup_ports(struct flow_js_type *type, const char *buf, size_t len)
+{
+    struct duk_context *duk_ctx;
+
+    duk_ctx = duk_create_heap_default();
+    if (!duk_ctx) {
+        SOL_ERR("Failed to create a Duktape heap");
+        return false;
+    }
+
+    if (duk_peval_lstring(duk_ctx, buf, len) != 0) {
+        SOL_ERR("Failed to parse javascript content: %s", duk_safe_to_string(duk_ctx, -1));
+        duk_destroy_heap(duk_ctx);
+        return false;
+    }
+    duk_pop(duk_ctx); /* duk_peval_lstring() result */
+
+    duk_push_global_object(duk_ctx);
+
+    if (!duk_get_prop_string(duk_ctx, -1, "node")) {
+        SOL_ERR("'node' variable not found in javascript file.");
+        duk_destroy_heap(duk_ctx);
+        return false;
+    }
+
+    type->str_arena = sol_arena_new();
+    if (!type->str_arena) {
+        SOL_ERR("Couldn't create sol_arena.");
+        duk_destroy_heap(duk_ctx);
+        return false;
+    }
+
+    if (!setup_ports_in(duk_ctx, type->str_arena, &type->ports_in)) {
+        duk_destroy_heap(duk_ctx);
+        return false;
+    }
+
+    if (!setup_ports_out(duk_ctx, type->str_arena, &type->ports_out)) {
+        duk_destroy_heap(duk_ctx);
+        return false;
+    }
+
+    duk_destroy_heap(duk_ctx);
+    return true;
+}
+
+static void
+flow_js_type_fini(struct flow_js_type *type)
+{
+#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
+    if (type->base.description)
+        free_description(type);
+#endif
+
+    if (type->str_arena)
+        sol_arena_del(type->str_arena);
+
+    sol_vector_clear(&type->ports_in);
+    sol_vector_clear(&type->ports_out);
+
+    free(type->js_content_buf);
+}
+
+static void
+flow_dispose_type(struct sol_flow_node_type *type)
+{
+    struct flow_js_type *js_type;
+
+    SOL_NULL_CHECK(type);
+
+    js_type = (struct flow_js_type *)type;
+    flow_js_type_fini(js_type);
+    free(js_type);
+}
+
+static bool
+flow_js_type_init(struct flow_js_type *type, const char *buf, size_t len)
+{
+    char *js_content_buf;
+
+    *type = (const struct flow_js_type) {
+        .base = {
+            .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
+            .data_size = sizeof(struct flow_js_data),
+            .open = flow_js_open,
+            .close = flow_js_close,
+            .get_ports_counts = flow_js_get_ports_counts,
+            .get_port_in = flow_js_get_port_in,
+            .get_port_out = flow_js_get_port_out,
+            .dispose_type = flow_dispose_type,
+        },
+    };
+
+    if (!setup_ports(type, buf, len))
+        return false;
+
+    js_content_buf = strndup(buf, len);
+    SOL_NULL_CHECK(js_content_buf, false);
+
+    type->js_content_buf = js_content_buf;
+    type->js_content_buf_len = len;
+
+#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
+    if (setup_description(type) < 0)
+        SOL_WRN("Failed to setup description");
+#endif
+
+    return true;
+}
+
+SOL_API struct sol_flow_node_type *
+sol_flow_js_new_type(const char *buf, size_t len)
+{
+    struct flow_js_type *type;
+
+    type = calloc(1, sizeof(struct flow_js_type));
+    SOL_NULL_CHECK(type, NULL);
+
+    if (!flow_js_type_init(type, buf, len)) {
+        flow_js_type_fini(type);
+        free(type);
+        return NULL;
+    }
+
+    return &type->base;
+}

--- a/src/samples/flow/js/attendee.fbp
+++ b/src/samples/flow/js/attendee.fbp
@@ -1,0 +1,53 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This is a sample where you have the attendee (that will call the next in line)
+# and two different lines, common and preferential (that has higher priority).
+#
+# Everytime the a line button is pressed (common or preferential) it generates
+# a new number to be called, preferential numbers are 1-99 and common are 101-999.
+#
+# In order to do so we created our custom JS node type, MyAttendee from attendee.js
+# file.
+
+DECLARE=MyAttendee:js:attendee.js
+
+_(constant/int:value=999) OUT -> IN[0] common_eq(int/equal)
+_(constant/int:value=99) OUT -> IN[0] preferential_eq(int/equal)
+
+common_btn(gtk/pushbutton) OUT -> IN _(boolean/filter) TRUE -> INC common_acc(int/accumulator:setup_value=val:100|min:100|max:999|step:1)
+common_acc OUT -> IN[1] common_eq OUT -> IN _(boolean/filter) TRUE -> INC common_acc
+common_acc OUT -> IN _(int/filter:min=101) OUT -> IN_COMMON attendee(MyAttendee) OUT_COMMON -> IN common_out(gtk/label)
+
+preferential_btn(gtk/pushbutton) OUT -> IN _(boolean/filter) TRUE -> INC preferential_acc(int/accumulator:setup_value=val:0|min:0|max:99|step:1)
+preferential_acc OUT -> IN[1] preferential_eq OUT -> IN _(boolean/filter) TRUE -> INC preferential_acc
+preferential_acc OUT -> IN _(int/filter:min=1) OUT -> IN_PREFERENTIAL attendee OUT_PREFERENTIAL -> IN preferential_out(gtk/label)
+
+attendee_btn(gtk/pushbutton) OUT -> IN _(boolean/filter) TRUE -> IN_ATTENDEE attendee OUT_ATTENDEE -> IN attendee_out(gtk/label)

--- a/src/samples/flow/js/attendee.js
+++ b/src/samples/flow/js/attendee.js
@@ -1,0 +1,95 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This is our custom JS node type in order to be used in the attendee.fbp sample.
+ *
+ * This node has three in/out ports representing common line, preferential line
+ * and attendee.
+ *
+ * Everytime we receive a number from 'IN_COMMON' or 'IN_PREFERENTIAL' we'll append
+ * to the respective vector (representing the line).
+ *
+ * Everytime we receive a boolean from 'IN_ATTENDEE' we'll return the next in line
+ * (considering that preferential line has higher priority).
+ */
+
+var node = {
+    in: [
+        {
+            name:'IN_COMMON',
+            type:'int',
+            process: function(v) {
+                if (v.val > 0) {
+                    sendPacket("OUT_COMMON", v.val);
+                    this.common_line.push(v.val);
+                }
+            }
+        },
+        {
+            name:'IN_PREFERENTIAL',
+            type:'int',
+            process: function(v) {
+                if (v.val > 0) {
+                    sendPacket("OUT_PREFERENTIAL", v.val);
+                    this.preferential_line.push(v.val);
+                }
+            }
+        },
+        {
+            name:'IN_ATTENDEE',
+            type:'boolean',
+            process: function(v) {
+                if (this.preferential_line.length > 0) {
+                    sendPacket("OUT_ATTENDEE", this.preferential_line[0]);
+                    this.preferential_line.shift();
+                    return;
+                }
+
+                if (this.common_line.length > 0) {
+                    sendPacket("OUT_ATTENDEE", this.common_line[0]);
+                    this.common_line.shift();
+                    return;
+                }
+
+                sendPacket("OUT_ATTENDEE", 0);
+            }
+        }
+    ],
+    out: [
+        { name:'OUT_COMMON', type:'int' },
+        { name:'OUT_PREFERENTIAL', type:'int' },
+        { name:'OUT_ATTENDEE', type:'int' }
+    ],
+    common_line: [],
+    preferential_line: []
+};

--- a/src/samples/flow/js/mycounter.fbp
+++ b/src/samples/flow/js/mycounter.fbp
@@ -1,0 +1,46 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This sample shows that JS node types can be used multiple times to
+# create nodes.
+#
+# c1 and c2 are different nodes, but from the same JS type, MyCounter.
+#
+# MyCounter receives a boolean value and adds or subtracts from the
+# initial counter value (0) depending on this boolean value.
+#
+# +1 for TRUE and -1 for FALSE
+
+DECLARE=MyCounter:js:mycounter.js
+
+_(timer:interval=400) OUT -> IN _(boolean/toggle) OUT -> IN filter(boolean/filter)
+
+filter TRUE -> IN c1(MyCounter) OUT -> IN _(console:prefix="c1: ")
+filter FALSE -> IN c2(MyCounter) OUT -> IN _(console:prefix="c2: ")

--- a/src/samples/flow/js/mycounter.js
+++ b/src/samples/flow/js/mycounter.js
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This is our custom JS node type in order to be used in the mycounter.fbp sample.
+ *
+ * Everytime we receive a boolean from 'IN' we'll add or subtract from this value
+ * depending on boolean value, TRUE will add 1 and FALSE will subtract 1, after we'll
+ * send this value to 'OUT' port.
+ */
+
+var node = {
+    in: [
+        {
+            name:'IN',
+            type:'boolean',
+            process: function(v) {
+                this.counter += v ? 1 : -1;
+                sendPacket("OUT", this.counter);
+            }
+        }
+    ],
+    out: [
+        { name:'OUT', type:'int' }
+    ],
+    counter: 0
+};

--- a/src/samples/flow/js/splitter.js
+++ b/src/samples/flow/js/splitter.js
@@ -1,0 +1,64 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This is our splitter JS node type in order to be used in the telegram.fbp sample.
+ *
+ * This node has the 'SEPARATOR' port, that will receive the separator string and
+ * the 'IN' port, that will receive a string to be splitted using the separator
+ * and send a string packet for each entry of this separation.
+ */
+
+var node = {
+    in: [
+        {
+            name:'IN',
+            type:'string',
+            process: function(v) {
+                var words = v.split(this.separator);
+                for (var i in words)
+                    sendPacket("OUT", words[i]);
+            }
+        },
+        {
+            name:'SEPARATOR',
+            type:'string',
+            process: function(v) {
+                this.separator = v;
+            }
+        }
+    ],
+    out: [
+        { name:'OUT', type:'string' }
+    ],
+    separator: ' '
+};

--- a/src/samples/flow/js/telegram.fbp
+++ b/src/samples/flow/js/telegram.fbp
@@ -1,0 +1,55 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This is an example of the "Telegram problem" that receives inputs as
+# text, wraps-up the words and send them when the wrap reach a certain
+# length.
+#
+# Wikipedia: https://en.wikipedia.org/wiki/Flow-based_programming#.22Telegram_Problem.22
+#
+# In this sample we split the words of the text (lorem ipsum) using the custom MySplitter
+# node and send each word as a packet to the custom MyTelegram node IN port. When the
+# telegram reaches its maximum length (80) it will send the telegram to OUT port.
+#
+# In order to do so we created two JS node types, MySplitter from splitter.js and MyTelegram
+# from telegram.js files.
+
+DECLARE=MyTelegram:js:telegram.js
+DECLARE=MySplitter:js:splitter.js
+
+text(constant/string:value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce ullamcorper nisi ut augue commodo, quis ultricies diam scelerisque. Sed bibendum, eros hendrerit viverra malesuada, velit lectus facilisis urna, in tempus libero mi sed libero. Vestibulum id augue odio. Aenean quis placerat erat. Vestibulum elementum tellus turpis, non sagittis purus pulvinar nec. Nam laoreet tempor enim non interdum. Pellentesque efficitur nunc luctus, lacinia neque nec, congue felis. Vivamus velit odio, pulvinar mollis libero id, condimentum dictum sem. Phasellus ac tellus congue, tempor velit et, dignissim arcu. Sed suscipit ante non metus auctor ultricies. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. In in luctus sem. Aliquam non consequat sem.")
+
+_(constant/string:value=" ") OUT -> SEPARATOR splitter(MySplitter)
+
+_(constant/int:value=80) OUT -> LENGTH telegram(MyTelegram)
+
+text OUT -> IN splitter
+
+splitter OUT -> IN telegram OUT -> IN _(console:prefix="telegram: ")

--- a/src/samples/flow/js/telegram.js
+++ b/src/samples/flow/js/telegram.js
@@ -1,0 +1,67 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This is our telegram JS node type in order to be used in the telegram.fbp sample.
+ *
+ * This node has the 'IN' port, that will be receiving the 'words' and appending
+ * them to the buffer, 'LENGTH' that is used to set the maximum length, in other
+ * words, when the telegram should be sent and the 'OUT' port that sends the telegram.
+ */
+
+var node = {
+    in: [
+        {
+            name:'IN',
+            type:'string',
+            process: function(v) {
+                if (v.length + this.buffer.length > this.length) {
+                    sendPacket("OUT", this.buffer);
+                    this.buffer = '';
+                }
+                this.buffer += v + ' ';
+            }
+        },
+        {
+            name:'LENGTH',
+            type:'int',
+            process: function(v) {
+                this.length = v.val;
+            }
+        }
+    ],
+    out: [
+        { name:'OUT', type:'string' }
+    ],
+    buffer: '',
+    length: 0
+};

--- a/src/test-fbp/javascript.fbp
+++ b/src/test-fbp/javascript.fbp
@@ -1,0 +1,55 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+DECLARE=MyScript:js:javascript.js
+
+_(constant/boolean:value=true) OUT -> IN_BOOLEAN s(MyScript)
+_(constant/byte:value=66) OUT -> IN_BYTE s
+_(constant/float:value=0.42) OUT -> IN_FLOAT s
+_(constant/int:value=42) OUT -> IN_INT s
+_(constant/rgb:value=0|125|255) OUT -> IN_RGB s
+_(constant/string:value="my string") OUT -> IN_STRING s
+
+s OUT_BOOLEAN -> IN c(console)
+s OUT_BYTE -> IN c
+s OUT_FLOAT -> IN c
+s OUT_INT -> IN c
+s OUT_RGB -> IN c
+s OUT_STRING -> IN c
+
+_(constant/int:value=1) OUT -> INTERVAL _(timer) OUT -> QUIT _(app/quit)
+
+## TEST-OUTPUT
+# c true (boolean)
+# c #42 (byte)
+# c 0.420000 (float range)
+# c 42 (integer range)
+# c (0, 125, 255) (rgb)
+# c my string (string)

--- a/src/test-fbp/javascript.js
+++ b/src/test-fbp/javascript.js
@@ -1,0 +1,104 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+var node = {
+    in: [
+        {
+            name:'IN_BOOLEAN',
+            type:'boolean',
+            process: function(v) {
+                sendPacket("OUT_BOOLEAN", v);
+            }
+        },
+        {
+            name:'IN_BYTE',
+            type:'byte',
+            process: function(v) {
+                sendPacket("OUT_BYTE", v);
+            }
+        },
+        {
+            name:'IN_FLOAT',
+            type:'float',
+            process: function(v) {
+                sendPacket("OUT_FLOAT", v);
+            }
+        },
+        {
+            name:'IN_INT',
+            type:'int',
+            process: function(v) {
+                sendPacket("OUT_INT", v);
+            }
+        },
+        {
+            name:'IN_RGB',
+            type:'rgb',
+            process: function(v) {
+                sendPacket("OUT_RGB", v);
+            }
+        },
+        {
+            name:'IN_STRING',
+            type:'string',
+            process: function(v) {
+                sendPacket("OUT_STRING", v);
+            }
+        }
+    ],
+    out: [
+        {
+            name:'OUT_BOOLEAN',
+            type:'boolean'
+        },
+        {
+            name:'OUT_BYTE',
+            type:'byte'
+        },
+        {
+            name:'OUT_FLOAT',
+            type:'float'
+        },
+        {
+            name:'OUT_INT',
+            type:'int'
+        },
+        {
+            name:'OUT_RGB',
+            type:'rgb'
+        },
+        {
+            name:'OUT_STRING',
+            type:'string'
+        },
+    ]
+};

--- a/src/test/.gitignore
+++ b/src/test/.gitignore
@@ -13,6 +13,7 @@
 /test-io-converter
 /test-io-link
 /test-io-monitor
+/test-javascript
 /test-json
 /test-mainloop
 /test-mainloop-linux

--- a/src/test/Kconfig
+++ b/src/test/Kconfig
@@ -34,6 +34,11 @@ config TEST_FLOW_PARSER
 	depends on FLOW && NODE_DESCRIPTION
 	default y
 
+config TEST_JAVASCRIPT
+	bool "javascript"
+	depends on JAVASCRIPT
+	default y
+
 config TEST_MAINLOOP
 	bool "mainloop"
 	default y

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -20,6 +20,9 @@ test-test-flow-builder-$(TEST_FLOW_BUILDER) := test.c test-flow-builder.c
 test-$(TEST_FLOW_PARSER) += test-flow-parser
 test-test-flow-parser-$(TEST_FLOW_PARSER) := test.c test-flow-parser.c
 
+test-$(TEST_JAVASCRIPT) += test-javascript
+test-test-javascript-$(TEST_JAVASCRIPT) := test.c test-javascript.c
+
 test-$(TEST_MAINLOOP) += test-mainloop
 test-test-mainloop-$(TEST_MAINLOOP) := test-mainloop.c
 

--- a/src/test/test-javascript.c
+++ b/src/test/test-javascript.c
@@ -1,0 +1,87 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+
+#include "sol-flow.h"
+#include "sol-flow-js.h"
+#include "sol-log.h"
+#include "sol-util.h"
+
+#include "test.h"
+
+#define JS_ASSERT_TRUE(_buf) {                                               \
+        struct sol_flow_node_type *t = sol_flow_js_new_type(_buf, strlen(_buf)); \
+        if (!t) {                                                                \
+            SOL_WRN("Failed to parse '%s'.", _buf);                              \
+            ASSERT(false);                                                       \
+        }                                                                        \
+        sol_flow_node_type_del(t); }
+
+#define JS_ASSERT_FALSE(_buf) {                                              \
+        struct sol_flow_node_type *t = sol_flow_js_new_type(_buf, strlen(_buf)); \
+        if (t) {                                                                 \
+            SOL_WRN("Parse should not be successful '%s'.", _buf);               \
+            ASSERT(false);                                                       \
+        }                                                                        \
+        sol_flow_node_type_del(t); }
+
+DEFINE_TEST(test_js);
+
+static void
+test_js(void)
+{
+    JS_ASSERT_FALSE("");
+
+    /* variables and methods */
+    JS_ASSERT_FALSE("var ports = {};");
+    JS_ASSERT_FALSE("var foo = 123; var my_ports = {};");
+    JS_ASSERT_FALSE("function in_port() { print('hello!'); }");
+    JS_ASSERT_TRUE("var node = {};");
+    JS_ASSERT_TRUE("var foo = 123; var node = {}; var bar = 'bar';");
+    JS_ASSERT_TRUE("function bar() { print('hello!'); } var node = {};");
+
+    /* in/out ports */
+    JS_ASSERT_TRUE("var node = { in: [{ name: 'IN_PORT', type:'int' }, { name: 'IN_PORT2', type: 'string'}]};");
+    JS_ASSERT_TRUE("var node = { out: [{ name: 'OUT_PORT', type:'float' }, { name: 'OUT_PORT2', type: 'byte'}]};");
+    JS_ASSERT_TRUE("var node = { in: [{ name: 'IN_PORT', type:'string' }], out: [{ name: 'OUT_PORT', type: 'int'}]};");
+
+    /* methods */
+    JS_ASSERT_TRUE("var node = { in: [{ name: 'IN', type: 'rgb', process: function() { print('process'); }} ]};");
+    JS_ASSERT_TRUE("var node = { out: [{ name: 'OUT', type: 'string', connect: function() { print('connect'); }} ]};");
+
+    /* properties on node variable */
+    JS_ASSERT_TRUE("var node = { in: [{ name: 'IN', type: 'rgb', process: function() { print('process'); }} ], property_1:123 };");
+}
+
+
+TEST_MAIN();

--- a/src/thirdparty/Makefile
+++ b/src/thirdparty/Makefile
@@ -1,0 +1,9 @@
+obj-$(JAVASCRIPT) := javascript.mod
+
+obj-javascript-$(JAVASCRIPT) := \
+	duktape/src/duktape.o
+
+obj-javascript-$(JAVASCRIPT)-extra-cflags := \
+	-Wno-float-equal \
+	-Wno-format-nonliteral \
+	-Wno-suggest-attribute=noreturn

--- a/src/thirdparty/README
+++ b/src/thirdparty/README
@@ -1,0 +1,10 @@
+Thirdparty
+----------
+
+- Duktape
+      - Site/Repository: http://duktape.org / https://github.com/svaarala/duktape
+      - Version: 1.2.2
+      - License: MIT - src/thirdparty/duktape/LICENSE.txt
+      - Duktape is an embeddable Javascript engine, with focus on
+        portabillity and compact footprint. This is used in order
+        to create JS node types in flow.

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -258,7 +258,7 @@ $(SOL_LIB_SO): $(PRE_GEN) $(SOL_LIB_AR) $(builtin-objs)
 	$(Q)$(TARGETCC) -shared $(builtin-objs) $(sort $(builtin-ldflags)) $(LIB_LDFLAGS) -o $(@).$(VERSION)
 	$(Q)$(LN) -fs $(notdir $(@).$(VERSION)) $(@)
 
-$(DEPENDENCY_CACHE):
+$(DEPENDENCY_CACHE): submodules-init
 	$(Q)$(PYTHON) $(DEPENDENCY_SCRIPT) --compiler="$(TARGETCC)" --cflags="$(DEP_RESOLVER_CFLAGS)" \
 		--prefix="$(PREFIX)" --cache="$(DEPENDENCY_CACHE)" --pkg-config="$(PKG_CONFIG)"
 
@@ -309,6 +309,11 @@ endef
 $(eval $(call install-resource,$(NODE_TYPE_SCHEMA),$(NODE_TYPE_SCHEMA_DEST)))
 $(eval $(call install-resource,$(PLATFORM_DETECT),$(PLATFORM_DETECT_DEST)))
 $(eval $(call install-resource,$(GDB_AUTOLOAD_PY),$(GDB_AUTOLOAD_PY_DEST)))
+
+submodules-init:
+	$(Q)$(PYTHON)$(SUBMODULE_SCRIPT)
+
+PHONY += submodules-init
 
 $(FLOW_OIC_GEN): $(FLOW_OIC_GEN_SCRIPT)
 	$(Q)echo "     "GEN"   "$(@)

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -30,6 +30,7 @@ ifneq (,$(LCOV))
 run-coverage: check check-fbp
 	$(Q)$(MKDIR) -p $(coveragedir)
 	$(Q)$(LCOV) --capture --directory $(top_srcdir) --output-file $(coveragedir)coverage.info
+	$(Q)$(LCOV) --remove $(coveragedir)coverage.info *thirdparty* --output-file $(coveragedir)coverage.info
 	$(Q)$(MV) *.gcda $(build_bindir)
 	$(Q)$(GENHTML) coverage/coverage.info --output-directory coverage/
 

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -131,6 +131,7 @@ TEMPLATE_SCRIPT := $(SCRIPTDIR)template.py
 
 # flags and comp. helpers
 HEADERDIRS := $(addprefix $(top_srcdir),src/shared src/lib/common)
+HEADERDIRS += $(addprefix $(top_srcdir),src/thirdparty/duktape/src)
 HEADERDIRS += $(addprefix $(top_srcdir),src/lib/flow src/lib/comms/)
 HEADERDIRS += $(addprefix $(top_srcdir),$(KCONFIG_INCLUDE)generated/)
 HEADERDIRS += $(build_includedir)
@@ -313,6 +314,8 @@ DOXYGEN_GENERATED = \
 	doc/doxygen/html \
 	doc/doxygen/latex \
 	doc/doxygen/man
+
+SUBMODULE_SCRIPT := $(SCRIPTDIR)git-init-submodules.py
 
 ## oic flow
 FLOW_OIC_GEN := $(flow-dir)oic/oic.json $(flow-dir)oic/oic.c


### PR DESCRIPTION
Differences from v2:
    - use git modules to get duktape sources ( @dorileo helped me a lot, thanks! )
    - fixed typo in warning message

DIfferences from v1:
    - start raising javascript exceptions in error cases
    - start comparing packet type pointers in `send_packet()`
    - remove useless `| 0` in `duk_def_prop()` flags
    - create auxiliary functions to process functions
    - use `strndupa()` instead of `sol_arena_strdup_slice()` in `create_js_type()`
    - small changes on samples

This series introduce Javascript node using Duktape[1] as third party library,
allowing the usage of Javascript language to create new and customizable node types.

The aim of this series is to introduce an initial support for Javascript nodes, there is
other features that we'll add later on.

A JS node type is specified with one object containing each input and output port
declarations (name and type) and its callback functions that will be trigged on the
occurrence of certain events like input/output ports processes, open/close
processes, so forth and so on.