### PR TITLE
Build random cleanups v6

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -63,7 +63,7 @@
             }
 	},
 	{
-	    "dependency": "check_flags",
+	    "dependency": "check_cflags",
 	    "type": "cflags",
 	    "cflags": [
                 "-pipe",
@@ -108,6 +108,14 @@
             ],
             "comment": "append to COMMON_CFLAGS so it's used for further checks",
             "append_to": "COMMON_CFLAGS"
+	},
+	{
+	    "dependency": "check_ldflags",
+	    "type": "ldflags",
+	    "ldflags": [
+                "-Wl,--gc-sections"
+            ],
+            "append_to": "COMMON_LDFLAGS"
 	}
     ],
     "dependencies": [

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -38,6 +38,19 @@
             }
 	},
 	{
+	    "dependency": "ldl",
+	    "type": "ccode",
+	    "headers": [
+		"<dlfcn.h>"
+            ],
+            "fragment": "dlopen(0,0);",
+            "ldflags": {
+                "comment": "append to COMMON_LDFLAGS so it's used for further checks, and else where in the build system",
+                "append_to": "COMMON_LDFLAGS",
+                "value": "-ldl"
+            }
+	},
+	{
 	    "dependency": "check_flags",
 	    "type": "cflags",
 	    "cflags": [

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -51,6 +51,18 @@
             }
 	},
 	{
+	    "dependency": "lib_math",
+	    "type": "ccode",
+	    "headers": [
+		"<math.h>"
+            ],
+            "fragment": "isinf(0);",
+            "ldflags": {
+                "append_to": "COMMON_LDFLAGS",
+                "value": "-lm"
+            }
+	},
+	{
 	    "dependency": "check_flags",
 	    "type": "cflags",
 	    "cflags": [

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -146,7 +146,7 @@
 	    "pkgname": "libudev"
 	},
 	{
-	    "dependency": "kdbus",
+	    "dependency": "sd_dbus",
 	    "type": "ccode",
 	    "headers": [
 		"<systemd/sd-bus.h>"

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -143,16 +143,10 @@
 	{
 	    "dependency": "decl_dladdr",
 	    "type": "ccode",
-	    "defines": [
-		"_GNU_SOURCE"
-	    ],
 	    "headers": [
 		"<dlfcn.h>"
 	    ],
-	    "fragment": "dladdr(0, 0);",
-	    "ldflags": {
-		"value": "-ldl"
-	    }
+	    "fragment": "dladdr(0, 0);"
 	},
 	{
 	    "dependency": "pthread_h",

--- a/data/scripts/dependency-resolver.py
+++ b/data/scripts/dependency-resolver.py
@@ -178,11 +178,15 @@ def handle_ccode_check(args, conf, context):
         source += "#include %s\n" % header
 
     common_cflags = context.find_makefile_var(args.common_cflags_var)
+    common_ldflags = context.find_makefile_var(args.common_ldflags_var)
+
+    test_cflags = (cflags.get("value", ""), args.cflags, common_cflags)
+    test_ldflags = (ldflags.get("value", ""), common_ldflags)
+
     fragment = conf.get("fragment") or ""
     source = cstub.format(headers=source, fragment=fragment)
-    success = compile_test(source, args.compiler, "%s %s %s" %
-                           (cflags.get("value", ""), args.cflags, common_cflags),
-                           ldflags.get("value", ""))
+    success = compile_test(source, args.compiler, (" ").join(test_cflags),
+                           (" ").join(test_ldflags))
 
     if success:
         context.add_kconfig("HAVE_%s" % dep, "bool", "y")
@@ -401,6 +405,9 @@ if __name__ == "__main__":
     parser.add_argument("--common-cflags-var", help=("The makefile variable to "
                                                      "group common cflags"),
                         type=str, default="COMMON_CFLAGS")
+    parser.add_argument("--common-ldflags-var", help=("The makefile variable to "
+                                                      "group common ldflags"),
+                        type=str, default="COMMON_LDFLAGS")
     parser.add_argument("--cache", help="The configuration cache.", type=str,
                         default=".config-cache")
     parser.add_argument("--prefix", help="The installation prefix",

--- a/data/scripts/dependency-resolver.py
+++ b/data/scripts/dependency-resolver.py
@@ -139,7 +139,7 @@ def compile_test(source, compiler, cflags, ldflags):
     f.write(bytes(source, 'UTF-8'))
     f.close()
     output = "%s-bin" % f.name
-    cmd = "{compiler} {cflags} {ldflags} {src} -o {out}".format(compiler=compiler,
+    cmd = "{compiler} {cflags} {src} -o {out} {ldflags}".format(compiler=compiler,
             cflags=cflags, ldflags=ldflags or "", src=f.name, out=output)
     out, status = run_command(cmd)
     if os.path.exists(output):

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -83,7 +83,7 @@ config PLATFORM_SYSTEMD
 	bool "systemd"
 	depends on HAVE_SYSTEMD
 	select SOL_PLATFORM_LINUX
-	select KDBUS
+	select SOL_BUS
 	help
             This platform uses systemd.
 
@@ -302,9 +302,9 @@ config MAXIMUM_LOG_LEVEL_UNLIMITED
 	bool "unlimited"
 endchoice
 
-config KDBUS
-	bool "Kdbus"
-	depends on SOL_PLATFORM_LINUX && HAVE_SYSTEMD && HAVE_KDBUS
+config SOL_BUS
+	bool "Sol-bus"
+	depends on SOL_PLATFORM_LINUX && HAVE_SYSTEMD && HAVE_SD_BUS
 	default n
 
 config SOCKET_LINUX

--- a/src/lib/common/Makefile
+++ b/src/lib/common/Makefile
@@ -17,10 +17,10 @@ obj-core-$(PLATFORM_CONTIKI) += \
     sol-log-impl-contiki.o
 endif
 
-obj-core-$(KDBUS) += \
+obj-core-$(SOL_BUS) += \
     sol-bus.o
-obj-core-$(KDBUS)-extra-cflags += $(SYSTEMD_CFLAGS) $(GLIB_CFLAGS)
-obj-core-$(KDBUS)-extra-ldflags += $(SYSTEMD_LDFLAGS) $(GLIB_LDFLAGS)
+obj-core-$(SOL_BUS)-extra-cflags += $(SYSTEMD_CFLAGS) $(GLIB_CFLAGS)
+obj-core-$(SOL_BUS)-extra-ldflags += $(SYSTEMD_LDFLAGS) $(GLIB_LDFLAGS)
 
 obj-core-$(MAINLOOP_GLIB) += \
     sol-mainloop-impl-glib.o

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -380,10 +380,8 @@ define clean-resource
 
 endef
 
-cleanup-files := $(shell find $(top_srcdir)src/ -name '*.o' -o -name '*.so' -o -name '*.a')
-cleanup-files += $(shell find $(top_srcdir) -name '*.gcda' -o -name '*.gcno')
-cleanup-files += $(CLEANUP_GEN) $(kconfig-clean-objs) $(BUILDDIR) $(CHEAT_SHEET_INDEX_HTML)
-cleanup-files += $(DOXYGEN_GENERATED)
+cleanup-files := $(tests-out) $(CLEANUP_GEN) $(kconfig-clean-objs)
+cleanup-files += $(BUILDDIR) $(CHEAT_SHEET_INDEX_HTML) $(DOXYGEN_GENERATED)
 
 clean:
 	$(foreach curr,$(wildcard $(cleanup-files)),$(call clean-resource,$(curr)))

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -52,8 +52,6 @@ parse-common-module = \
 	$(eval mod-objs     := $(filter %.o,$(artifacts))) \
 	$(eval $(1)-cflags  := $(obj-$(1)-$(3)-extra-cflags)) \
 	$(eval $(1)-ldflags := $(obj-$(1)-$(3)-extra-ldflags)) \
-	$(eval all-ldflags  += $($(1)-ldflags)) \
-	$(eval all-cflags   += $($(1)-ldflags)) \
 	$(eval $(1)-bs      := $(addprefix $(2),Makefile)) \
 	$(eval $(1)-bs      += $(if $(wildcard $(2)/Kconfig),$(addprefix $(2),Kconfig))) \
 	$(eval $(1)-hdrs    := $(filter %.h,$(artifacts))) \
@@ -85,9 +83,6 @@ parse-mod-output = \
 
 parse-mod-module = \
 	$(call parse-common-module,$(1),$(2),m) \
-	$(eval mod-flows       += $(call flow-type,$(artifacts))) \
-	$(eval mod-linux-micro += $(call linux-micro-type,$(artifacts))) \
-	$(eval mod-pin-mux     += $(call pin-mux-type,$(artifacts))) \
 	$(eval $(mod)-deps     := $(subst .mod,,$(obj-$(mod)-m-deps))) \
 	$(call parse-mod-output,$(1),$(2)) \
 	$(eval modules-out += $($(mod)-out)) \

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -207,12 +207,6 @@ COMMON_CFLAGS += -fno-asynchronous-unwind-tables
 EXEC_LDFLAGS := $(COMMON_LDFLAGS) -lm
 LIB_LDFLAGS := $(COMMON_LDFLAGS) -lm
 
-## make sure we link agains ldl only on linux
-ifeq (y,$(SOL_PLATFORM_LINUX))
-EXEC_LDFLAGS += -ldl
-LIB_LDFLAGS += -ldl
-endif
-
 LINKED_OBJS_LDFLAGS := $(addprefix -L,$(LIB_OUTPUTDIR))
 LINKED_OBJS_LDFLAGS += -lsoletta
 LINKED_OBJS_LDFLAGS += -Wl,-R$(abspath $(build_libdir))

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -201,9 +201,6 @@ COMMON_CFLAGS += -include $(abspath $(KCONFIG_AUTOHEADER))
 COMMON_CFLAGS += -include $(abspath $(DEFINITIONS_H))
 COMMON_CFLAGS += $(addprefix -I,$(HEADERDIRS))
 
-## Reduce .eh_frame size.
-COMMON_CFLAGS += -fno-asynchronous-unwind-tables
-
 EXEC_LDFLAGS := $(COMMON_LDFLAGS)
 LIB_LDFLAGS := $(COMMON_LDFLAGS)
 

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -204,8 +204,8 @@ COMMON_CFLAGS += $(addprefix -I,$(HEADERDIRS))
 ## Reduce .eh_frame size.
 COMMON_CFLAGS += -fno-asynchronous-unwind-tables
 
-EXEC_LDFLAGS := $(COMMON_LDFLAGS) -lm
-LIB_LDFLAGS := $(COMMON_LDFLAGS) -lm
+EXEC_LDFLAGS := $(COMMON_LDFLAGS)
+LIB_LDFLAGS := $(COMMON_LDFLAGS)
 
 LINKED_OBJS_LDFLAGS := $(addprefix -L,$(LIB_OUTPUTDIR))
 LINKED_OBJS_LDFLAGS += -lsoletta

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -15,9 +15,6 @@ builtin-objs :=
 # module objects, deps and configs lookup variables
 modules :=
 modules-out :=
-mod-flows :=
-mod-linux-micro :=
-mod-pin-mux :=
 mod-ar :=
 mod-so :=
 
@@ -39,8 +36,6 @@ all-dest-hdr :=
 all-hdr :=
 all-dest-bin :=
 all-mod-descs :=
-all-cflags :=
-all-ldflags :=
 
 module-types := flow linux-micro pin-mux
 


### PR DESCRIPTION
v4:
   + added patch: build: add ldflags check

v5:
   + added patch: dep-resolver: fix flags order on compile_test()

v6:
  + added patch "build: rename kdbus to sol_bus" - brought from PR #183 