### PR TITLE
Build selective hardware v3

### DIFF
--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -311,6 +311,10 @@ menu "Hardware Options"
 config USE_PWM
 	bool "PWM Support"
 	default y
+
+config USE_SPI
+	bool "SPI Support"
+	default y
 endmenu
 
 

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -315,8 +315,11 @@ config USE_PWM
 config USE_SPI
 	bool "SPI Support"
 	default y
-endmenu
 
+config USE_UART
+	bool "UART Support"
+	default y
+endmenu
 
 config SOCKET_LINUX
 	bool "Linux sockets"

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -319,6 +319,10 @@ config USE_SPI
 config USE_UART
 	bool "UART Support"
 	default y
+
+config USE_I2C
+	bool "I2C Support"
+	default y
 endmenu
 
 config SOCKET_LINUX

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -307,6 +307,13 @@ config KDBUS
 	depends on SOL_PLATFORM_LINUX && HAVE_SYSTEMD && HAVE_KDBUS
 	default n
 
+menu "Hardware Options"
+config USE_PWM
+	bool "PWM Support"
+	default y
+endmenu
+
+
 config SOCKET_LINUX
 	bool "Linux sockets"
 	depends on SOL_PLATFORM_LINUX && NETWORK

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -334,7 +334,7 @@ config SOCKET_LINUX
 	depends on SOL_PLATFORM_LINUX && NETWORK
 	default y
 
-menuconfig HAVE_PIN_MUX
+menuconfig USE_PIN_MUX
         bool "Pin Multiplexer"
         depends on USE_GPIO
         default y

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -323,6 +323,10 @@ config USE_UART
 config USE_I2C
 	bool "I2C Support"
 	default y
+
+config USE_GPIO
+	bool "GPIO Support"
+	default y
 endmenu
 
 config SOCKET_LINUX
@@ -332,6 +336,7 @@ config SOCKET_LINUX
 
 menuconfig HAVE_PIN_MUX
         bool "Pin Multiplexer"
+        depends on USE_GPIO
         default y
         help
           Pin Multiplexer is a feature that helps to setup

--- a/src/lib/common/Makefile
+++ b/src/lib/common/Makefile
@@ -72,7 +72,7 @@ obj-core-$(MAINLOOP_POSIX) += \
 obj-core-y-extra-ldflags += $(PTHREAD_H_LDFLAGS)
 endif
 
-obj-core-$(HAVE_PIN_MUX) += \
+obj-core-$(USE_PIN_MUX) += \
     sol-pin-mux.o
 
 headers-y := \
@@ -82,7 +82,7 @@ headers-y := \
     include/sol-platform.h \
     include/sol-types.h
 
-headers-$(HAVE_PIN_MUX) += \
+headers-$(USE_PIN_MUX) += \
     include/sol-pin-mux-modules.h
 
 headers-$(PTHREAD) += \

--- a/src/lib/common/sol-interrupt_scheduler_riot.c
+++ b/src/lib/common/sol-interrupt_scheduler_riot.c
@@ -40,8 +40,10 @@ static kernel_pid_t pid;
 
 enum interrupt_type {
     GPIO,
+#ifdef USE_UART
     UART_RX,
     UART_TX
+#endif
 };
 
 struct interrupt_data_base {
@@ -54,6 +56,7 @@ struct interrupt_data {
     void *data;
 };
 
+#ifdef USE_UART
 struct uart_interrupt_data {
     struct interrupt_data_base base;
     uart_t uart_id;
@@ -66,6 +69,7 @@ struct uart_rx_interrupt_data {
     char char_read;
     struct uart_interrupt_data *uart_int;
 };
+#endif
 
 void
 sol_interrupt_scheduler_set_pid(kernel_pid_t p)
@@ -136,6 +140,7 @@ sol_interrupt_scheduler_gpio_stop(gpio_t dev, void *handler)
 }
 
 /* Run in interrupt context */
+#ifdef USE_UART
 static void
 uart_rx_cb(void *data, char char_read)
 {
@@ -203,6 +208,7 @@ sol_interrupt_scheduler_uart_stop(uart_t uart, void *handler)
     uart_init_blocking(uart, 9600);
     interrupt_scheduler_handler_free(handler);
 }
+#endif
 
 void
 sol_interrupt_scheduler_process(msg_t *msg)
@@ -216,6 +222,7 @@ sol_interrupt_scheduler_process(msg_t *msg)
         interrupt_data_base_unref(&int_data->base);
         break;
     }
+#ifdef USE_UART
     case UART_RX: {
         struct uart_rx_interrupt_data *rx_data = (void *)msg->content.ptr;
         uart_rx_cb_t cb = rx_data->uart_int->rx_cb;
@@ -235,5 +242,6 @@ sol_interrupt_scheduler_process(msg_t *msg)
         interrupt_data_base_unref(&int_data->base);
         break;
     }
+#endif
     }
 }

--- a/src/lib/common/sol-interrupt_scheduler_riot.h
+++ b/src/lib/common/sol-interrupt_scheduler_riot.h
@@ -33,14 +33,19 @@
 #include "kernel_types.h"
 #include "msg.h"
 #include "periph/gpio.h"
+
+#ifdef USE_UART
 #include "periph/uart.h"
+#endif
 
 void sol_interrupt_scheduler_set_pid(kernel_pid_t pid);
 
 int sol_interrupt_scheduler_gpio_init_int(gpio_t dev, gpio_pp_t pullup, gpio_flank_t flank, gpio_cb_t cb, void *arg, void **handler);
 void sol_interrupt_scheduler_gpio_stop(gpio_t dev, void *handler);
 
+#ifdef USE_UART
 int sol_interrupt_scheduler_uart_init_int(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, uart_tx_cb_t tx_cb, void *arg, void **handler);
 void sol_interrupt_scheduler_uart_stop(uart_t uart, void *handler);
+#endif
 
 void sol_interrupt_scheduler_process(msg_t *msg);

--- a/src/lib/common/sol-mainloop.c
+++ b/src/lib/common/sol-mainloop.c
@@ -53,7 +53,7 @@ sol_log_shutdown(void)
 }
 #endif
 
-#ifdef HAVE_PIN_MUX
+#ifdef USE_PIN_MUX
 extern int sol_pin_mux_init(void);
 extern void sol_pin_mux_shutdown(void);
 #else

--- a/src/lib/io/Makefile
+++ b/src/lib/io/Makefile
@@ -13,13 +13,17 @@ ifeq (y,$(PLATFORM_RIOTOS))
 obj-io-$(IO) += \
     sol-gpio-riot.o \
     sol-i2c-riot.o \
-    sol-spi-riot.o \
     sol-uart-riot.o
 
 ifeq (y, $(USE_PWM))
 obj-io-$(IO) += \
     sol-pwm-riot.o
 endif # USE_PWM
+
+ifeq (y, $(USE_SPI))
+obj-io-$(IO) += \
+    sol-spi-riot.o
+endif # USE_SPI
 endif
 
 ifeq (y,$(PLATFORM_CONTIKI))
@@ -31,22 +35,30 @@ ifeq (y,$(SOL_PLATFORM_LINUX))
 obj-io-$(IO) += \
     sol-gpio-linux.o \
     sol-i2c-linux.o \
-    sol-spi-linux.o \
     sol-uart-linux.o
 
 ifeq (y, $(USE_PWM))
 obj-io-$(IO) += \
     sol-pwm-linux.o
 endif # USE_PWM
+
+ifeq (y, $(USE_SPI))
+obj-io-$(IO) += \
+    sol-spi-linux.o
+endif # USE_SPI
 endif
 
 headers-$(IO) := \
     include/sol-gpio.h \
     include/sol-i2c.h \
-    include/sol-spi.h \
     include/sol-uart.h
 
 ifeq (y, $(USE_PWM))
 headers-$(IO) += \
     include/sol-pwm.h
+endif
+
+ifeq (y, $(USE_SPI))
+headers-$(IO) += \
+    include/sol-spi.h
 endif

--- a/src/lib/io/Makefile
+++ b/src/lib/io/Makefile
@@ -12,8 +12,7 @@ endif
 ifeq (y,$(PLATFORM_RIOTOS))
 obj-io-$(IO) += \
     sol-gpio-riot.o \
-    sol-i2c-riot.o \
-    sol-uart-riot.o
+    sol-i2c-riot.o
 
 ifeq (y, $(USE_PWM))
 obj-io-$(IO) += \
@@ -24,6 +23,11 @@ ifeq (y, $(USE_SPI))
 obj-io-$(IO) += \
     sol-spi-riot.o
 endif # USE_SPI
+
+ifeq (y, $(USE_UART))
+obj-io-$(IO) += \
+    sol-uart-riot.o
+endif # USE_UART
 endif
 
 ifeq (y,$(PLATFORM_CONTIKI))
@@ -34,8 +38,7 @@ endif
 ifeq (y,$(SOL_PLATFORM_LINUX))
 obj-io-$(IO) += \
     sol-gpio-linux.o \
-    sol-i2c-linux.o \
-    sol-uart-linux.o
+    sol-i2c-linux.o
 
 ifeq (y, $(USE_PWM))
 obj-io-$(IO) += \
@@ -46,12 +49,16 @@ ifeq (y, $(USE_SPI))
 obj-io-$(IO) += \
     sol-spi-linux.o
 endif # USE_SPI
+
+ifeq (y, $(USE_UART))
+obj-io-$(IO) += \
+    sol-uart-linux.o
+endif # USE_UART
 endif
 
 headers-$(IO) := \
     include/sol-gpio.h \
-    include/sol-i2c.h \
-    include/sol-uart.h
+    include/sol-i2c.h
 
 ifeq (y, $(USE_PWM))
 headers-$(IO) += \
@@ -61,4 +68,9 @@ endif
 ifeq (y, $(USE_SPI))
 headers-$(IO) += \
     include/sol-spi.h
+endif
+
+ifeq (y, $(USE_UART))
+headers-$(IO) += \
+    include/sol-uart.h
 endif

--- a/src/lib/io/Makefile
+++ b/src/lib/io/Makefile
@@ -2,16 +2,24 @@ obj-$(IO) += io.mod
 
 obj-io-$(IO) := \
     sol-gpio-common.o \
-    sol-i2c-common.o \
-    sol-pwm-common.o \
+    sol-i2c-common.o
+
+ifeq (y, $(USE_PWM))
+obj-io-$(IO) += \
+    sol-pwm-common.o
+endif
 
 ifeq (y,$(PLATFORM_RIOTOS))
 obj-io-$(IO) += \
     sol-gpio-riot.o \
     sol-i2c-riot.o \
-    sol-pwm-riot.o \
     sol-spi-riot.o \
     sol-uart-riot.o
+
+ifeq (y, $(USE_PWM))
+obj-io-$(IO) += \
+    sol-pwm-riot.o
+endif # USE_PWM
 endif
 
 ifeq (y,$(PLATFORM_CONTIKI))
@@ -23,14 +31,22 @@ ifeq (y,$(SOL_PLATFORM_LINUX))
 obj-io-$(IO) += \
     sol-gpio-linux.o \
     sol-i2c-linux.o \
-    sol-pwm-linux.o \
     sol-spi-linux.o \
     sol-uart-linux.o
+
+ifeq (y, $(USE_PWM))
+obj-io-$(IO) += \
+    sol-pwm-linux.o
+endif # USE_PWM
 endif
 
 headers-$(IO) := \
     include/sol-gpio.h \
     include/sol-i2c.h \
-    include/sol-pwm.h \
     include/sol-spi.h \
     include/sol-uart.h
+
+ifeq (y, $(USE_PWM))
+headers-$(IO) += \
+    include/sol-pwm.h
+endif

--- a/src/lib/io/Makefile
+++ b/src/lib/io/Makefile
@@ -1,18 +1,21 @@
 obj-$(IO) += io.mod
 
 obj-io-$(IO) := \
-    sol-gpio-common.o \
-    sol-i2c-common.o
+    sol-gpio-common.o
 
 ifeq (y, $(USE_PWM))
 obj-io-$(IO) += \
     sol-pwm-common.o
 endif
 
+ifeq (y, $(USE_I2C))
+obj-io-$(IO) += \
+    sol-i2c-common.o
+endif
+
 ifeq (y,$(PLATFORM_RIOTOS))
 obj-io-$(IO) += \
-    sol-gpio-riot.o \
-    sol-i2c-riot.o
+    sol-gpio-riot.o
 
 ifeq (y, $(USE_PWM))
 obj-io-$(IO) += \
@@ -28,7 +31,12 @@ ifeq (y, $(USE_UART))
 obj-io-$(IO) += \
     sol-uart-riot.o
 endif # USE_UART
-endif
+
+ifeq (y, $(USE_I2C))
+obj-io-$(IO) += \
+    sol-i2c-riot.o
+endif # USE_I2C
+endif # PLATFORM_RIOTOS
 
 ifeq (y,$(PLATFORM_CONTIKI))
 obj-io-$(IO) += \
@@ -37,8 +45,7 @@ endif
 
 ifeq (y,$(SOL_PLATFORM_LINUX))
 obj-io-$(IO) += \
-    sol-gpio-linux.o \
-    sol-i2c-linux.o
+    sol-gpio-linux.o
 
 ifeq (y, $(USE_PWM))
 obj-io-$(IO) += \
@@ -54,11 +61,15 @@ ifeq (y, $(USE_UART))
 obj-io-$(IO) += \
     sol-uart-linux.o
 endif # USE_UART
-endif
+
+ifeq (y, $(USE_I2C))
+obj-io-$(IO) += \
+    sol-i2c-linux.o
+endif # USE_I2C
+endif # PLATFORM_LINUX
 
 headers-$(IO) := \
-    include/sol-gpio.h \
-    include/sol-i2c.h
+    include/sol-gpio.h
 
 ifeq (y, $(USE_PWM))
 headers-$(IO) += \
@@ -73,4 +84,9 @@ endif
 ifeq (y, $(USE_UART))
 headers-$(IO) += \
     include/sol-uart.h
+endif
+
+ifeq (y, $(USE_I2C))
+headers-$(IO) += \
+    include/sol-i2c.h
 endif

--- a/src/lib/io/Makefile
+++ b/src/lib/io/Makefile
@@ -1,7 +1,9 @@
 obj-$(IO) += io.mod
 
-obj-io-$(IO) := \
+ifeq (y, $(USE_GPIO))
+obj-io-$(IO) += \
     sol-gpio-common.o
+endif
 
 ifeq (y, $(USE_PWM))
 obj-io-$(IO) += \
@@ -14,8 +16,10 @@ obj-io-$(IO) += \
 endif
 
 ifeq (y,$(PLATFORM_RIOTOS))
+ifeq (y, $(USE_GPIO))
 obj-io-$(IO) += \
     sol-gpio-riot.o
+endif # USE_GPIO
 
 ifeq (y, $(USE_PWM))
 obj-io-$(IO) += \
@@ -39,13 +43,17 @@ endif # USE_I2C
 endif # PLATFORM_RIOTOS
 
 ifeq (y,$(PLATFORM_CONTIKI))
+ifeq (y, $(USE_GPIO))
 obj-io-$(IO) += \
     sol-gpio-contiki.o
-endif
+endif # USE_GPIO
+endif # PLATFORM_CONTIKI
 
 ifeq (y,$(SOL_PLATFORM_LINUX))
+ifeq (y, $(USE_GPIO))
 obj-io-$(IO) += \
     sol-gpio-linux.o
+endif # USE_GPIO
 
 ifeq (y, $(USE_PWM))
 obj-io-$(IO) += \
@@ -68,8 +76,10 @@ obj-io-$(IO) += \
 endif # USE_I2C
 endif # PLATFORM_LINUX
 
-headers-$(IO) := \
+ifeq (y, $(USE_GPIO))
+headers-$(IO) += \
     include/sol-gpio.h
+endif
 
 ifeq (y, $(USE_PWM))
 headers-$(IO) += \

--- a/src/lib/io/sol-gpio-common.c
+++ b/src/lib/io/sol-gpio-common.c
@@ -38,7 +38,7 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "gpio");
 
 #include "sol-gpio.h"
 
-#ifdef HAVE_PIN_MUX
+#ifdef USE_PIN_MUX
 #include "sol-pin-mux.h"
 #endif
 
@@ -52,7 +52,7 @@ sol_gpio_open(int pin, const struct sol_gpio_config *config)
     SOL_NULL_CHECK(config, NULL);
 
     gpio = sol_gpio_open_raw(pin, config);
-#ifdef HAVE_PIN_MUX
+#ifdef USE_PIN_MUX
     if (gpio && sol_pin_mux_setup_gpio(pin, config->dir)) {
         SOL_ERR("Pin Multiplexer Recipe for gpio=%d found, but couldn't be applied.", pin);
         sol_gpio_close(gpio);

--- a/src/lib/io/sol-i2c-common.c
+++ b/src/lib/io/sol-i2c-common.c
@@ -37,7 +37,7 @@
 SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "i2c");
 
 #include "sol-i2c.h"
-#ifdef HAVE_PIN_MUX
+#ifdef USE_PIN_MUX
 #include "sol-pin-mux.h"
 #endif
 
@@ -49,7 +49,7 @@ sol_i2c_open(uint8_t bus, enum sol_i2c_speed speed)
     SOL_LOG_INTERNAL_INIT_ONCE;
 
     i2c = sol_i2c_open_raw(bus, speed);
-#ifdef HAVE_PIN_MUX
+#ifdef USE_PIN_MUX
     if (i2c && sol_pin_mux_setup_i2c(bus) < 0) {
         SOL_ERR("Pin Multiplexer Recipe for i2c bus=%u found, but couldn't be applied.", bus);
         sol_i2c_close(i2c);

--- a/src/lib/io/sol-pwm-common.c
+++ b/src/lib/io/sol-pwm-common.c
@@ -37,7 +37,7 @@
 SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "pwm");
 
 #include "sol-pwm.h"
-#ifdef HAVE_PIN_MUX
+#ifdef USE_PIN_MUX
 #include "sol-pin-mux.h"
 #endif
 
@@ -49,7 +49,7 @@ sol_pwm_open(int device, int channel, const struct sol_pwm_config *config)
     SOL_LOG_INTERNAL_INIT_ONCE;
 
     pwm = sol_pwm_open_raw(device, channel, config);
-#ifdef HAVE_PIN_MUX
+#ifdef USE_PIN_MUX
     if (pwm && sol_pin_mux_setup_pwm(device, channel)) {
         SOL_WRN("Pin Multiplexer Recipe for pwm device=%d channel=%d found, \
             but couldn't be applied.", device, channel);

--- a/src/modules/flow/accelerometer/Kconfig
+++ b/src/modules/flow/accelerometer/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_ACCELEROMETER
 	tristate "Node type: accelerometer"
-	depends on FLOW && SOL_PLATFORM_LINUX
+	depends on FLOW && SOL_PLATFORM_LINUX && USE_I2C
 	default m

--- a/src/modules/flow/calamari/Kconfig
+++ b/src/modules/flow/calamari/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_CALAMARI
 	tristate "Node type: calamari"
-	depends on FLOW && (FLOW_NODE_TYPE_GPIO = y)
+	depends on FLOW && (FLOW_NODE_TYPE_GPIO = y) && USE_PWM
 	default m

--- a/src/modules/flow/calamari/Kconfig
+++ b/src/modules/flow/calamari/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_CALAMARI
 	tristate "Node type: calamari"
-	depends on FLOW && (FLOW_NODE_TYPE_GPIO = y) && USE_PWM
+	depends on FLOW && (FLOW_NODE_TYPE_GPIO = y) && USE_PWM && USE_SPI
 	default m

--- a/src/modules/flow/gpio/Kconfig
+++ b/src/modules/flow/gpio/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_GPIO
 	tristate "Node type: gpio"
-	depends on FLOW
+	depends on FLOW && USE_GPIO
 	default y

--- a/src/modules/flow/grove/Kconfig
+++ b/src/modules/flow/grove/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_GROVE
 	tristate "Node type: grove"
-	depends on FLOW
+	depends on FLOW && USE_I2C
 	default m

--- a/src/modules/flow/gyroscope/Kconfig
+++ b/src/modules/flow/gyroscope/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_GYROSCOPE
 	tristate "Node type: gyroscope"
-	depends on FLOW && SOL_PLATFORM_LINUX
+	depends on FLOW && SOL_PLATFORM_LINUX && USE_I2C
 	default m

--- a/src/modules/flow/led-strip/Kconfig
+++ b/src/modules/flow/led-strip/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_LED_STRIP
 	tristate "Node type: led-strip"
-	depends on FLOW
+	depends on FLOW && USE_SPI
 	default m

--- a/src/modules/flow/piezo-speaker/Kconfig
+++ b/src/modules/flow/piezo-speaker/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_PIEZO_SPEAKER
 	tristate "Node type: piezo-speaker"
-	depends on FLOW
+	depends on FLOW && USE_PWM
 	default m

--- a/src/modules/flow/pwm/Kconfig
+++ b/src/modules/flow/pwm/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_PWM
 	tristate "Node type: pwm"
-	depends on FLOW
+	depends on FLOW && USE_PWM
 	default y

--- a/src/modules/flow/servo-motor/Kconfig
+++ b/src/modules/flow/servo-motor/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_SERVO_MOTOR
 	tristate "Node type: servo-motor"
-	depends on FLOW
+	depends on FLOW && USE_PWM
 	default m

--- a/src/modules/pin-mux/intel-edison-rev-c/Kconfig
+++ b/src/modules/pin-mux/intel-edison-rev-c/Kconfig
@@ -1,4 +1,4 @@
 config PIN_MUX_INTEL_EDISON_REV_C
         tristate "Intel Edison (Rev C)"
-        depends on HAVE_PIN_MUX
+        depends on USE_PIN_MUX
         default m

--- a/src/modules/pin-mux/intel-galileo-rev-d/Kconfig
+++ b/src/modules/pin-mux/intel-galileo-rev-d/Kconfig
@@ -1,4 +1,4 @@
 config PIN_MUX_INTEL_GALILEO_REV_D
         tristate "Intel Galileo (Rev D)"
-        depends on HAVE_PIN_MUX
+        depends on USE_PIN_MUX
         default m

--- a/src/modules/pin-mux/intel-galileo-rev-g/Kconfig
+++ b/src/modules/pin-mux/intel-galileo-rev-g/Kconfig
@@ -1,4 +1,4 @@
 config PIN_MUX_INTEL_GALILEO_REV_G
         tristate "Intel Galileo Gen 2 (Rev G)"
-        depends on HAVE_PIN_MUX
+        depends on USE_PIN_MUX
         default m

--- a/src/test/test-flow.c
+++ b/src/test/test-flow.c
@@ -37,7 +37,11 @@
 #include "sol-vector.h"
 
 #include "console-gen.h"
+
+#ifdef USE_PWM
 #include "pwm-gen.h"
+#endif
+
 #include "timer-gen.h"
 
 #include "test.h"
@@ -1152,13 +1156,17 @@ node_options_from_strv(void)
     const char *timer_strv[2] = { "interval=1000", NULL };
     const char *timer_irange_strv[2] = { "interval=50|20|60|2", NULL };
     const char *timer_irange_different_format_strv[2] = { "interval=val:100|min:10|max:200|step:5", NULL };
+#ifdef USE_PWM
     const char *pwm_strv[6] = { "chip=2", "pin=7", "enabled=true", "period=42", "duty_cycle=88", NULL };
+#endif
     const char *console_strv[4] = { "prefix=console prefix:", "suffix=. suffix!", "output_on_stdout=true", NULL };
     const char *timer_unknown_field_strv[2] = { "this_is_not_a_valid_field=100", NULL };
     const char *timer_wrongly_formatted_strv[2] = { "interval = 1000", NULL };
 
     struct sol_flow_node_type_timer_options *timer_opts;
+#ifdef USE_PWM
     struct sol_flow_node_type_pwm_options *pwm_opts;
+#endif
     struct sol_flow_node_type_console_options *console_opts;
     struct sol_flow_node_options *opts;
 
@@ -1169,6 +1177,7 @@ node_options_from_strv(void)
     ASSERT_INT_EQ(timer_opts->interval.val, 1000);
     sol_flow_node_options_del(SOL_FLOW_NODE_TYPE_TIMER, (struct sol_flow_node_options *)timer_opts);
 
+#ifdef USE_PWM
     /* Multiple options */
     pwm_opts = (struct sol_flow_node_type_pwm_options *)
         sol_flow_node_options_new_from_strv(SOL_FLOW_NODE_TYPE_PWM, pwm_strv);
@@ -1179,6 +1188,7 @@ node_options_from_strv(void)
     ASSERT_INT_EQ(pwm_opts->period.val, 42);
     ASSERT_INT_EQ(pwm_opts->duty_cycle.val, 88);
     sol_flow_node_options_del(SOL_FLOW_NODE_TYPE_PWM, (struct sol_flow_node_options *)pwm_opts);
+#endif
 
     /* String options */
     console_opts = (struct sol_flow_node_type_console_options *)

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -268,7 +268,7 @@ ifeq (y,$(PLATFORM_LINUX_MICRO))
 HEADER_GEN += $(LINUX_MICRO_BUILTINS_H)
 endif
 
-ifeq (y,$(HAVE_PIN_MUX))
+ifeq (y,$(USE_PIN_MUX))
 HEADER_GEN += $(PIN_MUX_BUILTINS_H)
 endif
 


### PR DESCRIPTION
# Changes
v2:
  + fixed indentation;
  + changed the config variables from HARDWARE_ to USE_;
  + pinmux now depends on gpio;
  + changed labels and help according to @lpereira and @mbelluzzo suggestions;
  + added a patch to rename HAVE_PIN_MUX to USE_PIN_MUX so we don't spread the mixed and wrong use of HAVE_ variables;

v3:
  + upstream rebase;
  + dropped patch (since it moved to #355): "build: rename kdbus to sol_bus"
  + dropped patch (it's not required anymore due the - new - networking config options): "	build: general network configuration"

# Rationale
Some boards will not have all the hardware support we offer, with that we should have hardware options to disable our interface and build only what the board or OS supports. A clear example is RIOT on minnow-board which supports only gpio, in that case we should disable spi, pwm etc.