### PR TITLE
UART: Simplify API V4

### DIFF
--- a/src/lib/io/include/sol-uart.h
+++ b/src/lib/io/include/sol-uart.h
@@ -119,8 +119,11 @@ void sol_uart_close(struct sol_uart *uart);
  * an error happen during the transmission
  * @param data the first parameter of tx_cb
  * @return true if transfer was started
+ *
+ * @note Caller should guarantee that tx buffer will not be freed until
+ * callback is called.
  */
-bool sol_uart_write(struct sol_uart *uart, const unsigned char *tx, unsigned int length, void (*tx_cb)(void *data, struct sol_uart *uart, int status), const void *data);
+bool sol_uart_write(struct sol_uart *uart, const unsigned char *tx, unsigned int length, void (*tx_cb)(void *data, struct sol_uart *uart, unsigned char *tx, int status), const void *data);
 
 /**
  * @}

--- a/src/lib/io/include/sol-uart.h
+++ b/src/lib/io/include/sol-uart.h
@@ -53,36 +53,74 @@ extern "C" {
 
 struct sol_uart;
 
-struct sol_uart *sol_uart_open(const char *port_name);
+enum sol_uart_baud_rate {
+    SOL_UART_BAUD_RATE_9600 = 0,
+    SOL_UART_BAUD_RATE_19200,
+    SOL_UART_BAUD_RATE_38400,
+    SOL_UART_BAUD_RATE_57600,
+    SOL_UART_BAUD_RATE_115200
+};
+
+enum sol_uart_data_bits {
+    SOL_UART_DATA_BITS_8 = 0,
+    SOL_UART_DATA_BITS_7,
+    SOL_UART_DATA_BITS_6,
+    SOL_UART_DATA_BITS_5
+};
+
+enum sol_uart_parity {
+    SOL_UART_PARITY_NONE = 0,
+    SOL_UART_PARITY_EVEN,
+    SOL_UART_PARITY_ODD
+};
+
+enum sol_uart_stop_bits {
+    SOL_UART_STOP_BITS_ONE = 0,
+    SOL_UART_STOP_BITS_TWO
+};
+
+struct sol_uart_config {
+#define SOL_UART_CONFIG_API_VERSION (1)
+    uint16_t api_version;
+    enum sol_uart_baud_rate baud_rate;
+    enum sol_uart_data_bits data_bits;
+    enum sol_uart_parity parity;
+    enum sol_uart_stop_bits stop_bits;
+    void (*rx_cb)(void *user_data, struct sol_uart *uart, unsigned char byte_read); /** Set a callback to be called every time a character is received on UART */
+    const void *rx_cb_user_data;
+    bool flow_control; /** Enables software flow control(XOFF and XON) */
+};
+
+/**
+ * Open an UART bus.
+ *
+ * @param port_name the name of UART port, on Linux it should be ttyUSB0 or
+ * ttyACM0 in small OSes it should be a id number.
+ * @param config The UART bus configuration
+ * @return A new UART bus handle
+ */
+struct sol_uart *sol_uart_open(const char *port_name, const struct sol_uart_config *config);
+
+/**
+ * Close an UART bus.
+ *
+ * @param uart The UART bus handle
+ */
 void sol_uart_close(struct sol_uart *uart);
 
-bool sol_uart_set_baud_rate(struct sol_uart *uart, uint32_t baud_rate);
-uint32_t sol_uart_get_baud_rate(const struct sol_uart *uart);
-
-bool sol_uart_set_parity_bit(struct sol_uart *uart, bool enable, bool odd_paraty);
-bool sol_uart_get_parity_bit_enable(struct sol_uart *uart);
-bool sol_uart_get_parity_bit_odd(struct sol_uart *uart);
-
-bool sol_uart_set_data_bits_length(struct sol_uart *uart, uint8_t lenght);
-uint8_t sol_uart_get_data_bits_length(struct sol_uart *uart);
-
-bool sol_uart_set_stop_bits_length(struct sol_uart *uart, bool two_bits);
-uint8_t sol_uart_get_stop_bits_length(struct sol_uart *uart);
-
-bool sol_uart_set_flow_control(struct sol_uart *uart, bool enable);
-bool sol_uart_get_flow_control(struct sol_uart *uart);
-
 /**
- * Write X characters on UART without block the execution, when the
- * transmission finish the callback will be called.
+ * Perform a UART asynchronous transmission.
+ *
+ * @param uart The UART bus handle
+ * @param tx The output buffer to be sent
+ * @param length number of bytes to be transfer
+ * @param tx_cb callback to be called when transmission finish, in case of
+ * success the status parameter on tx_cb should be equal to length otherwise
+ * an error happen during the transmission
+ * @param data the first parameter of tx_cb
+ * @return true if transfer was started
  */
-bool sol_uart_write(struct sol_uart *uart, const char *tx, unsigned int length, void (*tx_cb)(struct sol_uart *uart, int status, void *data), const void *data);
-
-/**
- * Set a callback to be called every time a character is received on UART.
- */
-bool sol_uart_set_rx_callback(struct sol_uart *uart, void (*rx_cb)(struct sol_uart *uart, char read_char, void *data), const void *data);
-void sol_uart_del_rx_callback(struct sol_uart *uart);
+bool sol_uart_write(struct sol_uart *uart, const unsigned char *tx, unsigned int length, void (*tx_cb)(void *data, struct sol_uart *uart, int status), const void *data);
 
 /**
  * @}

--- a/src/lib/io/sol-uart-linux.c
+++ b/src/lib/io/sol-uart-linux.c
@@ -44,7 +44,6 @@
 #include "sol-mainloop.h"
 #include "sol-uart.h"
 #include "sol-util.h"
-#include "sol-vector.h"
 
 SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "uart");
 
@@ -58,16 +57,11 @@ struct sol_uart {
         const void *rx_user_data;
 
         void *tx_fd_handler;
-        struct sol_vector tx_queue;
+        void (*tx_cb)(void *data, struct sol_uart *uart, unsigned char *tx, int status);
+        const void *tx_user_data;
+        const unsigned char *tx_buffer;
+        unsigned int tx_length, tx_index;
     } async;
-};
-
-struct uart_write_data {
-    unsigned char *buffer;
-    unsigned int length;
-    unsigned int index;
-    void (*cb)(void *data, struct sol_uart *uart, int write);
-    const void *user_data;
 };
 
 static bool
@@ -165,8 +159,6 @@ sol_uart_open(const char *port_name, const struct sol_uart_config *config)
     }
     tcflush(uart->fd, TCIOFLUSH);
 
-    sol_vector_init(&uart->async.tx_queue, sizeof(struct uart_write_data));
-
     uart->async.rx_fd_handler = sol_fd_add(uart->fd,
         FD_ERROR_FLAGS | SOL_FD_FLAGS_IN, uart_rx_callback, uart);
     if (!uart->async.rx_fd_handler) {
@@ -185,19 +177,6 @@ open_fail:
     return NULL;
 }
 
-static void
-clean_tx_queue(struct sol_uart *uart, int error_code)
-{
-    struct uart_write_data *write_data;
-    uint16_t i;
-
-    SOL_VECTOR_FOREACH_IDX (&uart->async.tx_queue, write_data, i) {
-        write_data->cb((void *)write_data->user_data, uart, -1);
-        free(write_data->buffer);
-    }
-    sol_vector_clear(&uart->async.tx_queue);
-}
-
 SOL_API void
 sol_uart_close(struct sol_uart *uart)
 {
@@ -207,85 +186,66 @@ sol_uart_close(struct sol_uart *uart)
     if (uart->async.tx_fd_handler)
         sol_fd_del(uart->async.tx_fd_handler);
     close(uart->fd);
-    clean_tx_queue(uart, -1);
     free(uart);
+}
+
+static void
+uart_tx_dispatch(struct sol_uart *uart, int status)
+{
+    uart->async.tx_fd_handler = NULL;
+    if (!uart->async.tx_cb)
+        return;
+    uart->async.tx_cb((void *)uart->async.tx_user_data, uart,
+        (unsigned char *)uart->async.tx_buffer, status);
 }
 
 static bool
 uart_tx_callback(void *data, int fd, unsigned int active_flags)
 {
     struct sol_uart *uart = data;
-    struct uart_write_data *write_data = sol_vector_get(&uart->async.tx_queue, 0);
     int ret;
 
     if (active_flags & FD_ERROR_FLAGS) {
         SOL_ERR("Error flag was set on UART file descriptor %d.", fd);
+        ret = -1;
         goto error;
     }
 
-    if (write_data->index == write_data->length) {
-        free(write_data->buffer);
-        write_data->cb((void *)write_data->user_data, uart, write_data->index);
-        sol_vector_del(&uart->async.tx_queue, 0);
-
-        if (!uart->async.tx_queue.len) {
-            uart->async.tx_fd_handler = NULL;
-            return false;
-        }
-
-        return uart_tx_callback(uart, fd, active_flags);
+    if (uart->async.tx_index == uart->async.tx_length) {
+        uart_tx_dispatch(uart, uart->async.tx_index);
+        return false;
     }
 
-    ret = write(fd, write_data->buffer + write_data->index,
-        write_data->length - write_data->index);
+    ret = write(fd, uart->async.tx_buffer + uart->async.tx_index,
+        uart->async.tx_length - uart->async.tx_index);
     if (ret < 0) {
         SOL_ERR("Error when writing to file descriptor %d.", fd);
-        write_data->cb((void *)write_data->user_data, uart, ret);
-        free(write_data->buffer);
-        sol_vector_del(&uart->async.tx_queue, 0);
         goto error;
     }
-    write_data->index += ret;
+
+    uart->async.tx_index += ret;
     return true;
 
 error:
-    clean_tx_queue(uart, -1);
-    uart->async.tx_fd_handler = NULL;
+    uart_tx_dispatch(uart, ret);
     return false;
 }
 
 SOL_API bool
-sol_uart_write(struct sol_uart *uart, const unsigned char *tx, unsigned int length, void (*tx_cb)(void *data, struct sol_uart *uart, int status), const void *data)
+sol_uart_write(struct sol_uart *uart, const unsigned char *tx, unsigned int length, void (*tx_cb)(void *data, struct sol_uart *uart, unsigned char *tx, int status), const void *data)
 {
-    struct uart_write_data *write_data;
-
     SOL_NULL_CHECK(uart, false);
+    SOL_EXP_CHECK(uart->async.tx_fd_handler != NULL, false);
 
-    if (!uart->async.tx_fd_handler) {
-        uart->async.tx_fd_handler = sol_fd_add(uart->fd,
-            FD_ERROR_FLAGS | SOL_FD_FLAGS_OUT,
-            uart_tx_callback, uart);
-        SOL_NULL_CHECK(uart->async.tx_fd_handler, false);
-    }
+    uart->async.tx_fd_handler = sol_fd_add(uart->fd,
+        FD_ERROR_FLAGS | SOL_FD_FLAGS_OUT, uart_tx_callback, uart);
+    SOL_NULL_CHECK(uart->async.tx_fd_handler, false);
 
-    write_data = sol_vector_append(&uart->async.tx_queue);
-    SOL_NULL_CHECK_GOTO(write_data, append_write_data_fail);
-
-    write_data->buffer = malloc(length);
-    SOL_NULL_CHECK_GOTO(write_data->buffer, malloc_buffer_fail);
-
-    memcpy(write_data->buffer, tx, length);
-    write_data->cb = tx_cb;
-    write_data->user_data = data;
-    write_data->index = 0;
-    write_data->length = length;
+    uart->async.tx_buffer = tx;
+    uart->async.tx_cb = tx_cb;
+    uart->async.tx_user_data = data;
+    uart->async.tx_index = 0;
+    uart->async.tx_length = length;
 
     return true;
-
-malloc_buffer_fail:
-    sol_vector_del(&uart->async.tx_queue, uart->async.tx_queue.len - 1);
-append_write_data_fail:
-    sol_fd_del(uart->async.tx_fd_handler);
-    uart->async.tx_fd_handler = NULL;
-    return false;
 }

--- a/src/lib/io/sol-uart-linux.c
+++ b/src/lib/io/sol-uart-linux.c
@@ -48,16 +48,14 @@
 
 SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "uart");
 
-#define REG_SET(reg, reg_mask, value) reg = ((reg & ~reg_mask) | value)
-
 #define FD_ERROR_FLAGS (SOL_FD_FLAGS_ERR | SOL_FD_FLAGS_HUP | SOL_FD_FLAGS_NVAL)
 
 struct sol_uart {
     int fd;
     struct {
         void *rx_fd_handler;
-        void (*rx_cb)(struct sol_uart *uart, char read_char, void *data);
-        void *rx_user_data;
+        void (*rx_cb)(void *data, struct sol_uart *uart, unsigned char byte_read);
+        const void *rx_user_data;
 
         void *tx_fd_handler;
         struct sol_vector tx_queue;
@@ -65,22 +63,63 @@ struct sol_uart {
 };
 
 struct uart_write_data {
-    char *buffer;
+    unsigned char *buffer;
     unsigned int length;
     unsigned int index;
-    void (*cb)(struct sol_uart *uart, int write, void *data);
-    void *user_data;
+    void (*cb)(void *data, struct sol_uart *uart, int write);
+    const void *user_data;
 };
 
+static bool
+uart_rx_callback(void *data, int fd, unsigned int active_flags)
+{
+    struct sol_uart *uart = data;
+
+    if (!uart->async.rx_cb)
+        return true;
+
+    if (active_flags & FD_ERROR_FLAGS) {
+        SOL_ERR("Error flag was set on UART file descriptor %d.", fd);
+        return true;
+    }
+    if (active_flags & SOL_FD_FLAGS_IN) {
+        unsigned char buf[1];
+        int status = read(uart->fd, buf, sizeof(buf));
+        if (status > 0)
+            uart->async.rx_cb((void *)uart->async.rx_user_data, uart, buf[0]);
+    }
+    return true;
+}
+
 SOL_API struct sol_uart *
-sol_uart_open(const char *port_name)
+sol_uart_open(const char *port_name, const struct sol_uart_config *config)
 {
     struct sol_uart *uart;
     struct termios tty;
     char device[PATH_MAX];
     int r;
+    const speed_t baud_table[] = {
+        [SOL_UART_BAUD_RATE_9600] = B9600,
+        [SOL_UART_BAUD_RATE_19200] = B19200,
+        [SOL_UART_BAUD_RATE_38400] = B38400,
+        [SOL_UART_BAUD_RATE_57600] = B57600,
+        [SOL_UART_BAUD_RATE_115200] = B115200
+    };
+    const uint32_t data_bits_table[] = {
+        [SOL_UART_DATA_BITS_8] = CS8,
+        [SOL_UART_DATA_BITS_7] = CS7,
+        [SOL_UART_DATA_BITS_6] = CS6,
+        [SOL_UART_DATA_BITS_5] = CS5
+    };
 
     SOL_LOG_INTERNAL_INIT_ONCE;
+
+    if (unlikely(config->api_version != SOL_UART_CONFIG_API_VERSION)) {
+        SOL_WRN("Couldn't open UART that has unsupported version '%u', "
+            "expected version is '%u'",
+            config->api_version, SOL_UART_CONFIG_API_VERSION);
+        return NULL;
+    }
 
     SOL_NULL_CHECK(port_name, NULL);
 
@@ -97,17 +136,49 @@ sol_uart_open(const char *port_name)
     }
 
     memset(&tty, 0, sizeof(struct termios));
-    if (tcsetattr(uart->fd, TCSANOW, &tty) != 0) {
-        SOL_ERR("Unable to set default configuration of UART.");
-        goto tcsetattr_fail;
+
+    if (cfsetospeed(&tty, baud_table[config->baud_rate]) != 0)
+        goto fail;
+    if (cfsetispeed(&tty, B0) != 0)
+        goto fail;
+
+    tty.c_cflag |= data_bits_table[config->data_bits];
+
+    if (config->parity != SOL_UART_PARITY_NONE) {
+        tty.c_cflag |= PARENB;
+        tty.c_iflag |= INPCK;
+        if (config->parity == SOL_UART_PARITY_ODD)
+            tty.c_cflag |= PARODD;
     }
 
+    if (config->stop_bits == SOL_UART_STOP_BITS_TWO)
+        tty.c_cflag |= CSTOPB;
+
+    if (config->flow_control) {
+        tty.c_cflag |= CRTSCTS;
+        tty.c_iflag |= (IXON | IXOFF | IXANY);
+    }
+
+    if (tcsetattr(uart->fd, TCSANOW, &tty) != 0) {
+        SOL_ERR("Unable to set UART configuration.");
+        goto fail;
+    }
     tcflush(uart->fd, TCIOFLUSH);
+
     sol_vector_init(&uart->async.tx_queue, sizeof(struct uart_write_data));
+
+    uart->async.rx_fd_handler = sol_fd_add(uart->fd,
+        FD_ERROR_FLAGS | SOL_FD_FLAGS_IN, uart_rx_callback, uart);
+    if (!uart->async.rx_fd_handler) {
+        SOL_ERR("Unable to add file descriptor to watch UART.");
+        goto fail;
+    }
+    uart->async.rx_cb = config->rx_cb;
+    uart->async.rx_user_data = config->rx_cb_user_data;
 
     return uart;
 
-tcsetattr_fail:
+fail:
     close(uart->fd);
 open_fail:
     free(uart);
@@ -121,7 +192,7 @@ clean_tx_queue(struct sol_uart *uart, int error_code)
     uint16_t i;
 
     SOL_VECTOR_FOREACH_IDX (&uart->async.tx_queue, write_data, i) {
-        write_data->cb(uart, -1, write_data->user_data);
+        write_data->cb((void *)write_data->user_data, uart, -1);
         free(write_data->buffer);
     }
     sol_vector_clear(&uart->async.tx_queue);
@@ -140,278 +211,6 @@ sol_uart_close(struct sol_uart *uart)
     free(uart);
 }
 
-static speed_t
-uint_to_speed(uint32_t baud_rate)
-{
-    switch (baud_rate) {
-    case 230400:
-        return B230400;
-    case 115200:
-        return B115200;
-    case 57600:
-        return B57600;
-    case 38400:
-        return B38400;
-    case 19200:
-        return B19200;
-    case 9600:
-        return B9600;
-    case 4800:
-        return B4800;
-    case 2400:
-        return B2400;
-    case 1800:
-        return B1800;
-    default:
-    case 0:
-        return B0;
-    }
-}
-
-SOL_API bool
-sol_uart_set_baud_rate(struct sol_uart *uart, uint32_t baud_rate)
-{
-    struct termios tty;
-
-    SOL_NULL_CHECK(uart, false);
-
-    if (tcgetattr(uart->fd, &tty) != 0) {
-        SOL_ERR("Unable to get UART settings.");
-        return false;
-    }
-
-    if (cfsetospeed(&tty, uint_to_speed(baud_rate)) != 0)
-        goto error_setting_baud_rate;
-
-    if (cfsetispeed(&tty, B0) != 0)
-        goto error_setting_baud_rate;
-
-    if (tcsetattr(uart->fd, TCSANOW, &tty) != 0)
-        goto error_setting_baud_rate;
-
-    return true;
-
-error_setting_baud_rate:
-    SOL_ERR("Error setting baud rate.");
-    return false;
-}
-
-static uint32_t
-speed_to_uint(speed_t baud_rate)
-{
-    switch (baud_rate) {
-    case B230400:
-        return 230400;
-    case B115200:
-        return 115200;
-    case B57600:
-        return 57600;
-    case B38400:
-        return 38400;
-    case B19200:
-        return 19200;
-    case B9600:
-        return 9600;
-    case B4800:
-        return 4800;
-    case B2400:
-        return 2400;
-    case B1800:
-        return 1800;
-    default:
-    case B0:
-        return 0;
-    }
-}
-
-SOL_API uint32_t
-sol_uart_get_baud_rate(const struct sol_uart *uart)
-{
-    struct termios tty;
-
-    SOL_NULL_CHECK(uart, 0);
-
-    if (tcgetattr(uart->fd, &tty) != 0) {
-        SOL_ERR("Unable to get UART settings.");
-        return false;
-    }
-
-    return speed_to_uint(cfgetospeed(&tty));
-}
-
-SOL_API bool
-sol_uart_set_parity_bit(struct sol_uart *uart, bool enable, bool odd_paraty)
-{
-    struct termios tty;
-
-    SOL_NULL_CHECK(uart, false);
-
-    if (tcgetattr(uart->fd, &tty) != 0) {
-        SOL_ERR("Unable to get UART settings.");
-        return false;
-    }
-
-    REG_SET(tty.c_cflag, PARENB, enable ? PARENB : 0);
-    REG_SET(tty.c_iflag, INPCK, enable ? INPCK : 0);
-    REG_SET(tty.c_cflag, PARODD, odd_paraty ? PARODD : 0);
-
-    if (tcsetattr(uart->fd, TCSANOW, &tty) != 0) {
-        SOL_ERR("Error setting parity bit.");
-        return false;
-    }
-
-    return true;
-}
-
-static tcflag_t
-uart_get_control_flags(struct sol_uart *uart)
-{
-    struct termios tty;
-
-    if (tcgetattr(uart->fd, &tty) != 0) {
-        SOL_ERR("Unable to get UART settings.");
-        return 0;
-    }
-
-    return tty.c_cflag;
-}
-
-SOL_API bool
-sol_uart_get_parity_bit_enable(struct sol_uart *uart)
-{
-    SOL_NULL_CHECK(uart, false);
-    return uart_get_control_flags(uart) & PARENB;
-}
-
-SOL_API bool
-sol_uart_get_parity_bit_odd(struct sol_uart *uart)
-{
-    SOL_NULL_CHECK(uart, false);
-    return uart_get_control_flags(uart) & PARODD;
-}
-
-SOL_API bool
-sol_uart_set_data_bits_length(struct sol_uart *uart, uint8_t length)
-{
-    struct termios tty;
-    uint32_t reg_length_value = 0;
-
-    SOL_NULL_CHECK(uart, false);
-    SOL_INT_CHECK(length, < 5, false);
-    SOL_INT_CHECK(length, > 9, false);
-
-    if (tcgetattr(uart->fd, &tty) != 0) {
-        SOL_ERR("Unable to get UART settings.");
-        return false;
-    }
-
-    switch (length) {
-    case 5:
-        reg_length_value = CS5;
-        break;
-    case 6:
-        reg_length_value = CS6;
-        break;
-    case 7:
-        reg_length_value = CS7;
-        break;
-    case 8:
-        reg_length_value = CS8;
-    }
-
-    REG_SET(tty.c_cflag, CSIZE, reg_length_value);
-
-    if (tcsetattr(uart->fd, TCSANOW, &tty) != 0) {
-        SOL_ERR("Error setting data bit length.");
-        return false;
-    }
-
-    return true;
-}
-
-SOL_API uint8_t
-sol_uart_get_data_bits_length(struct sol_uart *uart)
-{
-    uint32_t reg_length_value;
-
-    SOL_NULL_CHECK(uart, false);
-
-    reg_length_value = uart_get_control_flags(uart) & CSIZE;
-    switch (reg_length_value) {
-    case CS5:
-        return 5;
-    case CS6:
-        return 6;
-    case CS7:
-        return 7;
-    case CS8:
-        return 8;
-    default:
-        return 0;
-    }
-}
-
-SOL_API bool
-sol_uart_set_stop_bits_length(struct sol_uart *uart, bool two_bits)
-{
-    struct termios tty;
-
-    SOL_NULL_CHECK(uart, false);
-
-    if (tcgetattr(uart->fd, &tty) != 0) {
-        SOL_ERR("Unable to get UART settings.");
-        return false;
-    }
-
-    REG_SET(tty.c_cflag, CSTOPB, two_bits ? CSTOPB : 0);
-
-    if (tcsetattr(uart->fd, TCSANOW, &tty) != 0) {
-        SOL_ERR("Error setting stop bit length.");
-        return false;
-    }
-
-    return true;
-}
-
-SOL_API uint8_t
-sol_uart_get_stop_bits_length(struct sol_uart *uart)
-{
-    SOL_NULL_CHECK(uart, false);
-    return uart_get_control_flags(uart) & CSTOPB ? 2 : 1;
-}
-
-SOL_API bool
-sol_uart_set_flow_control(struct sol_uart *uart, bool enable)
-{
-    struct termios tty;
-
-    SOL_NULL_CHECK(uart, false);
-
-    if (tcgetattr(uart->fd, &tty) != 0) {
-        SOL_ERR("Unable to get UART settings.");
-        return false;
-    }
-
-    REG_SET(tty.c_cflag, CRTSCTS, enable ? CRTSCTS : 0);
-    REG_SET(tty.c_iflag, (IXON | IXOFF | IXANY),
-        enable ? (IXON | IXOFF | IXANY) : 0);
-
-    if (tcsetattr(uart->fd, TCSANOW, &tty) != 0) {
-        SOL_ERR("Error setting flow control.");
-        return false;
-    }
-
-    return true;
-}
-
-SOL_API bool
-sol_uart_get_flow_control(struct sol_uart *uart)
-{
-    SOL_NULL_CHECK(uart, false);
-
-    return uart_get_control_flags(uart) & CRTSCTS;
-}
-
 static bool
 uart_tx_callback(void *data, int fd, unsigned int active_flags)
 {
@@ -420,13 +219,13 @@ uart_tx_callback(void *data, int fd, unsigned int active_flags)
     int ret;
 
     if (active_flags & FD_ERROR_FLAGS) {
-        SOL_ERR("Some error flag was set on UART file descriptor %d.", fd);
+        SOL_ERR("Error flag was set on UART file descriptor %d.", fd);
         goto error;
     }
 
     if (write_data->index == write_data->length) {
         free(write_data->buffer);
-        write_data->cb(uart, write_data->index, write_data->user_data);
+        write_data->cb((void *)write_data->user_data, uart, write_data->index);
         sol_vector_del(&uart->async.tx_queue, 0);
 
         if (!uart->async.tx_queue.len) {
@@ -441,7 +240,7 @@ uart_tx_callback(void *data, int fd, unsigned int active_flags)
         write_data->length - write_data->index);
     if (ret < 0) {
         SOL_ERR("Error when writing to file descriptor %d.", fd);
-        write_data->cb(uart, ret, write_data->user_data);
+        write_data->cb((void *)write_data->user_data, uart, ret);
         free(write_data->buffer);
         sol_vector_del(&uart->async.tx_queue, 0);
         goto error;
@@ -456,7 +255,7 @@ error:
 }
 
 SOL_API bool
-sol_uart_write(struct sol_uart *uart, const char *tx, unsigned int length, void (*tx_cb)(struct sol_uart *uart, int status, void *data), const void *data)
+sol_uart_write(struct sol_uart *uart, const unsigned char *tx, unsigned int length, void (*tx_cb)(void *data, struct sol_uart *uart, int status), const void *data)
 {
     struct uart_write_data *write_data;
 
@@ -477,7 +276,7 @@ sol_uart_write(struct sol_uart *uart, const char *tx, unsigned int length, void 
 
     memcpy(write_data->buffer, tx, length);
     write_data->cb = tx_cb;
-    write_data->user_data = (void *)data;
+    write_data->user_data = data;
     write_data->index = 0;
     write_data->length = length;
 
@@ -489,47 +288,4 @@ append_write_data_fail:
     sol_fd_del(uart->async.tx_fd_handler);
     uart->async.tx_fd_handler = NULL;
     return false;
-}
-
-static bool
-uart_rx_callback(void *data, int fd, unsigned int active_flags)
-{
-    struct sol_uart *uart = data;
-
-    if (active_flags & FD_ERROR_FLAGS) {
-        SOL_ERR("Some error flag was set on UART file descriptor %d.", fd);
-        return true;
-    }
-    if (active_flags & SOL_FD_FLAGS_IN) {
-        char buf[1];
-        int status = read(uart->fd, buf, sizeof(buf));
-        if (status > 0)
-            uart->async.rx_cb(uart, buf[0], uart->async.rx_user_data);
-    }
-    return true;
-}
-
-SOL_API bool
-sol_uart_set_rx_callback(struct sol_uart *uart, void (*rx_cb)(struct sol_uart *uart, char read_char, void *data), const void *data)
-{
-    SOL_NULL_CHECK(uart, false);
-    SOL_EXP_CHECK(uart->async.rx_fd_handler != NULL, false);
-
-    uart->async.rx_fd_handler = sol_fd_add(uart->fd,
-        FD_ERROR_FLAGS | SOL_FD_FLAGS_IN,
-        uart_rx_callback, uart);
-    SOL_NULL_CHECK(uart->async.rx_fd_handler, false);
-    uart->async.rx_cb = rx_cb;
-    uart->async.rx_user_data = (void *)data;
-    return true;
-}
-
-SOL_API void
-sol_uart_del_rx_callback(struct sol_uart *uart)
-{
-    SOL_NULL_CHECK(uart);
-    SOL_NULL_CHECK(uart->async.rx_fd_handler);
-
-    sol_fd_del(uart->async.rx_fd_handler);
-    uart->async.rx_fd_handler = NULL;
 }

--- a/src/lib/io/sol-uart-riot.c
+++ b/src/lib/io/sol-uart-riot.c
@@ -48,23 +48,22 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "uart");
 
 struct sol_uart {
     uart_t id;
-    uint32_t baud_rate;
     struct {
         void *handler;
 
-        void (*rx_cb)(struct sol_uart *uart, char read_char, void *data);
-        void *rx_user_data;
+        void (*rx_cb)(void *data, struct sol_uart *uart, unsigned char byte_read);
+        const void *rx_user_data;
 
         struct sol_vector tx_queue;
     } async;
 };
 
 struct uart_write_data {
-    char *buffer;
+    unsigned char *buffer;
     unsigned int length;
     unsigned int index;
-    void (*cb)(struct sol_uart *uart, int write, void *data);
-    void *user_data;
+    void (*cb)(void *data, struct sol_uart *uart, int write);
+    const void *user_data;
     struct sol_uart *uart;
 };
 
@@ -75,14 +74,15 @@ uart_rx_cb(void *arg, char data)
 
     if (!uart->async.rx_cb)
         return;
-    uart->async.rx_cb(uart, data, uart->async.rx_user_data);
+    uart->async.rx_cb((void *)uart->async.rx_user_data, uart,
+        (unsigned char)data);
 }
 
 static void
 uart_dispatch_write_data(struct uart_write_data *write_data, int write)
 {
     free(write_data->buffer);
-    write_data->cb(write_data->uart, write, write_data->user_data);
+    write_data->cb((void *)write_data->user_data, write_data->uart, write);
 }
 
 static int
@@ -95,7 +95,8 @@ uart_tx_cb(void *arg)
     if (!write_data)
         return 0;
 
-    if (uart_write(uart->id, write_data->buffer[write_data->index]) == -1) {
+    if (uart_write(uart->id, (char)write_data->buffer[write_data->index])
+        == -1) {
         uint16_t i;
 
         SOL_ERR("Error when writing to UART %d.", uart->id);
@@ -119,24 +120,32 @@ uart_tx_cb(void *arg)
     return 1;
 }
 
-static bool
-uart_setup(struct sol_uart *uart)
-{
-    if (uart->async.handler) {
-        sol_interrupt_scheduler_uart_stop(uart->id, uart->async.handler);
-        uart->async.handler = NULL;
-    }
-    return sol_interrupt_scheduler_uart_init_int(uart->id, uart->baud_rate,
-        uart_rx_cb, uart_tx_cb,
-        uart, &uart->async.handler) == 0;
-}
-
 SOL_API struct sol_uart *
-sol_uart_open(const char *port_name)
+sol_uart_open(const char *port_name, const struct sol_uart_config *config)
 {
     struct sol_uart *uart;
+    const unsigned int baud_rata_table[] = {
+        [SOL_UART_BAUD_RATE_9600] = 9600,
+        [SOL_UART_BAUD_RATE_19200] = 19200,
+        [SOL_UART_BAUD_RATE_38400] = 38400,
+        [SOL_UART_BAUD_RATE_57600] = 57600,
+        [SOL_UART_BAUD_RATE_115200] = 115200
+    };
+    int ret;
 
     SOL_LOG_INTERNAL_INIT_ONCE;
+
+    if (unlikely(config->api_version != SOL_UART_CONFIG_API_VERSION)) {
+        SOL_WRN("Couldn't open UART that has unsupported version '%u', "
+            "expected version is '%u'",
+            config->api_version, SOL_UART_CONFIG_API_VERSION);
+        return NULL;
+    }
+
+    SOL_EXP_CHECK(config->parity != SOL_UART_PARITY_NONE, NULL);
+    SOL_EXP_CHECK(config->data_bits != SOL_UART_DATA_BITS_8, NULL);
+    SOL_EXP_CHECK(config->stop_bits != SOL_UART_STOP_BITS_ONE, NULL);
+    SOL_EXP_CHECK(config->flow_control, NULL);
 
     SOL_NULL_CHECK(port_name, NULL);
     uart = calloc(1, sizeof(struct sol_uart));
@@ -144,10 +153,19 @@ sol_uart_open(const char *port_name)
 
     uart->id = strtol(port_name, NULL, 10);
     uart_poweron(uart->id);
-    uart->baud_rate = 9600;
-    uart_setup(uart);
+    ret = sol_interrupt_scheduler_uart_init_int(uart->id,
+        baud_rata_table[config->baud_rate], uart_rx_cb, uart_tx_cb, uart,
+        &uart->async.handler);
+    SOL_INT_CHECK_GOTO(ret, != 0, fail);
+
+    uart->async.rx_cb = config->rx_cb;
+    uart->async.rx_user_data = config->rx_cb_user_data;
     sol_vector_init(&uart->async.tx_queue, sizeof(struct uart_write_data));
     return uart;
+
+fail:
+    free(uart);
+    return NULL;
 }
 
 SOL_API void
@@ -163,7 +181,7 @@ sol_uart_close(struct sol_uart *uart)
 
     SOL_VECTOR_FOREACH_IDX (&uart->async.tx_queue, write_data, i) {
         free(write_data->buffer);
-        write_data->cb(uart, -1, write_data->user_data);
+        write_data->cb((void *)write_data->user_data, uart, -1);
     }
     sol_vector_clear(&uart->async.tx_queue);
 
@@ -171,86 +189,7 @@ sol_uart_close(struct sol_uart *uart)
 }
 
 SOL_API bool
-sol_uart_set_baud_rate(struct sol_uart *uart, uint32_t baud_rate)
-{
-    SOL_NULL_CHECK(uart, false);
-    uart->baud_rate = baud_rate;
-    return uart_setup(uart);
-}
-
-SOL_API uint32_t
-sol_uart_get_baud_rate(const struct sol_uart *uart)
-{
-    SOL_NULL_CHECK(uart, 0);
-    return uart->baud_rate;
-}
-
-SOL_API bool
-sol_uart_set_parity_bit(struct sol_uart *uart, bool enable, bool odd_paraty)
-{
-    SOL_NULL_CHECK(uart, false);
-    return !enable;
-}
-
-SOL_API bool
-sol_uart_get_parity_bit_enable(struct sol_uart *uart)
-{
-    SOL_NULL_CHECK(uart, false);
-    return false;
-}
-
-
-SOL_API bool
-sol_uart_get_parity_bit_odd(struct sol_uart *uart)
-{
-    SOL_NULL_CHECK(uart, false);
-    return false;
-}
-
-SOL_API bool
-sol_uart_set_data_bits_length(struct sol_uart *uart, uint8_t length)
-{
-    SOL_NULL_CHECK(uart, false);
-    return length == 8;
-}
-
-SOL_API uint8_t
-sol_uart_get_data_bits_length(struct sol_uart *uart)
-{
-    SOL_NULL_CHECK(uart, 0);
-    return 8;
-}
-
-SOL_API bool
-sol_uart_set_stop_bits_length(struct sol_uart *uart, bool two_bits)
-{
-    SOL_NULL_CHECK(uart, false);
-    return !two_bits;
-}
-
-SOL_API uint8_t
-sol_uart_get_stop_bits_length(struct sol_uart *uart)
-{
-    SOL_NULL_CHECK(uart, 0);
-    return 1;
-}
-
-SOL_API bool
-sol_uart_set_flow_control(struct sol_uart *uart, bool enable)
-{
-    SOL_NULL_CHECK(uart, false);
-    return !enable;
-}
-
-SOL_API bool
-sol_uart_get_flow_control(struct sol_uart *uart)
-{
-    SOL_NULL_CHECK(uart, false);
-    return false;
-}
-
-SOL_API bool
-sol_uart_write(struct sol_uart *uart, const char *tx, unsigned int length, void (*tx_cb)(struct sol_uart *uart, int status, void *data), const void *data)
+sol_uart_write(struct sol_uart *uart, const unsigned char *tx, unsigned int length, void (*tx_cb)(void *data, struct sol_uart *uart, int status), const void *data)
 {
     struct uart_write_data *write_data;
 
@@ -264,7 +203,7 @@ sol_uart_write(struct sol_uart *uart, const char *tx, unsigned int length, void 
 
     memcpy(write_data->buffer, tx, length);
     write_data->cb = tx_cb;
-    write_data->user_data = (void *)data;
+    write_data->user_data = data;
     write_data->index = 0;
     write_data->length = length;
     write_data->uart = uart;
@@ -277,25 +216,4 @@ sol_uart_write(struct sol_uart *uart, const char *tx, unsigned int length, void 
 malloc_buffer_fail:
     sol_vector_del(&uart->async.tx_queue, uart->async.tx_queue.len - 1);
     return false;
-}
-
-SOL_API bool
-sol_uart_set_rx_callback(struct sol_uart *uart, void (*rx_cb)(struct sol_uart *uart, char read_char, void *data), const void *data)
-{
-    SOL_NULL_CHECK(uart, false);
-    SOL_EXP_CHECK(uart->async.rx_cb != NULL, false);
-
-    uart->async.rx_cb = rx_cb;
-    uart->async.rx_user_data = (void *)data;
-    return true;
-}
-
-SOL_API void
-sol_uart_del_rx_callback(struct sol_uart *uart)
-{
-    SOL_NULL_CHECK(uart);
-    SOL_NULL_CHECK(uart->async.rx_cb);
-
-    uart->async.rx_cb = NULL;
-    uart->async.rx_user_data = NULL;
 }

--- a/src/lib/io/sol-uart-riot.c
+++ b/src/lib/io/sol-uart-riot.c
@@ -41,7 +41,6 @@
 #include "sol-uart.h"
 #include "sol-mainloop.h"
 #include "sol-util.h"
-#include "sol-vector.h"
 #include "sol-interrupt_scheduler_riot.h"
 
 SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "uart");
@@ -54,17 +53,11 @@ struct sol_uart {
         void (*rx_cb)(void *data, struct sol_uart *uart, unsigned char byte_read);
         const void *rx_user_data;
 
-        struct sol_vector tx_queue;
+        void (*tx_cb)(void *data, struct sol_uart *uart, unsigned char *tx, int status);
+        const void *tx_user_data;
+        const unsigned char *tx_buffer;
+        unsigned int tx_length, tx_index;
     } async;
-};
-
-struct uart_write_data {
-    unsigned char *buffer;
-    unsigned int length;
-    unsigned int index;
-    void (*cb)(void *data, struct sol_uart *uart, int write);
-    const void *user_data;
-    struct sol_uart *uart;
 };
 
 static void
@@ -79,42 +72,33 @@ uart_rx_cb(void *arg, char data)
 }
 
 static void
-uart_dispatch_write_data(struct uart_write_data *write_data, int write)
+uart_tx_dispatch(struct sol_uart *uart, int status)
 {
-    free(write_data->buffer);
-    write_data->cb((void *)write_data->user_data, write_data->uart, write);
+    unsigned char *tx = (unsigned char *)uart->async.tx_buffer;
+
+    uart->async.tx_buffer = NULL;
+    if (!uart->async.tx_cb)
+        return;
+    uart->async.tx_cb((void *)uart->async.tx_user_data, uart, tx, -1);
 }
 
 static int
 uart_tx_cb(void *arg)
 {
     struct sol_uart *uart = arg;
-    struct uart_write_data *write_data;
 
-    write_data = sol_vector_get(&uart->async.tx_queue, 0);
-    if (!write_data)
-        return 0;
-
-    if (uart_write(uart->id, (char)write_data->buffer[write_data->index])
+    if (uart_write(uart->id, (char)uart->async.tx_buffer[uart->async.tx_index])
         == -1) {
-        uint16_t i;
-
         SOL_ERR("Error when writing to UART %d.", uart->id);
-
-        SOL_VECTOR_FOREACH_IDX (&uart->async.tx_queue, write_data, i)
-            uart_dispatch_write_data(write_data, -1);
-        sol_vector_clear(&uart->async.tx_queue);
-
-        return 0;
+        uart_tx_dispatch(uart, -1);
+        return uart->async.tx_buffer != NULL;
     }
 
-    write_data->index++;
+    uart->async.tx_index++;
 
-    if (write_data->index == write_data->length) {
-        uart_dispatch_write_data(write_data, write_data->index);
-        sol_vector_del(&uart->async.tx_queue, 0);
-
-        return !!uart->async.tx_queue.len;
+    if (uart->async.tx_index == uart->async.tx_length) {
+        uart_tx_dispatch(uart, uart->async.tx_index);
+        return uart->async.tx_buffer != NULL;
     }
 
     return 1;
@@ -160,7 +144,7 @@ sol_uart_open(const char *port_name, const struct sol_uart_config *config)
 
     uart->async.rx_cb = config->rx_cb;
     uart->async.rx_user_data = config->rx_cb_user_data;
-    sol_vector_init(&uart->async.tx_queue, sizeof(struct uart_write_data));
+    uart->async.tx_buffer = NULL;
     return uart;
 
 fail:
@@ -171,49 +155,31 @@ fail:
 SOL_API void
 sol_uart_close(struct sol_uart *uart)
 {
-    struct uart_write_data *write_data;
-    uint16_t i;
-
     SOL_NULL_CHECK(uart);
+
+    if (uart->async.tx_buffer)
+        uart_tx_dispatch(uart, -1);
+
     if (uart->async.handler)
         sol_interrupt_scheduler_uart_stop(uart->id, uart->async.handler);
     uart_poweroff(uart->id);
-
-    SOL_VECTOR_FOREACH_IDX (&uart->async.tx_queue, write_data, i) {
-        free(write_data->buffer);
-        write_data->cb((void *)write_data->user_data, uart, -1);
-    }
-    sol_vector_clear(&uart->async.tx_queue);
 
     free(uart);
 }
 
 SOL_API bool
-sol_uart_write(struct sol_uart *uart, const unsigned char *tx, unsigned int length, void (*tx_cb)(void *data, struct sol_uart *uart, int status), const void *data)
+sol_uart_write(struct sol_uart *uart, const unsigned char *tx, unsigned int length, void (*tx_cb)(void *data, struct sol_uart *uart, unsigned char *tx, int status), const void *data)
 {
-    struct uart_write_data *write_data;
-
     SOL_NULL_CHECK(uart, false);
+    SOL_EXP_CHECK(uart->async.tx_buffer, false);
 
-    write_data = sol_vector_append(&uart->async.tx_queue);
-    SOL_NULL_CHECK(write_data, false);
+    uart->async.tx_buffer = tx;
+    uart->async.tx_cb = tx_cb;
+    uart->async.tx_user_data = data;
+    uart->async.tx_index = 0;
+    uart->async.tx_length = length;
 
-    write_data->buffer = malloc(length);
-    SOL_NULL_CHECK_GOTO(write_data->buffer, malloc_buffer_fail);
-
-    memcpy(write_data->buffer, tx, length);
-    write_data->cb = tx_cb;
-    write_data->user_data = data;
-    write_data->index = 0;
-    write_data->length = length;
-    write_data->uart = uart;
-
-    if (uart->async.tx_queue.len == 1)
-        uart_tx_begin(uart->id);
+    uart_tx_begin(uart->id);
 
     return true;
-
-malloc_buffer_fail:
-    sol_vector_del(&uart->async.tx_queue, uart->async.tx_queue.len - 1);
-    return false;
 }

--- a/src/modules/flow/piezo-speaker/piezo-speaker.c
+++ b/src/modules/flow/piezo-speaker/piezo-speaker.c
@@ -44,7 +44,6 @@
 #include "sol-pwm.h"
 #include "sol-str-table.h"
 #include "sol-util.h"
-#include "sol-worker-thread.h"
 
 static bool be_quiet(void *data);
 

--- a/src/samples/common/uart.c
+++ b/src/samples/common/uart.c
@@ -35,67 +35,46 @@
 #include "sol-mainloop.h"
 #include "sol-uart.h"
 
-static void
-string_received(void)
-{
-    static unsigned string_receveid = 0;
+struct uart_data {
+    unsigned int id;
+    char rx_buffer[8];
+    unsigned int rx_index;
+};
 
-    string_receveid++;
-    if (string_receveid > 2) {
-        sol_quit();
+static void
+uart_rx(void *data, struct sol_uart *uart, unsigned char read_char)
+{
+    struct uart_data *uart_data = data;
+    static unsigned char missing_strings = 3;
+
+    uart_data->rx_buffer[uart_data->rx_index] = (char)read_char;
+    if (read_char == 0) {
+        uart_data->rx_index = 0;
+        printf("Data received on UART%d: %s\n",
+            uart_data->id, uart_data->rx_buffer);
+        missing_strings--;
+        if (missing_strings == 0)
+            sol_quit();
+    } else
+        uart_data->rx_index++;
+}
+
+static void
+uart_tx(void *data, struct sol_uart *uart, unsigned char *tx, int status)
+{
+    static bool missing_tx = true;
+    struct uart_data *uart_data = data;
+
+    if (status > 0)
+        printf("UART%d data transmitted.\n", uart_data->id);
+    else
+        printf("UART%d transmission error.\n", uart_data->id);
+
+    if (missing_tx) {
+        missing_tx = false;
+        sprintf((char *)tx, "async");
+        sol_uart_write(uart, tx, strlen((char *)tx) + 1, uart_tx, uart_data);
     }
-}
-
-static void
-uart1_rx(void *data, struct sol_uart *uart, unsigned char read_char)
-{
-    static int index = 0;
-    static char string[64];
-
-    string[index] = (char)read_char;
-    if (string[index] == 0) {
-        printf("Async transmission received on uart1: %s\n", string);
-        string_received();
-        index = 0;
-    } else {
-        index++;
-    }
-}
-
-static void
-uart2_rx(void *data, struct sol_uart *uart, unsigned char read_char)
-{
-    static int index = 0;
-    static char string[64];
-
-    string[index] = (char)read_char;
-    if (string[index] == 0) {
-        printf("Async transmission received on uart2: %s\n", string);
-        string_received();
-        index = 0;
-    } else {
-        index++;
-    }
-}
-
-static void
-uart_tx_completed(void *data, struct sol_uart *uart, unsigned char *tx, int status)
-{
-    const char *string = data;
-
-    printf("%s\n", string);
-}
-
-static void
-uart1_tx_completed(void *data, struct sol_uart *uart, unsigned char *tx, int status)
-{
-    const char *string = data;
-
-    printf("%s\n", string);
-
-    sprintf((char *)tx, "async");
-    sol_uart_write(uart, tx, strlen((char *)tx) + 1,
-        uart_tx_completed, "Uart1 transmission completed.");
 }
 
 int
@@ -104,6 +83,7 @@ main(int argc, char *argv[])
     struct sol_uart *uart1, *uart2;
     struct sol_uart_config config;
     char uart1_buffer[8], uart2_buffer[8];
+    struct uart_data uart1_data, uart2_data;
 
     sol_init();
 
@@ -113,30 +93,32 @@ main(int argc, char *argv[])
     config.parity = SOL_UART_PARITY_NONE;
     config.stop_bits = SOL_UART_STOP_BITS_ONE;
     config.flow_control = false;
-    config.rx_cb = uart1_rx;
-    config.rx_cb_user_data = NULL;
+    config.rx_cb = uart_rx;
+    config.rx_cb_user_data = &uart1_data;
     uart1 = sol_uart_open("ttyUSB0", &config);
     if (!uart1) {
         printf("Unable to get uart1.\n");
         goto error_uart1;
     }
+    uart1_data.id = 1;
+    uart1_data.rx_index = 0;
 
-    config.rx_cb = uart2_rx;
+    config.rx_cb_user_data = &uart2_data;
     uart2 = sol_uart_open("ttyUSB1", &config);
     if (!uart2) {
         printf("Unable to get uart2.\n");
         goto error;
     }
+    uart2_data.id = 2;
+    uart2_data.rx_index = 0;
 
     sprintf(uart1_buffer, "Hello");
     sol_uart_write(uart1, (unsigned char *)uart1_buffer,
-        strlen(uart1_buffer) + 1, uart1_tx_completed,
-        "Uart1 transmission completed.");
+        strlen(uart1_buffer) + 1, uart_tx, &uart1_data);
 
     sprintf(uart2_buffer, "world");
     sol_uart_write(uart2, (unsigned char *)uart2_buffer,
-        strlen(uart2_buffer) + 1, uart_tx_completed,
-        "Uart2 transmission completed.");
+        strlen(uart2_buffer) + 1, uart_tx, &uart2_data);
 
     sol_run();
 

--- a/src/samples/common/uart.c
+++ b/src/samples/common/uart.c
@@ -79,11 +79,23 @@ uart2_rx(void *data, struct sol_uart *uart, unsigned char read_char)
 }
 
 static void
-uart_tx_completed(void *data, struct sol_uart *uart, int status)
+uart_tx_completed(void *data, struct sol_uart *uart, unsigned char *tx, int status)
 {
     const char *string = data;
 
     printf("%s\n", string);
+}
+
+static void
+uart1_tx_completed(void *data, struct sol_uart *uart, unsigned char *tx, int status)
+{
+    const char *string = data;
+
+    printf("%s\n", string);
+
+    sprintf((char *)tx, "async");
+    sol_uart_write(uart, tx, strlen((char *)tx) + 1,
+        uart_tx_completed, "Uart1 transmission completed.");
 }
 
 int
@@ -91,7 +103,7 @@ main(int argc, char *argv[])
 {
     struct sol_uart *uart1, *uart2;
     struct sol_uart_config config;
-    char buf[64];
+    char uart1_buffer[8], uart2_buffer[8];
 
     sol_init();
 
@@ -116,17 +128,15 @@ main(int argc, char *argv[])
         goto error;
     }
 
-    sprintf(buf, "Hello");
-    sol_uart_write(uart1, (unsigned char *)buf, strlen(buf) + 1,
-        uart_tx_completed, "Uart1 transmission completed.");
+    sprintf(uart1_buffer, "Hello");
+    sol_uart_write(uart1, (unsigned char *)uart1_buffer,
+        strlen(uart1_buffer) + 1, uart1_tx_completed,
+        "Uart1 transmission completed.");
 
-    sprintf(buf, "async");
-    sol_uart_write(uart1, (unsigned char *)buf, strlen(buf) + 1,
-        uart_tx_completed, "Uart1 transmission completed.");
-
-    sprintf(buf, "world");
-    sol_uart_write(uart2, (unsigned char *)buf, strlen(buf) + 1,
-        uart_tx_completed, "Uart2 transmission completed.");
+    sprintf(uart2_buffer, "world");
+    sol_uart_write(uart2, (unsigned char *)uart2_buffer,
+        strlen(uart2_buffer) + 1, uart_tx_completed,
+        "Uart2 transmission completed.");
 
     sol_run();
 


### PR DESCRIPTION
Changes from V3:
- Added documentation to all UART functions
- Squashed 'UART: Fix callback parameter order' into 'UART: Simplify API'
- Changed tx buffer and received byte to unsigned char, as it is not necessary a character.
- Making user responsible to handle tx buffer allocation.