### PR TITLE
SPI refactor V2

### DIFF
--- a/src/lib/io/include/sol-spi.h
+++ b/src/lib/io/include/sol-spi.h
@@ -71,18 +71,26 @@ struct sol_spi_config {
 };
 
 /**
- * Perform a SPI transfer.
+ * Perform a SPI asynchronous transfer.
  *
  * @param spi The SPI bus handle
  * @param tx The output buffer
  * @param rx The input buffer
  * @param count number of bytes to be transfer
- * @return true if transfer was completed with success.
+ * @param transfer_cb callback to be called when transmission finish,
+ * in case of success the status parameters on callback should be the same
+ * value as count, otherwise a error happen.
+ * @param cb_data user data, first parameter of transfer_cb
+ * @return true if transfer was started.
  *
  * As SPI works in full-duplex, data are going in and out
  * at same time, so both buffers must have the count size.
+ * Caller should guarantee that both buffers will not be
+ * freed until callback is called.
+ * Also there is no transfer queue, calling this function when there is
+ * transfer happening would return false.
  */
-bool sol_spi_transfer(const struct sol_spi *spi, const uint8_t *tx, uint8_t *rx, size_t count);
+bool sol_spi_transfer(struct sol_spi *spi, const uint8_t *tx, uint8_t *rx, size_t count, void (*transfer_cb)(void *cb_data, struct sol_spi *spi, const uint8_t *tx, uint8_t *rx, ssize_t status), const void *cb_data);
 
 /**
  * Close an SPI bus.

--- a/src/lib/io/include/sol-spi.h
+++ b/src/lib/io/include/sol-spi.h
@@ -65,7 +65,6 @@ int32_t sol_spi_get_max_speed(const struct sol_spi *spi);
 bool sol_spi_set_max_speed(struct sol_spi *spi, uint32_t speed);
 
 bool sol_spi_transfer(const struct sol_spi *spi, uint8_t *tx, uint8_t *rx, size_t count);
-bool sol_spi_raw_transfer(const struct sol_spi *spi, void *tr, size_t count);
 
 void sol_spi_close(struct sol_spi *spi);
 struct sol_spi *sol_spi_open(unsigned int bus, unsigned int chip_select);

--- a/src/lib/io/include/sol-spi.h
+++ b/src/lib/io/include/sol-spi.h
@@ -52,22 +52,53 @@ extern "C" {
 
 struct sol_spi;
 
-int32_t sol_spi_get_transfer_mode(const struct sol_spi *spi);
-bool sol_spi_set_transfer_mode(struct sol_spi *spi, uint32_t mode);
+enum sol_spi_mode {
+    SOL_SPI_MODE_0 = 0, /** CPOL = 0 and CPHA = 0 */
+    SOL_SPI_MODE_1, /** CPOL = 0 and CPHA = 1 */
+    SOL_SPI_MODE_2, /** CPOL = 1 and CPHA = 0 */
+    SOL_SPI_MODE_3 /** CPOL = 1 and CPHA = 1 */
+};
 
-int8_t sol_spi_get_bit_justification(const struct sol_spi *spi);
-bool sol_spi_set_bit_justification(struct sol_spi *spi, uint8_t justification);
+#define SOL_SPI_DATA_BITS_DEFAULT 8
 
-int8_t sol_spi_get_bits_per_word(const struct sol_spi *spi);
-bool sol_spi_set_bits_per_word(struct sol_spi *spi, uint8_t bits_per_word);
+struct sol_spi_config {
+#define SOL_SPI_CONFIG_API_VERSION (1)
+    uint16_t api_version;
+    unsigned int chip_select; /** Also know as slave select */
+    enum sol_spi_mode mode;
+    uint32_t frequency; /** Clock frequency in Hz */
+    uint8_t bits_per_word;
+};
 
-int32_t sol_spi_get_max_speed(const struct sol_spi *spi);
-bool sol_spi_set_max_speed(struct sol_spi *spi, uint32_t speed);
+/**
+ * Perform a SPI transfer.
+ *
+ * @param spi The SPI bus handle
+ * @param tx The output buffer
+ * @param rx The input buffer
+ * @param count number of bytes to be transfer
+ * @return true if transfer was completed with success.
+ *
+ * As SPI works in full-duplex, data are going in and out
+ * at same time, so both buffers must have the count size.
+ */
+bool sol_spi_transfer(const struct sol_spi *spi, const uint8_t *tx, uint8_t *rx, size_t count);
 
-bool sol_spi_transfer(const struct sol_spi *spi, uint8_t *tx, uint8_t *rx, size_t count);
-
+/**
+ * Close an SPI bus.
+ *
+ * @param spi The SPI bus handle
+ */
 void sol_spi_close(struct sol_spi *spi);
-struct sol_spi *sol_spi_open(unsigned int bus, unsigned int chip_select);
+
+/**
+ * Open an SPI bus.
+ *
+ * @param bus The SPI bus number to open
+ * @param config The SPI bus configuration
+ * @return A new SPI bus handle
+ */
+struct sol_spi *sol_spi_open(unsigned int bus, const struct sol_spi_config *config);
 
 /**
  * @}

--- a/src/lib/io/sol-spi-linux.c
+++ b/src/lib/io/sol-spi-linux.c
@@ -184,23 +184,6 @@ sol_spi_transfer(const struct sol_spi *spi, uint8_t *tx, uint8_t *rx, size_t siz
     return true;
 }
 
-SOL_API bool
-sol_spi_raw_transfer(const struct sol_spi *spi, void *tr, size_t count)
-{
-    struct spi_ioc_transfer *_tr = (struct spi_ioc_transfer *)tr;
-
-    SOL_NULL_CHECK(spi, false);
-    SOL_NULL_CHECK(tr, false);
-    SOL_INT_CHECK(count, == 0, false);
-
-    if (ioctl(spi->fd, SPI_IOC_MESSAGE(count), _tr) == -1) {
-        SOL_WRN("%u,%u: Unable to perform SPI transfer", spi->bus, spi->chip_select);
-        return false;
-    }
-
-    return true;
-}
-
 SOL_API void
 sol_spi_close(struct sol_spi *spi)
 {

--- a/src/lib/io/sol-spi-linux.c
+++ b/src/lib/io/sol-spi-linux.c
@@ -57,107 +57,8 @@ struct sol_spi {
     uint8_t bits_per_word;
 };
 
-SOL_API int32_t
-sol_spi_get_transfer_mode(const struct sol_spi *spi)
-{
-    uint32_t mode;
-
-    SOL_NULL_CHECK(spi, -EINVAL);
-
-    if (ioctl(spi->fd, SPI_IOC_RD_MODE, &mode) == -1) {
-        SOL_WRN("%u,%u: Unable to read SPI mode", spi->bus, spi->chip_select);
-        return -errno;
-    }
-
-    return mode;
-}
-
 SOL_API bool
-sol_spi_set_transfer_mode(struct sol_spi *spi, uint32_t mode)
-{
-    SOL_NULL_CHECK(spi, false);
-
-    if (ioctl(spi->fd, SPI_IOC_WR_MODE, &mode) == -1) {
-        SOL_WRN("%u,%u: Unable to write SPI mode", spi->bus, spi->chip_select);
-        return false;
-    }
-
-    return true;
-}
-
-SOL_API int8_t
-sol_spi_get_bit_justification(const struct sol_spi *spi)
-{
-    uint8_t justification;
-
-    SOL_NULL_CHECK(spi, -EINVAL);
-
-    if (ioctl(spi->fd, SPI_IOC_RD_LSB_FIRST, &justification) == -1) {
-        SOL_WRN("%u,%u: Unable to read SPI bit justification", spi->bus, spi->chip_select);
-        return -errno;
-    }
-
-    return justification;
-}
-
-SOL_API bool
-sol_spi_set_bit_justification(struct sol_spi *spi, uint8_t justification)
-{
-    SOL_NULL_CHECK(spi, false);
-
-    if (ioctl(spi->fd, SPI_IOC_WR_LSB_FIRST, &justification) == -1) {
-        SOL_WRN("%u,%u: Unable to write SPI bit justification", spi->bus, spi->chip_select);
-        return false;
-    }
-
-    return true;
-}
-
-SOL_API int8_t
-sol_spi_get_bits_per_word(const struct sol_spi *spi)
-{
-    SOL_NULL_CHECK(spi, -EINVAL);
-    return spi->bits_per_word;
-}
-
-SOL_API bool
-sol_spi_set_bits_per_word(struct sol_spi *spi, uint8_t bits_per_word)
-{
-    SOL_NULL_CHECK(spi, false);
-    spi->bits_per_word = bits_per_word;
-    return true;
-}
-
-SOL_API int32_t
-sol_spi_get_max_speed(const struct sol_spi *spi)
-{
-    uint32_t speed;
-
-    SOL_NULL_CHECK(spi, -EINVAL);
-
-    if (ioctl(spi->fd, SPI_IOC_RD_MAX_SPEED_HZ, &speed) == -1) {
-        SOL_WRN("%u,%u: Unable to read SPI max speed", spi->bus, spi->chip_select);
-        return -errno;
-    }
-
-    return speed;
-}
-
-SOL_API bool
-sol_spi_set_max_speed(struct sol_spi *spi, uint32_t speed)
-{
-    SOL_NULL_CHECK(spi, false);
-
-    if (ioctl(spi->fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed) == -1) {
-        SOL_WRN("%u,%u: Unable to write SPI max speed", spi->bus, spi->chip_select);
-        return false;
-    }
-
-    return true;
-}
-
-SOL_API bool
-sol_spi_transfer(const struct sol_spi *spi, uint8_t *tx, uint8_t *rx, size_t size)
+sol_spi_transfer(const struct sol_spi *spi, const uint8_t *tx, uint8_t *rx, size_t size)
 {
     struct spi_ioc_transfer tr;
 
@@ -190,31 +91,57 @@ sol_spi_close(struct sol_spi *spi)
 }
 
 SOL_API struct sol_spi *
-sol_spi_open(unsigned int bus, unsigned int chip_select)
+sol_spi_open(unsigned int bus, const struct sol_spi_config *config)
 {
     struct sol_spi *spi;
     char spi_dir[PATH_MAX];
 
     SOL_LOG_INTERNAL_INIT_ONCE;
 
-    spi = calloc(1, sizeof(*spi));
+    if (unlikely(config->api_version != SOL_SPI_CONFIG_API_VERSION)) {
+        SOL_WRN("Couldn't open SPI that has unsupported version '%u', "
+            "expected version is '%u'",
+            config->api_version, SOL_SPI_CONFIG_API_VERSION);
+        return NULL;
+    }
+
+    spi = malloc(sizeof(*spi));
     if (!spi) {
-        SOL_WRN("%u,%u: Unable to allocate spi", bus, chip_select);
+        SOL_WRN("%u,%u: Unable to allocate SPI", bus, config->chip_select);
         return NULL;
     }
 
     spi->bus = bus;
-    spi->chip_select = chip_select;
-    spi->bits_per_word = 8;
+    spi->chip_select = config->chip_select;
+    spi->bits_per_word = config->bits_per_word;
 
-    snprintf(spi_dir, sizeof(spi_dir), "/dev/spidev%u.%u", bus, chip_select);
+    snprintf(spi_dir, sizeof(spi_dir), "/dev/spidev%u.%u", bus,
+        config->chip_select);
     spi->fd = open(spi_dir, O_RDWR | O_CLOEXEC);
 
     if (spi->fd < 0) {
-        SOL_WRN("%u,%u:Unable to access spi device - %s", bus, chip_select, spi_dir);
-        free(spi);
-        return NULL;
+        SOL_WRN("%u,%u: Unable to access SPI device - %s", bus,
+            config->chip_select, spi_dir);
+        goto open_error;
+    }
+
+    if (ioctl(spi->fd, SPI_IOC_WR_MODE, &config->mode) == -1) {
+        SOL_WRN("%u,%u: Unable to write SPI mode: %s", spi->bus,
+            spi->chip_select, sol_util_strerrora(errno));
+        goto config_error;
+    }
+
+    if (ioctl(spi->fd, SPI_IOC_WR_MAX_SPEED_HZ, &config->frequency) == -1) {
+        SOL_WRN("%u,%u: Unable to write SPI clock frequency: %s", spi->bus,
+            spi->chip_select, sol_util_strerrora(errno));
+        goto config_error;
     }
 
     return spi;
+
+config_error:
+    close(spi->fd);
+open_error:
+    free(spi);
+    return NULL;
 }

--- a/src/lib/io/sol-spi-riot.c
+++ b/src/lib/io/sol-spi-riot.c
@@ -195,10 +195,3 @@ sol_spi_transfer(const struct sol_spi *spi, uint8_t *tx, uint8_t *rx, size_t cou
 
     return ret > 0 && ((unsigned int)ret) == count;
 }
-
-SOL_API bool
-sol_spi_raw_transfer(const struct sol_spi *spi, void *tr, size_t count)
-{
-    SOL_CRI("Unsupported");
-    return false;
-}

--- a/src/lib/io/sol-spi-riot.c
+++ b/src/lib/io/sol-spi-riot.c
@@ -36,6 +36,7 @@
 #define SOL_LOG_DOMAIN &_log_domain
 #include "sol-log-internal.h"
 #include "sol-macros.h"
+#include "sol-mainloop.h"
 #include "sol-spi.h"
 #include "sol-util.h"
 
@@ -44,9 +45,22 @@
 
 SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "spi");
 
+#define INTERN_ALLOCATED_TX_BUFFER (1 << 0)
+#define INTERN_ALLOCATED_RX_BUFFER (1 << 1)
+
 struct sol_spi {
     unsigned int bus;
     unsigned int cs_pin;
+    struct {
+        void (*cb)(void *cb_data, struct sol_spi *spi, const uint8_t *tx, uint8_t *rx, ssize_t status);
+        const void *cb_data;
+        uint8_t *tx;
+        uint8_t *rx;
+        struct sol_timeout *timeout;
+        uint8_t intern_allocated_buffer_flags;
+        size_t count;
+        ssize_t status;
+    } transfer;
 };
 
 static spi_speed_t
@@ -95,32 +109,99 @@ sol_spi_open(unsigned int bus, const struct sol_spi_config *config)
 
     spi->bus = bus;
     spi->cs_pin = config->chip_select;
+    spi->transfer.timeout = NULL;
 
     gpio_init_out(spi->cs_pin, GPIO_NOPULL);
     gpio_set(spi->cs_pin);
     return spi;
 }
 
+static void
+spi_transfer_dispatch(struct sol_spi *spi)
+{
+    if (spi->transfer.intern_allocated_buffer_flags & INTERN_ALLOCATED_TX_BUFFER) {
+        free(spi->transfer.tx);
+        spi->transfer.tx = NULL;
+    }
+    if (spi->transfer.intern_allocated_buffer_flags & INTERN_ALLOCATED_RX_BUFFER) {
+        free(spi->transfer.rx);
+        spi->transfer.rx = NULL;
+    }
+
+    if (!spi->transfer.cb) return;
+    spi->transfer.cb((void *)spi->transfer.cb_data, spi, spi->transfer.tx,
+        spi->transfer.rx, spi->transfer.status);
+}
+
+static bool
+spi_timeout_cb(void *data)
+{
+    struct sol_spi *spi = data;
+    int ret;
+
+    spi_acquire(spi->bus);
+    gpio_clear(spi->cs_pin);
+    ret = spi_transfer_bytes(spi->bus, (char *)spi->transfer.tx,
+        (char *)spi->transfer.rx, spi->transfer.count);
+    gpio_set(spi->cs_pin);
+    spi_release(spi->bus);
+
+    spi->transfer.status = ret;
+    spi->transfer.timeout = NULL;
+    spi_transfer_dispatch(spi);
+
+    return false;
+}
+
+SOL_API bool
+sol_spi_transfer(struct sol_spi *spi, const uint8_t *tx_user, uint8_t *rx, size_t count, void (*transfer_cb)(void *cb_data, struct sol_spi *spi, const uint8_t *tx, uint8_t *rx, ssize_t status), const void *cb_data)
+{
+    uint8_t *tx = (uint8_t *)tx_user;
+
+    SOL_NULL_CHECK(spi, false);
+    SOL_EXP_CHECK(spi->transfer.timeout, false);
+
+    spi->transfer.intern_allocated_buffer_flags = 0;
+    if (tx == NULL) {
+        tx = calloc(count, sizeof(uint8_t));
+        SOL_NULL_CHECK(tx, false);
+        spi->transfer.intern_allocated_buffer_flags = INTERN_ALLOCATED_TX_BUFFER;
+    }
+    if (rx == NULL) {
+        rx = calloc(count, sizeof(uint8_t));
+        SOL_NULL_CHECK_GOTO(rx, rx_alloc_fail);
+        spi->transfer.intern_allocated_buffer_flags = INTERN_ALLOCATED_RX_BUFFER;
+    }
+
+    spi->transfer.tx = tx;
+    spi->transfer.rx = rx;
+    spi->transfer.count = count;
+    spi->transfer.status = -1;
+    spi->transfer.cb = transfer_cb;
+    spi->transfer.cb_data = cb_data;
+
+    spi->transfer.timeout = sol_timeout_add(0, spi_timeout_cb, spi);
+    SOL_NULL_CHECK_GOTO(spi->transfer.timeout, timeout_fail);
+
+    return true;
+
+timeout_fail:
+    if (spi->transfer.intern_allocated_buffer_flags & INTERN_ALLOCATED_RX_BUFFER)
+        free(rx);
+rx_alloc_fail:
+    if (spi->transfer.intern_allocated_buffer_flags & INTERN_ALLOCATED_TX_BUFFER)
+        free(tx);
+    return false;
+}
+
 SOL_API void
 sol_spi_close(struct sol_spi *spi)
 {
     SOL_NULL_CHECK(spi);
+    if (spi->transfer.timeout) {
+        sol_timeout_del(spi->transfer.timeout);
+        spi_transfer_dispatch(spi);
+    }
     spi_poweroff(spi->bus);
     free(spi);
-}
-
-SOL_API bool
-sol_spi_transfer(const struct sol_spi *spi, const uint8_t *tx, uint8_t *rx, size_t count)
-{
-    int ret;
-
-    SOL_NULL_CHECK(spi, false);
-
-    spi_acquire(spi->bus);
-    gpio_clear(spi->cs_pin);
-    ret = spi_transfer_bytes(spi->bus, (char *)tx, (char *)rx, count);
-    gpio_set(spi->cs_pin);
-    spi_release(spi->bus);
-
-    return ret > 0 && ((unsigned int)ret) == count;
 }

--- a/src/modules/flow/calamari/calamari.c
+++ b/src/modules/flow/calamari/calamari.c
@@ -365,7 +365,7 @@ calamari_lever_convert_range(const struct calamari_lever_data *mdata, int value)
 static int
 calamari_lever_spi_read(struct sol_spi *spi)
 {
-    int i, value;
+    unsigned int value;
 
     /* MCP300X message - Start, Single ended - pin 0, null */
     uint8_t tx[] = { 0x01, 0x80, 0x00 };
@@ -375,12 +375,8 @@ calamari_lever_spi_read(struct sol_spi *spi)
     if (!sol_spi_transfer(spi, tx, rx, ARRAY_SIZE(tx)))
         return -EIO;
 
-    for (i = ARRAY_SIZE(rx) - 1, value = 0; i >= 0; i--) {
-        value |= rx[i] << 8 * (ARRAY_SIZE(rx) - 1 - i);
-    }
-
     /* MCP300x - 10 bit precision */
-    value &= 0x3ff;
+    value = (rx[1] << 8 | rx[2]) & 0x3ff;
 
     return value;
 }

--- a/src/modules/flow/calamari/calamari.c
+++ b/src/modules/flow/calamari/calamari.c
@@ -438,6 +438,7 @@ calamari_lever_open(struct sol_flow_node *node, void *data, const struct sol_flo
     struct calamari_lever_data *mdata = data;
     const struct sol_flow_node_type_calamari_lever_options *opts =
         (const struct sol_flow_node_type_calamari_lever_options *)options;
+    struct sol_spi_config spi_config;
 
     SOL_NULL_CHECK(options, 0);
 
@@ -445,7 +446,12 @@ calamari_lever_open(struct sol_flow_node *node, void *data, const struct sol_flo
     mdata->last_value = 0;
     mdata->forced = true;
     mdata->val = opts->range;
-    mdata->spi = sol_spi_open(opts->bus.val, opts->chip_select.val);
+    spi_config.api_version = SOL_SPI_CONFIG_API_VERSION;
+    spi_config.chip_select = opts->chip_select.val;
+    spi_config.mode = SOL_SPI_MODE_0;
+    spi_config.frequency = 100 * 1000; //100KHz
+    spi_config.bits_per_word = SOL_SPI_DATA_BITS_DEFAULT;
+    mdata->spi = sol_spi_open(opts->bus.val, &spi_config);
 
     if (opts->poll_interval.val != 0)
         mdata->timer = sol_timeout_add(opts->poll_interval.val,

--- a/src/modules/flow/led-strip/lpd8806.c
+++ b/src/modules/flow/led-strip/lpd8806.c
@@ -64,6 +64,7 @@ led_strip_controler_open(struct sol_flow_node *node, void *data, const struct so
     const struct sol_flow_node_type_led_strip_lpd8806_options *opts;
     uint32_t data_bytes, pixel_array_length;
     uint8_t latch_bytes;
+    struct sol_spi_config spi_config;
 
     opts = (const struct sol_flow_node_type_led_strip_lpd8806_options *)options;
 
@@ -84,10 +85,13 @@ led_strip_controler_open(struct sol_flow_node *node, void *data, const struct so
     memset(mdata->pixels, 0x80, data_bytes); // Init to RGB 'off' state
     memset(&mdata->pixels[data_bytes], 0, latch_bytes); // Clear latch bytes
 
-    mdata->spi = sol_spi_open(opts->bus.val, opts->chip_select.val);
+    spi_config.api_version = SOL_SPI_CONFIG_API_VERSION;
+    spi_config.chip_select = opts->chip_select.val;
+    spi_config.mode = SOL_SPI_MODE_0;
+    spi_config.frequency = 100 * 1000; //100KHz
+    spi_config.bits_per_word = SOL_SPI_DATA_BITS_DEFAULT;
+    mdata->spi = sol_spi_open(opts->bus.val, &spi_config);
     if (mdata->spi) {
-        sol_spi_set_transfer_mode(mdata->spi, 0);
-
         // Initial reset
         sol_spi_transfer(mdata->spi, &mdata->pixels[mdata->pixel_count * 3], NULL, latch_bytes);
     }


### PR DESCRIPTION
Changes from V1:
- Removed SPI_SPEED enum, going back to uint32_t to give user more flexibility
- Using timeout_add(0,...) instead of idle_add()
- Added more information on documentation