### PR TITLE
build: bring back fbp sample

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -63,6 +63,7 @@ endmenu
 menu "Samples"
 source "src/samples/coap/Kconfig"
 source "src/samples/common/Kconfig"
+source "src/samples/flow/Kconfig"
 endmenu
 
 menu "Tools"

--- a/src/samples/flow/Kconfig
+++ b/src/samples/flow/Kconfig
@@ -1,0 +1,14 @@
+config FLOW_SAMPLES
+	bool "Flow samples"
+	depends on FLOW
+	default y
+
+config FLOW_BASIC_SAMPLE
+	bool "Simple fbp sample"
+	depends on FLOW_SAMPLES && FBP_GENERATOR
+	default y
+
+config FLOW_CMDLINE_ARGS_SAMPLE
+	bool "Command line arguments sample"
+	depends on FLOW_SAMPLES && FBP_GENERATOR
+	default y

--- a/src/samples/flow/Makefile
+++ b/src/samples/flow/Makefile
@@ -1,0 +1,6 @@
+sample-$(FLOW_BASIC_SAMPLE) += simple-fbp
+sample-simple-fbp-$(FLOW_BASIC_SAMPLE) := basics/simple.fbp
+sample-simple-fbp-$(FLOW_BASIC_SAMPLE)-deps := timer.mod
+
+sample-$(FLOW_CMDLINE_ARGS_SAMPLE) += cmdline-args
+sample-cmdline-args-$(FLOW_CMDLINE_ARGS_SAMPLE) := basics/cmdline-args.fbp

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -108,8 +108,18 @@ parse-test = \
 	$(eval $(1)-deps      := $(subst .mod,,$($(3)-$(1)-y-deps))) \
 	$(eval tests-out      += $(test-$(1)-out)) \
 
+gen-fbp-artifact = \
+	$(foreach fbp,$(filter %.fbp,$(2)), \
+		$(eval $(fbp)-src       := $(subst $(top_srcdir)src,$(build_stagedir),$(subst .fbp,-gen.c,$(fbp)))) \
+		$(eval $(3)             += $($(fbp)-src)) \
+		$(eval sample-$(1)-gens += $(fbp)) \
+		$(eval all-fbp-gens     += $(fbp)) \
+	) \
+
 parse-sample = \
-	$(eval sample-$(1)-srcs := $(addprefix $(2),$(sample-$(1)-y))) \
+	$(eval sample-$(1)-srcs := $(addprefix $(2),$(filter-out %.fbp,$(sample-$(1)-y)))) \
+	$(eval artifacts        := $(addprefix $(2),$(filter %.fbp,$(sample-$(1)-y)))) \
+	$(call gen-fbp-artifact,$(1),$(artifacts),sample-$(1)-srcs) \
 	$(eval sample-$(1)-out  := $(addprefix $(2),$(1))) \
 	$(eval $(1)-deps        := $(subst .mod,,$(sample-$(1)-y-deps))) \
 	$(eval samples-out      += $(sample-$(1)-out)) \
@@ -191,10 +201,13 @@ $(bin-$(1)-out): $(PRE_GEN) $(SOL_LIB_SO) $(bin-$(1)-srcs) $(call find-deps,$(1)
 endef
 $(foreach curr,$(bins),$(eval $(call make-bin,$(curr))))
 
+include-mods-gen-h = $(foreach gen,$(all-gens),$(if $(filter %.h,$($(gen)-hdr)),-include $($(gen)-hdr)))
+
 define make-sample
 $(sample-$(1)-out): $(PRE_GEN) $(SOL_LIB_SO) $(sample-$(1)-srcs) $(call find-deps,$(1))
 	$(Q)echo "     "SMP"   "$$@
-	$(Q)$(TARGETCC) $(SAMPLE_CFLAGS) $(sample-$(1)-cflags) $(filter-out %.h,$(sample-$(1)-srcs)) -o $(sample-$(1)-out) $(SAMPLE_LDFLAGS) $(sample-$(1)-ldflags) $(sort $(builtin-ldflags))
+	$(Q)$(TARGETCC) $(SAMPLE_CFLAGS) $(sample-$(1)-cflags) $(include-mods-gen-h) $(filter-out %.h,$(sample-$(1)-srcs)) \
+	$(call find-deps,$(1)) -o $(sample-$(1)-out) $(SAMPLE_LDFLAGS) $(sample-$(1)-ldflags) $(sort $(builtin-ldflags))
 endef
 $(foreach sample,$(samples),$(eval $(call make-sample,$(sample))))
 
@@ -293,6 +306,14 @@ $($(1)-hdr) $($(1)-src) $($(1)-desc): $(1) $(NODE_TYPE_GEN_SCRIPT)
 		--genspec-schema=$(NODE_TYPE_SCHEMA) $(1) $($(1)-hdr) $($(1)-src) $($(1)-desc)
 endef
 $(foreach gen,$(all-gens),$(eval $(call make-gen,$(gen))))
+
+define make-fbp-gen
+$($(1)-src): $(1) $(SOL_FBP_GENERATOR_BIN)
+	$(Q)echo "     "GEN"   "$$@
+	$(Q)$(MKDIR) -p $(dir $($(1)-src))
+	$(Q)$(SOL_FBP_GENERATOR_BIN) -j $(build_descdir) $(1) $($(1)-src)
+endef
+$(foreach gen,$(all-fbp-gens),$(eval $(call make-fbp-gen,$(gen))))
 
 $(FLOW_BUILTINS_DESC): $(PRE_GEN) $(SOL_LIB_SO) $(SOL_LIB_AR) $(all-mod-descs) $(JSON_FORMAT_SCRIPT)
 	$(Q)echo "     "GEN"   "$@

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -33,6 +33,7 @@ tests-out :=
 samples :=
 samples-out :=
 
+all-fbp-gens :=
 all-gens :=
 all-objs :=
 all-dest-hdr :=
@@ -289,6 +290,7 @@ TEST_VALGRIND_SUPP := $(top_srcdir)src/test/test.supp
 
 TEST_FBP_SCRIPT := $(top_srcdir)tools/run-fbp-tests
 SOL_FBP_RUNNER_BIN := $(build_bindir)sol-fbp-runner
+SOL_FBP_GENERATOR_BIN := $(build_bindir)sol-fbp-generator
 
 DOXYGEN_RESOURCES = \
 	doc/doxygen/Doxyfile \


### PR DESCRIPTION
This patch introduces the basic infra to build the fbp based samples,
new or different requirements may appear to non-basic samples but the
infra must evolve from here.

A clean exception is the c-api that will need an special care, for that,
new patches are comming next.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>