### PR TITLE
build: install only current prefix

### DIFF
--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -75,7 +75,7 @@ $(foreach bin,$(bins-out),$(eval $(call rpath-cleanup,$(bin))))
 pre-install: $(PRE_INSTALL)
 	$(Q)echo "     "INSTALLING SYSROOT TO: $(DESTDIR)
 	$(Q)$(MKDIR) -p $(DESTDIR)
-	$(Q)$(CP) -R $(build_sysroot)/* $(DESTDIR)
+	$(Q)$(CP) -R $(build_sysroot)/$(PREFIX)/ $(DESTDIR)
 
 post-install: pre-install $(all-rpath-bins)
 


### PR DESCRIPTION
If we change PREFIX between builds the build_sysroot will be left with
more than a single prefix, the next install will copy all prefixes
previously configured. This patch changes the install target to consoder
only the current PREFIX.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>