### PR TITLE
build: provide ldflags to dependency resolver

### DIFF
--- a/data/scripts/dependency-resolver.py
+++ b/data/scripts/dependency-resolver.py
@@ -181,7 +181,7 @@ def handle_ccode_check(args, conf, context):
     common_ldflags = context.find_makefile_var(args.common_ldflags_var)
 
     test_cflags = (cflags.get("value", ""), args.cflags, common_cflags)
-    test_ldflags = (ldflags.get("value", ""), common_ldflags)
+    test_ldflags = (ldflags.get("value", ""), args.ldflags, common_ldflags)
 
     fragment = conf.get("fragment") or ""
     source = cstub.format(headers=source, fragment=fragment)
@@ -415,6 +415,8 @@ if __name__ == "__main__":
     parser.add_argument("--compiler", help="The gcc compiler[for headers based tests]",
                         type=str, default="gcc")
     parser.add_argument("--cflags", help="Additional cflags[for headers based tests]",
+                        type=str, default="")
+    parser.add_argument("--ldflags", help="Additional/environment ldflags",
                         type=str, default="")
     parser.add_argument("--pkg-config", help="What to use for pkg-config",
                         type=str, default="pkg-config")

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -255,24 +255,25 @@ $(SOL_LIB_SO): $(PRE_GEN) $(SOL_LIB_AR) $(builtin-objs)
 
 $(DEPENDENCY_CACHE): submodules-init
 	$(Q)$(PYTHON) $(DEPENDENCY_SCRIPT) --compiler="$(TARGETCC)" --cflags="$(DEP_RESOLVER_CFLAGS)" \
-		--prefix="$(PREFIX)" --cache="$(DEPENDENCY_CACHE)" --pkg-config="$(PKG_CONFIG)"
+		--ldflags="$(DEP_RESOLVER_LDFLAGS)" --prefix="$(PREFIX)" --cache="$(DEPENDENCY_CACHE)" \
+		--pkg-config="$(PKG_CONFIG)"
 
 $(KCONFIG_GEN): $(DEPENDENCY_CACHE)
 	$(Q)$(PYTHON) $(DEPENDENCY_SCRIPT) --compiler="$(TARGETCC)" --cflags="$(DEP_RESOLVER_CFLAGS)" \
-		--prefix="$(PREFIX)" --cache="$(DEPENDENCY_CACHE)" --pkg-config="$(PKG_CONFIG)" \
-                --kconfig-gen
+		--ldflags="$(DEP_RESOLVER_LDFLAGS)" --prefix="$(PREFIX)" --cache="$(DEPENDENCY_CACHE)" \
+		--pkg-config="$(PKG_CONFIG)" --kconfig-gen
 
 $(MAKEFILE_GEN): $(DEPENDENCY_CACHE) $(KCONFIG_CONFIG)
 	$(Q)$(PYTHON) $(DEPENDENCY_SCRIPT) --compiler="$(TARGETCC)" --cflags="$(DEP_RESOLVER_CFLAGS)" \
-		--prefix="$(PREFIX)" --cache="$(DEPENDENCY_CACHE)" --pkg-config="$(PKG_CONFIG)" \
-                --definitions-header="$(DEFINITIONS_H)" --makefile-gen
+		--ldflags="$(DEP_RESOLVER_LDFLAGS)" --prefix="$(PREFIX)" --cache="$(DEPENDENCY_CACHE)" \
+		--pkg-config="$(PKG_CONFIG)" --definitions-header="$(DEFINITIONS_H)" --makefile-gen
 
 reconf: $(DEPENDENCY_SCRIPT)
 	$(Q)echo "[re]running dependency-resolver..."
 	$(Q)$(RM) -f $(DEPENDENCY_FILES)
 	$(Q)$(RM) $(DEPENDENCY_CACHE)
 	$(Q) V=1 $(PYTHON) $(DEPENDENCY_SCRIPT) --compiler=$(TARGETCC) --cflags="$(DEP_RESOLVER_CFLAGS)" \
-		--prefix="$(PREFIX)" --definitions-header="$(DEFINITIONS_H)" \
+		--ldflags="$(DEP_RESOLVER_LDFLAGS)" --prefix="$(PREFIX)" --definitions-header="$(DEFINITIONS_H)" \
 		--cache="$(DEPENDENCY_CACHE)" --kconfig-gen --makefile-gen
 
 PHONY += reconf

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -191,6 +191,7 @@ COMMON_LDFLAGS += -lgcov
 endif
 
 DEP_RESOLVER_CFLAGS := $(CFLAGS) -Werror=implicit-function-declaration
+DEP_RESOLVER_LDFLAGS := $(LDFLAGS)
 DEFINITIONS_H := $(top_srcdir)include/generated/sol_definitions.h
 
 COMMON_CFLAGS += -std=gnu99 -fPIC


### PR DESCRIPTION
## Changes
v3
   + upstream rebase.

## Rationale
We must provide the environment ldflags to dependency resolver so we run
the tests in a consistently with the environment.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>