### PR TITLE
git-init-submodules: make sure to always complete

### DIFF
--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -253,7 +253,7 @@ $(SOL_LIB_SO): $(PRE_GEN) $(SOL_LIB_AR) $(builtin-objs)
 	$(Q)$(TARGETCC) -shared $(builtin-objs) $(sort $(builtin-ldflags)) $(LIB_LDFLAGS) -o $(@).$(VERSION)
 	$(Q)$(LN) -fs $(notdir $(@).$(VERSION)) $(@)
 
-$(DEPENDENCY_CACHE): submodules-init
+$(DEPENDENCY_CACHE): $(MODULES_OK_FILE)
 	$(Q)$(PYTHON) $(DEPENDENCY_SCRIPT) --compiler="$(TARGETCC)" --cflags="$(DEP_RESOLVER_CFLAGS)" \
 		--ldflags="$(DEP_RESOLVER_LDFLAGS)" --prefix="$(PREFIX)" --cache="$(DEPENDENCY_CACHE)" \
 		--pkg-config="$(PKG_CONFIG)"
@@ -306,10 +306,8 @@ $(eval $(call install-resource,$(NODE_TYPE_SCHEMA),$(NODE_TYPE_SCHEMA_DEST)))
 $(eval $(call install-resource,$(PLATFORM_DETECT),$(PLATFORM_DETECT_DEST)))
 $(eval $(call install-resource,$(GDB_AUTOLOAD_PY),$(GDB_AUTOLOAD_PY_DEST)))
 
-submodules-init:
-	$(Q)$(PYTHON)$(SUBMODULE_SCRIPT)
-
-PHONY += submodules-init
+$(MODULES_OK_FILE):
+	$(Q)$(PYTHON)$(SUBMODULE_SCRIPT) || (false)
 
 $(FLOW_OIC_GEN): $(FLOW_OIC_GEN_SCRIPT)
 	$(Q)echo "     "GEN"   "$(@)

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -325,3 +325,5 @@ warning-targets = all check check-fbp check-valgrind check-fbp-valgrind coverage
 		pre-install post-install install doc cheat-sheet samples doxygen: warning
 
 PACKAGE_DOCNAME := "soletta"-$(VERSION)-doc
+
+MODULES_OK_FILE := $(top_srcdir).git/modules-ok


### PR DESCRIPTION
Don't ignore if git-init-submodule fails to initialize submodules or is
interrupted by the user and keep trying to complete.

For that we keep the .git/modules-ok control file to be sure if
submodule initialization process is sanitized.

We force a [re]initialization case .git/modules-ok is not found.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>