### PR TITLE
Revert "datatypes: Cast SOL_VECTOR_INIT() appropriately"

### DIFF
--- a/src/lib/datatypes/include/sol-vector.h
+++ b/src/lib/datatypes/include/sol-vector.h
@@ -72,7 +72,7 @@ struct sol_vector {
     uint16_t elem_size;
 };
 
-#define SOL_VECTOR_INIT(TYPE) (struct sol_vector){ .data = NULL, .len = 0, .elem_size = sizeof(TYPE) }
+#define SOL_VECTOR_INIT(TYPE) { NULL, 0, sizeof(TYPE) }
 
 void sol_vector_init(struct sol_vector *v, uint16_t elem_size);
 


### PR DESCRIPTION
This reverts commit 75a18c9e2344fd759d509d31ff42206cb229ab7c.

If we want to use the SOL_VECTOR_INIT() macro with an objects with
static storage initialization this "cast" will be considered as a
"compound literal" resulting in compilation errors for older compilers
(even gcc).

The gcc documentation states the following:

"As a GNU extension, GCC allows initialization of objects with static
storage duration by compound literals (which is not possible in ISO C99,
because the initializer is not a constant)..."

But it seems not to be true, the versions working with that is 5.1.0
on-wards.