### PR TITLE
test: fix warnings when using ASSERT_STR_EQ/NE

### DIFF
--- a/src/test/test-buffer.c
+++ b/src/test/test-buffer.c
@@ -131,11 +131,11 @@ test_set_slice(void)
     ASSERT(err >= 0);
 
     ASSERT_INT_EQ(buf.used, strlen(backend));
-    ASSERT_STR_EQ(buf.data, backend);
+    ASSERT_STR_EQ((char *)buf.data, backend);
 
     backend[1] = 'a';
-    ASSERT_STR_NE(buf.data, backend);
-    ASSERT_STR_EQ(buf.data, str);
+    ASSERT_STR_NE((char *)buf.data, backend);
+    ASSERT_STR_EQ((char *)buf.data, str);
 
     sol_buffer_fini(&buf);
 
@@ -163,15 +163,15 @@ test_append_slice(void)
     ASSERT(err >= 0);
 
     ASSERT_INT_EQ(buf.used, strlen(backend));
-    ASSERT_STR_EQ(buf.data, backend);
+    ASSERT_STR_EQ((char *)buf.data, backend);
 
     err = sol_buffer_append_slice(&buf, slice);
     ASSERT(err >= 0);
     ASSERT_INT_EQ(buf.used, strlen(expected_str));
 
     backend[1] = 'a';
-    ASSERT_STR_NE(buf.data, backend);
-    ASSERT_STR_EQ(buf.data, expected_str);
+    ASSERT_STR_NE((char *)buf.data, backend);
+    ASSERT_STR_EQ((char *)buf.data, expected_str);
 
     sol_buffer_fini(&buf);
 


### PR DESCRIPTION
The macros expect strictly a 'char *' since it will be used as part of a
fprintf, the implict 'void *' conversion doesn't kick in, so in
test-buffer, ensure we cast appropriatedly the buffer in case of
asserts.

For the reference, GCC 5.2 was giving the following

    warning: format ‘%s’ expects argument of type ‘char *’, but argument 6 has type ‘void *’ [-Wformat=]
                 fprintf(stderr, "%s:%d: %s: Assertion string_different(\"%s\", \"%s\") failed.\n", \

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>