### PR TITLE
build: fail (return exit 1) if no required deps are found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ warning:
 	$(Q)echo -e "$(NOT_FOUND)"
 	$(Q)echo -e "If you've just installed it, run: make reconf"
 	$(Q)echo -e "For more information/options, run: make help"
+	(false)
 $(warning-targets)
 else
 ifeq ($(HAVE_KCONFIG_CONFIG),)
@@ -37,6 +38,7 @@ warning: $(KCONFIG_GEN)
 	$(Q)echo "You need a config file first. Please run a config target, e.g.: make menuconfig"
 	$(Q)echo "For a quick default config run: make alldefconfig"
 	$(Q)echo "For more information/options run: make help"
+	(false)
 $(warning-targets)
 else
 include $(top_srcdir)tools/build/Makefile.targets


### PR DESCRIPTION
This patch forces gnu make to return exit code 1 if we can't find
required build dependencies. With that the build bots work properly and
report errors on those conditions.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>