### PR TITLE
build: start migrating template proc to a generic infra

### DIFF
--- a/src/lib/common/Makefile
+++ b/src/lib/common/Makefile
@@ -80,7 +80,8 @@ headers-y := \
     include/sol-macros.h \
     include/sol-mainloop.h \
     include/sol-platform.h \
-    include/sol-types.h
+    include/sol-types.h \
+    sol-common-buildopts.h.in
 
 headers-$(HAVE_PIN_MUX) += \
     include/sol-pin-mux-modules.h

--- a/src/lib/flow/Makefile
+++ b/src/lib/flow/Makefile
@@ -37,4 +37,5 @@ headers-$(FLOW) := \
     include/sol-flow-parser.h \
     include/sol-flow-resolver.h \
     include/sol-flow-simplectype.h \
-    include/sol-flow-static.h
+    include/sol-flow-static.h \
+    sol-flow-buildopts.h.in

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -39,9 +39,16 @@ gen-artifact = \
 
 extra-headers = \
 	$(foreach hdr,$(1), \
-		$(eval $(hdr)-dest  := $(build_includedir)$(notdir $(hdr))) \
-		$(eval all-dest-hdr += $($(hdr)-dest)) \
-		$(eval all-hdr += $(hdr)) \
+		$(if $(filter %.h.in,$(hdr)), \
+			$(eval gen-file      := $(subst .h.in,.h,$(hdr))) \
+			$(eval $(hdr)-dest   := $(build_includedir)$(notdir $(gen-file))) \
+			$(eval all-templates += $(hdr)) \
+			$(eval all-hdr       += $($(hdr)-dest)) \
+		, \
+			$(eval $(hdr)-dest  := $(build_includedir)$(notdir $(hdr))) \
+			$(eval all-dest-hdr += $($(hdr)-dest)) \
+			$(eval all-hdr += $(hdr)) \
+		) \
 	) \
 
 parse-common-module = \
@@ -157,7 +164,6 @@ SUBDIRS += $(M)/
 endif # $(M)
 
 $(eval $(call inc-subdirs))
-$(eval $(call extra-headers,$(EXTRA_HEADERS)))
 $(eval $(call extra-bins))
 
 PRE_GEN += $(all-gen-hdrs) $(all-dest-hdr) $(all-dest-bin)
@@ -290,6 +296,14 @@ $($(1)-hdr) $($(1)-src) $($(1)-desc): $(1) $(NODE_TYPE_GEN_SCRIPT)
 endef
 $(foreach gen,$(all-gens),$(eval $(call make-gen,$(gen))))
 
+define make-template-gen
+$($(1)-dest): $(1) $(KCONFIG_CONFIG)
+	$(Q)echo "     "GEN"   "$(@)
+	$(Q)$(PYTHON) $(TEMPLATE_SCRIPT) --context-files $(KCONFIG_CONFIG) $(MAKEFILE_GEN) \
+		--template=$(1) --output=$($(1)-dest)
+endef
+$(foreach tpl,$(all-templates),$(eval $(call make-template-gen,$(tpl))))
+
 $(FLOW_BUILTINS_DESC): $(PRE_GEN) $(SOL_LIB_SO) $(SOL_LIB_AR) $(all-mod-descs) $(JSON_FORMAT_SCRIPT)
 	$(Q)echo "     "GEN"   "$@
 	$(Q)$(MKDIR) -p $(dir $(@))
@@ -347,16 +361,6 @@ $(PIN_MUX_BUILTINS_H): $(BUILTINS_SCRIPT) $(KCONFIG_CONFIG)
                 --decl="const struct sol_pin_mux SOL_PIN_MUX_@NAME@" \
                 --item="&SOL_PIN_MUX_@NAME@" \
                 $(subst -,_,$(builtin-pin-mux))
-
-$(FLOW_BUILDOPTS_H): $(FLOW_BUILDOPTS_H_IN) $(KCONFIG_CONFIG)
-	$(Q)echo "     "GEN"   "$(@)
-	$(Q)$(PYTHON) $(TEMPLATE_SCRIPT) --context-files $(KCONFIG_CONFIG) $(MAKEFILE_GEN) \
-		--template=$(FLOW_BUILDOPTS_H_IN) --output=$(FLOW_BUILDOPTS_H)
-
-$(COMMON_BUILDOPTS_H): $(COMMON_BUILDOPTS_H_IN) $(KCONFIG_CONFIG) $(KCONFIG_CONFIG)
-	$(Q)echo "     "GEN"   "$(@)
-	$(Q)$(PYTHON) $(TEMPLATE_SCRIPT) --context-files $(KCONFIG_CONFIG) $(MAKEFILE_GEN) \
-		--template=$(COMMON_BUILDOPTS_H_IN) --output=$(COMMON_BUILDOPTS_H)
 
 $(PC_GEN): $(PC_GEN_IN) $(KCONFIG_CONFIG)
 	$(Q)echo "     "GEN"   "$(PC_GEN)

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -31,6 +31,7 @@ samples :=
 samples-out :=
 
 all-gens :=
+all-templates :=
 all-objs :=
 all-dest-hdr :=
 all-hdr :=
@@ -229,12 +230,6 @@ LINUX_MICRO_BUILTINS_H := $(top_srcdir)src/lib/common/sol-platform-linux-micro-b
 FLOW_BUILTINS_H := $(top_srcdir)src/lib/flow/sol-flow-builtins-gen.h
 PIN_MUX_BUILTINS_H := $(top_srcdir)src/lib/common/sol-pin-mux-builtins-gen.h
 
-FLOW_BUILDOPTS_H := $(top_srcdir)src/lib/flow/sol-flow-buildopts.h
-FLOW_BUILDOPTS_H_IN := $(addsuffix .in,$(FLOW_BUILDOPTS_H))
-
-COMMON_BUILDOPTS_H := $(top_srcdir)src/lib/common/sol-common-buildopts.h
-COMMON_BUILDOPTS_H_IN := $(addsuffix .in,$(COMMON_BUILDOPTS_H))
-
 NODE_TYPE_SCHEMA := $(top_srcdir)data/schemas/node-type-genspec.schema
 NODE_TYPE_SCHEMA_DEST := $(build_flowdatadir)schemas/node-type-genspec.schema
 
@@ -261,8 +256,6 @@ HEADER_GEN += $(PIN_MUX_BUILTINS_H)
 endif
 
 HEADER_GEN += $(FLOW_BUILTINS_H)
-HEADER_GEN += $(FLOW_BUILDOPTS_H)
-HEADER_GEN += $(COMMON_BUILDOPTS_H)
 
 ## scripts
 BUILTINS_SCRIPT := $(SCRIPTDIR)sol-builtins-gen.py
@@ -315,8 +308,6 @@ PRE_GEN := $(HEADER_GEN) $(KCONFIG_AUTOHEADER) $(KCONFIG_CONFIG) $(BSDEPS)
 PRE_GEN += $(NODE_TYPE_GEN_SCRIPT)
 
 CLEANUP_GEN := $(FLOW_OIC_GEN) $(HEADER_GEN)
-
-EXTRA_HEADERS := $(COMMON_BUILDOPTS_H) $(FLOW_BUILDOPTS_H)
 
 EXTRA_BINS := $(FLOW_NODE_TYPE_FIND)
 EXTRA_BINS += $(addprefix $(SCRIPTDIR),sol-flow-node-type-gen.py sol-flow-node-type-validate.py)


### PR DESCRIPTION
This patch starts moving all the template processing to a single common
template rule. At first we're moving the headers generation to the
already present modules headers definition.

Next patches will attempt to move the still 3 remaining specific
template processing to the common infra.

Since we've moved the headers processing to the generic header infra
this patch also fixes the issue addressed by: #287

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>