### PR TITLE
build: fix make install

### DIFF
--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -75,7 +75,7 @@ $(foreach bin,$(bins-out),$(eval $(call rpath-cleanup,$(bin))))
 pre-install: $(PRE_INSTALL)
 	$(Q)echo "     "INSTALLING SYSROOT TO: $(DESTDIR)
 	$(Q)$(MKDIR) -p $(DESTDIR)
-	$(Q)$(CP) -R $(build_sysroot)/$(PREFIX)/ $(DESTDIR)
+	$(Q)$(CP) -R $(build_sysroot)/$(PREFIX)/ $(DESTDIR)/$(PREFIX)
 
 post-install: pre-install $(all-rpath-bins)
 


### PR DESCRIPTION
It was b0rked in commit d38ac6b3985, since it was missing
the first directory in prefix path.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>