### PR TITLE
Rewrite ~ from scratch for the conffile handling v2

### DIFF
--- a/src/shared/sol-conffile.c
+++ b/src/shared/sol-conffile.c
@@ -43,7 +43,8 @@
 #include "sol-vector.h"
 #include "sol-json.h"
 
-static struct sol_ptr_vector sol_conffile_entry_vector;
+static struct sol_ptr_vector _conffile_entry_vector; /* entries created by conffiles */
+static struct sol_ptr_vector _conffiles_loaded; /* paths of the currently loaded conffiles */
 
 struct sol_conffile_entry {
     char *id;
@@ -52,7 +53,7 @@ struct sol_conffile_entry {
 };
 
 static int
-sol_conffile_entry_sort_cb(const void *data1, const void *data2)
+_entry_sort_cb(const void *data1, const void *data2)
 {
     const struct sol_conffile_entry *e1 = data1;
     const struct sol_conffile_entry *e2 = data2;
@@ -61,10 +62,13 @@ sol_conffile_entry_sort_cb(const void *data1, const void *data2)
 }
 
 static void
-sol_free_conffile_entry(struct sol_conffile_entry *entry)
+_free_entry(struct sol_conffile_entry *entry)
 {
     int idx;
     void *ptr;
+
+    if (!entry)
+        return;
 
     free(entry->id);
     free(entry->type);
@@ -120,18 +124,32 @@ sol_conffile_set_entry_options(struct sol_conffile_entry *entry, struct sol_json
 }
 
 static char *
-sol_dup_json_str(struct sol_json_token token)
+_dup_json_str(struct sol_json_token token)
 {
     char *ret = sol_json_token_get_size(&token) >= 2 ?
         strndup(token.start + 1, sol_json_token_get_size(&token) - 2) : NULL;
 
     if (!ret)
-        SOL_WRN("Error alocating memory for string");
+        SOL_DBG("Error alocating memory for string");
     return ret;
 }
 
+static bool
+_entry_vector_contains(const char *id)
+{
+    uint16_t i;
+    struct sol_conffile_entry *ptr;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&_conffile_entry_vector, ptr, i) {
+        if (strcmp(ptr->id, id) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static int
-sol_conffile_json_to_vector(struct sol_json_scanner scanner, struct sol_ptr_vector *pv)
+_json_to_vector(struct sol_json_scanner scanner)
 {
     struct sol_conffile_entry *entry = NULL;
     const char *node_group = "nodetypes";
@@ -142,9 +160,6 @@ sol_conffile_json_to_vector(struct sol_json_scanner scanner, struct sol_ptr_vect
     struct sol_json_scanner obj_scanner;
     enum sol_json_loop_reason reason;
     bool found_nodes = false;
-    int i;
-
-    sol_ptr_vector_init(pv);
 
     SOL_JSON_SCANNER_OBJECT_LOOP (&scanner, &token, &key, &value, reason) {
         if (sol_json_token_str_eq(&key, node_group, strlen(node_group))) {
@@ -153,7 +168,7 @@ sol_conffile_json_to_vector(struct sol_json_scanner scanner, struct sol_ptr_vect
         }
     }
     if (reason != SOL_JSON_LOOP_REASON_OK) {
-        SOL_DBG("Error: Invalid JSON.");
+        SOL_DBG("Error: Invalid Json.");
         goto err;
     }
 
@@ -162,24 +177,27 @@ sol_conffile_json_to_vector(struct sol_json_scanner scanner, struct sol_ptr_vect
 
     sol_json_scanner_init_from_token(&obj_scanner, &value);
     SOL_JSON_SCANNER_ARRAY_LOOP (&obj_scanner, &token, SOL_JSON_TYPE_OBJECT_START, reason) {
+        bool duplicate = false;
+
         entry = calloc(1, sizeof(*entry));
         SOL_NULL_CHECK_GOTO(entry, err);
-        entry->id = NULL;
-        entry->type = NULL;
         sol_ptr_vector_init(&entry->options);
-
         SOL_JSON_SCANNER_OBJECT_LOOP_NEST (&obj_scanner, &token, &key, &value, reason) {
-            if (reason != SOL_JSON_LOOP_REASON_OK) {
-                SOL_DBG("Error: Invalid JSON.");
-                break;
-            }
             if (sol_json_token_str_eq(&key, node_name, strlen(node_name))) {
-                entry->id = sol_dup_json_str(value);
+                entry->id = _dup_json_str(value);
+                /* if we already have this entry on the vector, try the next.
+                 * this could be caused by some config files trying to setup
+                 * nodes with the same name
+                 */
                 if (!entry->id) {
                     goto entry_err;
                 }
+                if (_entry_vector_contains(entry->id)) {
+                    duplicate = true;
+                    break;
+                }
             } else if (sol_json_token_str_eq(&key, node_type, strlen(node_type))) {
-                entry->type = sol_dup_json_str(value);
+                entry->type = _dup_json_str(value);
                 if (!entry->type) {
                     goto entry_err;
                 }
@@ -189,46 +207,50 @@ sol_conffile_json_to_vector(struct sol_json_scanner scanner, struct sol_ptr_vect
                 }
             }
         }
+
+        if (duplicate) {
+            _free_entry(entry);
+            entry = NULL;
+            continue;
+        }
+
+        if (reason != SOL_JSON_LOOP_REASON_OK) {
+            SOL_DBG("Error: Invalid Json.");
+            goto entry_err;
+        }
+
         if (!entry->type || !entry->id) {
             SOL_DBG("Error: Invalid config type entry, please check your config file.");
             goto entry_err;
         }
 
-        if (reason != SOL_JSON_LOOP_REASON_OK) {
-            SOL_DBG("Error: Invalid JSON.");
+        if (sol_ptr_vector_insert_sorted(&_conffile_entry_vector, entry, _entry_sort_cb) == -1) {
+            SOL_DBG("Error: Couldn't setup config entry");
             goto entry_err;
         }
-
-        if (sol_ptr_vector_insert_sorted(pv, entry, sol_conffile_entry_sort_cb) == -1)
-            goto entry_err;
     }
     if (reason != SOL_JSON_LOOP_REASON_OK) {
-        SOL_DBG("Error: Invalid JSON.");
+        SOL_DBG("Error: Invalid Json.");
         goto entry_err;
     }
 
     return 0;
 
 entry_err:
-    sol_free_conffile_entry(entry);
+    _free_entry(entry);
 err:
-    SOL_PTR_VECTOR_FOREACH_IDX (pv, entry, i) {
-        sol_free_conffile_entry(entry);
-    }
-    sol_ptr_vector_clear(pv);
-
     return -ENOMEM;
 }
 
 static void
-sol_conffile_get_json_include_paths(
+_get_json_include_paths(
     struct sol_json_scanner json_scanner,
     char **include,
     char **include_fallbacks)
 {
-    static const char *include_group = "SolettaInclude";
-    static const char *include_str = "Include";
-    static const char *include_fallback = "IncludeFallbacks";
+    static const char *include_group = "config_includes";
+    static const char *include_str = "include";
+    static const char *include_fallback = "include_fallbacks";
 
     bool found_include = false;
 
@@ -237,15 +259,14 @@ sol_conffile_get_json_include_paths(
     enum sol_json_loop_reason reason;
 
     SOL_JSON_SCANNER_OBJECT_LOOP (&json_scanner, &token, &key, &value, reason) {
-        if (reason != SOL_JSON_LOOP_REASON_OK) {
-            SOL_DBG("Error: Invalid Json.");
-            break;
-        }
-
         if (sol_json_token_str_eq(&key, include_group, strlen(include_group))) {
             found_include = true;
             break;
         }
+    }
+    if (reason != SOL_JSON_LOOP_REASON_OK) {
+        SOL_DBG("Error: Invalid Json.");
+        return;
     }
 
     if (!found_include)
@@ -253,70 +274,114 @@ sol_conffile_get_json_include_paths(
 
     sol_json_scanner_init_from_token(&include_scanner, &value);
     SOL_JSON_SCANNER_OBJECT_LOOP (&include_scanner, &token, &key, &value, reason) {
-        if (reason != SOL_JSON_LOOP_REASON_OK) {
-            SOL_DBG("Error: Invalid Json.");
-            break;
-        }
         if (sol_json_token_str_eq(&key, include_str, strlen(include_str))) {
-            *include = strndup(value.start, sol_json_token_get_size(&value));
+            *include = strndup(value.start + 1, sol_json_token_get_size(&value) - 2);
             if (!*include)
                 SOL_DBG("Error: couldn't allocate memory for string.");
             continue;
         }
         if (sol_json_token_str_eq(&key, include_fallback, strlen(include_fallback))) {
-            *include_fallbacks = strndup(value.start, sol_json_token_get_size(&value));
+            *include_fallbacks = strndup(value.start + 1, sol_json_token_get_size(&value) - 2);
             if (!*include_fallbacks)
                 SOL_DBG("Error: couldn't allocate memory for string.");
             continue;
         }
     }
+    if (reason != SOL_JSON_LOOP_REASON_OK) {
+        SOL_DBG("Error: Invalid Json.");
+    }
+}
+
+static bool
+_already_loaded(const char *filename)
+{
+    uint16_t i;
+    char *ptr;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&_conffiles_loaded, ptr, i) {
+        if (strcmp(ptr, filename) == 0) {
+            return true;
+        }
+    }
+    return false;
 }
 
 static struct sol_str_slice
-sol_conffile_load_json_from_dirs(const char *file, char **full_path, struct sol_file_reader **file_reader)
+_load_json_from_dirs(const char *file, char **full_path, struct sol_file_reader **file_reader)
 {
     size_t i;
     struct sol_str_slice config_file_contents = SOL_STR_SLICE_EMPTY;
+    char *curr_dir;
     const char *search_dirs[] = {
-        NULL,
-        ".",
-        PKGSYSCONFDIR,
-        NULL,
+        NULL, /* current dir ( setup later ) */
+        ".",  /* another way of current dir */
+        "",   /* full path */
+        PKGSYSCONFDIR /* pkg system install */
     };
 
-    /* absolute path */
-    if (file[0] == '/') {
-        *file_reader = sol_file_reader_open(file);
-        if (*file_reader)
+    search_dirs[0] = curr_dir = get_current_dir_name();
+
+    for (i = 0; i < ARRAY_SIZE(search_dirs); i++) {
+        char *filename;
+        asprintf(&filename, "%s/%s", search_dirs[i], file);
+        if (!filename) {
+            SOL_WRN("Couldn't allocate memory for config file.");
+            break;
+        }
+
+        // if we _already_loaded this particular conffile, we don't actually need to do a thing.
+        if (_already_loaded(filename)) {
+            free(filename);
+            goto exit;
+        }
+        *file_reader = sol_file_reader_open(filename);
+        if (*file_reader) {
             config_file_contents = sol_file_reader_get_all(*file_reader);
-    } else {
-        for (i = 0; i < ARRAY_SIZE(search_dirs); i++) {
-            char *filename;
-            if (asprintf(&filename, "%s/%s", search_dirs[i], file) <= 0) {
-                SOL_WRN("Couldn't allocate memory for config file.");
+
+            /* We can't close the file_reader on sucess because then the slice would
+             * also be killed, so we postpone it till later. */
+            if (config_file_contents.len != 0) {
+                sol_ptr_vector_append(&_conffiles_loaded, filename);
                 break;
             }
 
-            *file_reader = sol_file_reader_open(file);
-            if (*file_reader) {
-                config_file_contents = sol_file_reader_get_all(*file_reader);
-                if (config_file_contents.len != 0)
-                    break;
-
-                sol_file_reader_close(*file_reader);
-                *file_reader = NULL;
-            }
+            /* but then there's no need to keep it open if it failed. */
+            free(filename);
+            sol_file_reader_close(*file_reader);
+            *file_reader = NULL;
         }
     }
 
     if (!config_file_contents.data)
         SOL_DBG("could not load config file.");
 
+exit:
+    free(curr_dir);
     return config_file_contents;
 }
 
+static void
+_clear_data(void)
+{
+    void *ptr;
+    struct sol_conffile_entry *e;
+    uint16_t i;
+
+    // Clear the entries.
+    SOL_PTR_VECTOR_FOREACH_IDX (&_conffile_entry_vector, e, i) {
+        _free_entry(e);
+    }
+    sol_ptr_vector_clear(&_conffile_entry_vector);
+
+    // Clear the filenames.
+    SOL_PTR_VECTOR_FOREACH_IDX (&_conffiles_loaded, ptr, i) {
+        free(ptr);
+    }
+    sol_ptr_vector_clear(&_conffiles_loaded);
+}
+
 static struct sol_str_slice
-sol_conffile_load_json_from_paths(const char *path,
+_load_json_from_paths(const char *path,
     const char *fallback_paths,
     char **full_path,
     struct sol_file_reader **file_reader)
@@ -324,14 +389,14 @@ sol_conffile_load_json_from_paths(const char *path,
     struct sol_str_slice config_file_contents = SOL_STR_SLICE_EMPTY;
 
     if (path)
-        config_file_contents = sol_conffile_load_json_from_dirs(path, full_path, file_reader);
+        config_file_contents = _load_json_from_dirs(path, full_path, file_reader);
 
     if (fallback_paths && !config_file_contents.len) {
         uint16_t idx;
         struct sol_str_slice *s_ptr;
         struct sol_vector str_splitted = sol_util_str_split(sol_str_slice_from_str(fallback_paths), ";", 0);
         SOL_VECTOR_FOREACH_IDX (&str_splitted, s_ptr, idx) {
-            config_file_contents = sol_conffile_load_json_from_dirs(s_ptr->data, full_path, file_reader);
+            config_file_contents = _load_json_from_dirs(s_ptr->data, full_path, file_reader);
             if (config_file_contents.len)
                 break;
         }
@@ -341,84 +406,27 @@ sol_conffile_load_json_from_paths(const char *path,
 }
 
 static void
-sol_conffile_free_entry_vector(struct sol_ptr_vector *pv)
-{
-    struct sol_conffile_entry *e;
-    uint16_t i;
-
-    SOL_PTR_VECTOR_FOREACH_IDX (pv, e, i) {
-        sol_free_conffile_entry(e);
-    }
-
-    sol_ptr_vector_clear(pv);
-}
-
-static bool
-sol_conffile_append_to_entry_vector(struct sol_ptr_vector pv)
-{
-    struct sol_conffile_entry *sol_conffile_entry_vector_entry;
-    struct sol_conffile_entry *pv_entry;
-    uint16_t i, j;
-
-    if (sol_ptr_vector_get_len(&pv) <= 0)
-        return false;
-
-    if (sol_ptr_vector_get_len(&sol_conffile_entry_vector) <= 0) {
-        sol_conffile_entry_vector = pv;
-        return true;
-    }
-
-    SOL_PTR_VECTOR_FOREACH_IDX (&pv, pv_entry, i) {
-        SOL_PTR_VECTOR_FOREACH_IDX (&sol_conffile_entry_vector, sol_conffile_entry_vector_entry, j) {
-            if (streq(pv_entry->id, sol_conffile_entry_vector_entry->id)) {
-                SOL_WRN("Ignoring entry [%s], as it already exists", pv_entry->id);
-                sol_conffile_free_entry_vector(&pv);
-                return false;
-            }
-        }
-    }
-
-    SOL_PTR_VECTOR_FOREACH_IDX (&pv, pv_entry, i) {
-        sol_ptr_vector_insert_sorted(&sol_conffile_entry_vector, pv_entry, sol_conffile_entry_sort_cb);
-    }
-
-    sol_ptr_vector_clear(&pv);
-    return true;
-}
-
-static void
-sol_conffile_fill_vector(const char *path, const char *fallback_paths)
+_fill_vector(const char *path, const char *fallback_paths)
 {
     char *full_path = NULL;
     char *include = NULL;
     char *include_fallbacks = NULL;
     struct sol_str_slice config_file_contents = SOL_STR_SLICE_EMPTY;
     struct sol_file_reader *file_reader = NULL;
-    struct sol_ptr_vector pv;
     struct sol_json_scanner json_scanner;
 
-    config_file_contents = sol_conffile_load_json_from_paths(path, fallback_paths, &full_path, &file_reader);
-    if (!config_file_contents.len) {
-        if (file_reader)
-            sol_file_reader_close(file_reader);
+    config_file_contents = _load_json_from_paths(path, fallback_paths, &full_path, &file_reader);
+    if (!config_file_contents.len)
         return;
-    }
 
     sol_json_scanner_init(&json_scanner, config_file_contents.data, config_file_contents.len);
-    sol_conffile_get_json_include_paths(json_scanner, &include, &include_fallbacks);
+    _get_json_include_paths(json_scanner, &include, &include_fallbacks);
 
-    if (sol_conffile_json_to_vector(json_scanner, &pv) != 0) {
-        SOL_DBG("Ignoring confile %s", full_path);
+    if (_json_to_vector(json_scanner) != 0)
         goto free_for_all;
-    }
-
-    if (!sol_conffile_append_to_entry_vector(pv)) {
-        SOL_DBG("Ignoring conffile %s", full_path);
-        goto free_for_all;
-    }
 
     if (include || include_fallbacks)
-        sol_conffile_fill_vector(include, include_fallbacks);
+        _fill_vector(include, include_fallbacks);
 
 free_for_all:
     sol_file_reader_close(file_reader);
@@ -428,9 +436,9 @@ free_for_all:
 }
 
 static void
-sol_conffile_load_vector(void)
+_load_vector_defaults(void)
 {
-    sol_conffile_fill_vector(getenv("SOL_FLOW_MODULE_RESOLVER_CONFFILE"),
+    _fill_vector(getenv("SOL_FLOW_MODULE_RESOLVER_CONFFILE"),
         "sol-flow.json");
     /*
      * TODO: Add the following fill priority:
@@ -442,37 +450,43 @@ sol_conffile_load_vector(void)
 }
 
 static void
-sol_conffile_clear_data(void)
+_init(void)
 {
-    sol_conffile_free_entry_vector(&sol_conffile_entry_vector);
+    static int first_call = true;
+
+    if (first_call) {
+        sol_ptr_vector_init(&_conffile_entry_vector);
+        sol_ptr_vector_init(&_conffiles_loaded);
+        atexit(_clear_data);
+    }
+    first_call = false;
 }
 
 static int
-sol_conffile_bsearch_entry_sort_cb(const void *data1, const void *data2)
+_bsearch_entry_cb(const void *data1, const void *data2)
 {
-    /* sol_ptr_vector holds a vector of pointers rather than a vector of data. */
     const void **p = (const void **)data2;
 
-    return sol_conffile_entry_sort_cb(data1, *p);
+    return _entry_sort_cb(data1, *p);
 }
 
 static int
-_sol_conffile_resolve(const char *id, const char **type, const char ***opts)
+_resolve_config(const char *id, const char **type, const char ***opts)
 {
     struct sol_conffile_entry key;
     struct sol_conffile_entry *entry;
     void **vector_pointer;
 
-    if (sol_ptr_vector_get_len(&sol_conffile_entry_vector) <= 0) {
+    if (sol_ptr_vector_get_len(&_conffile_entry_vector) <= 0) {
         return -EINVAL;
     }
 
     key.id = (char *)id;
     vector_pointer = bsearch(&key,
-        sol_conffile_entry_vector.base.data,
-        sol_ptr_vector_get_len(&sol_conffile_entry_vector),
-        sol_conffile_entry_vector.base.elem_size,
-        sol_conffile_bsearch_entry_sort_cb);
+        _conffile_entry_vector.base.data,
+        sol_ptr_vector_get_len(&_conffile_entry_vector),
+        _conffile_entry_vector.base.elem_size,
+        _bsearch_entry_cb);
     if (!vector_pointer) {
         SOL_DBG("could not find entry [%s]", id);
         return -EINVAL;
@@ -498,23 +512,19 @@ _sol_conffile_resolve(const char *id, const char **type, const char ***opts)
 int
 sol_conffile_resolve(const char *id, const char **type, const char ***opts)
 {
-    if (sol_ptr_vector_get_len(&sol_conffile_entry_vector) > 0)
-        sol_conffile_clear_data();
+    static bool first_call = true;
 
-    sol_conffile_load_vector();
-    atexit(sol_conffile_clear_data);
+    _init();
+    if (first_call)
+        _load_vector_defaults();
 
-    return _sol_conffile_resolve(id, type, opts);
+    return _resolve_config(id, type, opts);
 }
 
 int
 sol_conffile_resolve_path(const char *id, const char **type, const char ***opts, const char *path)
 {
-    if (sol_ptr_vector_get_len(&sol_conffile_entry_vector) > 0)
-        sol_conffile_clear_data();
-
-    sol_conffile_fill_vector(path, NULL);
-    atexit(sol_conffile_clear_data);
-
-    return _sol_conffile_resolve(id, type, opts);
+    _init();
+    _fill_vector(path, NULL);
+    return _resolve_config(id, type, opts);
 }


### PR DESCRIPTION
The old config file handling made a few assumptions that I overloocked
regarding to how it managed the configuration files. This new version
has the following adjustments:

- Only register the clear_data function to be called atexit once
- Do not free / reload the entry vector for each different node
- Shorter function names for internal functions
- More carefull memory handling
- Keep a cache of different files that where loaded
- Do not use intermediary vector step to fill the entry_vector
- Sub-includes and fallbacks working.

the "need to fo a thing" typo sneaked into this commit but it's already fixed here locally, don't need to coment on that.