### PR TITLE
modules/gtk: use type rgb instead of string on led

### DIFF
--- a/src/modules/flow/gtk/gtk.json
+++ b/src/modules/flow/gtk/gtk.json
@@ -67,10 +67,14 @@
       "options": {
         "members": [
           {
-            "data_type": "string",
+            "data_type": "rgb",
             "description": "The led's RGB color components",
             "name": "rgb",
-            "default": "0|0|255"
+            "default": {
+              "red": 0,
+              "green": 0,
+              "blue": 255
+            }
           }
         ],
         "version": 1


### PR DESCRIPTION
It shouldn't be trying to parse a string to define a color
if we have a rgb option type already.

@otaviobp reported an issue thanks to that

@glima , when you have some time, please review it.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>