### PR TITLE
Undocument missing.h.

### DIFF
--- a/src/lib/common/sol-missing.h
+++ b/src/lib/common/sol-missing.h
@@ -36,17 +36,6 @@
 extern "C" {
 #endif
 
-/**
- * @file
- * @brief These routines are Solleta replacements for others that aren't found in the underlying system.
- */
-
-/**
- * @defgroup Missing Missing
- *
- * @{
- */
-
 #ifndef HAVE_DECL_STRNDUPA
 #include <alloca.h>
 
@@ -109,10 +98,6 @@ err:
 #ifndef I2C_RDRW_IOCTL_MAX_MSGS
 #define I2C_RDRW_IOCTL_MAX_MSGS 42
 #endif
-
-/**
- * @}
- */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
That file should never have been documented. It was by mistake, since it
was erroneously installed at the time.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>