### PR TITLE
Build bring back fbp based samples v2

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -63,6 +63,7 @@ endmenu
 menu "Samples"
 source "src/samples/coap/Kconfig"
 source "src/samples/common/Kconfig"
+source "src/samples/flow/Kconfig"
 endmenu
 
 menu "Tools"

--- a/data/oic/oicgen.py
+++ b/data/oic/oicgen.py
@@ -1337,6 +1337,9 @@ server_handle_get(const struct sol_network_link_addr *cliaddr, const void *data,
     return SOL_COAP_RSPCODE_CONTENT;
 }
 
+// log_init() implementation happens within oic-gen.c
+static void log_init(void);
+
 static int
 server_resource_init(struct server_resource *resource, struct sol_flow_node *node,
     struct sol_str_slice resource_type, struct sol_str_slice defn_endpoint,
@@ -1344,7 +1347,7 @@ server_resource_init(struct server_resource *resource, struct sol_flow_node *nod
 {
     struct sol_oic_device_definition *def;
 
-    SOL_LOG_INTERNAL_INIT_ONCE;
+    log_init();
 
     if (!sol_oic_server_init(DEFAULT_UDP_PORT)) {
         SOL_WRN("Could not create %%.*s server", SOL_STR_SLICE_PRINT(resource_type));
@@ -1398,7 +1401,7 @@ static int
 client_resource_init(struct sol_flow_node *node, struct client_resource *resource, const char *resource_type,
     const char *hwaddr, const struct client_resource_funcs *funcs)
 {
-    SOL_LOG_INTERNAL_INIT_ONCE;
+    log_init();
     if (!initialize_multicast_addresses_once()) {
         SOL_ERR("Could not initialize multicast addresses");
         return -ENOTCONN;

--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -416,7 +416,6 @@ extern "C" {
 def generate_header_tail(outfile, data):
     outfile.write("""
 #ifndef SOL_LOG_DOMAIN
-#define SOL_LOG_DOMAIN &_log_domain
 #include "sol-log.h"
 
 #ifdef SOL_LOG_ENABLED
@@ -429,40 +428,21 @@ def generate_header_tail(outfile, data):
 
 #define SOL_LOG_INTERNAL_DECLARE_STATIC(_var, _name) \
     static SOL_LOG_INTERNAL_DECLARE(_var, _name)
-
-#define SOL_LOG_INTERNAL_INIT_ONCE \
-    do { \
-        static bool _log_internal_init_once_first = true; \
-        if (_log_internal_init_once_first) { \
-            sol_log_domain_init_level(SOL_LOG_DOMAIN); \
-            _log_internal_init_once_first = false; \
-        } \
-    } while (0)
-#else
+#else // #ifdef SOL_LOG_ENABLED
 #define SOL_LOG_INTERNAL_DECLARE(_var, _name)
 #define SOL_LOG_INTERNAL_DECLARE_STATIC(_var, _name)
-#define SOL_LOG_INTERNAL_INIT_ONCE
 #ifdef SOL_LOG_DOMAIN
 #undef SOL_LOG_DOMAIN
 #define SOL_LOG_DOMAIN NULL
+
 #endif // #ifdef SOL_LOG_DOMAIN
 #endif // #ifdef SOL_LOG_ENABLED
-
-SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, \"%(domain)s\");
-
-static void
-log_init(void)
-{
-    SOL_LOG_INTERNAL_INIT_ONCE;
-}
 #endif // ifndef SOL_LOG_DOMAIN
 
 #ifdef __cplusplus
 }
 #endif
-"""  % {
-    "domain": "flow-" + c_clean(data["name"].lower())
-})
+""")
 
 
 def generate_header_entry(outfile, data):
@@ -570,11 +550,37 @@ def generate_code_head(outfile, data):
 #include <sol-macros.h>
 #include <errno.h>
 %(float_h)s
+
+#ifdef SOL_LOG_ENABLED
+#define SOL_LOG_INTERNAL_INIT_ONCE \
+    do { \
+        static bool _log_internal_init_once_first = true; \
+        if (_log_internal_init_once_first) { \
+            sol_log_domain_init_level(SOL_LOG_DOMAIN); \
+            _log_internal_init_once_first = false; \
+        } \
+    } while (0)
+#else
+#define SOL_LOG_INTERNAL_INIT_ONCE
+#endif // #ifdef SOL_LOG_ENABLED
+
+#ifndef SOL_LOG_DOMAIN
+#define SOL_LOG_DOMAIN &_log_domain
+SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, \"%(domain)s\");
+#endif // ifndef SOL_LOG_DOMAIN
+
+static void
+log_init(void)
+{
+    SOL_LOG_INTERNAL_INIT_ONCE;
+}
+
 """ % {
     "input": data["input"],
     "header": os.path.basename(data["header"]),
     "NAME_C": data["NAME_C"],
     "float_h": uses_float(data),
+    "domain": "flow-" + c_clean(data["name"].lower())
 })
 
 

--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -580,7 +580,23 @@ generate_node_type_assignments(const struct fbp_data *data)
 static bool
 generate_create_type_function(struct fbp_data *data)
 {
-    dprintf(fd, "static const struct sol_flow_node_type *\n"
+    uint16_t i;
+
+    /** Make sure to #include all the node type's headers in use. The header
+     * name is inferred on the node's module name. */
+    for (i = 0; i < (&data->graph.nodes)->len; i++) {
+        char *needle, *module;
+
+        module = data->descriptions[i]->name;
+        needle = strstr(module, "/");
+        if (needle) {
+            module = strndupa(module, strlen(module) - strlen(needle));
+        }
+
+        dprintf(fd, "#include \"%s-gen.h\"\n", module);
+    }
+
+    dprintf(fd, "\nstatic const struct sol_flow_node_type *\n"
         "create_%d_%s_type(void)\n"
         "{\n",
         data->id,

--- a/src/modules/flow/gtk/gtk.c
+++ b/src/modules/flow/gtk/gtk.c
@@ -34,14 +34,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-// The gtk module is a bit of an alien WRT logging, as it has to share
-// the domain symbol externally with the various .o objects that will
-// be linked together. Let's redeclare it by hand, then, and before
-// including gtk-gen.h. Also, log_init() is defined here instead.
 #include "common.h"
-SOL_LOG_INTERNAL_DECLARE(_gtk_log_domain, "flow-gtk");
-
 #include "gtk-gen.h"
+
+SOL_LOG_INTERNAL_DECLARE(_gtk_log_domain, "flow-gtk");
 
 #include "sol-mainloop.h"
 #include "sol-util.h"
@@ -66,12 +62,6 @@ struct gtk_state {
 
 static struct gtk_state *gtk_state = NULL;
 static struct gtk_state _gtk_state;
-
-static void
-log_init(void)
-{
-    SOL_LOG_INTERNAL_INIT_ONCE;
-}
 
 static void
 init(void)

--- a/src/modules/flow/process/process.c
+++ b/src/modules/flow/process/process.c
@@ -1,15 +1,5 @@
 #include "common.h"
 
-// The process module is a bit of an alien WRT logging, as it has to
-// share the domain symbol externally with the various .o objects that
-// will be linked together. Also, log_init() is defined here instead.
 SOL_LOG_INTERNAL_DECLARE(_process_log_domain, "flow-process");
-
-static void
-log_init(void)
-{
-    SOL_LOG_INTERNAL_INIT_ONCE;
-}
-
 
 #include "process-gen.c"

--- a/src/modules/flow/test/test.c
+++ b/src/modules/flow/test/test.c
@@ -38,14 +38,9 @@
 
 #include "test-module.h"
 
-// The test module is a bit of an alien WRT logging, as it has to
-// share the domain symbol externally with the various .o objects that
-// will be linked together. Let's redeclare it by hand, then, and
-// before including test-gen.h. Also, log_init() is defined here
-// instead.
-SOL_LOG_INTERNAL_DECLARE(_test_log_domain, "flow-test");
-
 #include "test-gen.h"
+
+SOL_LOG_INTERNAL_DECLARE(_test_log_domain, "flow-test");
 
 #include "result.h"
 #include "boolean-generator.h"
@@ -55,11 +50,5 @@ SOL_LOG_INTERNAL_DECLARE(_test_log_domain, "flow-test");
 #include "int-validator.h"
 #include "int-generator.h"
 #include "blob-validator.h"
-
-static void
-log_init(void)
-{
-    SOL_LOG_INTERNAL_INIT_ONCE;
-}
 
 #include "test-gen.c"

--- a/src/samples/flow/Kconfig
+++ b/src/samples/flow/Kconfig
@@ -1,0 +1,14 @@
+config FLOW_SAMPLES
+	bool "Flow samples"
+	depends on FLOW
+	default y
+
+config FLOW_BASIC_SAMPLE
+	bool "Simple fbp sample"
+	depends on FLOW_SAMPLES && FBP_GENERATOR
+	default y
+
+config FLOW_CMDLINE_ARGS_SAMPLE
+	bool "Command line arguments sample"
+	depends on FLOW_SAMPLES && FBP_GENERATOR
+	default y

--- a/src/samples/flow/Makefile
+++ b/src/samples/flow/Makefile
@@ -1,0 +1,8 @@
+sample-$(FLOW_BASIC_SAMPLE) += simple-fbp
+sample-simple-fbp-$(FLOW_BASIC_SAMPLE) := basics/simple.fbp
+sample-simple-fbp-$(FLOW_BASIC_SAMPLE)-deps := timer.mod boolean.mod console.mod
+
+sample-$(FLOW_CMDLINE_ARGS_SAMPLE) += cmdline-args
+sample-cmdline-args-$(FLOW_CMDLINE_ARGS_SAMPLE) := basics/cmdline-args.fbp
+sample-cmdline-args-$(FLOW_CMDLINE_ARGS_SAMPLE)-deps := boolean.mod app.mod console.mod int.mod constant.mod
+sample-cmdline-args-$(FLOW_CMDLINE_ARGS_SAMPLE)-deps += converter.mod

--- a/src/test/test-flow.c
+++ b/src/test/test-flow.c
@@ -36,9 +36,6 @@
 #include "sol-util.h"
 #include "sol-vector.h"
 
-/* we include some -gen.h but are not building a module, disregard
- * log_init() */
-static void log_init(void) SOL_ATTR_UNUSED;
 #include "console-gen.h"
 #ifdef USE_PWM
 #include "pwm-gen.h"

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -115,7 +115,7 @@ parse-sample = \
 	$(eval sample-$(1)-srcs := $(addprefix $(2),$(filter-out %.fbp,$(sample-$(1)-y)))) \
 	$(eval artifacts        := $(addprefix $(2),$(filter %.fbp,$(sample-$(1)-y)))) \
 	$(call gen-fbp-artifact,$(1),$(artifacts),sample-$(1)-srcs) \
-	$(eval sample-$(1)-out  := $(addprefix $(2),$(1))) \
+	$(eval sample-$(1)-out  := $(subst $(top_srcdir)src,$(build_stagedir),$(addprefix $(2),$(1)))) \
 	$(eval $(1)-deps        := $(subst .mod,,$(sample-$(1)-y-deps))) \
 	$(eval samples-out      += $(sample-$(1)-out)) \
 
@@ -199,6 +199,7 @@ $(foreach curr,$(bins),$(eval $(call make-bin,$(curr))))
 define make-sample
 $(sample-$(1)-out): $(PRE_GEN) $(SOL_LIB_SO) $(sample-$(1)-srcs) $(call find-deps,$(1))
 	$(Q)echo "     "SMP"   "$$@
+	$(Q)$(MKDIR) -p $(dir $(sample-$(1)-out))
 	$(Q)$(TARGETCC) $(SAMPLE_CFLAGS) $(sample-$(1)-cflags) $(filter-out %.h,$(sample-$(1)-srcs)) \
 	$(call find-deps,$(1)) -o $(sample-$(1)-out) $(SAMPLE_LDFLAGS) $(sample-$(1)-ldflags) $(sort $(builtin-ldflags))
 endef

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -103,8 +103,18 @@ parse-test = \
 	$(eval $(1)-deps      := $(subst .mod,,$($(3)-$(1)-y-deps))) \
 	$(eval tests-out      += $(test-$(1)-out)) \
 
+gen-fbp-artifact = \
+	$(foreach fbp,$(filter %.fbp,$(2)), \
+		$(eval $(fbp)-src       := $(subst $(top_srcdir)src,$(build_stagedir),$(subst .fbp,-gen.c,$(fbp)))) \
+		$(eval $(3)             += $($(fbp)-src)) \
+		$(eval sample-$(1)-gens += $(fbp)) \
+		$(eval all-fbp-gens     += $(fbp)) \
+	) \
+
 parse-sample = \
-	$(eval sample-$(1)-srcs := $(addprefix $(2),$(sample-$(1)-y))) \
+	$(eval sample-$(1)-srcs := $(addprefix $(2),$(filter-out %.fbp,$(sample-$(1)-y)))) \
+	$(eval artifacts        := $(addprefix $(2),$(filter %.fbp,$(sample-$(1)-y)))) \
+	$(call gen-fbp-artifact,$(1),$(artifacts),sample-$(1)-srcs) \
 	$(eval sample-$(1)-out  := $(addprefix $(2),$(1))) \
 	$(eval $(1)-deps        := $(subst .mod,,$(sample-$(1)-y-deps))) \
 	$(eval samples-out      += $(sample-$(1)-out)) \
@@ -189,7 +199,8 @@ $(foreach curr,$(bins),$(eval $(call make-bin,$(curr))))
 define make-sample
 $(sample-$(1)-out): $(PRE_GEN) $(SOL_LIB_SO) $(sample-$(1)-srcs) $(call find-deps,$(1))
 	$(Q)echo "     "SMP"   "$$@
-	$(Q)$(TARGETCC) $(SAMPLE_CFLAGS) $(sample-$(1)-cflags) $(filter-out %.h,$(sample-$(1)-srcs)) -o $(sample-$(1)-out) $(SAMPLE_LDFLAGS) $(sample-$(1)-ldflags) $(sort $(builtin-ldflags))
+	$(Q)$(TARGETCC) $(SAMPLE_CFLAGS) $(sample-$(1)-cflags) $(filter-out %.h,$(sample-$(1)-srcs)) \
+	$(call find-deps,$(1)) -o $(sample-$(1)-out) $(SAMPLE_LDFLAGS) $(sample-$(1)-ldflags) $(sort $(builtin-ldflags))
 endef
 $(foreach sample,$(samples),$(eval $(call make-sample,$(sample))))
 
@@ -289,6 +300,14 @@ $($(1)-hdr) $($(1)-src) $($(1)-desc): $(1) $(NODE_TYPE_GEN_SCRIPT)
 		--genspec-schema=$(NODE_TYPE_SCHEMA) $(1) $($(1)-hdr) $($(1)-src) $($(1)-desc)
 endef
 $(foreach gen,$(all-gens),$(eval $(call make-gen,$(gen))))
+
+define make-fbp-gen
+$($(1)-src): $(1) $(SOL_FBP_GENERATOR_BIN)
+	$(Q)echo "     "GEN"   "$$@
+	$(Q)$(MKDIR) -p $(dir $($(1)-src))
+	$(Q)$(SOL_FBP_GENERATOR_BIN) -j $(build_descdir) $(1) $($(1)-src)
+endef
+$(foreach gen,$(all-fbp-gens),$(eval $(call make-fbp-gen,$(gen))))
 
 $(FLOW_BUILTINS_DESC): $(PRE_GEN) $(SOL_LIB_SO) $(SOL_LIB_AR) $(all-mod-descs) $(JSON_FORMAT_SCRIPT)
 	$(Q)echo "     "GEN"   "$@

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -30,6 +30,7 @@ tests-out :=
 samples :=
 samples-out :=
 
+all-fbp-gens :=
 all-gens :=
 all-objs :=
 all-dest-hdr :=
@@ -276,6 +277,7 @@ TEST_VALGRIND_SUPP := $(top_srcdir)src/test/test.supp
 
 TEST_FBP_SCRIPT := $(top_srcdir)tools/run-fbp-tests
 SOL_FBP_RUNNER_BIN := $(build_bindir)sol-fbp-runner
+SOL_FBP_GENERATOR_BIN := $(build_bindir)sol-fbp-generator
 
 DOXYGEN_RESOURCES = \
 	doc/doxygen/Doxyfile \


### PR DESCRIPTION
# Changes
v2:
  + new patch: fbp-generator: Make sure to #include required -gen.h;
  + new patch: node-type: move log_init() implementation to -gen.c;
  + new patch: build: move samples compiled bin to build/stage/;
  + since now sol-fbp-generator does the #include for node types - removed the -include build directive for every -gen.h on patch: build: bring back fbp sample;