### PR TITLE
Reduce the amount of allocations and code for options

### DIFF
--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -805,8 +805,6 @@ static void
 }
 """)
 
-    new_options_func = "NULL"
-    free_options_func = "NULL"
     if "options" in data:
         outfile.write("""
 static const struct %(name_c)s_options %(name_c)s_options_defaults = %(NAME_C)s_OPTIONS_DEFAULTS();
@@ -814,78 +812,7 @@ static const struct %(name_c)s_options %(name_c)s_options_defaults = %(NAME_C)s_
     "name_c": data["name_c"],
     "NAME_C": data["NAME_C"],
     })
-        new_options_func = None
-        free_options_func = None
-        if "methods" in data["options"]:
-            new_options_func = data["options"]["methods"].get("new", None)
-            free_options_func = data["options"]["methods"].get("free", None)
 
-    if new_options_func is None:
-        new_options_func = "%s_new_options_internal" % data["name_c"]
-        outfile.write("""
-static struct sol_flow_node_options *
-%(name_func)s(const struct sol_flow_node_type *type, const struct sol_flow_node_options *copy_from)
-{
-    struct %(name_c)s_options *opts;
-    const struct %(name_c)s_options *from;
-
-    if (!copy_from) from = &%(name_c)s_options_defaults;
-    else from = (struct %(name_c)s_options *)copy_from;
-    if (from->base.sub_api != %(NAME_C)s_OPTIONS_API_VERSION) {
-        errno = -EINVAL;
-        return NULL;
-    }
-
-    opts = malloc(sizeof(*opts));
-    if (!opts) {
-        errno = -ENOMEM;
-        return NULL;
-    }
-    *opts = *from;
-""" % {
-    "name_c": data["name_c"],
-    "NAME_C": data["NAME_C"],
-    "name_func": new_options_func
-    })
-        members = data["options"].get("members", [])
-        for m in members:
-            if m["data_type"] == "string":
-                outfile.write("""
-    if (opts->%(member)s)
-        opts->%(member)s = strdup(opts->%(member)s);
-""" % {
-    "member": m["name"]
-    })
-        outfile.write("""
-    return &opts->base;
-}
-""")
-
-    if free_options_func is None:
-        free_options_func = "%s_free_options_internal" % data["name_c"]
-        outfile.write("""
-static void
-%(name_func)s(const struct sol_flow_node_type *type, struct sol_flow_node_options *options)
-{
-    struct %(name_c)s_options *opts;
-    if (!options) return;
-    opts = (struct %(name_c)s_options *)options;
-""" % {
-    "name_c": data["name_c"],
-    "name_func": free_options_func
-    })
-        members = data["options"].get("members", [])
-        for m in members:
-            if m["data_type"] == "string":
-                outfile.write("""
-    free((void *)opts->%(member)s);
-""" % {
-    "member": m["name"]
-    })
-        outfile.write("""
-    free(opts);
-}
-""")
 
     outfile.write("""
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
@@ -1031,6 +958,12 @@ static const struct sol_flow_node_type_description %(name_c)s_description = {
     }),
 """)
 
+    outfile.write("""\
+};
+#endif
+
+""")
+
     node_type = "struct sol_flow_node_type"
     node_base_type_access_open = ""
     node_base_type_access_close = ""
@@ -1046,16 +979,20 @@ static const struct sol_flow_node_type_description %(name_c)s_description = {
     data_size = "0"
     if "private_data_type" in data:
         data_size = "sizeof(struct " + data.get("private_data_type") + ")"
-    outfile.write("""\
-};
-#endif
 
+    options_size = "sizeof(struct sol_flow_node_options)"
+    default_options = "NULL"
+    if "options" in data:
+        options_size = "sizeof(struct " + data["name_c"] + "_options)"
+        default_options = "&" + data["name_c"] + "_options_defaults"
+
+    outfile.write("""\
 static const %(node_type)s %(name_c)s = {%(node_base_type_access_open)s
     .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
     .data_size = %(data_size)s,
+    .options_size = %(options_size)s,
+    .default_options = %(default_options)s,
     .init_type = %(name_c)s_init_type_internal,
-    .new_options = %(new_opts)s,
-    .free_options = %(free_opts)s,
     .open = %(open)s,
     .close = %(close)s,
     .get_ports_counts = %(name_c)s_get_ports_counts_internal,
@@ -1064,8 +1001,8 @@ static const %(node_type)s %(name_c)s = {%(node_base_type_access_open)s
     "node_base_type_access_open": node_base_type_access_open,
     "name_c": data["name_c"],
     "data_size": data_size,
-    "new_opts": new_options_func,
-    "free_opts": free_options_func,
+    "options_size": options_size,
+    "default_options": default_options,
     "open": methods.get("open", "NULL"),
     "close": methods.get("close", "NULL"),
     })

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -306,12 +306,11 @@ struct sol_flow_node_type {
 #define SOL_FLOW_NODE_TYPE_API_VERSION (1) /**< compile time API version to be checked during runtime */
     uint16_t api_version; /**< must match SOL_FLOW_NODE_TYPE_API_VERSION at runtime */
     uint16_t data_size; /**< size of the whole sol_flow_node_type derivate */
+    uint16_t options_size;
     uint16_t flags; /**< @see #sol_flow_node_type_flags */
 
     const void *type_data; /**< pointer to per-type user data */
-
-    struct sol_flow_node_options *(*new_options)(const struct sol_flow_node_type *type, const struct sol_flow_node_options *copy_from); /**< member function to instantiate new options for the node. If @a copy_from is not @c NULL, its members will be copied into the new returned struct */
-    void (*free_options)(const struct sol_flow_node_type *type, struct sol_flow_node_options *opts); /**< member function to delete the node options */
+    const void *default_options;
 
     void (*get_ports_counts)(const struct sol_flow_node_type *type, uint16_t *ports_in_count, uint16_t *ports_out_count); /**< member function to get the number of input/output ports of the node */
     const struct sol_flow_port_type_in *(*get_port_in)(const struct sol_flow_node_type *type, uint16_t port); /**< member function to get the array of the node's input ports */

--- a/src/lib/flow/sol-flow-internal.h
+++ b/src/lib/flow/sol-flow-internal.h
@@ -131,8 +131,7 @@ int sol_flow_node_init(struct sol_flow_node *node, struct sol_flow_node *parent,
 /* Update libsoletta-gdb.py before changing the function and parameters below. */
 void sol_flow_node_fini(struct sol_flow_node *node);
 
-struct sol_flow_node_options *sol_flow_node_get_options(const struct sol_flow_node_type *type, const struct sol_flow_node_options *copy_from);
-void sol_flow_node_free_options(const struct sol_flow_node_type *type, struct sol_flow_node_options *options);
+extern const struct sol_flow_node_options sol_flow_node_options_empty;
 
 #define SOL_FLOW_NODE_CHECK(handle, ...)                 \
     do {                                                \

--- a/src/lib/flow/sol-flow-resolver.c
+++ b/src/lib/flow/sol-flow-resolver.c
@@ -62,13 +62,6 @@ sol_flow_resolve(
         return -ENOENT;
     }
 
-    if (!tmp_type->new_options && tmp_opts_strv) {
-        SOL_ERR("Error resolving node type for id='%s'. "
-            "The type doesn't support options, but resolver returned them", id);
-        sol_flow_node_options_strv_del((char **)tmp_opts_strv);
-        return -EINVAL;
-    }
-
     *type = tmp_type;
     *opts_strv = tmp_opts_strv;
     return 0;

--- a/src/modules/flow/calamari/calamari.c
+++ b/src/modules/flow/calamari/calamari.c
@@ -259,8 +259,8 @@ calamari_7seg_new_type(const struct sol_flow_node_type **current)
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
     type->description = (*current)->description;
 #endif
-    type->new_options = (*current)->new_options;
-    type->free_options = (*current)->free_options;
+    type->options_size = (*current)->options_size;
+    type->default_options = (*current)->default_options;
     *current = type;
 }
 
@@ -586,8 +586,8 @@ calamari_rgb_led_new_type(const struct sol_flow_node_type **current)
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
     type->description = (*current)->description;
 #endif
-    type->new_options = (*current)->new_options;
-    type->free_options = (*current)->free_options;
+    type->options_size = (*current)->options_size;
+    type->default_options = (*current)->default_options;
     *current = type;
 }
 

--- a/src/modules/flow/grove/grove.c
+++ b/src/modules/flow/grove/grove.c
@@ -114,8 +114,8 @@ grove_rotary_sensor_new_type(const struct sol_flow_node_type **current)
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
     type->description = (*current)->description;
 #endif
-    type->new_options = (*current)->new_options;
-    type->free_options = (*current)->free_options;
+    type->options_size = (*current)->options_size;
+    type->default_options = (*current)->default_options;
     *current = type;
 }
 
@@ -232,8 +232,8 @@ grove_light_sensor_new_type(const struct sol_flow_node_type **current)
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
     type->description = (*current)->description;
 #endif
-    type->new_options = (*current)->new_options;
-    type->free_options = (*current)->free_options;
+    type->options_size = (*current)->options_size;
+    type->default_options = (*current)->default_options;
     *current = type;
 }
 
@@ -412,8 +412,8 @@ grove_temperature_sensor_new_type(const struct sol_flow_node_type **current)
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
     type->description = (*current)->description;
 #endif
-    type->new_options = (*current)->new_options;
-    type->free_options = (*current)->free_options;
+    type->options_size = (*current)->options_size;
+    type->default_options = (*current)->default_options;
     *current = type;
 }
 

--- a/src/test/test-flow-parser.c
+++ b/src/test/test-flow-parser.c
@@ -204,30 +204,19 @@ static const struct sol_flow_node_type_description test_node_description = {
         })
 };
 
-static struct sol_flow_node_options *
-test_node_type_new_options(const struct sol_flow_node_type *type,
-    const struct sol_flow_node_options *copy_from)
-{
-    struct test_node_options *opts, *from = (struct test_node_options *)copy_from;
-
-    opts = malloc(sizeof(*opts));
-    opts->base.api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION;
-    opts->base.sub_api = 1;
-    opts->opt = from ? from->opt : true;
-    return &opts->base;
-}
-
-static void
-test_node_type_free_options(const struct sol_flow_node_type *type, struct sol_flow_node_options *opts)
-{
-    free(opts);
-}
+static const struct test_node_options default_opts = {
+    .base = {
+        .api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION,
+        .sub_api = 1,
+    },
+    .opt = true,
+};
 
 static const struct sol_flow_node_type test_node_type = {
     .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
 
-    .new_options = test_node_type_new_options,
-    .free_options = test_node_type_free_options,
+    .options_size = sizeof(struct test_node_options),
+    .default_options = &default_opts,
 
     .get_ports_counts = test_node_get_ports_counts,
     .get_port_in = test_node_get_port_in,

--- a/src/test/test-flow.c
+++ b/src/test/test-flow.c
@@ -1268,37 +1268,6 @@ merge_options(void)
 }
 
 
-DEFINE_TEST(copy_options);
-
-static void
-copy_options(void)
-{
-    struct sol_flow_node_type_console_options opts = {}, *copied_opts;
-    char prefix[] = { 'A', 'B', 'C', '\0' };
-
-    opts.base.api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION;
-    opts.base.sub_api = SOL_FLOW_NODE_TYPE_CONSOLE_OPTIONS_API_VERSION;
-    opts.prefix = prefix;
-    opts.output_on_stdout = true;
-    opts.flush = false;
-
-    copied_opts = (struct sol_flow_node_type_console_options *)
-        sol_flow_node_options_copy(SOL_FLOW_NODE_TYPE_CONSOLE, &opts.base);
-    ASSERT(copied_opts);
-
-    /* Will touch some of the values after the copy. */
-    prefix[0] = 'X';
-    prefix[1] = '\0';
-    opts.output_on_stdout = false;
-
-    ASSERT(streq(copied_opts->prefix, "ABC"));
-    ASSERT(copied_opts->output_on_stdout);
-    ASSERT(!copied_opts->flush);
-
-    sol_flow_node_options_del(SOL_FLOW_NODE_TYPE_CONSOLE, &copied_opts->base);
-}
-
-
 DEFINE_TEST(need_a_valid_type_to_create_packets);
 
 static void


### PR DESCRIPTION
Improvements to how we deal with `struct sol_flow_node_options`.

The second patch ensures that we simply pass thru the options from the spec if nothing is being exported, as discussed in #335.