### PR TITLE
JSON number parsing

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -246,9 +246,14 @@
 	    "fragment": "strndupa(0, 0);"
 	},
 	{
-	    "dependency": "builtin_umull_overflow",
+	    "dependency": "builtin_mul_overflow",
 	    "type": "ccode",
-	    "fragment": "__builtin_umull_overflow(0, 0, (void *)0);"
+	    "fragment": "__builtin_mul_overflow(0ULL, 0ULL, (unsigned long long *)0);"
+	},
+	{
+	    "dependency": "builtin_add_overflow",
+	    "type": "ccode",
+	    "fragment": "__builtin_add_overflow(0ULL, 0ULL, (unsigned long long *)0);"
 	},
 	{
 	    "dependency": "decl_ifla_inet6_addr_gen_mode",

--- a/src/lib/parsers/sol-json.c
+++ b/src/lib/parsers/sol-json.c
@@ -34,10 +34,13 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+#include <locale.h>
 
 #include "sol-json.h"
 #include "sol-log.h"
 #include "sol-util.h"
+#include <float.h>
+#include <math.h>
 
 static bool
 check_symbol(struct sol_json_scanner *scanner, struct sol_json_token *token,
@@ -136,6 +139,193 @@ check_number(struct sol_json_scanner *scanner, struct sol_json_token *token)
 
     token->end = scanner->current;
     return true;
+}
+
+static int
+token_get_uint64(const struct sol_json_token *token, uint64_t *value)
+{
+    const char *itr = token->start;
+    uint64_t tmpvar = 0;
+
+    if (*itr == '+')
+        itr++;
+
+    for (; itr < token->end; itr++) {
+        const char c = *itr;
+        if (c >= '0' && c <= '9') {
+            int r;
+
+            r = sol_util_uint64_mul(tmpvar, 10, &tmpvar);
+            if (r < 0)
+                goto overflow;
+
+            r = sol_util_uint64_add(tmpvar, c - '0', &tmpvar);
+            if (r < 0)
+                goto overflow;
+            continue;
+        }
+        *value = tmpvar; /* best effort */
+        SOL_DBG("unexpected char '%c' at position %u of integer token %.*s",
+            c, (unsigned)(itr - token->start),
+            sol_json_token_get_size(token), token->start);
+        return -EINVAL;
+
+overflow:
+        *value = UINT64_MAX; /* best effort */
+        SOL_DBG("number is too large at position %u of integer token %.*s",
+            (unsigned)(itr - token->start),
+            sol_json_token_get_size(token), token->start);
+        return -ERANGE;
+    }
+
+    *value = tmpvar;
+    return 0;
+}
+
+static int
+token_get_int64(const struct sol_json_token *token, int64_t *value)
+{
+    struct sol_json_token inttoken = *token;
+    int r, sign = 1;
+    uint64_t tmpvar;
+
+    if (*inttoken.start == '-') {
+        sign = -1;
+        inttoken.start++;
+    }
+
+    r = token_get_uint64(&inttoken, &tmpvar);
+    if (r == 0) {
+        if (sign > 0 && tmpvar > INT64_MAX) {
+            *value = INT64_MAX;
+            return -ERANGE;
+        } else if (sign < 0 && tmpvar > ((uint64_t)INT64_MAX + 1)) {
+            *value = INT64_MIN;
+            return -ERANGE;
+        }
+        *value = sign * tmpvar;
+        return 0;
+    } else {
+        /* best effort to help users ignoring return false */
+        if (r == -ERANGE) {
+            if (sign > 0)
+                *value = INT64_MAX;
+            else
+                *value = INT64_MIN;
+        } else {
+            if (sign > 0 && tmpvar > INT64_MAX)
+                *value = INT64_MAX;
+            else if (sign < 0 && tmpvar > ((uint64_t)INT64_MAX + 1))
+                *value = INT64_MIN;
+            else
+                *value = sign * tmpvar;
+        }
+        return r;
+    }
+}
+
+SOL_API int
+sol_json_token_get_uint64(const struct sol_json_token *token, uint64_t *value)
+{
+    *value = 0;
+    SOL_NULL_CHECK(token, -EINVAL);
+    SOL_NULL_CHECK(value, -EINVAL);
+    if (token->start >= token->end) {
+        SOL_WRN("invalid token: start=%p, end=%p",
+            token->start, token->end);
+        return -EINVAL;
+    }
+    if (sol_json_token_get_type(token) != SOL_JSON_TYPE_NUMBER) {
+        SOL_WRN("expected number, got token type '%c' for token \"%.*s\"",
+            sol_json_token_get_type(token),
+            sol_json_token_get_size(token), token->start);
+        return -EINVAL;
+    }
+    if (*token->start == '-') {
+        SOL_DBG("%.*s: negative number where unsigned is expected",
+            sol_json_token_get_size(token), token->start);
+        return -ERANGE;
+    }
+
+    return token_get_uint64(token, value);
+}
+
+SOL_API int
+sol_json_token_get_int64(const struct sol_json_token *token, int64_t *value)
+{
+    *value = 0;
+    SOL_NULL_CHECK(token, -EINVAL);
+    SOL_NULL_CHECK(value, -EINVAL);
+    if (token->start >= token->end) {
+        SOL_WRN("invalid token: start=%p, end=%p",
+            token->start, token->end);
+        return -EINVAL;
+    }
+    if (sol_json_token_get_type(token) != SOL_JSON_TYPE_NUMBER) {
+        SOL_WRN("expected number, got token type '%c' for token \"%.*s\"",
+            sol_json_token_get_type(token),
+            sol_json_token_get_size(token), token->start);
+        return -EINVAL;
+    }
+
+    return token_get_int64(token, value);
+}
+
+SOL_API int
+sol_json_token_get_double(const struct sol_json_token *token, double *value)
+{
+    char *endptr, *oldlocale;
+    int r;
+
+    /* NOTE: Using a copy to ensure trailing \0 and strtod() so we
+     * properly parse numbers with large precision.
+     *
+     * Splitting the integer, fractional and exponent parts and doing
+     * the math using double numbers will result in rounding errors
+     * when parsing DBL_MAX using "%.64g" formatting.
+     *
+     * Since parsing it is complex (ie:
+     * http://www.netlib.org/fp/dtoa.c), we take the short path to
+     * call our helper around libc's strtod() that limits the amount
+     * of bytes.
+     *
+     * Extra care is needed since strtod() is locale-dependent, in
+     * pt_BR it will use ',' as fractional/decimal separator and we do
+     * not want that as JSON uses '.' in the same way as the 'C'
+     * locale. Then force 'C' and save oldlocale, restoring it before
+     * we return.
+     */
+    oldlocale = setlocale(LC_NUMERIC, NULL);
+    if (oldlocale && !streq(oldlocale, "C")) {
+        oldlocale = strdupa(oldlocale);
+        setlocale(LC_NUMERIC, "C");
+    }
+
+    *value = sol_util_strtodn(token->start, &endptr,
+        sol_json_token_get_size(token));
+
+    r = -errno;
+    if (endptr == token->start)
+        r = -EINVAL;
+    else if (isinf(*value)) {
+        SOL_DBG("token '%.*s' is infinite",
+            sol_json_token_get_size(token), token->start);
+        if (*value < 0)
+            *value = -DBL_MAX;
+        else
+            *value = DBL_MAX;
+        r = -ERANGE;
+    } else if (isnan(*value)) {
+        SOL_DBG("token '%.*s' is not a number",
+            sol_json_token_get_size(token), token->start);
+        *value = 0;
+        r = -EINVAL;
+    }
+
+    if (oldlocale && !streq(oldlocale, "C"))
+        setlocale(LC_NUMERIC, oldlocale);
+
+    return r;
 }
 
 SOL_API bool

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -52,6 +52,30 @@ sol_util_memdup(const void *data, size_t len)
     return ptr;
 }
 
+double
+sol_util_strtodn(const char *nptr, char **endptr, size_t len)
+{
+    char *tmpbuf, *tmpbuf_endptr;
+    double value;
+
+    /* NOTE: Using a copy to ensure trailing \0 and strtod() so we
+     * properly parse numbers with large precision.
+     *
+     * Since parsing it is complex (ie:
+     * http://www.netlib.org/fp/dtoa.c), we take the short path to
+     * call libc.
+     */
+    tmpbuf = strndupa(nptr, len);
+
+    errno = 0;
+    value = strtod(tmpbuf, &tmpbuf_endptr);
+
+    if (endptr)
+        *endptr = (char *)nptr + (tmpbuf_endptr - tmpbuf);
+
+    return value;
+}
+
 #ifdef SOL_PLATFORM_CONTIKI
 #include <contiki.h>
 

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -40,6 +40,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <time.h>
+#include <errno.h>
 #include <sys/types.h>
 
 #ifdef SOL_PLATFORM_LINUX
@@ -160,11 +161,35 @@ struct sol_vector sol_util_str_split(const struct sol_str_slice slice, const cha
 static inline int
 sol_util_size_mul(size_t elem_size, size_t num_elems, size_t *out)
 {
-#ifdef HAVE_UMULL_OVERFLOW
-    if (__builtin_umull_overflow(elem_size, num_elems, out))
+#ifdef HAVE_BUILTIN_MUL_OVERFLOW
+    if (__builtin_mul_overflow(elem_size, num_elems, out))
         return -EOVERFLOW;
 #else
     *out = elem_size * num_elems;
+#endif
+    return 0;
+}
+
+static inline uint64_t
+sol_util_uint64_mul(const uint64_t a, const uint64_t b, uint64_t *out)
+{
+#ifdef HAVE_BUILTIN_MUL_OVERFLOW
+    if (__builtin_mul_overflow(a, b, out))
+        return -EOVERFLOW;
+#else
+    *out = a * b;
+#endif
+    return 0;
+}
+
+static inline uint64_t
+sol_util_uint64_add(const uint64_t a, const uint64_t b, uint64_t *out)
+{
+#ifdef HAVE_BUILTIN_ADD_OVERFLOW
+    if (__builtin_add_overflow(a, b, out))
+        return -EOVERFLOW;
+#else
+    *out = a + b;
 #endif
     return 0;
 }

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -51,6 +51,28 @@
 #define streqn(a, b, n) (strncmp((a), (b), (n)) == 0)
 #define strstartswith(a, b) streqn((a), (b), strlen(b))
 
+/**
+ * Wrapper over strtod() that consumes up to @c len bytes.
+ *
+ * This variation of strtod() will work with buffers that are not
+ * null-terminated.
+ *
+ * All the formats accepted by strtod() are accepted and the behavior
+ * should be the same, including using information from @c LC_NUMERIC
+ * if locale is configured.
+ *
+ * @param nptr the string containing the number to convert.
+ * @param endptr if non-NULL, it will contain the last character used
+ *        in the conversion. If no conversion was done, endptr is @a nptr.
+ *
+ * @param len use at most this amount of bytes of @a nptr.
+ *
+ * @return the converted value, if any. The converted value may be @c
+ *         NAN, @c INF (positive or negative). See the strtod(3)
+ *         documentation for the details.
+ */
+double sol_util_strtodn(const char *nptr, char **endptr, size_t len);
+
 #define STATIC_ASSERT_LITERAL(_s) ("" _s)
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 


### PR DESCRIPTION
Parse numbers from JSON tokens as both signed and unsigned integers of 32 or 64 bits, as well as a double float point precision.