### PR TITLE
dependency-resolver: produce stable output

### DIFF
--- a/data/scripts/dependency-resolver.py
+++ b/data/scripts/dependency-resolver.py
@@ -322,7 +322,7 @@ def makefile_gen(args, context):
 
 def kconfig_gen(args, context):
     output = ""
-    for k,v in context.get_kconfig().items():
+    for k,v in sorted(context.get_kconfig().items()):
         output += "config {config}\n{indent}{ktype}\n{indent}default {enabled}\n". \
                   format(config=k, indent="       ", ktype=v["type"], enabled=v["value"])
     f = open(args.kconfig_output, "w+")


### PR DESCRIPTION
Without this, the order of the config entries changes every time the
dependency resolver is executed. As a result the order of the variables in
the .config file changes as well. This is rather annoying if the .config
file is stored elsewhere (e.g. in another git repository).

Enforce a defined order by sorting the items. This way the files only
change when with actual dependency changes.

Signed-off-by: Michael Olbrich <m.olbrich@pengutronix.de>