### PR TITLE
build: sol-bus uses glib so depend on it

### DIFF
--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -83,7 +83,6 @@ config PLATFORM_SYSTEMD
 	bool "systemd"
 	depends on HAVE_SYSTEMD
 	select SOL_PLATFORM_LINUX
-	select SOL_BUS
 	help
             This platform uses systemd.
 
@@ -304,7 +303,7 @@ endchoice
 
 config SOL_BUS
 	bool "Sd-bus support"
-	depends on SOL_PLATFORM_LINUX && HAVE_SYSTEMD && HAVE_SD_BUS
+	depends on SOL_PLATFORM_LINUX && HAVE_SYSTEMD && HAVE_SD_DBUS && HAVE_GLIB
 	help
           Systemd's sd-bus support.
 	default n


### PR DESCRIPTION
Also update the dependencies for PLATFORM_SYSTEMD. It selects SOL_BUS so it
must depend on the same symbols as SOL_BUS. Otherwise kconfig may be unable
to resolve the dependencies.

Signed-off-by: Michael Olbrich <m.olbrich@pengutronix.de>