### PR TITLE
String upper/lower v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,9 +383,10 @@ gpio/writer (a single boolean OUT port):
 
 Flow can be created directly in C using low-level primitives from
 sol-flow.h or using a higher-level API in sol-flow-builder.h. An
-alternative is to write the flow in a domain-specific language "FBP"
-that is easier to express. As an example imagine one wants to blink an
-LED linked to GPIO pin 123 every 200ms:
+alternative is to write the flow in a domain-specific
+language—"FBP"<sup>[1](#footnote_01)</sup>—that is easier to express.
+As an example imagine one wants to blink an LED linked to GPIO pin 123
+every 200ms:
 
         MyTimer(timer:interval=200) OUT -> IN MyToggler(boolean/toggle)
         MyToggler OUT -> IN MyLED(gpio/writer:pin=123)
@@ -499,3 +500,6 @@ By making a contribution to this project, I certify that:
     maintained indefinitely and may be redistributed consistent with
     this project or the open source license(s) involved.
 ```
+
+<a name="footnote_01">1</a>: Soletta expects that FBP files are
+utf-8-encoded

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -222,6 +222,20 @@
 	    "fragment": "accept4(0, 0, 0, 0);"
 	},
 	{
+	    "dependency": "locale",
+	    "type": "ccode",
+	    "headers": [
+		"<locale.h>"
+	    ],
+	    "fragment": "setlocale(LC_ALL, NULL);"
+	},
+	{
+	    "dependency": "icu",
+	    "type": "pkg-config",
+	    "pkgname": "icu-uc icu-i18n",
+	    "atleast-version": "52.1"
+	},
+	{
 	    "dependency": "isatty",
 	    "type": "ccode",
 	    "headers": [

--- a/src/modules/flow/string/Makefile
+++ b/src/modules/flow/string/Makefile
@@ -1,2 +1,4 @@
 obj-$(FLOW_NODE_TYPE_STRING) += string.mod
 obj-string-$(FLOW_NODE_TYPE_STRING) := string.json string.o
+obj-string-$(FLOW_NODE_TYPE_STRING)-extra-cflags += $(LOCALE_CFLAGS) $(ICU_CFLAGS)
+obj-string-$(FLOW_NODE_TYPE_STRING)-extra-ldflags += $(LOCALE_LDFLAGS) $(ICU_LDFLAGS)

--- a/src/modules/flow/string/string.json
+++ b/src/modules/flow/string/string.json
@@ -205,6 +205,52 @@
       ],
       "private_data_type": "string_split_data",
       "url": "http://solettaproject.org/doc/latest/node_types/string/split.html"
+    },
+    {
+      "category": "string",
+      "description": "Given an input string, output a copy with all original characters in lower case.",
+      "in_ports": [
+        {
+          "data_type": "string",
+          "description": "String to be output in lowercase",
+          "methods": {
+            "process": "string_lowercase"
+          },
+          "name": "IN"
+        }
+      ],
+      "name": "string/lowercase",
+      "out_ports": [
+        {
+          "data_type": "string",
+          "description": "The original input string now in lowercase characters",
+          "name": "OUT"
+        }
+      ],
+      "url": "http://solettaproject.org/doc/latest/node_types/string/lowercase.html"
+    },
+    {
+      "category": "string",
+      "description": "Given an input string, output a copy with all original characters in upper case.",
+      "in_ports": [
+        {
+          "data_type": "string",
+          "description": "String to be output in uppercase",
+          "methods": {
+            "process": "string_uppercase"
+          },
+          "name": "IN"
+        }
+      ],
+      "name": "string/uppercase",
+      "out_ports": [
+        {
+          "data_type": "string",
+          "description": "The original input string now in uppercase characters",
+          "name": "OUT"
+        }
+      ],
+      "url": "http://solettaproject.org/doc/latest/node_types/string/uppercase.html"
     }
   ]
 }

--- a/src/test-fbp/string-lower-upper.fbp
+++ b/src/test-fbp/string-lower-upper.fbp
@@ -1,0 +1,57 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+test_01(constant/string:value="Hello, world")
+test_02(constant/string:value="çççÇÇÇ")
+test_03(constant/string:value="şşşŞŞŞ")
+
+test_01 OUT -> IN test_01_lower(string/lowercase)
+test_01_lower_expected(constant/string:value="hello, world") OUT -> IN[0] test_01_lower_cmp(string/compare)
+test_01_lower OUT -> IN[1] test_01_lower_cmp EQUAL -> RESULT _(test/result)
+
+test_01 OUT -> IN test_01_upper(string/uppercase)
+test_01_upper_expected(constant/string:value="HELLO, WORLD") OUT -> IN[0] test_01_upper_cmp(string/compare)
+test_01_upper OUT -> IN[1] test_01_upper_cmp EQUAL -> RESULT _(test/result)
+
+test_02 OUT -> IN test_02_lower(string/lowercase)
+test_02_lower_expected(constant/string:value="çççççç") OUT -> IN[0] test_02_lower_cmp(string/compare)
+test_02_lower OUT -> IN[1] test_02_lower_cmp EQUAL -> RESULT _(test/result)
+
+test_02 OUT -> IN test_02_upper(string/uppercase)
+test_02_upper_expected(constant/string:value="ÇÇÇÇÇÇ") OUT -> IN[0] test_02_upper_cmp(string/compare)
+test_02_upper OUT -> IN[1] test_02_upper_cmp EQUAL -> RESULT _(test/result)
+
+test_03 OUT -> IN test_03_lower(string/lowercase)
+test_03_lower_expected(constant/string:value="şşşşşş") OUT -> IN[0] test_03_lower_cmp(string/compare)
+test_03_lower OUT -> IN[1] test_03_lower_cmp EQUAL -> RESULT _(test/result)
+
+test_03 OUT -> IN test_03_upper(string/uppercase)
+test_03_upper_expected(constant/string:value="ŞŞŞŞŞŞ") OUT -> IN[0] test_03_upper_cmp(string/compare)
+test_03_upper OUT -> IN[1] test_03_upper_cmp EQUAL -> RESULT _(test/result)


### PR DESCRIPTION
Changes since v1:

The ascii-only code is now a fallback only if ICU is not found on the system at build time. Two new deps are now declared, locale and icu, then. If the latter is not found, a CPP #warning line is output to inform the user of the limitations of the string nodes in this form.

If this is ok, I'll proceed adding i18n support on other string operations throughout the code. Soletta now expects that fbp files are encoded in utf-8, not just plain ASCII.