### PR TITLE
JSON number parsing (v2)

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -246,9 +246,14 @@
 	    "fragment": "strndupa(0, 0);"
 	},
 	{
-	    "dependency": "builtin_umull_overflow",
+	    "dependency": "builtin_mul_overflow",
 	    "type": "ccode",
-	    "fragment": "__builtin_umull_overflow(0, 0, (void *)0);"
+	    "fragment": "__builtin_mul_overflow(0ULL, 0ULL, (unsigned long long *)0);"
+	},
+	{
+	    "dependency": "builtin_add_overflow",
+	    "type": "ccode",
+	    "fragment": "__builtin_add_overflow(0ULL, 0ULL, (unsigned long long *)0);"
 	},
 	{
 	    "dependency": "decl_ifla_inet6_addr_gen_mode",

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -269,6 +269,14 @@
 	    "fragment": "int v = IFLA_INET6_ADDR_GEN_MODE;"
 	},
 	{
+	    "dependency": "strtod_l",
+	    "type": "ccode",
+	    "headers": [
+		"<stdlib.h>"
+	    ],
+	    "fragment": "strtod_l(0, 0, 0);"
+	},
+	{
 	    "dependency": "valgrind",
 	    "type": "exec",
 	    "exec": "valgrind"

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -51,6 +51,36 @@
 #define streqn(a, b, n) (strncmp((a), (b), (n)) == 0)
 #define strstartswith(a, b) streqn((a), (b), strlen(b))
 
+/**
+ * Wrapper over strtod() that consumes up to @c len bytes and may not
+ * use a locale.
+ *
+ * This variation of strtod() will work with buffers that are not
+ * null-terminated.
+ *
+ * It also offers a way to skip the currently set locale, forcing
+ * plain "C". This is required to parse numbers in formats that
+ * require '.' as the decimal point while the current locale may use
+ * ',' such as in pt_BR.
+ *
+ * All the formats accepted by strtod() are accepted and the behavior
+ * should be the same, including using information from @c LC_NUMERIC
+ * if locale is configured and @a use_locale is true.
+ *
+ * @param nptr the string containing the number to convert.
+ * @param endptr if non-NULL, it will contain the last character used
+ *        in the conversion. If no conversion was done, endptr is @a nptr.
+ * @param use_locale if true, then current locale is used, if false
+ *        then "C" locale is forced.
+ *
+ * @param len use at most this amount of bytes of @a nptr.
+ *
+ * @return the converted value, if any. The converted value may be @c
+ *         NAN, @c INF (positive or negative). See the strtod(3)
+ *         documentation for the details.
+ */
+double sol_util_strtodn(const char *nptr, char **endptr, size_t len, bool use_locale);
+
 #define STATIC_ASSERT_LITERAL(_s) ("" _s)
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -40,6 +40,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <time.h>
+#include <errno.h>
 #include <sys/types.h>
 
 #ifdef SOL_PLATFORM_LINUX
@@ -160,11 +161,35 @@ struct sol_vector sol_util_str_split(const struct sol_str_slice slice, const cha
 static inline int
 sol_util_size_mul(size_t elem_size, size_t num_elems, size_t *out)
 {
-#ifdef HAVE_UMULL_OVERFLOW
-    if (__builtin_umull_overflow(elem_size, num_elems, out))
+#ifdef HAVE_BUILTIN_MUL_OVERFLOW
+    if (__builtin_mul_overflow(elem_size, num_elems, out))
         return -EOVERFLOW;
 #else
     *out = elem_size * num_elems;
+#endif
+    return 0;
+}
+
+static inline uint64_t
+sol_util_uint64_mul(const uint64_t a, const uint64_t b, uint64_t *out)
+{
+#ifdef HAVE_BUILTIN_MUL_OVERFLOW
+    if (__builtin_mul_overflow(a, b, out))
+        return -EOVERFLOW;
+#else
+    *out = a * b;
+#endif
+    return 0;
+}
+
+static inline uint64_t
+sol_util_uint64_add(const uint64_t a, const uint64_t b, uint64_t *out)
+{
+#ifdef HAVE_BUILTIN_ADD_OVERFLOW
+    if (__builtin_add_overflow(a, b, out))
+        return -EOVERFLOW;
+#else
+    *out = a + b;
 #endif
     return 0;
 }

--- a/src/test/Kconfig
+++ b/src/test/Kconfig
@@ -81,3 +81,7 @@ config TEST_VECTOR
 config TEST_JSON
 	bool "json"
 	default y
+
+config TEST_UTIL
+	bool "util"
+	default y

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -57,3 +57,6 @@ test-test-buffer-$(TEST_BUFFER) := test.c test-buffer.c
 
 test-$(TEST_JSON) += test-json
 test-test-json-$(TEST_JSON) := test.c test-json.c
+
+test-$(TEST_UTIL) += test-util
+test-test-util-$(TEST_UTIL) := test.c test-util.c

--- a/src/test/test-util.c
+++ b/src/test/test-util.c
@@ -33,10 +33,17 @@
 #include <errno.h>
 #include <limits.h>
 #include <stdbool.h>
+#include <float.h>
+#define HAVE_LOCALE 1 /* TODO: remove me when glima's patch gets in */
+#ifdef HAVE_LOCALE
+#include <locale.h>
+#endif
 
 #include "sol-util.h"
+#include "sol-log.h"
 
 #include "test.h"
+
 
 DEFINE_TEST(test_align_power2);
 
@@ -82,12 +89,194 @@ static void
 test_size_mul(void)
 {
     const size_t half_size = SIZE_MAX / 2;
+    const size_t half_double_size = (SIZE_MAX % 2) ? (SIZE_MAX - 1) : SIZE_MAX;
     size_t out;
 
     ASSERT(sol_util_size_mul(half_size, 2, &out) == 0);
-    ASSERT_INT_EQ(out, SIZE_MAX);
+    ASSERT_INT_EQ(out, half_double_size);
 
     ASSERT_INT_EQ(sol_util_size_mul(half_size, 4, &out), -EOVERFLOW);
+}
+
+DEFINE_TEST(test_strtodn);
+
+static void
+test_strtodn(void)
+{
+#ifdef HAVE_LOCALE
+    char *oldloc;
+    const char *comma_locales[] = {
+        "pt", "pt_BR", "de", "it", "ru", NULL
+    };
+    const char *comma_locale;
+#endif
+    char dbl_max_str[256], neg_dbl_max_str[256];
+    char dbl_max_str_overflow[256], neg_dbl_max_str_overflow[256];
+    const struct test {
+        const char *str;
+        double reference;
+        int expected_errno;
+        bool use_locale;
+        int endptr_offset;
+    } *itr, tests[] = {
+        { "0", 0.0, 0, false, -1 },
+        { "123", 123.0, 0, false, -1 },
+        { "1.0", 1.0, 0, false, -1 },
+        { "123.456", 123.456, 0, false, -1 },
+        { "345e+12", 345e12, 0, false, -1 },
+        { "345e-12", 345e-12, 0, false, -1 },
+        { "345E+12", 345e12, 0, false, -1 },
+        { "345E-12", 345e-12, 0, false, -1 },
+        { "-1.0", -1.0, 0, false, -1 },
+        { "-123.456", -123.456, 0, false, -1 },
+        { "-345e+12", -345e12, 0, false, -1 },
+        { "-345e-12", -345e-12, 0, false, -1 },
+        { "-345E+12", -345e12, 0, false, -1 },
+        { "-345E-12", -345e-12, 0, false, -1 },
+        { "-345.678e+12", -345.678e12, 0, false, -1 },
+        { "-345.678e-12", -345.678e-12, 0, false, -1 },
+        { "-345.678E+12", -345.678e12, 0, false, -1 },
+        { "-345.678E-12", -345.678e-12, 0, false, -1 },
+        { dbl_max_str, DBL_MAX, 0, false, -1 },
+        { neg_dbl_max_str, -DBL_MAX, 0, false, -1 },
+        { dbl_max_str_overflow, DBL_MAX, ERANGE, false, -1 },
+        { neg_dbl_max_str_overflow, -DBL_MAX, ERANGE, false, -1 },
+        { "x", 0, 0, false, 0 },
+        { "1x", 1.0, 0, false, 1 },
+        { "12,3", 12.0, 0, false, 2 },
+        { "", 0, 0, false, 0 },
+#ifdef HAVE_LOCALE
+        /* commas as decimal separators */
+        { "1,0", 1.0, 0, true, -1 },
+        { "123,456", 123.456, 0, true, -1 },
+        { "345e+12", 345e12, 0, true, -1 },
+        { "345e-12", 345e-12, 0, true, -1 },
+        { "345E+12", 345e12, 0, true, -1 },
+        { "345E-12", 345e-12, 0, true, -1 },
+        { "-1,0", -1.0, 0, true, -1 },
+        { "-123,456", -123.456, 0, true, -1 },
+        { "-345e+12", -345e12, 0, true, -1 },
+        { "-345e-12", -345e-12, 0, true, -1 },
+        { "-345E+12", -345e12, 0, true, -1 },
+        { "-345E-12", -345e-12, 0, true, -1 },
+        { "-345,678e+12", -345.678e12, 0, true, -1 },
+        { "-345,678e-12", -345.678e-12, 0, true, -1 },
+        { "-345,678E+12", -345.678e12, 0, true, -1 },
+        { "-345,678E-12", -345.678e-12, 0, true, -1 },
+        { "12.3", 12.0, 0, true, 2 },
+#endif
+        {}
+    };
+
+#ifdef HAVE_LOCALE
+    oldloc = setlocale(LC_ALL, NULL);
+    if (oldloc)
+        oldloc = strdupa(oldloc);
+    setlocale(LC_ALL, "C");
+#endif
+
+    snprintf(dbl_max_str, sizeof(dbl_max_str), "%.64g", DBL_MAX);
+    snprintf(neg_dbl_max_str, sizeof(neg_dbl_max_str), "%.64g", -DBL_MAX);
+    snprintf(dbl_max_str_overflow, sizeof(dbl_max_str_overflow), "%.64g0", DBL_MAX);
+    snprintf(neg_dbl_max_str_overflow, sizeof(neg_dbl_max_str_overflow), "%.64g0", -DBL_MAX);
+
+#ifdef HAVE_LOCALE
+    {
+        const char **loc;
+        comma_locale = NULL;
+        for (loc = comma_locales; *loc != NULL; loc++) {
+            if (setlocale(LC_ALL, *loc)) {
+                setlocale(LC_ALL, oldloc);
+                SOL_DBG("Using locale '%s' to produce commas as "
+                    "decimal separator. Ex: %0.2f", *loc, 1.23);
+                comma_locale = *loc;
+                break;
+            }
+        }
+        if (!comma_locale) {
+            setlocale(LC_ALL, oldloc);
+            SOL_WRN("Couldn't find a locale with decimal commas");
+        }
+    }
+#endif
+
+    for (itr = tests; itr->str != NULL; itr++) {
+        double value;
+        char buf[512];
+        char *endptr;
+        size_t slen = strlen(itr->str);
+        int endptr_offset, wanted_endptr_offset;
+        int reterr;
+
+        snprintf(buf, sizeof(buf), "%s123garbage", itr->str);
+
+        if (comma_locale)
+            setlocale(LC_ALL, comma_locale);
+        else if (itr->use_locale) {
+            SOL_DBG("SKIP (no comma locale): '%s'", itr->str);
+            continue;
+        }
+
+        value = sol_util_strtodn(buf, &endptr, slen, itr->use_locale);
+        reterr = errno;
+
+        endptr_offset = endptr - buf;
+
+        if (comma_locale)
+            setlocale(LC_ALL, oldloc);
+
+        wanted_endptr_offset = itr->endptr_offset;
+        if (wanted_endptr_offset < 0)
+            wanted_endptr_offset = slen;
+
+        if (itr->expected_errno == 0 && reterr == 0) {
+            if (sol_drange_val_equal(itr->reference, value)) {
+                SOL_DBG("OK: parsed '%s' as %g (locale:%u)", itr->str, value,
+                    itr->use_locale);
+            } else {
+                SOL_WRN("FAILED: parsed '%s' as %.64g where %.64g was expected"
+                    " (difference = %g) (locale:%u)",
+                    itr->str, value, itr->reference, itr->reference - value,
+                    itr->use_locale);
+                FAIL();
+            }
+        } else if (itr->expected_errno == 0 && reterr < 0) {
+            SOL_WRN("FAILED: parsing '%s' failed with errno = %d (%s) (locale:%u)",
+                itr->str, reterr, sol_util_strerrora(reterr), itr->use_locale);
+            FAIL();
+        } else if (itr->expected_errno != 0 && reterr == 0) {
+            SOL_WRN("FAILED: parsing '%s' should fail with errno = %d (%s)"
+                ", but got success with errno = %d (%s), value = %g (locale:%u)",
+                itr->str,
+                itr->expected_errno, sol_util_strerrora(itr->expected_errno),
+                reterr, sol_util_strerrora(reterr), value, itr->use_locale);
+            FAIL();
+        } else if (itr->expected_errno != 0 && reterr < 0) {
+            if (itr->expected_errno != reterr) {
+                SOL_WRN("FAILED: parsing '%s' should fail with errno = %d (%s)"
+                    ", but got errno = %d (%s), value = %g (locale:%u)",
+                    itr->str,
+                    itr->expected_errno, sol_util_strerrora(itr->expected_errno),
+                    reterr, sol_util_strerrora(reterr), value, itr->use_locale);
+                FAIL();
+            } else if (!sol_drange_val_equal(itr->reference, value)) {
+                SOL_WRN("FAILED: parsing '%s' should result in %.64g"
+                    ", but got %.64g (difference = %g) (locale:%u)",
+                    itr->str, itr->reference, value, itr->reference - value,
+                    itr->use_locale);
+                FAIL();
+            } else {
+                SOL_DBG("OK: parsed '%s' as %g, setting errno = %d (%s) (locale:%u)",
+                    itr->str, value, reterr, sol_util_strerrora(reterr), itr->use_locale);
+            }
+        }
+
+        if (wanted_endptr_offset != endptr_offset) {
+            SOL_WRN("FAILED: parsing '%s' should stop at offset %d, but got %d  (locale:%u)",
+                itr->str, wanted_endptr_offset, endptr_offset, itr->use_locale);
+            FAIL();
+        }
+    }
 }
 
 


### PR DESCRIPTION
Parse numbers from JSON tokens as both signed and unsigned integers of 32 or 64 bits, as well as a double float point precision.

Changes since v1 (PR #425):
 * changed sol_util_strtodn() to take a boolean `use_locale`. If so, the current locale is allowed (as in standard `strtod()`), otherwise `strtod_l()` is used with a "C" locale. In the case where `strtod_l()` is not available but there is locale support we translate the string exchanging '.' and `lc->decimal_point`, either in-place using the copy (tmpbuf) or creating yet-another copy if `lc->decimal_point` is more than one byte.
 * enable test-util.c to be compiled;
 * fix `test_size_mul()`, at least on my 32 bits machine, `SIZE_MAX` was odd and the test was failing since when multiplying by 2 it was not getting the same value;