### PR TITLE
Make I2C asynchronous

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -225,7 +225,7 @@
 	    "headers": [
 		"<locale.h>"
 	    ],
-	    "fragment": "setlocale(LC_ALL, NULL);"
+	    "fragment": "freelocale(NULL);"
 	},
 	{
 	    "dependency": "icu",

--- a/src/lib/common/include/sol-log.h
+++ b/src/lib/common/include/sol-log.h
@@ -141,6 +141,13 @@ extern "C" {
         }                                   \
     } while (0)                             \
 
+#define SOL_EXP_CHECK_GOTO(exp, label)       \
+    do {                                     \
+        if (log_unlikely((exp))) {           \
+            SOL_WRN("(" # exp ") is false"); \
+            goto label;                      \
+        }                                    \
+    } while (0)                              \
 
 enum sol_log_level {
     SOL_LOG_LEVEL_CRITICAL = 0,

--- a/src/lib/common/sol-platform-impl-linux-micro.c
+++ b/src/lib/common/sol-platform-impl-linux-micro.c
@@ -766,8 +766,10 @@ sol_platform_impl_set_target(const char *target)
         reboot_cmd = RB_POWER_OFF;
     else if (streq(target, SOL_PLATFORM_TARGET_REBOOT))
         reboot_cmd = RB_AUTOBOOT;
+#ifdef RB_SW_SUSPEND
     else if (streq(target, SOL_PLATFORM_TARGET_SUSPEND))
         reboot_cmd = RB_SW_SUSPEND;
+#endif
     else if (streq(target, SOL_PLATFORM_TARGET_DEFAULT))
         reboot_exec = "/sbin/init";
     else if (streq(target, SOL_PLATFORM_TARGET_RESCUE))

--- a/src/lib/io/include/sol-i2c.h
+++ b/src/lib/io/include/sol-i2c.h
@@ -99,13 +99,13 @@ struct sol_i2c *sol_i2c_open(uint8_t bus, enum sol_i2c_speed speed) SOL_ATTR_WAR
 void sol_i2c_close(struct sol_i2c *i2c);
 
 /**
- * Set a (slave) device address on a I2C bus to deliver SMBus commands
+ * Set a (slave) device address on a I2C bus to deliver commands
  * to.
  *
- * All other SMBus functions, after this call, will act on the given
+ * All other I2C functions, after this call, will act on the given
  * @a slave_address device address. Since other I2C calls might happen
  * in between your own ones, though, it's highly advisable that you
- * issue this call before using any of the SMBus read/write functions.
+ * issue this call before using any of the I2C read/write functions.
  *
  * @param i2c bus The I2C bus handle
  * @param slave_address The slave device address to deliver commands to
@@ -116,7 +116,7 @@ void sol_i2c_close(struct sol_i2c *i2c);
 bool sol_i2c_set_slave_address(struct sol_i2c *i2c, uint8_t slave_address);
 
 /**
- * Get the (slave) device address set on an I2C bus (to deliver SMBus
+ * Get the (slave) device address set on an I2C bus (to deliver I2C
  * commands)
  *
  * @param i2c bus The I2C bus handle
@@ -126,7 +126,7 @@ bool sol_i2c_set_slave_address(struct sol_i2c *i2c, uint8_t slave_address);
 uint8_t sol_i2c_get_slave_address(struct sol_i2c *i2c);
 
 /**
- * Perform a SMBus write quick operation
+ * Perform a I2C write quick operation
  *
  * This sends a single bit to a device (command designed to turn on
  * and off simple devices)
@@ -139,13 +139,13 @@ uint8_t sol_i2c_get_slave_address(struct sol_i2c *i2c);
 bool sol_i2c_write_quick(const struct sol_i2c *i2c, bool rw);
 
 /**
- * Perform successive SMBus byte read operations, with no specified
+ * Perform successive I2C byte read operations, with no specified
  * register
  *
- * This makes @a count read byte SMBus operations on the device @a bus
+ * This makes @a count read byte I2C operations on the device @a bus
  * is set to operate on, at no specific register. Some devices are so
  * simple that this interface is enough. For others, it is a shorthand
- * if you want to read the same register as in the previous SMBus
+ * if you want to read the same register as in the previous I2C
  * command.
  *
  * @param i2c bus The I2C bus handle
@@ -158,14 +158,14 @@ bool sol_i2c_write_quick(const struct sol_i2c *i2c, bool rw);
 ssize_t sol_i2c_read(const struct sol_i2c *i2c, uint8_t *data, size_t count);
 
 /**
- * Perform successive SMBus byte write operations, with no specified
+ * Perform successive I2C byte write operations, with no specified
  * register
  *
- * This makes @a count write byte SMBus operations on the device @a
+ * This makes @a count write byte I2C operations on the device @a
  * bus is set to operate on, at no specific register. Some devices are
  * so simple that this interface is enough. For others, it is a
  * shorthand if you want to write the same register as in the previous
- * SMBus command.
+ * I2C command.
  *
  * @param i2c bus The I2C bus handle
  * @param data The output buffer for the write operation
@@ -177,30 +177,12 @@ ssize_t sol_i2c_read(const struct sol_i2c *i2c, uint8_t *data, size_t count);
 bool sol_i2c_write(const struct sol_i2c *i2c, uint8_t *data, size_t count);
 
 /**
- * Perform a SMBus (byte/word/block) read operation on a given device
- * register
- *
- * This reads a block of up to 32 bytes from a device, at the
- * specified register @a reg. Depending on @a count, the underlying
- * bus message might be SMBbus read byte (@a count is 1), SMBbus read
- * word (@a count is 2) or SMBbus read block (@a count is greater than
- * 2 and less than 33). If @a count is 33 or greater, this will issue
- * a plain-I2C read/write transaction, with the first (write) message
- * specifying the register to operate on and the second (read) message
- * specifying the length and the destination of the read operation.
+ * Perform a I2C read operation on a given device register
  *
  * @param i2c bus The I2C bus handle
  * @param reg The I2C register for the read operation
  * @param data The output buffer for the read operation
  * @param count The bytes count for the read operation
- *
- * @note For the case of reading more the 32 of bytes from a register,
- * this call is useful for auto-increment capable devices. If the
- * device in question does not have that feature, one must issue
- * sol_i2c_read_register_multiple() instead.
- *
- * @warning This function will fail if @a count is bigger than 32 and
- *          the target I2C device does not accept plain-I2C messages
  *
  * @return The number of bytes read, on success, or a negative value,
  *         on errors.
@@ -208,15 +190,7 @@ bool sol_i2c_write(const struct sol_i2c *i2c, uint8_t *data, size_t count);
 ssize_t sol_i2c_read_register(const struct sol_i2c *i2c, uint8_t reg, uint8_t *data, size_t count);
 
 /**
- * Perform a SMBus (byte/word/block) write operation on a given device
- * register
- *
- * This writes a block of up to 32 bytes from a device, at the
- * specified register @a reg. Depending on @a count, the underlying
- * SMBus call might be write byte (@a count is 1), write word (@a
- * count is 2) or write block (@a count is greater than 2 and less
- * than 33). If @a count is 33 or greater, this will issue a plain-I2C
- * write transaction.
+ * Perform a I2C write operation on a given device register
  *
  * @param i2c bus The I2C bus handle
  * @param reg The I2C register for the write operation
@@ -235,11 +209,11 @@ bool sol_i2c_write_register(const struct sol_i2c *i2c, uint8_t reg, const uint8_
  *
  * This is so because a lot of devices will, after a read operation,
  * update its register values with new data to be read on subsequent
- * operations, until the total data lenght the user requested is read.
+ * operations, until the total data length the user requested is read.
  * If the device has the auto-increment feature,
  * sol_i2c_read_register() might be a better call than this function.
  *
- * This will issue multiple plain-I2C read/write transaction with the
+ * This will issue multiple I2C read/write transaction with the
  * first (write) message specifying the register to operate on and the
  * second (read) message specifying the length (always @a len per
  * read) and the destination of the read operation.
@@ -251,10 +225,7 @@ bool sol_i2c_write_register(const struct sol_i2c *i2c, uint8_t reg, const uint8_
  * @param times How many reads of size @a len to perform (on success,
  *              @a len * @a times bytes will be read)
  *
- * @warning This function will fail if the target I2C device does not
- *          accept plain-I2C messages
- *
- * @return @c true on succes, @c false otherwise
+ * @return @c true on success, @c false otherwise
  */
 bool sol_i2c_read_register_multiple(const struct sol_i2c *i2c, uint8_t reg, uint8_t *values, uint8_t len, uint8_t times);
 

--- a/src/lib/io/include/sol-i2c.h
+++ b/src/lib/io/include/sol-i2c.h
@@ -55,6 +55,8 @@ extern "C" {
 
 struct sol_i2c;
 
+struct sol_i2c_pending;
+
 enum sol_i2c_speed {
     SOL_I2C_SPEED_10KBIT = 0,
     SOL_I2C_SPEED_100KBIT,
@@ -151,7 +153,7 @@ uint8_t sol_i2c_get_slave_address(struct sol_i2c *i2c);
  *
  * @return pending handle if operation was started otherwise a NULL pointer
  */
-void *sol_i2c_write_quick(struct sol_i2c *i2c, bool rw, void (*write_quick_cb)(void *cb_data, struct sol_i2c *i2c, ssize_t status), const void *cb_data);
+struct sol_i2c_pending *sol_i2c_write_quick(struct sol_i2c *i2c, bool rw, void (*write_quick_cb)(void *cb_data, struct sol_i2c *i2c, ssize_t status), const void *cb_data);
 
 /**
  * Perform successive asynchronous I2C byte read operations, with no specified

--- a/src/lib/io/include/sol-spi.h
+++ b/src/lib/io/include/sol-spi.h
@@ -105,6 +105,9 @@ void sol_spi_close(struct sol_spi *spi);
  * @param bus The SPI bus number to open
  * @param config The SPI bus configuration
  * @return A new SPI bus handle
+ *
+ * @note For now it only support one user of the bus at time, 2 or mode devices
+ * with different chip select on the same bus will cause concurrency errors.
  */
 struct sol_spi *sol_spi_open(unsigned int bus, const struct sol_spi_config *config);
 

--- a/src/lib/io/include/sol-uart.h
+++ b/src/lib/io/include/sol-uart.h
@@ -98,6 +98,9 @@ struct sol_uart_config {
  * ttyACM0 in small OSes it should be a id number.
  * @param config The UART bus configuration
  * @return A new UART bus handle
+ *
+ * @note For now it only support one user of each port at time, 2 or more users
+ * on the same port will cause several concurrency errors.
  */
 struct sol_uart *sol_uart_open(const char *port_name, const struct sol_uart_config *config);
 

--- a/src/lib/io/sol-i2c-common.c
+++ b/src/lib/io/sol-i2c-common.c
@@ -40,22 +40,69 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "i2c");
 #ifdef USE_PIN_MUX
 #include "sol-pin-mux.h"
 #endif
+#include "sol-vector.h"
+
+struct sol_i2c_shared {
+    struct sol_i2c *i2c;
+    uint16_t refcount;
+};
+
+static struct sol_vector i2c_shared_vector = SOL_VECTOR_INIT(struct sol_i2c_shared);
 
 SOL_API struct sol_i2c *
 sol_i2c_open(uint8_t bus, enum sol_i2c_speed speed)
 {
     struct sol_i2c *i2c;
+    struct sol_i2c_shared *i2c_shared;
+    uint8_t i;
 
     SOL_LOG_INTERNAL_INIT_ONCE;
 
+    SOL_VECTOR_FOREACH_IDX (&i2c_shared_vector, i2c_shared, i) {
+        if (sol_i2c_bus_get(i2c_shared->i2c) == bus) {
+            i2c_shared->refcount++;
+            return i2c_shared->i2c;
+        }
+    }
+
     i2c = sol_i2c_open_raw(bus, speed);
+    SOL_NULL_CHECK(i2c, NULL);
 #ifdef USE_PIN_MUX
-    if (i2c && sol_pin_mux_setup_i2c(bus) < 0) {
+    if (sol_pin_mux_setup_i2c(bus) < 0) {
         SOL_ERR("Pin Multiplexer Recipe for i2c bus=%u found, but couldn't be applied.", bus);
         sol_i2c_close(i2c);
         i2c = NULL;
     }
 #endif
 
+    i2c_shared = sol_vector_append(&i2c_shared_vector);
+    SOL_NULL_CHECK_GOTO(i2c_shared, vector_append_fail);
+    i2c_shared->i2c = i2c;
+    i2c_shared->refcount = 1;
+
     return i2c;
+
+vector_append_fail:
+    sol_i2c_close(i2c);
+    return NULL;
+}
+
+SOL_API void
+sol_i2c_close(struct sol_i2c *i2c)
+{
+    struct sol_i2c_shared *i2c_shared;
+    uint8_t i;
+
+    SOL_NULL_CHECK(i2c);
+
+    SOL_VECTOR_FOREACH_IDX (&i2c_shared_vector, i2c_shared, i) {
+        if (i2c_shared->i2c == i2c) {
+            i2c_shared->refcount--;
+            if (!i2c_shared->refcount) {
+                sol_vector_del(&i2c_shared_vector, i);
+                sol_i2c_close_raw(i2c);
+            }
+            break;
+        }
+    }
 }

--- a/src/lib/io/sol-i2c-linux.c
+++ b/src/lib/io/sol-i2c-linux.c
@@ -255,7 +255,7 @@ i2c_write_quick_timeout_cb(void *data)
 }
 #endif
 
-SOL_API void *
+SOL_API struct sol_i2c_pending *
 sol_i2c_write_quick(struct sol_i2c *i2c, bool rw, void (*write_quick_cb)(void *cb_data, struct sol_i2c *i2c, ssize_t status), const void *cb_data)
 {
 #ifdef PTHREAD
@@ -283,11 +283,11 @@ sol_i2c_write_quick(struct sol_i2c *i2c, bool rw, void (*write_quick_cb)(void *c
 #ifdef PTHREAD
     i2c->async.worker = sol_worker_thread_new(&spec);
     SOL_NULL_CHECK(i2c->async.worker, NULL);
-    return i2c->async.worker;
+    return (struct sol_i2c_pending *)i2c->async.worker;
 #else
     i2c->async.timeout = sol_timeout_add(0, i2c_write_quick_timeout_cb, i2c);
     SOL_NULL_CHECK(i2c->async.timeout, NULL);
-    return i2c->async.timeout;
+    return (struct sol_i2c_pending *)i2c->async.timeout;
 #endif
 }
 

--- a/src/lib/io/sol-i2c-linux.c
+++ b/src/lib/io/sol-i2c-linux.c
@@ -336,12 +336,12 @@ SOL_API bool
 sol_i2c_read_register_multiple(const struct sol_i2c *i2c,
     uint8_t command,
     uint8_t *values,
-    uint8_t len,
-    uint8_t count)
+    uint8_t count,
+    uint8_t times)
 {
     struct i2c_msg msgs[I2C_RDRW_IOCTL_MAX_MSGS] = { };
     struct i2c_rdwr_ioctl_data data = { };
-    const unsigned int max_count = I2C_RDRW_IOCTL_MAX_MSGS / 2;
+    const unsigned int max_times = I2C_RDRW_IOCTL_MAX_MSGS / 2;
 
     SOL_NULL_CHECK(i2c, false);
     if (!i2c->plain_i2c) {
@@ -352,8 +352,8 @@ sol_i2c_read_register_multiple(const struct sol_i2c *i2c,
         return false;
     }
 
-    while (count > 0) {
-        unsigned int n = count > max_count ? max_count : count;
+    while (times > 0) {
+        unsigned int n = times > max_times ? max_times : times;
         unsigned int i;
         uint8_t *p = values;
 
@@ -364,9 +364,9 @@ sol_i2c_read_register_multiple(const struct sol_i2c *i2c,
             msgs[i].buf = &command;
             msgs[i + 1].addr = i2c->addr;
             msgs[i + 1].flags = I2C_M_RD;
-            msgs[i + 1].len = len;
+            msgs[i + 1].len = count;
             msgs[i + 1].buf = p;
-            p += len;
+            p += count;
         }
 
         data.msgs = msgs;
@@ -379,7 +379,7 @@ sol_i2c_read_register_multiple(const struct sol_i2c *i2c,
             return false;
         }
 
-        count -= n;
+        times -= n;
     }
 
     return true;

--- a/src/lib/io/sol-i2c-linux.c
+++ b/src/lib/io/sol-i2c-linux.c
@@ -59,15 +59,51 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "i2c");
 
 #include "sol-i2c.h"
 #include "sol-macros.h"
+#include "sol-mainloop.h"
 #include "sol-util.h"
-
+#ifdef PTHREAD
+#include "sol-worker-thread.h"
+#endif
 
 struct sol_i2c {
     int dev;
     uint8_t bus;
     uint8_t addr;
     bool plain_i2c;
+    struct {
+        const void *cb_data;
+#ifdef PTHREAD
+        struct sol_worker_thread *worker;
+#else
+        struct sol_timeout *timeout;
+#endif
+        uint8_t *data;
+        size_t count;
+        ssize_t status;
+        uint8_t reg;
+        uint8_t times; // Only used on read_register_multiple()
+        void (*dispatch)(struct sol_i2c *i2c);
+
+        union {
+            struct {
+                void (*cb)(void *cb_data, struct sol_i2c *i2c, ssize_t status);
+            } write_quick_cb;
+            struct {
+                void (*cb)(void *cb_data, struct sol_i2c *i2c, uint8_t *data, ssize_t status);
+            } read_write_cb;
+            struct {
+                void (*cb)(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status);
+            } read_write_reg_cb;
+        };
+    } async;
+
 };
+
+#ifdef PTHREAD
+#define BUSY_CHECK(i2c, ret) SOL_EXP_CHECK(i2c->async.worker, ret);
+#else
+#define BUSY_CHECK(i2c, ret) SOL_EXP_CHECK(i2c->async.timeout, ret);
+#endif
 
 SOL_API struct sol_i2c *
 sol_i2c_open_raw(uint8_t bus, enum sol_i2c_speed speed)
@@ -116,9 +152,17 @@ open_error:
 }
 
 SOL_API void
-sol_i2c_close(struct sol_i2c *i2c)
+sol_i2c_close_raw(struct sol_i2c *i2c)
 {
     SOL_NULL_CHECK(i2c);
+
+#ifdef PTHREAD
+    if (i2c->async.worker)
+        sol_i2c_pending_cancel(i2c, i2c->async.worker);
+#else
+    if (i2c->async.timeout)
+        sol_i2c_pending_cancel(i2c, i2c->async.timeout);
+#endif
 
     close(i2c->dev);
     free(i2c);
@@ -152,8 +196,8 @@ _i2c_smbus_ioctl(int dev, uint8_t rw, uint8_t command, size_t size, union i2c_sm
     return 0;
 }
 
-SOL_API bool
-sol_i2c_write_quick(const struct sol_i2c *i2c, bool rw)
+static void
+_i2c_write_quick(struct sol_i2c *i2c, bool rw)
 {
     struct i2c_smbus_ioctl_data ioctldata = {
         .read_write = rw,
@@ -162,16 +206,89 @@ sol_i2c_write_quick(const struct sol_i2c *i2c, bool rw)
         .data = NULL
     };
 
-    SOL_NULL_CHECK(i2c, false);
-
     if (ioctl(i2c->dev, I2C_SMBUS, &ioctldata) == -1) {
         SOL_WRN("Unable to perform I2C-SMBus write quick (bus = %u,"
             " device address = %u): %s", i2c->bus, i2c->addr,
             sol_util_strerrora(errno));
-        return false;
+        return;
     }
 
-    return true;
+    i2c->async.status = 1;
+}
+
+static void
+_i2c_write_quick_dispatch(struct sol_i2c *i2c)
+{
+    if (!i2c->async.write_quick_cb.cb) return;
+    i2c->async.write_quick_cb.cb((void *)i2c->async.cb_data, i2c,
+        i2c->async.status);
+}
+
+#ifdef PTHREAD
+static bool
+i2c_write_quick_worker_thread_iterate(void *data)
+{
+    struct sol_i2c *i2c = data;
+
+    _i2c_write_quick(i2c, (bool)(intptr_t)i2c->async.data);
+    return false;
+}
+
+static void
+i2c_worker_thread_finished(void *data)
+{
+    struct sol_i2c *i2c = data;
+
+    i2c->async.worker = NULL;
+    i2c->async.dispatch(i2c);
+}
+#else
+static bool
+i2c_write_quick_timeout_cb(void *data)
+{
+    struct sol_i2c *i2c = data;
+
+    _i2c_write_quick(i2c, (bool)(intptr_t)i2c->async.data);
+    i2c->async.timeout = NULL;
+    i2c->async.dispatch(i2c);
+    return false;
+}
+#endif
+
+SOL_API void *
+sol_i2c_write_quick(struct sol_i2c *i2c, bool rw, void (*write_quick_cb)(void *cb_data, struct sol_i2c *i2c, ssize_t status), const void *cb_data)
+{
+#ifdef PTHREAD
+    struct sol_worker_thread_spec spec = {
+        .api_version = SOL_WORKER_THREAD_SPEC_API_VERSION,
+        .setup = NULL,
+        .cleanup = NULL,
+        .iterate = i2c_write_quick_worker_thread_iterate,
+        .finished = i2c_worker_thread_finished,
+        .feedback = NULL,
+        .data = i2c
+    };
+#endif
+
+    SOL_NULL_CHECK(i2c, NULL);
+    SOL_INT_CHECK(i2c->dev, == 0, NULL);
+    BUSY_CHECK(i2c, NULL);
+
+    i2c->async.data = (uint8_t *)(long)rw;
+    i2c->async.status = -1;
+    i2c->async.write_quick_cb.cb = write_quick_cb;
+    i2c->async.dispatch = _i2c_write_quick_dispatch;
+    i2c->async.cb_data = cb_data;
+
+#ifdef PTHREAD
+    i2c->async.worker = sol_worker_thread_new(&spec);
+    SOL_NULL_CHECK(i2c->async.worker, NULL);
+    return i2c->async.worker;
+#else
+    i2c->async.timeout = sol_timeout_add(0, i2c_write_quick_timeout_cb, i2c);
+    SOL_NULL_CHECK(i2c->async.timeout, NULL);
+    return i2c->async.timeout;
+#endif
 }
 
 static bool
@@ -216,40 +333,162 @@ read_byte(const struct sol_i2c *i2c, uint8_t *byte)
     return true;
 }
 
-SOL_API ssize_t
-sol_i2c_read(const struct sol_i2c *i2c, uint8_t *values, size_t count)
+static void
+_i2c_read(struct sol_i2c *i2c, uint8_t *values)
 {
     size_t i;
 
-    SOL_NULL_CHECK(i2c, -EINVAL);
-    SOL_NULL_CHECK(values, -EINVAL);
-    SOL_INT_CHECK(count, == 0, -EINVAL);
-
-    for (i = 0; i < count; i++) {
+    for (i = 0; i < i2c->async.count; i++) {
         uint8_t byte;
         if (!read_byte(i2c, &byte))
-            return -errno;
+            return;
         *values = byte;
         values++;
     }
-    return i;
+    i2c->async.status = i2c->async.count;
 }
 
-SOL_API bool
-sol_i2c_write(const struct sol_i2c *i2c, uint8_t *values, size_t count)
+static void
+_i2c_read_write_dispatch(struct sol_i2c *i2c)
+{
+    if (!i2c->async.read_write_cb.cb) return;
+    i2c->async.read_write_cb.cb((void *)i2c->async.cb_data, i2c,
+        i2c->async.data, i2c->async.status);
+}
+
+#ifdef PTHREAD
+static bool
+i2c_read_worker_thread_iterate(void *data)
+{
+    struct sol_i2c *i2c = data;
+
+    _i2c_read(i2c, i2c->async.data);
+    return false;
+}
+#else
+static bool
+i2c_read_timeout_cb(void *data)
+{
+    struct sol_i2c *i2c = data;
+
+    _i2c_read(i2c, i2c->async.data);
+    i2c->async.timeout = NULL;
+    i2c->async.dispatch(i2c);
+    return false;
+}
+#endif
+
+SOL_API void *
+sol_i2c_read(struct sol_i2c *i2c, uint8_t *values, size_t count, void (*read_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t *data, ssize_t status), const void *cb_data)
+{
+#ifdef PTHREAD
+    struct sol_worker_thread_spec spec = {
+        .api_version = SOL_WORKER_THREAD_SPEC_API_VERSION,
+        .setup = NULL,
+        .cleanup = NULL,
+        .iterate = i2c_read_worker_thread_iterate,
+        .finished = i2c_worker_thread_finished,
+        .feedback = NULL,
+        .data = i2c
+    };
+#endif
+
+    SOL_NULL_CHECK(i2c, NULL);
+    SOL_NULL_CHECK(values, NULL);
+    SOL_INT_CHECK(count, == 0, NULL);
+    SOL_INT_CHECK(i2c->dev, == 0, NULL);
+    BUSY_CHECK(i2c, NULL);
+
+    i2c->async.data = values;
+    i2c->async.count = count;
+    i2c->async.status = -1;
+    i2c->async.read_write_cb.cb = read_cb;
+    i2c->async.dispatch = _i2c_read_write_dispatch;
+    i2c->async.cb_data = cb_data;
+
+#ifdef PTHREAD
+    i2c->async.worker = sol_worker_thread_new(&spec);
+    SOL_NULL_CHECK(i2c->async.worker, NULL);
+    return i2c->async.worker;
+#else
+    i2c->async.timeout = sol_timeout_add(0, i2c_read_timeout_cb, i2c);
+    SOL_NULL_CHECK(i2c->async.timeout, NULL);
+    return i2c->async.timeout;
+#endif
+}
+
+static void
+_i2c_write(struct sol_i2c *i2c, uint8_t *values)
 {
     size_t i;
 
-    SOL_NULL_CHECK(i2c, false);
-    SOL_NULL_CHECK(values, false);
-    SOL_INT_CHECK(count, == 0, false);
-
-    for (i = 0; i < count; i++) {
+    for (i = 0; i < i2c->async.count; i++) {
         if (!write_byte(i2c, *values))
-            return false;
+            return;
         values++;
     }
-    return true;
+    i2c->async.status = i2c->async.count;
+}
+
+#ifdef PTHREAD
+static bool
+i2c_write_worker_thread_iterate(void *data)
+{
+    struct sol_i2c *i2c = data;
+
+    _i2c_write(i2c, i2c->async.data);
+    return false;
+}
+#else
+static bool
+i2c_write_timeout_cb(void *data)
+{
+    struct sol_i2c *i2c = data;
+
+    _i2c_write(i2c, i2c->async.data);
+    i2c->async.timeout = NULL;
+    i2c->async.dispatch(i2c);
+    return false;
+}
+#endif
+
+SOL_API void *
+sol_i2c_write(struct sol_i2c *i2c, uint8_t *values, size_t count, void (*write_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t *data, ssize_t status), const void *cb_data)
+{
+#ifdef PTHREAD
+    struct sol_worker_thread_spec spec = {
+        .api_version = SOL_WORKER_THREAD_SPEC_API_VERSION,
+        .setup = NULL,
+        .cleanup = NULL,
+        .iterate = i2c_write_worker_thread_iterate,
+        .finished = i2c_worker_thread_finished,
+        .feedback = NULL,
+        .data = i2c
+    };
+#endif
+
+    SOL_NULL_CHECK(i2c, NULL);
+    SOL_NULL_CHECK(values, NULL);
+    SOL_INT_CHECK(count, == 0, NULL);
+    SOL_INT_CHECK(i2c->dev, == 0, NULL);
+    BUSY_CHECK(i2c, NULL);
+
+    i2c->async.data = values;
+    i2c->async.count = count;
+    i2c->async.status = -1;
+    i2c->async.read_write_cb.cb = write_cb;
+    i2c->async.dispatch = _i2c_read_write_dispatch;
+    i2c->async.cb_data = cb_data;
+
+#ifdef PTHREAD
+    i2c->async.worker = sol_worker_thread_new(&spec);
+    SOL_NULL_CHECK(i2c->async.worker, NULL);
+    return i2c->async.worker;
+#else
+    i2c->async.timeout = sol_timeout_add(0, i2c_write_timeout_cb, i2c);
+    SOL_NULL_CHECK(i2c->async.timeout, NULL);
+    return i2c->async.timeout;
+#endif
 }
 
 static int
@@ -295,26 +534,29 @@ sol_i2c_plain_read_register(const struct sol_i2c *i2c,
     return count;
 }
 
-SOL_API ssize_t
-sol_i2c_read_register(const struct sol_i2c *i2c, uint8_t command, uint8_t *values, size_t count)
+static void
+_i2c_read_register(struct sol_i2c *i2c)
 {
     union i2c_smbus_data data;
     ssize_t length;
     int32_t error;
+    size_t count = i2c->async.count;
+    uint8_t command = i2c->async.reg;
+    uint8_t *values = i2c->async.data;
 
-    SOL_NULL_CHECK(i2c, -EINVAL);
-    SOL_NULL_CHECK(values, -EINVAL);
-    SOL_INT_CHECK(count, == 0, -EINVAL);
-
-    if (count > 32)
-        return sol_i2c_plain_read_register(i2c, command, values, count);
+    if (count > 32) {
+        int ret = sol_i2c_plain_read_register(i2c, command, values, count);
+        if (ret > 0)
+            i2c->async.status = count;
+        return;
+    }
 
     if ((error = _i2c_smbus_ioctl(i2c->dev, I2C_SMBUS_READ, command,
             count, &data)) < 0) {
         SOL_WRN("Unable to perform I2C-SMBus read (byte/word/block) data "
             "(bus = %u, device address = 0x%x, register = 0x%x): %s",
             i2c->bus, i2c->addr, command, sol_util_strerrora(-error));
-        return error;
+        return;
     }
 
     // block[0] is the data block length. Up to I2C_SMBUS_BLOCK_MAX.
@@ -329,27 +571,96 @@ sol_i2c_read_register(const struct sol_i2c *i2c, uint8_t command, uint8_t *value
     } else
         memcpy(values, data.block + 1, length);
 
-    return length;
+    i2c->async.status = count;
 }
 
-SOL_API bool
-sol_i2c_read_register_multiple(const struct sol_i2c *i2c,
-    uint8_t command,
-    uint8_t *values,
-    uint8_t count,
-    uint8_t times)
+static void
+_i2c_read_write_reg_dispatch(struct sol_i2c *i2c)
+{
+    if (!i2c->async.read_write_reg_cb.cb) return;
+    i2c->async.read_write_reg_cb.cb((void *)i2c->async.cb_data, i2c,
+        i2c->async.reg, i2c->async.data, i2c->async.status);
+}
+
+#ifdef PTHREAD
+static bool
+i2c_read_reg_worker_thread_iterate(void *data)
+{
+    struct sol_i2c *i2c = data;
+
+    _i2c_read_register(i2c);
+    return false;
+}
+#else
+static bool
+i2c_read_reg_timeout_cb(void *data)
+{
+    struct sol_i2c *i2c = data;
+
+    _i2c_read_register(i2c);
+    i2c->async.timeout = NULL;
+    i2c->async.dispatch(i2c);
+    return false;
+}
+#endif
+
+SOL_API void *
+sol_i2c_read_register(struct sol_i2c *i2c, uint8_t reg, uint8_t *values, size_t count, void (*read_reg_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status), const void *cb_data)
+{
+#ifdef PTHREAD
+    struct sol_worker_thread_spec spec = {
+        .api_version = SOL_WORKER_THREAD_SPEC_API_VERSION,
+        .setup = NULL,
+        .cleanup = NULL,
+        .iterate = i2c_read_reg_worker_thread_iterate,
+        .finished = i2c_worker_thread_finished,
+        .feedback = NULL,
+        .data = i2c
+    };
+#endif
+
+    SOL_NULL_CHECK(i2c, NULL);
+    SOL_NULL_CHECK(values, NULL);
+    SOL_INT_CHECK(count, == 0, NULL);
+    SOL_INT_CHECK(i2c->dev, == 0, NULL);
+    BUSY_CHECK(i2c, NULL);
+
+    i2c->async.data = values;
+    i2c->async.count = count;
+    i2c->async.status = -1;
+    i2c->async.read_write_reg_cb.cb = read_reg_cb;
+    i2c->async.dispatch = _i2c_read_write_reg_dispatch;
+    i2c->async.reg = reg;
+    i2c->async.cb_data = cb_data;
+
+#ifdef PTHREAD
+    i2c->async.worker = sol_worker_thread_new(&spec);
+    SOL_NULL_CHECK(i2c->async.worker, NULL);
+    return i2c->async.worker;
+#else
+    i2c->async.timeout = sol_timeout_add(0, i2c_read_reg_timeout_cb, i2c);
+    SOL_NULL_CHECK(i2c->async.timeout, NULL);
+    return i2c->async.timeout;
+#endif
+}
+
+static void
+_i2c_read_register_multiple(struct sol_i2c *i2c)
 {
     struct i2c_msg msgs[I2C_RDRW_IOCTL_MAX_MSGS] = { };
     struct i2c_rdwr_ioctl_data data = { };
     const unsigned int max_times = I2C_RDRW_IOCTL_MAX_MSGS / 2;
+    uint8_t command = i2c->async.reg;
+    size_t count = i2c->async.count;
+    uint8_t times = i2c->async.times;
+    uint8_t *values = i2c->async.data;
 
-    SOL_NULL_CHECK(i2c, false);
     if (!i2c->plain_i2c) {
         SOL_WRN("Unable to read I2C data (bus = %u, device address = 0x%x, "
             "register = 0x%x): the bus/adapter does not support"
             " plain-I2C commands (only SMBus ones)",
             i2c->bus, i2c->addr, command);
-        return false;
+        return;
     }
 
     while (times > 0) {
@@ -376,13 +687,77 @@ sol_i2c_read_register_multiple(const struct sol_i2c *i2c,
             SOL_WRN("Unable to perform I2C read/write (bus = %u,"
                 " device address = 0x%x, register = 0x%x): %s",
                 i2c->bus, i2c->addr, command, sol_util_strerrora(errno));
-            return false;
+            return;
         }
 
         times -= n;
     }
 
-    return true;
+    i2c->async.status = i2c->async.count * i2c->async.times;
+}
+
+#ifdef PTHREAD
+static bool
+i2c_read_reg_multiple_worker_thread_iterate(void *data)
+{
+    struct sol_i2c *i2c = data;
+
+    _i2c_read_register_multiple(i2c);
+    return false;
+}
+#else
+static bool
+i2c_read_reg_multiple_timeout_cb(void *data)
+{
+    struct sol_i2c *i2c = data;
+
+    _i2c_read_register_multiple(i2c);
+    i2c->async.timeout = NULL;
+    i2c->async.dispatch(i2c);
+    return false;
+}
+#endif
+
+SOL_API void *
+sol_i2c_read_register_multiple(struct sol_i2c *i2c, uint8_t reg, uint8_t *values, size_t count, uint8_t times, void (*read_reg_multiple_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status), const void *cb_data)
+{
+#ifdef PTHREAD
+    struct sol_worker_thread_spec spec = {
+        .api_version = SOL_WORKER_THREAD_SPEC_API_VERSION,
+        .setup = NULL,
+        .cleanup = NULL,
+        .iterate = i2c_read_reg_multiple_worker_thread_iterate,
+        .finished = i2c_worker_thread_finished,
+        .feedback = NULL,
+        .data = i2c
+    };
+#endif
+
+    SOL_NULL_CHECK(i2c, NULL);
+    SOL_NULL_CHECK(values, NULL);
+    SOL_INT_CHECK(count, == 0, NULL);
+    SOL_INT_CHECK(times, == 0, NULL);
+    SOL_INT_CHECK(i2c->dev, == 0, NULL);
+    BUSY_CHECK(i2c, NULL);
+
+    i2c->async.data = values;
+    i2c->async.count = count;
+    i2c->async.status = -1;
+    i2c->async.read_write_reg_cb.cb = read_reg_multiple_cb;
+    i2c->async.dispatch = _i2c_read_write_reg_dispatch;
+    i2c->async.reg = reg;
+    i2c->async.cb_data = cb_data;
+    i2c->async.times = times;
+
+#ifdef PTHREAD
+    i2c->async.worker = sol_worker_thread_new(&spec);
+    SOL_NULL_CHECK(i2c->async.worker, NULL);
+    return i2c->async.worker;
+#else
+    i2c->async.timeout = sol_timeout_add(0, i2c_read_reg_multiple_timeout_cb, i2c);
+    SOL_NULL_CHECK(i2c->async.timeout, NULL);
+    return i2c->async.timeout;
+#endif
 }
 
 static bool
@@ -423,18 +798,20 @@ sol_i2c_plain_write_register(const struct sol_i2c *i2c, uint8_t command, const u
     return true;
 }
 
-SOL_API bool
-sol_i2c_write_register(const struct sol_i2c *i2c, uint8_t command, const uint8_t *values, size_t count)
+static void
+_i2c_write_register(struct sol_i2c *i2c)
 {
     int32_t error;
     union i2c_smbus_data data = { 0 };
+    size_t count = i2c->async.count;
+    uint8_t command = i2c->async.reg;
+    uint8_t *values = i2c->async.data;
 
-    SOL_NULL_CHECK(i2c, false);
-    SOL_NULL_CHECK(values, false);
-    SOL_INT_CHECK(count, == 0, false);
-
-    if (count > 32)
-        return sol_i2c_plain_write_register(i2c, command, values, count);
+    if (count > 32) {
+        if (sol_i2c_plain_write_register(i2c, command, values, count) == count)
+            i2c->async.status = count;
+        return;
+    }
 
     switch (count) {
     case 1:
@@ -453,16 +830,79 @@ sol_i2c_write_register(const struct sol_i2c *i2c, uint8_t command, const uint8_t
         SOL_WRN("Unable to perform I2C-SMBus write (byte/word/block) data "
             " (bus = %u, device address = 0x%x, register = 0x%x:): %s",
             i2c->bus, i2c->addr, command, sol_util_strerrora(-error));
-        return false;
+        return;
     }
 
-    return true;
+    i2c->async.status = i2c->async.count;
+}
+
+#ifdef PTHREAD
+static bool
+i2c_write_reg_worker_thread_iterate(void *data)
+{
+    struct sol_i2c *i2c = data;
+
+    _i2c_write_register(i2c);
+    return false;
+}
+#else
+static bool
+i2c_write_reg_timeout_cb(void *data)
+{
+    struct sol_i2c *i2c = data;
+
+    _i2c_write_register(i2c);
+    i2c->async.timeout = NULL;
+    i2c->async.dispatch(i2c);
+    return false;
+}
+#endif
+
+SOL_API void *
+sol_i2c_write_register(struct sol_i2c *i2c, uint8_t reg, const uint8_t *values, size_t count, void (*write_reg_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status), const void *cb_data)
+{
+#ifdef PTHREAD
+    struct sol_worker_thread_spec spec = {
+        .api_version = SOL_WORKER_THREAD_SPEC_API_VERSION,
+        .setup = NULL,
+        .cleanup = NULL,
+        .iterate = i2c_write_reg_worker_thread_iterate,
+        .finished = i2c_worker_thread_finished,
+        .feedback = NULL,
+        .data = i2c
+    };
+#endif
+
+    SOL_NULL_CHECK(i2c, NULL);
+    SOL_NULL_CHECK(values, NULL);
+    SOL_INT_CHECK(count, == 0, NULL);
+    SOL_INT_CHECK(i2c->dev, == 0, NULL);
+    BUSY_CHECK(i2c, NULL);
+
+    i2c->async.data = (uint8_t *)values;
+    i2c->async.count = count;
+    i2c->async.status = -1;
+    i2c->async.read_write_reg_cb.cb = write_reg_cb;
+    i2c->async.dispatch = _i2c_read_write_reg_dispatch;
+    i2c->async.reg = reg;
+    i2c->async.cb_data = cb_data;
+
+#ifdef PTHREAD
+    i2c->async.worker = sol_worker_thread_new(&spec);
+    SOL_NULL_CHECK(i2c->async.worker, false);
+    return i2c->async.worker;
+#else
+    i2c->async.timeout = sol_timeout_add(0, i2c_write_reg_timeout_cb, i2c);
+    SOL_NULL_CHECK(i2c->async.timeout, false);
+    return i2c->async.timeout;
+#endif
 }
 
 SOL_API bool
 sol_i2c_set_slave_address(struct sol_i2c *i2c, uint8_t slave_address)
 {
     SOL_NULL_CHECK(i2c, false);
+    BUSY_CHECK(i2c, false);
 
     if (ioctl(i2c->dev, I2C_SLAVE, slave_address) == -1) {
         SOL_WRN("I2C (bus = %u): could not specify device address 0x%x",
@@ -479,4 +919,44 @@ sol_i2c_get_slave_address(struct sol_i2c *i2c)
 {
     SOL_NULL_CHECK(i2c, 0);
     return i2c->addr;
+}
+
+SOL_API uint8_t
+sol_i2c_bus_get(const struct sol_i2c *i2c)
+{
+    SOL_NULL_CHECK(i2c, 0);
+    return i2c->bus;
+}
+
+SOL_API bool
+sol_i2c_busy(struct sol_i2c *i2c)
+{
+    SOL_NULL_CHECK(i2c, true);
+#ifdef PTHREAD
+    return i2c->async.worker;
+#else
+    return i2c->async.timeout;
+#endif
+}
+
+SOL_API void
+sol_i2c_pending_cancel(struct sol_i2c *i2c, void *pending)
+{
+    SOL_NULL_CHECK(i2c);
+    SOL_NULL_CHECK(pending);
+
+#ifdef PTHREAD
+    if (i2c->async.worker == pending) {
+        sol_worker_thread_cancel(i2c->async.worker);
+        i2c->async.worker = NULL;
+    } else {
+#else
+    if (i2c->async.timeout == pending) {
+        sol_timeout_del(i2c->async.timeout);
+        i2c->async.dispatch(i2c);
+        i2c->async.timeout = NULL;
+    } else {
+#endif
+        SOL_WRN("Invalid I2C pending handle.");
+    }
 }

--- a/src/lib/io/sol-i2c-riot.c
+++ b/src/lib/io/sol-i2c-riot.c
@@ -38,6 +38,7 @@
 #include "sol-log-internal.h"
 #include "sol-i2c.h"
 #include "sol-macros.h"
+#include "sol-mainloop.h"
 #include "sol-util.h"
 
 #include "periph/i2c.h"
@@ -47,6 +48,24 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "i2c");
 struct sol_i2c {
     i2c_t dev;
     uint8_t slave_address;
+    struct {
+        const void *cb_data;
+        struct sol_timeout *timeout;
+        uint8_t *data;
+        size_t count;
+        ssize_t status;
+        uint8_t reg;
+        uint8_t times;
+        void (*dispatch)(struct sol_i2c *i2c);
+        union {
+            struct {
+                void (*cb)(void *cb_data, struct sol_i2c *i2c, uint8_t *data, ssize_t status);
+            } read_write_cb;
+            struct {
+                void (*cb)(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status);
+            } read_write_reg_cb;
+        };
+    } async;
 };
 
 static i2c_speed_t
@@ -87,102 +106,240 @@ sol_i2c_open_raw(uint8_t bus, enum sol_i2c_speed speed)
 }
 
 SOL_API void
-sol_i2c_close(struct sol_i2c *i2c)
+sol_i2c_close_raw(struct sol_i2c *i2c)
 {
     SOL_NULL_CHECK(i2c);
+
+    if (i2c->async.timeout)
+        sol_i2c_pending_cancel(i2c, i2c->async.timeout);
+
     i2c_acquire(i2c->dev);
     i2c_poweroff(i2c->dev);
     i2c_release(i2c->dev);
     free(i2c);
 }
 
-SOL_API bool
-sol_i2c_write_quick(const struct sol_i2c *i2c, bool rw)
+SOL_API void *
+sol_i2c_write_quick(struct sol_i2c *i2c, bool rw, void (*write_quick_cb)(void *cb_data, struct sol_i2c *i2c, ssize_t status), const void *cb_data)
 {
     SOL_CRI("Unsupported");
+    return NULL;
+}
+
+static void
+_i2c_read_write_dispatch(struct sol_i2c *i2c)
+{
+    if (!i2c->async.read_write_cb.cb) return;
+    i2c->async.read_write_cb.cb((void *)i2c->async.cb_data, i2c,
+        i2c->async.data, i2c->async.status);
+}
+
+static bool
+i2c_read_timeout_cb(void *data)
+{
+    struct sol_i2c *i2c = data;
+
+    i2c_acquire(i2c->dev);
+    i2c->async.status = i2c_read_bytes(i2c->dev, i2c->slave_address,
+        (char *)i2c->async.data, i2c->async.count);
+    i2c_release(i2c->dev);
+
+    i2c->async.timeout = NULL;
+    i2c->async.dispatch(i2c);
     return false;
 }
 
-SOL_API ssize_t
-sol_i2c_read(const struct sol_i2c *i2c, uint8_t *data, size_t count)
+SOL_API void *
+sol_i2c_read(struct sol_i2c *i2c, uint8_t *data, size_t count, void (*read_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t *data, ssize_t status), const void *cb_data)
 {
-    ssize_t ret;
+    SOL_NULL_CHECK(i2c, NULL);
+    SOL_NULL_CHECK(data, NULL);
+    SOL_INT_CHECK(count, == 0, NULL);
+    SOL_EXP_CHECK(i2c->async.timeout, NULL);
 
-    SOL_NULL_CHECK(i2c, -EINVAL);
+    i2c->async.data = data;
+    i2c->async.count = count;
+    i2c->async.status = -1;
+    i2c->async.read_write_cb.cb = read_cb;
+    i2c->async.dispatch = _i2c_read_write_dispatch;
+    i2c->async.cb_data = cb_data;
 
-    i2c_acquire(i2c->dev);
-    ret = i2c_read_bytes(i2c->dev, i2c->slave_address, (char *)data, count);
-    i2c_release(i2c->dev);
-    return ret;
+    i2c->async.timeout = sol_timeout_add(0, i2c_read_timeout_cb, i2c);
+    SOL_NULL_CHECK(i2c->async.timeout, NULL);
+
+    return i2c->async.timeout;
 }
 
-SOL_API bool
-sol_i2c_write(const struct sol_i2c *i2c, uint8_t *data, size_t count)
+static bool
+i2c_write_timeout_cb(void *data)
 {
-    int write;
-
-    SOL_NULL_CHECK(i2c, false);
+    struct sol_i2c *i2c = data;
 
     i2c_acquire(i2c->dev);
-    write = i2c_write_bytes(i2c->dev, i2c->slave_address, (char *)data, count);
+    i2c->async.status = i2c_write_bytes(i2c->dev, i2c->slave_address,
+        (char *)i2c->async.data, i2c->async.count);
     i2c_release(i2c->dev);
-    if (write > -1)
-        return write == count;
+
+    i2c->async.timeout = NULL;
+    i2c->async.dispatch(i2c);
     return false;
 }
 
-SOL_API ssize_t
-sol_i2c_read_register(const struct sol_i2c *i2c, uint8_t reg, uint8_t *data, size_t count)
+SOL_API void *
+sol_i2c_write(struct sol_i2c *i2c, uint8_t *data, size_t count, void (*write_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t *data, ssize_t status), const void *cb_data)
 {
-    ssize_t ret;
+    SOL_NULL_CHECK(i2c, NULL);
+    SOL_NULL_CHECK(data, NULL);
+    SOL_INT_CHECK(count, == 0, NULL);
+    SOL_EXP_CHECK(i2c->async.timeout, NULL);
 
-    SOL_NULL_CHECK(i2c, -EINVAL);
+    i2c->async.data = data;
+    i2c->async.count = count;
+    i2c->async.status = -1;
+    i2c->async.read_write_cb.cb = write_cb;
+    i2c->async.dispatch = _i2c_read_write_dispatch;
+    i2c->async.cb_data = cb_data;
 
-    i2c_acquire(i2c->dev);
-    ret = i2c_read_regs(i2c->dev, i2c->slave_address, reg, (char *)data, count);
-    i2c_release(i2c->dev);
-    return ret;
+    i2c->async.timeout = sol_timeout_add(0, i2c_write_timeout_cb, i2c);
+    SOL_NULL_CHECK(i2c->async.timeout, NULL);
+
+    return i2c->async.timeout;
 }
 
-SOL_API bool
-sol_i2c_read_register_multiple(const struct sol_i2c *i2c, uint8_t command, uint8_t *values, uint8_t count, uint8_t times)
+static void
+_i2c_read_write_reg_dispatch(struct sol_i2c *i2c)
 {
+    if (!i2c->async.read_write_reg_cb.cb) return;
+    i2c->async.read_write_reg_cb.cb((void *)i2c->async.cb_data, i2c,
+        i2c->async.reg, i2c->async.data, i2c->async.status);
+}
+
+static bool
+i2c_read_reg_timeout_cb(void *data)
+{
+    struct sol_i2c *i2c = data;
+
+    i2c_acquire(i2c->dev);
+    i2c->async.status = i2c_read_regs(i2c->dev, i2c->slave_address,
+        i2c->async.reg, (char *)i2c->async.data, i2c->async.count);
+    i2c_release(i2c->dev);
+
+    i2c->async.timeout = NULL;
+    i2c->async.dispatch(i2c);
+    return false;
+}
+
+SOL_API void *
+sol_i2c_read_register(struct sol_i2c *i2c, uint8_t command, uint8_t *values, size_t count, void (*read_reg_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status), const void *cb_data)
+{
+    SOL_NULL_CHECK(i2c, NULL);
+    SOL_NULL_CHECK(values, NULL);
+    SOL_INT_CHECK(count, == 0, NULL);
+    SOL_EXP_CHECK(i2c->async.timeout, NULL);
+
+    i2c->async.data = values;
+    i2c->async.count = count;
+    i2c->async.status = -1;
+    i2c->async.read_write_reg_cb.cb = read_reg_cb;
+    i2c->async.dispatch = _i2c_read_write_reg_dispatch;
+    i2c->async.reg = command;
+    i2c->async.cb_data = cb_data;
+
+    i2c->async.timeout = sol_timeout_add(0, i2c_read_reg_timeout_cb, i2c);
+    SOL_NULL_CHECK(i2c->async.timeout, NULL);
+
+    return i2c->async.timeout;
+}
+
+static bool
+i2c_read_reg_multiple_timeout_cb(void *data)
+{
+    struct sol_i2c *i2c = data;
     uint8_t i;
-    ssize_t ret;
-
-    SOL_NULL_CHECK(i2c, false);
+    size_t ret;
 
     i2c_acquire(i2c->dev);
-    for (i = 0; i < times; i++) {
-        ret = i2c_read_regs(i2c->dev, i2c->slave_address, command,
-            (char *)(values + (count * i)), count);
-        if (ret != count)
+    for (i = 0; i < i2c->async.times; i++) {
+        ret = i2c_read_regs(i2c->dev, i2c->slave_address, i2c->async.reg,
+            (char *)(i2c->async.data + (i2c->async.count * i)),
+            i2c->async.count);
+        if (ret != i2c->async.count)
             break;
     }
     i2c_release(i2c->dev);
 
-    return ret == count;
+    if (ret == i2c->async.count)
+        i2c->async.status = i2c->async.count * i2c->async.times;
+
+    i2c->async.timeout = NULL;
+    i2c->async.dispatch(i2c);
+    return false;
 }
 
-SOL_API bool
-sol_i2c_write_register(const struct sol_i2c *i2c, uint8_t reg, const uint8_t *data, size_t count)
+SOL_API void *
+sol_i2c_read_register_multiple(struct sol_i2c *i2c, uint8_t reg, uint8_t *data, size_t count, uint8_t times, void (*read_reg_multiple_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status), const void *cb_data)
 {
-    int write;
+    SOL_NULL_CHECK(i2c, NULL);
+    SOL_NULL_CHECK(data, NULL);
+    SOL_INT_CHECK(count, == 0, NULL);
+    SOL_EXP_CHECK(i2c->async.timeout, NULL);
 
-    SOL_NULL_CHECK(i2c, false);
+    i2c->async.data = data;
+    i2c->async.count = count;
+    i2c->async.status = -1;
+    i2c->async.read_write_reg_cb.cb = read_reg_multiple_cb;
+    i2c->async.dispatch = _i2c_read_write_reg_dispatch;
+    i2c->async.reg = reg;
+    i2c->async.cb_data = cb_data;
+    i2c->async.times = times;
+
+    i2c->async.timeout = sol_timeout_add(0, i2c_read_reg_multiple_timeout_cb, i2c);
+    SOL_NULL_CHECK(i2c->async.timeout, NULL);
+    return i2c->async.timeout;
+}
+
+static bool
+i2c_write_reg_timeout_cb(void *data)
+{
+    struct sol_i2c *i2c = data;
 
     i2c_acquire(i2c->dev);
-    write = i2c_write_regs(i2c->dev, i2c->slave_address, reg, (char *)data, count);
+    i2c->async.status = i2c_write_regs(i2c->dev, i2c->slave_address,
+        i2c->async.reg, (char *)i2c->async.data, i2c->async.count);
     i2c_release(i2c->dev);
-    if (write > -1)
-        return write == count;
+
+    i2c->async.timeout = NULL;
+    i2c->async.dispatch(i2c);
     return false;
+}
+
+SOL_API void *
+sol_i2c_write_register(struct sol_i2c *i2c, uint8_t reg, const uint8_t *data, size_t count, void (*write_reg_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status), const void *cb_data)
+{
+    SOL_NULL_CHECK(i2c, NULL);
+    SOL_NULL_CHECK(data, NULL);
+    SOL_INT_CHECK(count, == 0, NULL);
+    SOL_EXP_CHECK(i2c->async.timeout, NULL);
+
+    i2c->async.data = (uint8_t *)data;
+    i2c->async.count = count;
+    i2c->async.status = -1;
+    i2c->async.read_write_reg_cb.cb = write_reg_cb;
+    i2c->async.dispatch = _i2c_read_write_reg_dispatch;
+    i2c->async.reg = reg;
+    i2c->async.cb_data = cb_data;
+
+    i2c->async.timeout = sol_timeout_add(0, i2c_write_reg_timeout_cb, i2c);
+    SOL_NULL_CHECK(i2c->async.timeout, false);
+    return i2c->async.timeout;
 }
 
 SOL_API bool
 sol_i2c_set_slave_address(struct sol_i2c *i2c, uint8_t slave_address)
 {
     SOL_NULL_CHECK(i2c, false);
+    SOL_EXP_CHECK(i2c->async.timeout, NULL);
+
     i2c->slave_address = slave_address;
     return true;
 }
@@ -192,4 +349,32 @@ sol_i2c_get_slave_address(struct sol_i2c *i2c)
 {
     SOL_NULL_CHECK(i2c, false);
     return i2c->slave_address;
+}
+
+SOL_API uint8_t
+sol_i2c_bus_get(const struct sol_i2c *i2c)
+{
+    SOL_NULL_CHECK(i2c, 0);
+    return i2c->dev;
+}
+
+SOL_API bool
+sol_i2c_busy(struct sol_i2c *i2c)
+{
+    SOL_NULL_CHECK(i2c, true);
+    return i2c->async.timeout;
+}
+
+SOL_API void
+sol_i2c_pending_cancel(struct sol_i2c *i2c, void *pending)
+{
+    SOL_NULL_CHECK(i2c);
+    SOL_NULL_CHECK(pending);
+
+    if (i2c->async.timeout == pending) {
+        sol_timeout_del(i2c->async.timeout);
+        i2c->async.dispatch(i2c);
+        i2c->async.timeout = NULL;
+    } else
+        SOL_WRN("Invalid I2C pending handle.");
 }

--- a/src/lib/io/sol-i2c-riot.c
+++ b/src/lib/io/sol-i2c-riot.c
@@ -145,14 +145,23 @@ sol_i2c_read_register(const struct sol_i2c *i2c, uint8_t reg, uint8_t *data, siz
 }
 
 SOL_API bool
-sol_i2c_read_register_multiple(const struct sol_i2c *i2c,
-    uint8_t command,
-    uint8_t *values,
-    uint8_t len,
-    uint8_t count)
+sol_i2c_read_register_multiple(const struct sol_i2c *i2c, uint8_t command, uint8_t *values, uint8_t count, uint8_t times)
 {
-    //TODO
-    return false;
+    uint8_t i;
+    ssize_t ret;
+
+    SOL_NULL_CHECK(i2c, false);
+
+    i2c_acquire(i2c->dev);
+    for (i = 0; i < times; i++) {
+        ret = i2c_read_regs(i2c->dev, i2c->slave_address, command,
+            (char *)(values + (count * i)), count);
+        if (ret != count)
+            break;
+    }
+    i2c_release(i2c->dev);
+
+    return ret == count;
 }
 
 SOL_API bool

--- a/src/modules/flow/accelerometer/adxl45.c
+++ b/src/modules/flow/accelerometer/adxl45.c
@@ -52,15 +52,27 @@
 struct accelerometer_adxl345_data {
     struct sol_flow_node *node;
     struct sol_i2c *i2c;
+    void *i2c_pending;
     struct sol_timeout *timer;
     double reading[3];
     unsigned init_sampling_cnt;
     unsigned pending_ticks;
-    uint8_t init_power;
+    //I2C buffers
+    union {
+        struct {
+            uint8_t buffer[64];
+        } common;
+        struct {
+            /* int16_t and 3 entries because of x, y and z axis are read,
+             * each consisting of L + H byte parts.
+             */
+            int16_t buffer[64][3];
+        } accel_data;
+    };
     bool ready : 1;
 };
 
-#define ACCEL_INIT_STEP_TIME 1
+#define ACCEL_STEP_TIME 1
 #define ACCEL_RANGE 8         // 8 g
 
 /* Accelerometer register definitions */
@@ -81,16 +93,13 @@ struct accelerometer_adxl345_data {
  */
 #define ACCEL_SCALE_M_S (GRAVITY_MSS / 256.0f)
 
+static bool accel_tick_do(void *data);
+
 static int
 accel_timer_resched(struct accelerometer_adxl345_data *mdata,
     unsigned int timeout_ms,
     bool (*cb)(void *data))
 {
-    SOL_NULL_CHECK(cb, -EINVAL);
-
-    if (mdata->timer)
-        sol_timeout_del(mdata->timer);
-
     mdata->timer = sol_timeout_add(timeout_ms, cb, mdata);
     SOL_NULL_CHECK(mdata->timer, -ENOMEM);
 
@@ -98,21 +107,24 @@ accel_timer_resched(struct accelerometer_adxl345_data *mdata,
 }
 
 static void
-read_samples(struct accelerometer_adxl345_data *mdata, uint8_t num_samples_available)
+i2c_read_multiple_data_cb(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status)
 {
-    int r;
-    /* int16_t and 3 entries because of x, y and z axis are read,
-     * each consisting of L + H byte parts
-     */
-    int16_t buffer[num_samples_available][3];
+    struct accelerometer_adxl345_data *mdata = cb_data;
+    uint8_t num_samples_available;
+    struct sol_direction_vector val =
+    {
+        .min = -ACCEL_RANGE,
+        .max = ACCEL_RANGE,
+        .x = mdata->reading[0],
+        .y = mdata->reading[1],
+        .z = mdata->reading[2]
+    };
 
-    r = sol_i2c_read_register_multiple(mdata->i2c,
-        ACCEL_REG_DATAX0, (uint8_t *)&buffer[0][0], sizeof(buffer[0]),
-        num_samples_available);
-    if (r <= 0) {
-        SOL_WRN("Failed to read ADXL345 accel samples");
+    mdata->i2c_pending = NULL;
+    if (status < 0)
         return;
-    }
+
+    num_samples_available = status / (sizeof(int16_t) * 3);
 
     /* At least with the current i2c driver implementation at the
      * time of testing, if too much time passes between two
@@ -122,7 +134,7 @@ read_samples(struct accelerometer_adxl345_data *mdata, uint8_t num_samples_avail
      * newer values)*/
 #define MAX_EPSILON (10.0f)
 #define EPSILON_CHECK(_axis) \
-    if (i > 0 && isgreater(fabs((buffer[i][_axis] * ACCEL_SCALE_M_S) \
+    if (i > 0 && isgreater(fabs((mdata->accel_data.buffer[i][_axis] * ACCEL_SCALE_M_S) \
         - mdata->reading[_axis]), MAX_EPSILON)) \
         break
 
@@ -132,35 +144,32 @@ read_samples(struct accelerometer_adxl345_data *mdata, uint8_t num_samples_avail
         EPSILON_CHECK(1);
         EPSILON_CHECK(2);
 
-        mdata->reading[0] = buffer[i][0] * ACCEL_SCALE_M_S;
-        mdata->reading[1] = -buffer[i][1] * ACCEL_SCALE_M_S;
-        mdata->reading[2] = -buffer[i][2] * ACCEL_SCALE_M_S;
+        mdata->reading[0] = mdata->accel_data.buffer[i][0] * ACCEL_SCALE_M_S;
+        mdata->reading[1] = -mdata->accel_data.buffer[i][1] * ACCEL_SCALE_M_S;
+        mdata->reading[2] = -mdata->accel_data.buffer[i][2] * ACCEL_SCALE_M_S;
     }
 #undef MAX_EPSILON
 #undef EPSILON_CHECK
+
+    sol_flow_send_direction_vector_packet(mdata->node,
+        SOL_FLOW_NODE_TYPE_ACCELEROMETER_ADXL345__OUT__OUT, &val);
+
+    mdata->pending_ticks--;
+    if (mdata->pending_ticks)
+        accel_tick_do(mdata);
 }
 
 static void
-accel_read(struct accelerometer_adxl345_data *mdata)
+i2c_read_fifo_status_cb(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status)
 {
+    struct accelerometer_adxl345_data *mdata = cb_data;
     uint8_t num_samples_available;
-    uint8_t fifo_status = 0;
-    int r;
 
-    if (!sol_i2c_set_slave_address(mdata->i2c, ACCEL_ADDRESS)) {
-        SOL_WRN("Failed to set slave at address 0x%02x\n", ACCEL_ADDRESS);
+    mdata->i2c_pending = NULL;
+    if (status < 0)
         return;
-    }
 
-    fifo_status = 0;
-    r = sol_i2c_read_register(mdata->i2c, ACCEL_REG_FIFO_STATUS, &fifo_status,
-        1);
-    if (r <= 0) {
-        SOL_WRN("Failed to read ADXL345 accel fifo status");
-        return;
-    }
-
-    num_samples_available = fifo_status & 0x3F;
+    num_samples_available = mdata->common.buffer[0] & 0x3F;
 
     if (!num_samples_available) {
         SOL_INF("No samples available");
@@ -169,53 +178,68 @@ accel_read(struct accelerometer_adxl345_data *mdata)
 
     SOL_DBG("%d samples available", num_samples_available);
 
-    read_samples(mdata, num_samples_available);
+    mdata->i2c_pending = sol_i2c_read_register_multiple(mdata->i2c,
+        ACCEL_REG_DATAX0, (uint8_t *)&mdata->accel_data.buffer[0][0],
+        sizeof(mdata->accel_data.buffer[0]), num_samples_available,
+        i2c_read_multiple_data_cb, mdata);
+    if (!mdata->i2c_pending)
+        SOL_WRN("Failed to read ADXL345 accel samples");
 }
 
-static int
-accel_tick_do(struct accelerometer_adxl345_data *mdata)
-{
-    struct sol_direction_vector val =
-    {
-        .min = -ACCEL_RANGE,
-        .max = ACCEL_RANGE,
-        .x = mdata->reading[0],
-        .y = mdata->reading[1],
-        .z = mdata->reading[2]
-    };
-    int r;
-
-    accel_read(mdata);
-
-    r = sol_flow_send_direction_vector_packet
-            (mdata->node, SOL_FLOW_NODE_TYPE_ACCELEROMETER_ADXL345__OUT__OUT,
-            &val);
-
-    return r;
-}
-
-static void
-accel_ready(void *data)
+static bool
+accel_tick_do(void *data)
 {
     struct accelerometer_adxl345_data *mdata = data;
 
     mdata->timer = NULL;
-    mdata->ready = true;
-
-    while (mdata->pending_ticks) {
-        accel_tick_do(mdata);
-        mdata->pending_ticks--;
+    if (sol_i2c_busy(mdata->i2c)) {
+        accel_timer_resched(mdata, ACCEL_STEP_TIME, accel_tick_do);
+        return false;
     }
 
+    if (!sol_i2c_set_slave_address(mdata->i2c, ACCEL_ADDRESS)) {
+        SOL_WRN("Failed to set slave at address 0x%02x\n", ACCEL_ADDRESS);
+        return false;
+    }
+
+    mdata->common.buffer[0] = 0;
+    mdata->i2c_pending = sol_i2c_read_register(mdata->i2c,
+        ACCEL_REG_FIFO_STATUS, mdata->common.buffer, 1,
+        i2c_read_fifo_status_cb, mdata);
+    if (!mdata->i2c_pending)
+        SOL_WRN("Failed to read ADXL345 accel fifo status");
+
+    return false;
+}
+
+static void
+i2c_write_fifo_ctl_cb(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status)
+{
+    struct accelerometer_adxl345_data *mdata = cb_data;
+
+    mdata->i2c_pending = NULL;
+    if (status < 0) {
+        SOL_WRN("could not set ADXL345 accel sensor's stream mode");
+        return;
+    }
+
+    mdata->ready = true;
     SOL_DBG("accel is ready for reading");
+
+    if (mdata->pending_ticks)
+        accel_tick_do(mdata);
 }
 
 static bool
 accel_init_stream(void *data)
 {
-    bool r;
     struct accelerometer_adxl345_data *mdata = data;
-    static const uint8_t value = ACCEL_REG_FIFO_CTL_STREAM;
+
+    mdata->timer = NULL;
+    if (sol_i2c_busy(mdata->i2c)) {
+        accel_timer_resched(mdata, ACCEL_STEP_TIME, accel_init_stream);
+        return false;
+    }
 
     if (!sol_i2c_set_slave_address(mdata->i2c, ACCEL_ADDRESS)) {
         SOL_WRN("Failed to set slave at address 0x%02x\n", ACCEL_ADDRESS);
@@ -223,129 +247,194 @@ accel_init_stream(void *data)
     }
 
     /* enable FIFO in stream mode */
-    r = sol_i2c_write_register(mdata->i2c, ACCEL_REG_FIFO_CTL, &value, 1);
-    if (!r) {
+    mdata->common.buffer[0] = ACCEL_REG_FIFO_CTL_STREAM;
+    mdata->i2c_pending = sol_i2c_write_register(mdata->i2c, ACCEL_REG_FIFO_CTL,
+        mdata->common.buffer, 1, i2c_write_fifo_ctl_cb, mdata);
+    if (!mdata->i2c_pending)
         SOL_WRN("could not set ADXL345 accel sensor's stream mode");
-        return false;
-    }
-
-    accel_ready(mdata);
 
     return false;
+}
+
+static void
+i2c_write_bw_rate_cb(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status)
+{
+    struct accelerometer_adxl345_data *mdata = cb_data;
+
+    mdata->i2c_pending = NULL;
+    if (status < 0) {
+        SOL_WRN("could not set ADXL345 accel sensor's sampling rate");
+        return;
+    }
+
+    if (accel_timer_resched(mdata, ACCEL_STEP_TIME,
+        accel_init_stream) < 0)
+        SOL_WRN("error in scheduling a ADXL345 accel's init command");
 }
 
 static bool
 accel_init_rate(void *data)
 {
-    bool r;
     struct accelerometer_adxl345_data *mdata = data;
-    static const uint8_t value = 0x0d;
+
+    mdata->timer = NULL;
+    if (sol_i2c_busy(mdata->i2c)) {
+        accel_timer_resched(mdata, ACCEL_STEP_TIME, accel_init_rate);
+        return false;
+    }
 
     if (!sol_i2c_set_slave_address(mdata->i2c, ACCEL_ADDRESS)) {
         SOL_WRN("Failed to set slave at address 0x%02x\n", ACCEL_ADDRESS);
         return false;
     }
 
-    r = sol_i2c_write_register(mdata->i2c, ACCEL_REG_BW_RATE, &value, 1);
-    if (!r) {
+    mdata->common.buffer[0] = 0x0d;
+    mdata->i2c_pending = sol_i2c_write_register(mdata->i2c, ACCEL_REG_BW_RATE,
+        mdata->common.buffer, 1, i2c_write_bw_rate_cb, mdata);
+    if (!mdata->i2c_pending)
         SOL_WRN("could not set ADXL345 accel sensor's sampling rate");
-        return false;
-    }
-
-    if (accel_timer_resched(mdata, ACCEL_INIT_STEP_TIME,
-        accel_init_stream) < 0)
-        SOL_WRN("error in scheduling a ADXL345 accel's init command");
 
     return false;
+}
+
+static void
+i2c_write_data_format_cb(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status)
+{
+    struct accelerometer_adxl345_data *mdata = cb_data;
+
+    mdata->i2c_pending = NULL;
+    if (status < 0) {
+        SOL_WRN("could not set ADXL345 accel sensor's resolution");
+        return;
+    }
+
+    if (accel_timer_resched(mdata, ACCEL_STEP_TIME,
+        accel_init_rate) < 0)
+        SOL_WRN("error in scheduling a ADXL345 accel's init command");
 }
 
 static bool
 accel_init_format(void *data)
 {
-    bool r;
     struct accelerometer_adxl345_data *mdata = data;
-    /* Full resolution, 8g:
-     * Caution, this must agree with ACCEL_SCALE_1G
-     * In full resoution mode, the scale factor need not change
-     */
-    static const uint8_t value = 0x08;
+
+    mdata->timer = NULL;
+    if (sol_i2c_busy(mdata->i2c)) {
+        accel_timer_resched(mdata, ACCEL_STEP_TIME, accel_init_format);
+        return false;
+    }
 
     if (!sol_i2c_set_slave_address(mdata->i2c, ACCEL_ADDRESS)) {
         SOL_WRN("Failed to set slave at address 0x%02x\n", ACCEL_ADDRESS);
         return false;
     }
 
-    r = sol_i2c_write_register(mdata->i2c, ACCEL_REG_DATA_FORMAT, &value, 1);
-    if (!r) {
+    /* Full resolution, 8g:
+     * Caution, this must agree with ACCEL_SCALE_1G
+     * In full resolution mode, the scale factor need not change
+     */
+    mdata->common.buffer[0] = 0x08;
+    mdata->i2c_pending = sol_i2c_write_register(mdata->i2c,
+        ACCEL_REG_DATA_FORMAT, mdata->common.buffer, 1,
+        i2c_write_data_format_cb, mdata);
+    if (!mdata->i2c_pending)
         SOL_WRN("could not set ADXL345 accel sensor's resolution");
-        return false;
-    }
-
-    if (accel_timer_resched(mdata, ACCEL_INIT_STEP_TIME,
-        accel_init_rate) < 0)
-        SOL_WRN("error in scheduling a ADXL345 accel's init command");
 
     return false;
 }
 
+static bool accel_init_power(void *data);
+
 /* meant to run 3 times */
-static bool
-accel_init_power(void *data)
+static void
+i2c_write_power_ctl_cb(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status)
 {
-    bool r, power_done = false;
-    static bool first_run = true;
-    struct accelerometer_adxl345_data *mdata = data;
+    struct accelerometer_adxl345_data *mdata = cb_data;
+    bool power_done = false;
 
-    if (!sol_i2c_set_slave_address(mdata->i2c, ACCEL_ADDRESS)) {
-        SOL_WRN("Failed to set slave at address 0x%02x\n", ACCEL_ADDRESS);
-        return false;
-    }
-
-    r = sol_i2c_write_register(mdata->i2c, ACCEL_REG_POWER_CTL,
-        &mdata->init_power, 1);
-    if (!r) {
+    mdata->i2c_pending = NULL;
+    if (status < 0) {
         SOL_WRN("could not set ADXL345 accel sensor's power mode");
-        return false;
+        return;
     }
 
-    if (mdata->init_power == INIT_POWER_OFF)
-        mdata->init_power = INIT_POWER_STARTING;
-    else if (mdata->init_power == INIT_POWER_STARTING)
-        mdata->init_power = INIT_POWER_MEASURING;
+    if (mdata->common.buffer[0] == INIT_POWER_OFF)
+        mdata->common.buffer[0] = INIT_POWER_STARTING;
+    else if (mdata->common.buffer[0] == INIT_POWER_STARTING)
+        mdata->common.buffer[0] = INIT_POWER_MEASURING;
     else
         power_done = true;
 
-    if (accel_timer_resched(mdata, ACCEL_INIT_STEP_TIME,
+    if (accel_timer_resched(mdata, ACCEL_STEP_TIME,
         power_done ?
         accel_init_format : accel_init_power) < 0) {
         SOL_WRN("error in scheduling a ADXL345 accel's init command");
     }
+}
 
-    if (first_run) {
-        first_run = false;
-        return true;
+static bool
+accel_init_power(void *data)
+{
+    struct accelerometer_adxl345_data *mdata = data;
+
+    mdata->timer = NULL;
+    if (sol_i2c_busy(mdata->i2c)) {
+        accel_timer_resched(mdata, ACCEL_STEP_TIME, accel_init_power);
+        return false;
     }
+
+    if (!sol_i2c_set_slave_address(mdata->i2c, ACCEL_ADDRESS)) {
+        SOL_WRN("Failed to set slave at address 0x%02x\n", ACCEL_ADDRESS);
+        return false;
+    }
+
+    mdata->i2c_pending = sol_i2c_write_register(mdata->i2c, ACCEL_REG_POWER_CTL,
+        mdata->common.buffer, 1, i2c_write_power_ctl_cb, mdata);
+    if (!mdata->i2c_pending)
+        SOL_WRN("could not set ADXL345 accel sensor's power mode");
 
     return false;
 }
 
-static int
-accel_init(struct accelerometer_adxl345_data *mdata)
+static void
+i2c_read_dev_id_cb(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status)
 {
-    ssize_t r;
-    uint8_t data = 0;
+    struct accelerometer_adxl345_data *mdata = cb_data;
 
-    r = sol_i2c_read_register(mdata->i2c, ACCEL_REG_DEV_ID, &data, 1);
-    if (r < 0) {
-        SOL_WRN("Failed to read i2c register");
-        return r;
-    }
-    if (data != ACCEL_DEV_ID) {
+    mdata->i2c_pending = NULL;
+    if (status < 0 || mdata->common.buffer[0] != ACCEL_DEV_ID) {
         SOL_WRN("could not find ADXL345 accel sensor");
-        return -EIO;
+        return;
     }
 
-    return accel_init_power(mdata) ? 0 : -EIO;
+    mdata->common.buffer[0] = INIT_POWER_OFF;
+    accel_init_power(mdata);
+}
+
+static bool
+accel_init(void *data)
+{
+    struct accelerometer_adxl345_data *mdata = data;
+
+    mdata->timer = NULL;
+    if (sol_i2c_busy(mdata->i2c)) {
+        accel_timer_resched(mdata, ACCEL_STEP_TIME, accel_init);
+        return false;
+    }
+
+    if (!sol_i2c_set_slave_address(mdata->i2c, ACCEL_ADDRESS)) {
+        SOL_WRN("Failed to set slave at address 0x%02x\n",
+            ACCEL_ADDRESS);
+        return false;
+    }
+
+    mdata->i2c_pending = sol_i2c_read_register(mdata->i2c, ACCEL_REG_DEV_ID,
+        mdata->common.buffer, 1, i2c_read_dev_id_cb, mdata);
+    if (!mdata->i2c_pending) {
+        SOL_WRN("Failed to read i2c register");
+    }
+
+    return false;
 }
 
 static int
@@ -365,17 +454,10 @@ accelerometer_adxl345_open(struct sol_flow_node *node,
         return -EIO;
     }
 
-    if (!sol_i2c_set_slave_address(mdata->i2c, ACCEL_ADDRESS)) {
-        SOL_WRN("Failed to set slave at address 0x%02x\n",
-            ACCEL_ADDRESS);
-        return -EIO;
-    }
-
-    mdata->init_power = INIT_POWER_OFF;
-    mdata->ready = false;
     mdata->node = node;
+    accel_init(mdata);
 
-    return accel_init(mdata);
+    return 0;
 }
 
 static void
@@ -386,6 +468,8 @@ accelerometer_adxl345_close(struct sol_flow_node *node, void *data)
     if (mdata->timer)
         sol_timeout_del(mdata->timer);
 
+    if (mdata->i2c_pending)
+        sol_i2c_pending_cancel(mdata->i2c, mdata->i2c_pending);
     if (mdata->i2c)
         sol_i2c_close(mdata->i2c);
 }
@@ -399,10 +483,11 @@ accelerometer_adxl345_tick(struct sol_flow_node *node,
 {
     struct accelerometer_adxl345_data *mdata = data;
 
-    if (!mdata->ready) {
+    if (!mdata->ready || mdata->pending_ticks) {
         mdata->pending_ticks++;
         return 0;
     }
 
-    return accel_tick_do(mdata);
+    accel_tick_do(mdata);
+    return 0;
 }

--- a/src/modules/flow/accelerometer/lsm303.c
+++ b/src/modules/flow/accelerometer/lsm303.c
@@ -51,48 +51,136 @@
 #define LSM303_ACCEL_REG_CTRL_REG1_A 0x20
 #define LSM303_ACCEL_REG_CTRL_REG4_A 0x23
 
+#define ACCEL_STEP_TIME 1
+
 struct accelerometer_lsm303_data {
+    struct sol_flow_node *node;
     struct sol_i2c *i2c;
+    void *i2c_pending;
+    struct sol_timeout *timer;
     double reading[3];
     double sensitivity;
     uint8_t slave;
     uint8_t scale;
+    uint8_t i2c_buffer[LSM303_ACCEL_BYTES_NUMBER];
+    uint8_t ready : 1;
+    unsigned pending_ticks;
 };
+
+static bool lsm303_read_data(void *data);
+
+static int
+lsm303_timer_resched(struct accelerometer_lsm303_data *mdata, unsigned int timeout_ms, bool (*cb)(void *data))
+{
+    mdata->timer = sol_timeout_add(timeout_ms, cb, mdata);
+    SOL_NULL_CHECK(mdata->timer, -ENOMEM);
+
+    return 0;
+}
+
+static void
+lsm303_i2c_write_scale_cb(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status)
+{
+    struct accelerometer_lsm303_data *mdata = cb_data;
+
+    mdata->i2c_pending = NULL;
+    if (status < 0) {
+        SOL_WRN("Could not set scale to LSM303 accelerometer");
+        return;
+    }
+
+    mdata->ready = true;
+    if (mdata->pending_ticks)
+        lsm303_read_data(mdata);
+}
+
+static void
+lsm303_scale_bit_set(struct accelerometer_lsm303_data *mdata)
+{
+    if (!sol_i2c_set_slave_address(mdata->i2c, mdata->slave)) {
+        SOL_WRN("Failed to set slave at address 0x%02x\n", mdata->slave);
+        return;
+    }
+
+    switch (mdata->scale) {
+    case 2:
+        mdata->i2c_buffer[0] = 0x00;
+        mdata->sensitivity = 1.0 / 1000;
+        break;
+    case 4:
+        mdata->i2c_buffer[0] = 0x01;
+        mdata->sensitivity = 2.0 / 1000;
+        break;
+    case 8:
+        mdata->i2c_buffer[0] = 0x02;
+        mdata->sensitivity = 4.0 / 1000;
+        break;
+    case 16:
+        mdata->i2c_buffer[0] = 0x03;
+        mdata->sensitivity = 12.0 / 1000;
+        break;
+    default:
+        SOL_WRN("Invalid scale. Expected one of 2, 4, 8 or 16");
+        return;
+    }
+
+    mdata->i2c_pending = sol_i2c_write_register(mdata->i2c,
+        LSM303_ACCEL_REG_CTRL_REG4_A, mdata->i2c_buffer, 1,
+        lsm303_i2c_write_scale_cb, mdata);
+    if (!mdata->i2c_pending)
+        SOL_WRN("Could not set scale to LSM303 accelerometer");
+}
+
+static void
+lsm303_i2c_write_mode_cb(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status)
+{
+    struct accelerometer_lsm303_data *mdata = cb_data;
+
+    mdata->i2c_pending = NULL;
+    if (status < 0) {
+        SOL_WRN("Could not enable LSM303 accelerometer");
+        return;
+    }
+
+    lsm303_scale_bit_set(mdata);
+}
+
+static bool
+lsm303_accel_init(void *data)
+{
+    struct accelerometer_lsm303_data *mdata = data;
+
+    mdata->timer = NULL;
+    if (sol_i2c_busy(mdata->i2c)) {
+        lsm303_timer_resched(mdata, ACCEL_STEP_TIME, lsm303_accel_init);
+        return false;
+    }
+
+    if (!sol_i2c_set_slave_address(mdata->i2c, mdata->slave)) {
+        SOL_WRN("Failed to set slave at address 0x%02x\n",
+            mdata->slave);
+        return false;
+    }
+
+    mdata->i2c_buffer[0] = LSM303_ACCEL_DEFAULT_MODE;
+    mdata->i2c_pending = sol_i2c_write_register(mdata->i2c,
+        LSM303_ACCEL_REG_CTRL_REG1_A, mdata->i2c_buffer, 1,
+        lsm303_i2c_write_mode_cb, mdata);
+    if (!mdata->i2c_pending)
+        SOL_WRN("Could not enable LSM303 accelerometer");
+
+    return false;
+}
 
 static int
 accelerometer_lsm303_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
 {
     struct accelerometer_lsm303_data *mdata = data;
     const struct sol_flow_node_type_accelerometer_lsm303_options *opts;
-    static const uint8_t mode = LSM303_ACCEL_DEFAULT_MODE;
-    uint8_t scale_bit;
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_ACCELEROMETER_LSM303_OPTIONS_API_VERSION,
         -EINVAL);
     opts = (const struct sol_flow_node_type_accelerometer_lsm303_options *)options;
-
-    switch (opts->scale.val) {
-    case 2:
-        scale_bit = 0x00;
-        mdata->sensitivity = 1.0 / 1000;
-        break;
-    case 4:
-        scale_bit = 0x01;
-        mdata->sensitivity = 2.0 / 1000;
-        break;
-    case 8:
-        scale_bit = 0x02;
-        mdata->sensitivity = 4.0 / 1000;
-        break;
-    case 16:
-        scale_bit = 0x03;
-        mdata->sensitivity = 12.0 / 1000;
-        break;
-    default:
-        SOL_WRN("Invalid scale. Expected one of 2, 4, 8 or 16");
-        return -EINVAL;
-    }
-    mdata->scale = opts->scale.val;
 
     mdata->i2c = sol_i2c_open(opts->i2c_bus.val, SOL_I2C_SPEED_10KBIT);
     if (!mdata->i2c) {
@@ -100,28 +188,12 @@ accelerometer_lsm303_open(struct sol_flow_node *node, void *data, const struct s
         return -EINVAL;
     }
 
-    if (!sol_i2c_set_slave_address(mdata->i2c, opts->i2c_slave.val)) {
-        SOL_WRN("Failed to set slave at address 0x%02x\n",
-            opts->i2c_slave.val);
-        goto fail;
-    }
+    mdata->node = node;
+    mdata->scale = opts->scale.val;
     mdata->slave = opts->i2c_slave.val;
-
-    if (!sol_i2c_write_register(mdata->i2c, LSM303_ACCEL_REG_CTRL_REG1_A, &mode, 1)) {
-        SOL_WRN("Could not enable LSM303 accelerometer");
-        goto fail;
-    }
-
-    if (!sol_i2c_write_register(mdata->i2c, LSM303_ACCEL_REG_CTRL_REG4_A, &scale_bit, 1)) {
-        SOL_WRN("Could not set scale to LSM303 accelerometer");
-        goto fail;
-    }
+    lsm303_accel_init(mdata);
 
     return 0;
-
-fail:
-    sol_i2c_close(mdata->i2c);
-    return -EIO;
 }
 
 static void
@@ -129,52 +201,51 @@ accelerometer_lsm303_close(struct sol_flow_node *node, void *data)
 {
     struct accelerometer_lsm303_data *mdata = data;
 
+    if (mdata->timer)
+        sol_timeout_del(mdata->timer);
+
+    if (mdata->i2c_pending)
+        sol_i2c_pending_cancel(mdata->i2c, mdata->i2c_pending);
     if (mdata->i2c)
         sol_i2c_close(mdata->i2c);
 }
 
 static void
-_lsm303_send_output_packets(struct sol_flow_node *node, struct accelerometer_lsm303_data *mdata)
+_lsm303_send_output_packets(struct accelerometer_lsm303_data *mdata)
 {
     struct sol_direction_vector val =
     {
         .min = -mdata->scale,
-        .max = -mdata->scale,
+        .max = mdata->scale,
         .x = mdata->reading[0],
         .y = mdata->reading[1],
         .z = mdata->reading[2]
     };
 
-    sol_flow_send_direction_vector_packet(node,
+    sol_flow_send_direction_vector_packet(mdata->node,
         SOL_FLOW_NODE_TYPE_ACCELEROMETER_LSM303__OUT__RAW, &val);
 
     val.x = val.x * GRAVITY_MSS;
     val.y = val.y * GRAVITY_MSS;
     val.z = val.z * GRAVITY_MSS;
 
-    sol_flow_send_direction_vector_packet(node,
+    sol_flow_send_direction_vector_packet(mdata->node,
         SOL_FLOW_NODE_TYPE_ACCELEROMETER_LSM303__OUT__OUT, &val);
+
+    mdata->pending_ticks--;
+    if (mdata->pending_ticks)
+        lsm303_read_data(mdata);
 }
 
-static int
-accelerometer_lsm303_tick(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+static void
+i2c_read_data_cb(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *buffer, ssize_t status)
 {
-    struct accelerometer_lsm303_data *mdata = data;
-    int8_t buffer[LSM303_ACCEL_BYTES_NUMBER];
-    int r;
+    struct accelerometer_lsm303_data *mdata = cb_data;
 
-    if (!sol_i2c_set_slave_address(mdata->i2c, mdata->slave)) {
-        SOL_WRN("Failed to set slave at address 0x%02x\n",
-            mdata->slave);
-        return -EIO;
-    }
-
-    /* ORing with 0x80 to read all bytes in a row */
-    r = sol_i2c_read_register(mdata->i2c, LSM303_ACCEL_REG_OUT_X_H_A | 0x80,
-        (uint8_t *)buffer, sizeof(buffer));
-    if (r <= 0) {
-        SOL_WRN("Failed to read LSM303 accel samples");
-        return -EIO;
+    mdata->i2c_pending = NULL;
+    if (status < 0) {
+        SOL_WRN("Could not enable LSM303 accelerometer");
+        return;
     }
 
     /* http://stackoverflow.com/a/19164062 says that it's necessary to >> 4 buffer result.
@@ -185,8 +256,47 @@ accelerometer_lsm303_tick(struct sol_flow_node *node, void *data, uint16_t port,
     mdata->reading[1] = ((buffer[2] | (buffer[3] << 8)) >> 4) * mdata->sensitivity;
     mdata->reading[2] = ((buffer[4] | (buffer[5] << 8)) >> 4) * mdata->sensitivity;
 
-    _lsm303_send_output_packets(node, mdata);
+    _lsm303_send_output_packets(mdata);
+}
+
+static bool
+lsm303_read_data(void *data)
+{
+    struct accelerometer_lsm303_data *mdata = data;
+
+    mdata->timer = NULL;
+    if (sol_i2c_busy(mdata->i2c)) {
+        lsm303_timer_resched(mdata, ACCEL_STEP_TIME, lsm303_read_data);
+        return false;
+    }
+
+    if (!sol_i2c_set_slave_address(mdata->i2c, mdata->slave)) {
+        SOL_WRN("Failed to set slave at address 0x%02x\n",
+            mdata->slave);
+        return false;
+    }
+
+    /* ORing with 0x80 to read all bytes in a row */
+    mdata->i2c_pending = sol_i2c_read_register(mdata->i2c,
+        LSM303_ACCEL_REG_OUT_X_H_A | 0x80, mdata->i2c_buffer,
+        sizeof(mdata->i2c_buffer), i2c_read_data_cb, mdata);
+    if (!mdata->i2c_pending)
+        SOL_WRN("Failed to read LSM303 accel samples");
+
+    return false;
+}
+
+static int
+accelerometer_lsm303_tick(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct accelerometer_lsm303_data *mdata = data;
+
+    if (!mdata->ready || mdata->pending_ticks) {
+        mdata->pending_ticks++;
+        return 0;
+    }
+
+    lsm303_read_data(mdata);
 
     return 0;
 }
-

--- a/src/modules/flow/magnetometer/lsm303.c
+++ b/src/modules/flow/magnetometer/lsm303.c
@@ -34,6 +34,7 @@
 #include "sol-flow-internal.h"
 
 #include <sol-i2c.h>
+#include <sol-mainloop.h>
 #include <sol-util.h>
 
 #include <errno.h>
@@ -44,14 +45,33 @@
 #define LSM303_MAG_REG_MR_REG_M 0x02
 #define LSM303_ACCEL_REG_OUT_X_H_M 0x03
 
+#define MAG_STEP_TIME 1
+
 struct magnetometer_lsm303_data {
+    struct sol_flow_node *node;
     struct sol_i2c *i2c;
-    double reading[3];
+    void *i2c_pending;
+    struct sol_timeout *timer;
     uint16_t gain_xy;
     uint16_t gain_z;
     uint8_t slave;
     uint8_t scale;
+    uint8_t ready : 1;
+    unsigned pending_ticks;
+    uint8_t i2c_buffer[LSM303_MAG_BYTES_NUMBER];
+    double reading[3];
 };
+
+static bool magnetometer_lsm303_tick_do(void *data);
+
+static int
+timer_sched(struct magnetometer_lsm303_data *mdata, unsigned int timeout_ms, bool (*cb)(void *data))
+{
+    mdata->timer = sol_timeout_add(timeout_ms, cb, mdata);
+    SOL_NULL_CHECK(mdata->timer, -ENOMEM);
+
+    return 0;
+}
 
 static bool
 _get_range_bits_and_gain(double range, uint8_t *range_bit, uint16_t *gain_xy, uint16_t *gain_z)
@@ -92,22 +112,83 @@ _get_range_bits_and_gain(double range, uint8_t *range_bit, uint16_t *gain_xy, ui
     return true;
 }
 
+static void
+i2c_write_range_cb(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status)
+{
+    struct magnetometer_lsm303_data *mdata = cb_data;
+
+    mdata->i2c_pending = NULL;
+    if (status < 0) {
+        SOL_WRN("Could not set LSM303 magnetometer range");
+        return;
+    }
+
+    mdata->ready = true;
+    if (mdata->pending_ticks)
+        magnetometer_lsm303_tick_do(mdata);
+}
+
+static void
+i2c_write_mode_cb(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status)
+{
+    struct magnetometer_lsm303_data *mdata = cb_data;
+
+    mdata->i2c_pending = NULL;
+    if (status < 0) {
+        SOL_WRN("Could not enable LSM303 magnetometer");
+        return;
+    }
+
+    if (!_get_range_bits_and_gain(mdata->scale, mdata->i2c_buffer,
+        &mdata->gain_xy, &mdata->gain_z)) {
+        SOL_WRN("Invalid gain. Expected one of 1.3, 1.9, 2.5, 4.0, 4.5, 5.6 or 8.1");
+        return;
+    }
+
+    mdata->i2c_pending = sol_i2c_write_register(mdata->i2c,
+        LSM303_MAG_REG_CRB_REG_M, mdata->i2c_buffer, 1, i2c_write_range_cb,
+        mdata);
+    if (!mdata->i2c_pending)
+        SOL_WRN("Could not set LSM303 magnetometer range");
+
+    return;
+}
+
+static bool
+lsm303_init(void *data)
+{
+    struct magnetometer_lsm303_data *mdata = data;
+
+    mdata->timer = NULL;
+    if (sol_i2c_busy(mdata->i2c)) {
+        timer_sched(mdata, MAG_STEP_TIME, lsm303_init);
+        return false;
+    }
+
+    if (!sol_i2c_set_slave_address(mdata->i2c, mdata->slave)) {
+        SOL_WRN("Failed to set slave at address 0x%02x\n", mdata->slave);
+        return false;
+    }
+
+    mdata->i2c_buffer[0] = LSM303_MAG_DEFAULT_MODE;
+    mdata->i2c_pending = sol_i2c_write_register(mdata->i2c,
+        LSM303_MAG_REG_MR_REG_M, mdata->i2c_buffer, 1, i2c_write_mode_cb,
+        mdata);
+    if (!mdata->i2c_pending)
+        SOL_WRN("Could not enable LSM303 magnetometer");
+
+    return false;
+}
+
 static int
 magnetometer_lsm303_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
 {
     struct magnetometer_lsm303_data *mdata = data;
     const struct sol_flow_node_type_magnetometer_lsm303_options *opts;
-    static const uint8_t mode = LSM303_MAG_DEFAULT_MODE;
-    uint8_t range_bit;
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_MAGNETOMETER_LSM303_OPTIONS_API_VERSION,
         -EINVAL);
     opts = (const struct sol_flow_node_type_magnetometer_lsm303_options *)options;
-
-    if (!_get_range_bits_and_gain(opts->scale.val, &range_bit, &mdata->gain_xy, &mdata->gain_z)) {
-        SOL_WRN("Invalid gain. Expected one of 1.3, 1.9, 2.5, 4.0, 4.5, 5.6 or 8.1");
-        return -EINVAL;
-    }
 
     mdata->i2c = sol_i2c_open(opts->i2c_bus.val, SOL_I2C_SPEED_10KBIT);
     if (!mdata->i2c) {
@@ -115,28 +196,12 @@ magnetometer_lsm303_open(struct sol_flow_node *node, void *data, const struct so
         return -EINVAL;
     }
 
-    if (!sol_i2c_set_slave_address(mdata->i2c, opts->i2c_slave.val)) {
-        SOL_WRN("Failed to set slave at address 0x%02x\n",
-            opts->i2c_slave.val);
-        goto fail;
-    }
     mdata->slave = opts->i2c_slave.val;
+    mdata->scale = opts->scale.val;
+    mdata->node = node;
 
-    if (!sol_i2c_write_register(mdata->i2c, LSM303_MAG_REG_MR_REG_M, &mode, 1)) {
-        SOL_WRN("Could not enable LSM303 magnetometer");
-        goto fail;
-    }
-
-    if (!sol_i2c_write_register(mdata->i2c, LSM303_MAG_REG_CRB_REG_M, &range_bit, 1)) {
-        SOL_WRN("Could not set LSM303 magnetometer range");
-        goto fail;
-    }
-
+    lsm303_init(mdata);
     return 0;
-
-fail:
-    sol_i2c_close(mdata->i2c);
-    return -EINVAL;
 }
 
 static void
@@ -144,47 +209,43 @@ magnetometer_lsm303_close(struct sol_flow_node *node, void *data)
 {
     struct magnetometer_lsm303_data *mdata = data;
 
+    if (mdata->i2c_pending)
+        sol_i2c_pending_cancel(mdata->i2c, mdata->i2c_pending);
     if (mdata->i2c)
         sol_i2c_close(mdata->i2c);
+
+    if (mdata->timer)
+        sol_timeout_del(mdata->timer);
 }
 
 static void
-_lsm303_send_output_packets(struct sol_flow_node *node, struct magnetometer_lsm303_data *mdata)
+_lsm303_send_output_packets(struct magnetometer_lsm303_data *mdata)
 {
     struct sol_direction_vector val =
     {
         .min = -mdata->scale,
-        .max = -mdata->scale,
+        .max = mdata->scale,
         .x = mdata->reading[0],
         .y = mdata->reading[1],
         .z = mdata->reading[2]
     };
 
-    sol_flow_send_direction_vector_packet(node,
+    sol_flow_send_direction_vector_packet(mdata->node,
         SOL_FLOW_NODE_TYPE_MAGNETOMETER_LSM303__OUT__OUT, &val);
 }
 
-static int
-magnetometer_lsm303_tick(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+static void
+i2c_lsm303_read_data_cb(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status)
 {
-    struct magnetometer_lsm303_data *mdata = data;
-    int8_t buffer[LSM303_MAG_BYTES_NUMBER];
-    int r;
+    struct magnetometer_lsm303_data *mdata = cb_data;
+    uint8_t *buffer = mdata->i2c_buffer;
 
-    if (!sol_i2c_set_slave_address(mdata->i2c, mdata->slave)) {
-        const char errmsg[] = "Failed to set slave at address 0x%02x";
-        SOL_WRN(errmsg, mdata->slave);
-        sol_flow_send_error_packet(node, EIO, errmsg, mdata->slave);
-        return -EIO;
-    }
-
-    r = sol_i2c_read_register(mdata->i2c, LSM303_ACCEL_REG_OUT_X_H_M,
-        (uint8_t *)buffer, sizeof(buffer));
-    if (r <= 0) {
+    mdata->i2c_pending = NULL;
+    if (status < 0) {
         const char errmsg[] = "Failed to read LSM303 magnetometer samples";
         SOL_WRN(errmsg);
-        sol_flow_send_error_packet(node, EIO, errmsg);
-        return -EIO;
+        sol_flow_send_error_packet(mdata->node, EIO, errmsg);
+        return;
     }
 
     /* Get X, Z and Y. That's why reading[] is indexed 0, 2 and 1. */
@@ -192,8 +253,54 @@ magnetometer_lsm303_tick(struct sol_flow_node *node, void *data, uint16_t port, 
     mdata->reading[2] = ((buffer[2] << 8) | buffer[3]) / mdata->gain_z;
     mdata->reading[1] = ((buffer[4] << 8) | buffer[5]) / mdata->gain_xy;
 
-    _lsm303_send_output_packets(node, mdata);
+    _lsm303_send_output_packets(mdata);
 
+    mdata->pending_ticks--;
+    if (mdata->pending_ticks)
+        magnetometer_lsm303_tick_do(mdata);
+}
+
+static bool
+magnetometer_lsm303_tick_do(void *data)
+{
+    struct magnetometer_lsm303_data *mdata = data;
+
+    mdata->timer = NULL;
+    if (sol_i2c_busy(mdata->i2c)) {
+        timer_sched(mdata, MAG_STEP_TIME, magnetometer_lsm303_tick_do);
+        return false;
+    }
+
+    if (!sol_i2c_set_slave_address(mdata->i2c, mdata->slave)) {
+        const char errmsg[] = "Failed to set slave at address 0x%02x";
+        SOL_WRN(errmsg, mdata->slave);
+        sol_flow_send_error_packet(mdata->node, EIO, errmsg, mdata->slave);
+        return false;
+    }
+
+    mdata->i2c_pending = sol_i2c_read_register(mdata->i2c,
+        LSM303_ACCEL_REG_OUT_X_H_M, mdata->i2c_buffer,
+        sizeof(mdata->i2c_buffer), i2c_lsm303_read_data_cb, mdata);
+    if (!mdata->i2c_pending) {
+        const char errmsg[] = "Failed to read LSM303 magnetometer samples";
+        SOL_WRN(errmsg);
+        sol_flow_send_error_packet(mdata->node, EIO, errmsg);
+    }
+
+    return false;
+}
+
+static int
+magnetometer_lsm303_tick(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct magnetometer_lsm303_data *mdata = data;
+
+    if (!mdata->ready || mdata->pending_ticks) {
+        mdata->pending_ticks++;
+        return 0;
+    }
+
+    magnetometer_lsm303_tick_do(mdata);
     return 0;
 }
 


### PR DESCRIPTION
The patches starting with squash will be squashed to I2C: Make API asynchronous, leaving this way to make easy each author check his code port.