### PR TITLE
build: dep-resolver set HAVE_* symbols

### DIFF
--- a/data/scripts/dependency-resolver.py
+++ b/data/scripts/dependency-resolver.py
@@ -202,6 +202,7 @@ def handle_ccode_check(args, conf, context):
 
 def handle_exec_check(args, conf, context):
     dep = conf.get("dependency")
+    dep_sym = dep.upper()
     exe = conf.get("exec")
 
     if not exe:
@@ -218,7 +219,8 @@ def handle_exec_check(args, conf, context):
         req_label += "executable: %s\\n" % exe
         context.add_append_makefile_var("NOT_FOUND", req_label, True)
 
-    context.add_cond_makefile_var(dep.upper(), path)
+    context.add_cond_makefile_var(dep_sym, path)
+    context.add_cond_makefile_var("HAVE_%s" % dep_sym, "y" if path else "n")
 
     return success
 

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -72,13 +72,6 @@ CP ?= cp
 MV ?= mv
 CHMOD ?= chmod
 
-HAVE_VALGRIND := $(if $(filter-out $(wildcard $(VALGRIND)),$(VALGRIND)),n,y)
-HAVE_DOXYGEN := $(if $(filter-out $(wildcard $(DOXYGEN)),$(DOXYGEN)),n,y)
-HAVE_TAR := $(if $(filter-out $(wildcard $(TAR)),$(TAR)),n,y)
-HAVE_BZIP2 := $(if $(filter-out $(wildcard $(BZIP2)),$(BZIP2)),n,y)
-HAVE_GRAPHVIZ := $(if $(filter $(GRAPHVIZ),$(GRAPHVIZ)),y,n)
-HAVE_IMAGEMAGICK := $(if $(filter $(IMAGEMAGICK),$(IMAGEMAGICK)),y,n)
-
 # installation
 PREFIX := $(patsubst "%",%,$(PREFIX))
 


### PR DESCRIPTION
Instead of calculating the HAVE_* symbols for exec dependencies whenever
required this patch instructs dependency-resolver.py to generate those
symbols into Makefile.gen.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>