### PR TITLE
Reduce the amount of allocations and code for options [v2]

### DIFF
--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -812,8 +812,6 @@ static void
 }
 """)
 
-    new_options_func = "NULL"
-    free_options_func = "NULL"
     if "options" in data:
         outfile.write("""
 static const struct %(name_c)s_options %(name_c)s_options_defaults = %(NAME_C)s_OPTIONS_DEFAULTS();
@@ -821,78 +819,7 @@ static const struct %(name_c)s_options %(name_c)s_options_defaults = %(NAME_C)s_
     "name_c": data["name_c"],
     "NAME_C": data["NAME_C"],
     })
-        new_options_func = None
-        free_options_func = None
-        if "methods" in data["options"]:
-            new_options_func = data["options"]["methods"].get("new", None)
-            free_options_func = data["options"]["methods"].get("free", None)
 
-    if new_options_func is None:
-        new_options_func = "%s_new_options_internal" % data["name_c"]
-        outfile.write("""
-static struct sol_flow_node_options *
-%(name_func)s(const struct sol_flow_node_type *type, const struct sol_flow_node_options *copy_from)
-{
-    struct %(name_c)s_options *opts;
-    const struct %(name_c)s_options *from;
-
-    if (!copy_from) from = &%(name_c)s_options_defaults;
-    else from = (struct %(name_c)s_options *)copy_from;
-    if (from->base.sub_api != %(NAME_C)s_OPTIONS_API_VERSION) {
-        errno = -EINVAL;
-        return NULL;
-    }
-
-    opts = malloc(sizeof(*opts));
-    if (!opts) {
-        errno = -ENOMEM;
-        return NULL;
-    }
-    *opts = *from;
-""" % {
-    "name_c": data["name_c"],
-    "NAME_C": data["NAME_C"],
-    "name_func": new_options_func
-    })
-        members = data["options"].get("members", [])
-        for m in members:
-            if m["data_type"] == "string":
-                outfile.write("""
-    if (opts->%(member)s)
-        opts->%(member)s = strdup(opts->%(member)s);
-""" % {
-    "member": m["name"]
-    })
-        outfile.write("""
-    return &opts->base;
-}
-""")
-
-    if free_options_func is None:
-        free_options_func = "%s_free_options_internal" % data["name_c"]
-        outfile.write("""
-static void
-%(name_func)s(const struct sol_flow_node_type *type, struct sol_flow_node_options *options)
-{
-    struct %(name_c)s_options *opts;
-    if (!options) return;
-    opts = (struct %(name_c)s_options *)options;
-""" % {
-    "name_c": data["name_c"],
-    "name_func": free_options_func
-    })
-        members = data["options"].get("members", [])
-        for m in members:
-            if m["data_type"] == "string":
-                outfile.write("""
-    free((void *)opts->%(member)s);
-""" % {
-    "member": m["name"]
-    })
-        outfile.write("""
-    free(opts);
-}
-""")
 
     outfile.write("""
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
@@ -1038,6 +965,12 @@ static const struct sol_flow_node_type_description %(name_c)s_description = {
     }),
 """)
 
+    outfile.write("""\
+};
+#endif
+
+""")
+
     node_type = "struct sol_flow_node_type"
     node_base_type_access_open = ""
     node_base_type_access_close = ""
@@ -1053,16 +986,20 @@ static const struct sol_flow_node_type_description %(name_c)s_description = {
     data_size = "0"
     if "private_data_type" in data:
         data_size = "sizeof(struct " + data.get("private_data_type") + ")"
-    outfile.write("""\
-};
-#endif
 
+    options_size = "sizeof(struct sol_flow_node_options)"
+    default_options = "NULL"
+    if "options" in data:
+        options_size = "sizeof(struct " + data["name_c"] + "_options)"
+        default_options = "&" + data["name_c"] + "_options_defaults"
+
+    outfile.write("""\
 static const %(node_type)s %(name_c)s = {%(node_base_type_access_open)s
     .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
     .data_size = %(data_size)s,
+    .options_size = %(options_size)s,
+    .default_options = %(default_options)s,
     .init_type = %(name_c)s_init_type_internal,
-    .new_options = %(new_opts)s,
-    .free_options = %(free_opts)s,
     .open = %(open)s,
     .close = %(close)s,
     .get_ports_counts = %(name_c)s_get_ports_counts_internal,
@@ -1071,8 +1008,8 @@ static const %(node_type)s %(name_c)s = {%(node_base_type_access_open)s
     "node_base_type_access_open": node_base_type_access_open,
     "name_c": data["name_c"],
     "data_size": data_size,
-    "new_opts": new_options_func,
-    "free_opts": free_options_func,
+    "options_size": options_size,
+    "default_options": default_options,
     "open": methods.get("open", "NULL"),
     "close": methods.get("close", "NULL"),
     })

--- a/src/lib/flow/include/sol-flow-simplectype.h
+++ b/src/lib/flow/include/sol-flow-simplectype.h
@@ -115,6 +115,9 @@ struct sol_flow_simplectype_event {
  *        the last argument. If zero is given, then this node
  *        shouldn't store per-instance information and data shouldn't
  *        be used.
+ * @param options_size the amount of bytes to store options used with
+ *        this type. The options struct must contain a struct
+ *        sol_flow_node_options as its first member.
  * @param func the function to call for all events of this node such
  *        as opening (creating), closing (destroying), ports being
  *        connected or disconnected as well as incoming packets on
@@ -127,7 +130,7 @@ struct sol_flow_simplectype_event {
  * @see sol_flow_simplectype_new_nocontext()
  * @see sol_flow_node_type_del()
  */
-struct sol_flow_node_type *sol_flow_simplectype_new_full(const char *name, size_t context_data_size, int (*func)(struct sol_flow_node *node, const struct sol_flow_simplectype_event *ev, void *data), ...) SOL_ATTR_SENTINEL;
+struct sol_flow_node_type *sol_flow_simplectype_new_full(const char *name, size_t context_data_size, uint16_t options_size, int (*func)(struct sol_flow_node *node, const struct sol_flow_simplectype_event *ev, void *data), ...) SOL_ATTR_SENTINEL;
 
 /**
  * @def sol_flow_simplectype_new(context_data_type, cb, ...)
@@ -141,7 +144,7 @@ struct sol_flow_node_type *sol_flow_simplectype_new_full(const char *name, size_
  * @see sol_flow_simplectype_new_full()
  * @see sol_flow_simplectype_new_nocontext()
  */
-#define sol_flow_simplectype_new(context_data_type, cb, ...) sol_flow_simplectype_new_full(#cb, sizeof(context_data_type), cb, ## __VA_ARGS__, NULL)
+#define sol_flow_simplectype_new(context_data_type, cb, ...) sol_flow_simplectype_new_full(#cb, sizeof(context_data_type), sizeof(struct sol_flow_node_type), cb, ## __VA_ARGS__, NULL)
 
 /**
  * @def sol_flow_simplectype_new_nocontext(cb, ...)
@@ -154,7 +157,7 @@ struct sol_flow_node_type *sol_flow_simplectype_new_full(const char *name, size_
  * @see sol_flow_simplectype_new_full()
  * @see sol_flow_simplectype_new()
  */
-#define sol_flow_simplectype_new_nocontext(cb, ...) sol_flow_simplectype_new_full(#cb, 0, cb, ## __VA_ARGS__, NULL)
+#define sol_flow_simplectype_new_nocontext(cb, ...) sol_flow_simplectype_new_full(#cb, 0, sizeof(struct sol_flow_node_type), cb, ## __VA_ARGS__, NULL)
 
 /**
  * Helper to retrieve the output port index from its name.

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -341,12 +341,11 @@ struct sol_flow_node_type {
 #define SOL_FLOW_NODE_TYPE_API_VERSION (1) /**< compile time API version to be checked during runtime */
     uint16_t api_version; /**< must match SOL_FLOW_NODE_TYPE_API_VERSION at runtime */
     uint16_t data_size; /**< size of the whole sol_flow_node_type derivate */
+    uint16_t options_size;
     uint16_t flags; /**< @see #sol_flow_node_type_flags */
 
     const void *type_data; /**< pointer to per-type user data */
-
-    struct sol_flow_node_options *(*new_options)(const struct sol_flow_node_type *type, const struct sol_flow_node_options *copy_from); /**< member function to instantiate new options for the node. If @a copy_from is not @c NULL, its members will be copied into the new returned struct */
-    void (*free_options)(const struct sol_flow_node_type *type, struct sol_flow_node_options *opts); /**< member function to delete the node options */
+    const void *default_options;
 
     void (*get_ports_counts)(const struct sol_flow_node_type *type, uint16_t *ports_in_count, uint16_t *ports_out_count); /**< member function to get the number of input/output ports of the node */
     const struct sol_flow_port_type_in *(*get_port_in)(const struct sol_flow_node_type *type, uint16_t port); /**< member function to get the array of the node's input ports */

--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -35,6 +35,7 @@
 #include <string.h>
 
 #include "sol-arena.h"
+#include "sol-buffer.h"
 #include "sol-flow-builder.h"
 #include "sol-flow-internal.h"
 #include "sol-flow-resolver.h"
@@ -46,6 +47,8 @@ struct builder_type_data {
     struct sol_flow_node_type_description desc;
 
     size_t options_size;
+    struct sol_buffer default_opts_buf;
+
     struct node_extra *node_extras;
 
     struct sol_arena *arena;
@@ -84,7 +87,6 @@ struct node_extra {
 struct sol_flow_builder_node_exported_option {
     uint16_t parent_offset, child_offset;
     uint16_t size;
-    bool is_string;
 };
 
 struct sol_flow_builder_options {
@@ -114,19 +116,30 @@ sol_flow_builder_init(struct sol_flow_builder *builder)
 static int
 sol_flow_builder_init_type_data(struct sol_flow_builder *builder)
 {
+    struct sol_flow_node_options *default_opts;
+    int r;
+
     builder->type_data = calloc(1, sizeof(struct builder_type_data));
     SOL_NULL_CHECK_GOTO(builder->type_data, error_type_data);
 
     builder->type_data->arena = sol_arena_new();
     SOL_NULL_CHECK_GOTO(builder->type_data->arena, error_arena);
 
+    sol_buffer_init(&builder->type_data->default_opts_buf);
+    builder->type_data->options_size = sizeof(struct sol_flow_builder_options);
+    r = sol_buffer_ensure(&builder->type_data->default_opts_buf, builder->type_data->options_size);
+    if (r < 0)
+        goto error_default_opts;
+    default_opts = builder->type_data->default_opts_buf.data;
+    default_opts->api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION;
+    default_opts->sub_api = SOL_FLOW_BUILDER_OPTIONS_API_VERSION;
+
     builder->type_data->spec.api_version = SOL_FLOW_STATIC_API_VERSION;
     builder->type_data->desc.api_version = SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION;
 
-    builder->type_data->options_size = sizeof(struct sol_flow_builder_options);
-
     return 0;
 
+error_default_opts:
 error_arena:
     free(builder->type_data);
 error_type_data:
@@ -214,6 +227,7 @@ dispose_builder_type(const void *data)
     free(type_data->node_extras);
 
     sol_arena_del(type_data->arena);
+    sol_buffer_fini(&type_data->default_opts_buf);
 
     free(type_data);
 }
@@ -258,6 +272,7 @@ sol_flow_builder_del(struct sol_flow_builder *builder)
     sol_vector_clear(&builder->exported_out);
 
     sol_arena_del(builder->type_data->arena);
+    sol_buffer_fini(&builder->type_data->default_opts_buf);
     free(builder->type_data);
 
 end:
@@ -561,8 +576,10 @@ get_node(struct sol_flow_builder *builder, const char *node_name, uint16_t *out_
 static int
 node_spec_add_options_reference(struct sol_flow_builder *builder, uint16_t node, const struct sol_flow_node_options_member_description *parent, const struct sol_flow_node_options_member_description *child)
 {
+    struct sol_flow_static_node_spec *node_spec;
     struct node_extra *node_extra;
     struct sol_flow_builder_node_exported_option *ref;
+    const struct sol_flow_node_options *child_opts;
 
     node_extra = sol_vector_get(&builder->node_extras, node);
     ref = sol_vector_append(&node_extra->exported_options);
@@ -570,7 +587,17 @@ node_spec_add_options_reference(struct sol_flow_builder *builder, uint16_t node,
     ref->parent_offset = parent->offset;
     ref->child_offset = child->offset;
     ref->size = parent->size;
-    ref->is_string = streq(parent->data_type, "string");
+
+    node_spec = sol_vector_get(&builder->nodes, node);
+    child_opts = node_spec->opts;
+    if (!child_opts)
+        child_opts = node_spec->type->default_options;
+
+    if (child_opts) {
+        memcpy((char *)(builder->type_data->default_opts_buf.data) + parent->offset,
+            (char *)(child_opts) + child->offset,
+            child->size);
+    }
 
     return 0;
 }
@@ -733,78 +760,6 @@ fill_options_description(struct sol_flow_builder *builder,
     opts->required = required;
 }
 
-static void
-builder_type_free_options(const struct sol_flow_node_type *type, struct sol_flow_node_options *options)
-{
-    struct sol_flow_builder_options *opts = (struct sol_flow_builder_options *)options;
-    const struct sol_flow_node_options_member_description *member;
-
-    SOL_FLOW_NODE_OPTIONS_API_CHECK(options, SOL_FLOW_NODE_OPTIONS_API_VERSION);
-    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_BUILDER_OPTIONS_API_VERSION);
-
-    for (member = type->description->options->members; member->name; member++) {
-        char **ptr;
-
-        if (!streq(member->data_type, "string"))
-            continue;
-
-        ptr = (char **)((char *)opts + member->offset);
-        free(*ptr);
-    }
-
-    free(opts);
-}
-
-static struct sol_flow_node_options *
-builder_type_new_options(const struct sol_flow_node_type *type, const struct sol_flow_node_options *copy_from)
-{
-    struct builder_type_data *type_data = (struct builder_type_data *)type->type_data;
-    struct sol_flow_builder_options *opts;
-    const struct sol_flow_node_options_member_description *member;
-
-    SOL_NULL_CHECK(type_data, NULL);
-
-    if (copy_from) {
-        SOL_FLOW_NODE_OPTIONS_API_CHECK(copy_from, SOL_FLOW_NODE_OPTIONS_API_VERSION, NULL);
-        SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(copy_from, SOL_FLOW_BUILDER_OPTIONS_API_VERSION, NULL);
-    }
-
-    opts = calloc(1, type_data->options_size);
-    SOL_NULL_CHECK(opts, NULL);
-
-    opts->base.api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION;
-    opts->base.sub_api = SOL_FLOW_BUILDER_OPTIONS_API_VERSION;
-
-    for (member = type->description->options->members; member->name; member++) {
-        char *dst;
-        const char **src;
-        bool is_string;
-
-        is_string = streq(member->data_type, "string");
-
-        dst = (char *)opts + member->offset;
-        if (copy_from)
-            src = (const char **)((char *)copy_from + member->offset);
-        else
-            src = (const char **)&member->defvalue.ptr;
-
-        if (is_string) {
-            char **s = (char **)dst;
-            free(*s);
-            if (*src) {
-                if (!(*s = strdup(*src))) {
-                    builder_type_free_options(type, &opts->base);
-                    return NULL;
-                }
-            } else
-                *s = NULL;
-        } else
-            memcpy(dst, src, member->size);
-    }
-
-    return &opts->base;
-}
-
 static int
 builder_child_opts_set(const struct sol_flow_node_type *type, uint16_t child, const struct sol_flow_node_options *options, struct sol_flow_node_options *child_opts)
 {
@@ -827,17 +782,7 @@ builder_child_opts_set(const struct sol_flow_node_type *type, uint16_t child, co
 
         src = (const char **)((char *)opts + opt_ref->parent_offset);
         dst = (char *)child_opts + opt_ref->child_offset;
-
-        if (opt_ref->is_string) {
-            char **s = (char **)dst;
-            free(*s);
-            if (*src) {
-                if (!(*s = strdup(*src)))
-                    return -ENOMEM;
-            } else
-                *s = NULL;
-        } else
-            memcpy(dst, src, opt_ref->size);
+        memcpy(dst, src, opt_ref->size);
     }
 
     return 0;
@@ -948,6 +893,7 @@ sol_flow_builder_get_node_type(struct sol_flow_builder *builder)
     struct builder_type_data *type_data;
     struct sol_flow_static_spec *spec;
     struct sol_flow_node_type_description *desc;
+    struct sol_flow_node_options *default_opts = NULL;
     struct sol_flow_node_options_description *opts = NULL;
     int err;
 
@@ -1003,10 +949,8 @@ sol_flow_builder_get_node_type(struct sol_flow_builder *builder)
         goto error;
     }
 
-    if (opts) {
-        builder->node_type->new_options = builder_type_new_options;
-        builder->node_type->free_options = builder_type_free_options;
-    }
+    builder->node_type->options_size = builder->type_data->options_size;
+    builder->node_type->default_options = builder->type_data->default_opts_buf.data;
 
     /* If the type was successfully created, detach the data from the
      * vectors. The data is owned by the type now. */
@@ -1027,6 +971,7 @@ sol_flow_builder_get_node_type(struct sol_flow_builder *builder)
     return builder->node_type;
 
 error:
+    free(default_opts);
     free(opts);
 
     remove_guards(builder);
@@ -1049,15 +994,23 @@ mark_own_opts(struct sol_flow_builder *builder, uint16_t node_idx)
     node_extra->owns_opts = true;
 }
 
-void
-sol_flow_builder_mark_own_all_options(struct sol_flow_builder *builder)
+int
+sol_flow_builder_add_node_taking_options(
+    struct sol_flow_builder *builder,
+    const char *name,
+    const struct sol_flow_node_type *type,
+    const struct sol_flow_node_options *options)
 {
-    struct node_extra *node_extra;
-    uint16_t i;
+    int r;
 
-    SOL_VECTOR_FOREACH_IDX (&builder->node_extras, node_extra, i) {
-        node_extra->owns_opts = true;
+    r = sol_flow_builder_add_node(builder, name, type, options);
+    if (r < 0) {
+        sol_flow_node_options_del(type, (struct sol_flow_node_options *)options);
+    } else {
+        mark_own_opts(builder, builder->nodes.len - 1);
     }
+
+    return r;
 }
 
 SOL_API int
@@ -1124,12 +1077,7 @@ sol_flow_builder_add_node_by_type(struct sol_flow_builder *builder, const char *
     if (r < 0)
         goto end;
 
-    r = sol_flow_builder_add_node(builder, name, node_type, opts);
-    if (r < 0) {
-        sol_flow_node_options_del(node_type, (struct sol_flow_node_options *)opts);
-    } else {
-        mark_own_opts(builder, builder->nodes.len - 1);
-    }
+    r = sol_flow_builder_add_node_taking_options(builder, name, node_type, opts);
 
 end:
     sol_flow_node_named_options_fini(&named_opts);
@@ -1334,7 +1282,7 @@ sol_flow_builder_export_option(struct sol_flow_builder *builder, const char *nod
     struct sol_flow_static_node_spec *node_spec;
     const struct sol_flow_node_options_member_description *opt;
     struct sol_flow_node_options_member_description *exported_opt;
-    size_t member_alignment, padding;
+    size_t member_alignment, padding, new_options_size;
     uint16_t node;
     int r;
 
@@ -1397,14 +1345,23 @@ sol_flow_builder_export_option(struct sol_flow_builder *builder, const char *nod
     member_alignment = get_member_alignment(opt);
     padding = builder->type_data->options_size % member_alignment;
     exported_opt->offset = builder->type_data->options_size + padding;
+    new_options_size = builder->type_data->options_size + exported_opt->size + padding;
 
-    builder->type_data->options_size += exported_opt->size + padding;
+    r = sol_buffer_ensure(&builder->type_data->default_opts_buf, new_options_size);
+    if (r < 0) {
+        SOL_ERR("Failed to allocate memory to export option '%s' from node '%s'",
+            option_name, node_name);
+        return r;
+    }
+
     r = node_spec_add_options_reference(builder, node, exported_opt, opt);
     if (r < 0) {
         sol_vector_del(&builder->options_description, builder->options_description.len - 1);
         SOL_ERR("Failed to export option '%s' from node '%s'", option_name, node_name);
         return r;
     }
+
+    builder->type_data->options_size = new_options_size;
 
     return 0;
 }

--- a/src/lib/flow/sol-flow-internal.h
+++ b/src/lib/flow/sol-flow-internal.h
@@ -131,8 +131,7 @@ int sol_flow_node_init(struct sol_flow_node *node, struct sol_flow_node *parent,
 /* Update libsoletta-gdb.py before changing the function and parameters below. */
 void sol_flow_node_fini(struct sol_flow_node *node);
 
-struct sol_flow_node_options *sol_flow_node_get_options(const struct sol_flow_node_type *type, const struct sol_flow_node_options *copy_from);
-void sol_flow_node_free_options(const struct sol_flow_node_type *type, struct sol_flow_node_options *options);
+extern const struct sol_flow_node_options sol_flow_node_options_empty;
 
 #define SOL_FLOW_NODE_CHECK(handle, ...)                 \
     do {                                                \
@@ -286,4 +285,8 @@ void sol_flow_node_free_options(const struct sol_flow_node_type *type, struct so
     } while (0)
 
 struct sol_flow_builder;
-void sol_flow_builder_mark_own_all_options(struct sol_flow_builder *builder);
+int sol_flow_builder_add_node_taking_options(
+    struct sol_flow_builder *builder,
+    const char *name,
+    const struct sol_flow_node_type *type,
+    const struct sol_flow_node_options *options);

--- a/src/lib/flow/sol-flow-js.c
+++ b/src/lib/flow/sol-flow-js.c
@@ -1303,6 +1303,7 @@ flow_js_type_init(struct flow_js_type *type, const char *buf, size_t len)
             .get_port_in = flow_js_get_port_in,
             .get_port_out = flow_js_get_port_out,
             .dispose_type = flow_dispose_type,
+            .options_size = sizeof(struct sol_flow_node_options),
         },
     };
 

--- a/src/lib/flow/sol-flow-parser.c
+++ b/src/lib/flow/sol-flow-parser.c
@@ -454,7 +454,7 @@ build_node(
         goto end;
     }
 
-    err = sol_flow_builder_add_node(state->builder, name, type, opts);
+    err = sol_flow_builder_add_node_taking_options(state->builder, name, type, opts);
     if (err < 0) {
         sol_fbp_log_print(state->filename, node->position.line, node->position.column,
             "Couldn't add node '%s'", name);
@@ -466,8 +466,6 @@ end:
 
     free(component);
     if (err < 0) {
-        if (opts)
-            sol_flow_node_options_del(type, opts);
         name = NULL;
         errno = -err;
     }
@@ -633,8 +631,6 @@ build_flow(struct parse_state *state)
             goto end;
         }
     }
-
-    sol_flow_builder_mark_own_all_options(state->builder);
 
     SOL_VECTOR_FOREACH_IDX (&graph->conns, c, i) {
         err = sol_buffer_set_slice(&src_port_buf, c->src_port);

--- a/src/lib/flow/sol-flow-resolver.c
+++ b/src/lib/flow/sol-flow-resolver.c
@@ -115,12 +115,6 @@ sol_flow_resolve(
         return -ENOENT;
     }
 
-    if (!tmp_type->new_options && tmp_named_opts.count > 0) {
-        SOL_ERR("Error resolving node type for id='%s'. "
-            "The type doesn't support options, but resolver returned them", id);
-        return -EINVAL;
-    }
-
     *type = tmp_type;
     *named_opts = tmp_named_opts;
 

--- a/src/lib/flow/sol-flow-simplectype.c
+++ b/src/lib/flow/sol-flow-simplectype.c
@@ -338,7 +338,7 @@ simplectype_port_out_disconnect(struct sol_flow_node *node, void *data, uint16_t
 }
 
 SOL_API struct sol_flow_node_type *
-sol_flow_simplectype_new_full(const char *name, size_t private_data_size, int (*func)(struct sol_flow_node *node, const struct sol_flow_simplectype_event *ev, void *data), ...)
+sol_flow_simplectype_new_full(const char *name, size_t private_data_size, uint16_t options_size, int (*func)(struct sol_flow_node *node, const struct sol_flow_simplectype_event *ev, void *data), ...)
 {
     struct sol_vector ports_in = SOL_VECTOR_INIT(struct simplectype_port_in);
     struct sol_vector ports_out = SOL_VECTOR_INIT(struct simplectype_port_out);
@@ -352,6 +352,7 @@ sol_flow_simplectype_new_full(const char *name, size_t private_data_size, int (*
     bool ok = true;
 
     SOL_NULL_CHECK(func, NULL);
+    SOL_INT_CHECK(options_size, < sizeof(struct sol_flow_node_options), NULL);
 
     va_start(ap, func);
     while ((port_name = va_arg(ap, const char *)) != NULL) {
@@ -421,6 +422,7 @@ sol_flow_simplectype_new_full(const char *name, size_t private_data_size, int (*
     type->open = simplectype_open;
     type->close = simplectype_close;
     type->dispose_type = simplectype_dispose;
+    type->options_size = options_size;
 
     if (!simplectype_create_description(type, name))
         goto error_desc;

--- a/src/modules/flow/calamari/calamari.c
+++ b/src/modules/flow/calamari/calamari.c
@@ -259,8 +259,8 @@ calamari_7seg_new_type(const struct sol_flow_node_type **current)
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
     type->description = (*current)->description;
 #endif
-    type->new_options = (*current)->new_options;
-    type->free_options = (*current)->free_options;
+    type->options_size = (*current)->options_size;
+    type->default_options = (*current)->default_options;
     *current = type;
 }
 
@@ -586,8 +586,8 @@ calamari_rgb_led_new_type(const struct sol_flow_node_type **current)
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
     type->description = (*current)->description;
 #endif
-    type->new_options = (*current)->new_options;
-    type->free_options = (*current)->free_options;
+    type->options_size = (*current)->options_size;
+    type->default_options = (*current)->default_options;
     *current = type;
 }
 

--- a/src/modules/flow/grove/grove.c
+++ b/src/modules/flow/grove/grove.c
@@ -114,8 +114,8 @@ grove_rotary_sensor_new_type(const struct sol_flow_node_type **current)
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
     type->description = (*current)->description;
 #endif
-    type->new_options = (*current)->new_options;
-    type->free_options = (*current)->free_options;
+    type->options_size = (*current)->options_size;
+    type->default_options = (*current)->default_options;
     *current = type;
 }
 
@@ -232,8 +232,8 @@ grove_light_sensor_new_type(const struct sol_flow_node_type **current)
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
     type->description = (*current)->description;
 #endif
-    type->new_options = (*current)->new_options;
-    type->free_options = (*current)->free_options;
+    type->options_size = (*current)->options_size;
+    type->default_options = (*current)->default_options;
     *current = type;
 }
 
@@ -412,8 +412,8 @@ grove_temperature_sensor_new_type(const struct sol_flow_node_type **current)
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
     type->description = (*current)->description;
 #endif
-    type->new_options = (*current)->new_options;
-    type->free_options = (*current)->free_options;
+    type->options_size = (*current)->options_size;
+    type->default_options = (*current)->default_options;
     *current = type;
 }
 

--- a/src/samples/flow/c-api/simplectype.c
+++ b/src/samples/flow/c-api/simplectype.c
@@ -239,8 +239,9 @@ startup(void)
      * input: IRANGE (index: 0), BOOLEAN (index: 1)
      * output: STRING (index: 0, as input and output have separate arrays)
      */
-    mytype = sol_flow_simplectype_new(
-        struct mytype_context, mytype_func,
+    mytype = sol_flow_simplectype_new_full(
+        "mytype", sizeof(struct mytype_context), sizeof(struct mytype_options),
+        mytype_func,
         SOL_FLOW_SIMPLECTYPE_PORT_IN("IRANGE", SOL_FLOW_PACKET_TYPE_IRANGE),
         SOL_FLOW_SIMPLECTYPE_PORT_IN("BOOLEAN", SOL_FLOW_PACKET_TYPE_BOOLEAN),
         SOL_FLOW_SIMPLECTYPE_PORT_OUT("STRING", SOL_FLOW_PACKET_TYPE_STRING),

--- a/src/test/test-flow-builder.c
+++ b/src/test/test-flow-builder.c
@@ -191,6 +191,7 @@ static const struct sol_flow_node_type test_node_type = {
     .get_ports_counts = test_node_get_ports_counts,
     .get_port_in = test_node_get_port_in,
     .get_port_out = test_node_get_port_out,
+    .options_size = sizeof(struct sol_flow_node_options),
 
     .description = &test_node_description,
 };

--- a/src/test/test-flow-parser.c
+++ b/src/test/test-flow-parser.c
@@ -204,30 +204,19 @@ static const struct sol_flow_node_type_description test_node_description = {
         })
 };
 
-static struct sol_flow_node_options *
-test_node_type_new_options(const struct sol_flow_node_type *type,
-    const struct sol_flow_node_options *copy_from)
-{
-    struct test_node_options *opts, *from = (struct test_node_options *)copy_from;
-
-    opts = malloc(sizeof(*opts));
-    opts->base.api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION;
-    opts->base.sub_api = 1;
-    opts->opt = from ? from->opt : true;
-    return &opts->base;
-}
-
-static void
-test_node_type_free_options(const struct sol_flow_node_type *type, struct sol_flow_node_options *opts)
-{
-    free(opts);
-}
+static const struct test_node_options default_opts = {
+    .base = {
+        .api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION,
+        .sub_api = 1,
+    },
+    .opt = true,
+};
 
 static const struct sol_flow_node_type test_node_type = {
     .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
 
-    .new_options = test_node_type_new_options,
-    .free_options = test_node_type_free_options,
+    .options_size = sizeof(struct test_node_options),
+    .default_options = &default_opts,
 
     .get_ports_counts = test_node_get_ports_counts,
     .get_port_in = test_node_get_port_in,

--- a/src/test/test-flow.c
+++ b/src/test/test-flow.c
@@ -1374,37 +1374,6 @@ node_options_new(void)
 }
 
 
-DEFINE_TEST(copy_options);
-
-static void
-copy_options(void)
-{
-    struct sol_flow_node_type_console_options opts = {}, *copied_opts;
-    char prefix[] = { 'A', 'B', 'C', '\0' };
-
-    opts.base.api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION;
-    opts.base.sub_api = SOL_FLOW_NODE_TYPE_CONSOLE_OPTIONS_API_VERSION;
-    opts.prefix = prefix;
-    opts.output_on_stdout = true;
-    opts.flush = false;
-
-    copied_opts = (struct sol_flow_node_type_console_options *)
-        sol_flow_node_options_copy(SOL_FLOW_NODE_TYPE_CONSOLE, &opts.base);
-    ASSERT(copied_opts);
-
-    /* Will touch some of the values after the copy. */
-    prefix[0] = 'X';
-    prefix[1] = '\0';
-    opts.output_on_stdout = false;
-
-    ASSERT(streq(copied_opts->prefix, "ABC"));
-    ASSERT(copied_opts->output_on_stdout);
-    ASSERT(!copied_opts->flush);
-
-    sol_flow_node_options_del(SOL_FLOW_NODE_TYPE_CONSOLE, &copied_opts->base);
-}
-
-
 DEFINE_TEST(need_a_valid_type_to_create_packets);
 
 static void


### PR DESCRIPTION
Improvements to how we deal with struct sol_flow_node_options.

The second patch ensures that we simply pass thru the options from the spec if nothing is being exported, as discussed in #335.