### PR TITLE
Now all string nodes are UTF-8-aware.

### DIFF
--- a/src/test-fbp/string-compare.fbp
+++ b/src/test-fbp/string-compare.fbp
@@ -28,11 +28,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-full_string(constant/string:value="Hello World")
-full_upper_string(constant/string:value="HELLO WORLD")
-same_string(constant/string:value="Hello World")
-lesser_string(constant/string:value="Hello")
-greater_string(constant/string:value="World")
+full_string(constant/string:value="Ħěĺļō Ɯőŗŀď")
+same_string(constant/string:value="Ħěĺļō Ɯőŗŀď")
+full_upper_string(constant/string:value="ĦĚĹĻŌ ƜŐŖĿĎ")
+lesser_string(constant/string:value="Ħěĺļō")
+greater_string(constant/string:value="Ɯőŗŀď")
 
 zero(constant/int:value=0)
 

--- a/src/test-fbp/string-concat.fbp
+++ b/src/test-fbp/string-concat.fbp
@@ -28,15 +28,15 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-hello(constant/string:value="Hello")
-world(constant/string:value=" World")
+hello(constant/string:value="Ħěĺļō")
+world(constant/string:value=" Ɯőŗŀď")
 
 hello OUT -> IN[0] concat(string/concatenate)
 world OUT -> IN[1] concat
-hello_world(constant/string:value="Hello World") OUT -> IN[0] concat_cmp(string/compare)
+hello_world(constant/string:value="Ħěĺļō Ɯőŗŀď") OUT -> IN[0] concat_cmp(string/compare)
 concat OUT -> IN[1] concat_cmp EQUAL -> RESULT concat_entire_strings(test/result)
 
 hello OUT -> IN[0] concat_n(string/concatenate:bytes=2)
 world OUT -> IN[1] concat_n
-hello_w(constant/string:value="Hello W") OUT -> IN[0] concat_n_cmp(string/compare)
+hello_w(constant/string:value="Ħěĺļō Ɯ") OUT -> IN[0] concat_n_cmp(string/compare)
 concat_n OUT -> IN[1] concat_n_cmp EQUAL -> RESULT concat_some_bytes(test/result)

--- a/src/test-fbp/string-length.fbp
+++ b/src/test-fbp/string-length.fbp
@@ -28,7 +28,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-hello_world(constant/string:value="Hello World")
+hello_world(constant/string:value="Ħěĺļō Ɯőŗŀď")
 
 hello_world OUT -> IN len(string/length)
 len OUT -> IN[0] is_len_correct(int/equal)

--- a/src/test-fbp/string-split.fbp
+++ b/src/test-fbp/string-split.fbp
@@ -28,9 +28,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-HelloWorld(constant/string:value="Hello World")
-Hello(constant/string:value="Hello")
-World(constant/string:value="World")
+HelloWorld(constant/string:value="Ħěĺļō Ɯőŗŀď")
+Hello(constant/string:value="Ħěĺļō")
+World(constant/string:value="Ɯőŗŀď")
 Len(constant/int:value=2)
 
 HelloWorld OUT -> IN split(string/split)


### PR DESCRIPTION
Tests expect that ICU is present, as usual.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>