### PR TITLE
test: add ASSERT_SIZE_T_EQ/ASSERT_SIZE_T_NE() macros

### DIFF
--- a/src/test/test-util.c
+++ b/src/test/test-util.c
@@ -92,7 +92,7 @@ test_size_mul(void)
     size_t out;
 
     ASSERT(sol_util_size_mul(half_size, 2, &out) == 0);
-    ASSERT_INT_EQ(out, half_double_size);
+    ASSERT_SIZE_T_EQ(out, half_double_size);
 
     ASSERT_INT_EQ(sol_util_size_mul(half_size, 4, &out), -EOVERFLOW);
 }

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -74,27 +74,39 @@ int test_main(struct test *start, struct test *stop, void (*reset_func)(void), i
         }                                                               \
     } while (0)
 
-#define ASSERT_INT_EQ(expr_a, expr_b)                                   \
+#define ASSERT_NUMBER_EQ(type, expr_a, expr_b)                          \
     do {                                                                \
-        const int __value_expr_a = expr_a;                              \
-        const int __value_expr_b = expr_b;                              \
+        const type __value_expr_a = expr_a;                             \
+        const type __value_expr_b = expr_b;                             \
         if ((__value_expr_a) != (__value_expr_b)) {                     \
-            fprintf(stderr, "%s:%d: %s: Assertion `" #expr_a "' (%d) == `" #expr_b "' (%d) failed.\n", \
+            fprintf(stderr, "%s:%l: %s: Assertion `" #expr_a "' (%l) == `" #expr_b "' (%l) failed.\n", \
                 __FILE__, __LINE__, __PRETTY_FUNCTION__, __value_expr_a, __value_expr_b); \
             exit(-1);                                                   \
         }                                                               \
     } while (0)
 
-#define ASSERT_INT_NE(expr_a, expr_b)                                   \
+#define ASSERT_NUMBER_NE(type, expr_a, expr_b)                          \
     do {                                                                \
-        const int __value_expr_a = expr_a;                              \
-        const int __value_expr_b = expr_b;                              \
+        const type __value_expr_a = expr_a;                              \
+        const type __value_expr_b = expr_b;                              \
         if ((__value_expr_a) == (__value_expr_b)) {                     \
-            fprintf(stderr, "%s:%d: %s: Assertion `" #expr_a "' (%d) != `" #expr_b "' (%d) failed.\n", \
+            fprintf(stderr, "%s:%l: %s: Assertion `" #expr_a "' (%l) != `" #expr_b "' (%l) failed.\n", \
                 __FILE__, __LINE__, __PRETTY_FUNCTION__, __value_expr_a, __value_expr_b); \
             exit(-1);                                                   \
         }                                                               \
     } while (0)
+
+#define ASSERT_SIZE_T_EQ(expr_a, expr_b)        \
+    ASSERT_NUMBER_EQ(size_t, expr_a, expr_b)
+
+#define ASSERT_SIZE_T_NE(expr_a, expr_b)        \
+    ASSERT_NUMBER_NE(size_t, expr_a, expr_b)
+
+#define ASSERT_INT_EQ(expr_a, expr_b)           \
+    ASSERT_NUMBER_EQ(int, expr_a, expr_b)
+
+#define ASSERT_INT_NE(expr_a, expr_b)           \
+    ASSERT_NUMBER_NE(int, expr_a, expr_b)
 
 #define ASSERT_STR_EQ(str_a, str_b)                                     \
     do {                                                                \


### PR DESCRIPTION
This patch adds the macros ASSERT_SIZE_T_EQ() and ASSERT_SIZE_T_NE() so
we can check for size_t variables.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>