### PR TITLE
Random fixes

### DIFF
--- a/src/lib/flow/sol-flow-node-options.c
+++ b/src/lib/flow/sol-flow-node-options.c
@@ -184,6 +184,12 @@ get_member_memory(const struct sol_flow_node_options_member_description *member,
         }                                                       \
     } while (0)
 
+static inline double
+strtod_no_locale(const char *nptr, char **endptr)
+{
+    return sol_util_strtodn(nptr, endptr, -1, false);
+}
+
 static int
 irange_parse(const char *value, struct sol_flow_node_named_options_member *m)
 {
@@ -258,22 +264,22 @@ drange_parse(const char *value, struct sol_flow_node_named_options_member *m)
 
     buf = strdup(value);
 
-    ASSIGN_KEY_VAL(double, min, strtod, false,
+    ASSIGN_KEY_VAL(double, min, strtod_no_locale, false,
         DBL_MAX, DBL_MAX_STR, DBL_MAX_STR_LEN,
         -DBL_MAX, DBL_MIN_STR, DBL_MIN_STR_LEN);
-    ASSIGN_KEY_VAL(double, max, strtod, false,
+    ASSIGN_KEY_VAL(double, max, strtod_no_locale, false,
         DBL_MAX, DBL_MAX_STR, DBL_MAX_STR_LEN,
         -DBL_MAX, DBL_MIN_STR, DBL_MIN_STR_LEN);
-    ASSIGN_KEY_VAL(double, step, strtod, false,
+    ASSIGN_KEY_VAL(double, step, strtod_no_locale, false,
         DBL_MAX, DBL_MAX_STR, DBL_MAX_STR_LEN,
         -DBL_MAX, DBL_MIN_STR, DBL_MIN_STR_LEN);
-    ASSIGN_KEY_VAL(double, val, strtod, false,
+    ASSIGN_KEY_VAL(double, val, strtod_no_locale, false,
         DBL_MAX, DBL_MAX_STR, DBL_MAX_STR_LEN,
         -DBL_MAX, DBL_MIN_STR, DBL_MIN_STR_LEN);
 
     KEY_VALUES_RECAP(DBL_MAX, -DBL_MAX);
 
-    ASSIGN_LINEAR_VALUES(strtod,
+    ASSIGN_LINEAR_VALUES(strtod_no_locale,
         DBL_MAX, DBL_MAX_STR, DBL_MAX_STR_LEN,
         -DBL_MAX, DBL_MIN_STR, DBL_MIN_STR_LEN);
 
@@ -409,19 +415,19 @@ direction_vector_parse(const char *value, struct sol_flow_node_named_options_mem
 
     buf = strdup(value);
 
-    ASSIGN_KEY_VAL(double, x, strtod, false,
+    ASSIGN_KEY_VAL(double, x, strtod_no_locale, false,
         DBL_MAX, DBL_MAX_STR, DBL_MAX_STR_LEN,
         -DBL_MAX, DBL_MIN_STR, DBL_MIN_STR_LEN);
-    ASSIGN_KEY_VAL(double, y, strtod, false,
+    ASSIGN_KEY_VAL(double, y, strtod_no_locale, false,
         DBL_MAX, DBL_MAX_STR, DBL_MAX_STR_LEN,
         -DBL_MAX, DBL_MIN_STR, DBL_MIN_STR_LEN);
-    ASSIGN_KEY_VAL(double, z, strtod, false,
+    ASSIGN_KEY_VAL(double, z, strtod_no_locale, false,
         DBL_MAX, DBL_MAX_STR, DBL_MAX_STR_LEN,
         -DBL_MAX, DBL_MIN_STR, DBL_MIN_STR_LEN);
-    ASSIGN_KEY_VAL(double, min, strtod, false,
+    ASSIGN_KEY_VAL(double, min, strtod_no_locale, false,
         DBL_MAX, DBL_MAX_STR, DBL_MAX_STR_LEN,
         -DBL_MAX, DBL_MIN_STR, DBL_MIN_STR_LEN);
-    ASSIGN_KEY_VAL(double, max, strtod, false,
+    ASSIGN_KEY_VAL(double, max, strtod_no_locale, false,
         DBL_MAX, DBL_MAX_STR, DBL_MAX_STR_LEN,
         -DBL_MAX, DBL_MIN_STR, DBL_MIN_STR_LEN);
 
@@ -433,7 +439,7 @@ direction_vector_parse(const char *value, struct sol_flow_node_named_options_mem
         if (!max_done) ret->max = DBL_MAX;
     }
 
-    ASSIGN_LINEAR_VALUES(strtod,
+    ASSIGN_LINEAR_VALUES(strtod_no_locale,
         DBL_MAX, DBL_MAX_STR, DBL_MAX_STR_LEN,
         -DBL_MAX, DBL_MIN_STR, DBL_MIN_STR_LEN);
 

--- a/src/modules/flow/converter/converter.c
+++ b/src/modules/flow/converter/converter.c
@@ -1232,8 +1232,7 @@ string_to_drange_convert(struct sol_flow_node *node, void *data, uint16_t port, 
     r = sol_flow_packet_get_string(packet, &in_value);
     SOL_INT_CHECK(r, < 0, r);
 
-    errno = 0;
-    out_value = strtod(in_value, &endptr);
+    out_value = sol_util_strtodn(in_value, &endptr, -1, false);
     if (errno) {
         SOL_WRN("Failed to convert string to float %s: %d", in_value, errno);
         return -errno;

--- a/src/modules/flow/freegeoip/freegeoip.c
+++ b/src/modules/flow/freegeoip/freegeoip.c
@@ -91,23 +91,21 @@ freegeoip_query_finished(void *data, struct sol_http_response *response)
     }
 
 #define JSON_FIELD_TO_FLOW_PORT(json_field_, flow_field_) \
-    do { \
-        if (sol_json_token_str_eq(&key, json_field_, strlen(json_field_))) { \
-            sol_flow_send_string_slice_packet(mdata->node, \
-                SOL_FLOW_NODE_TYPE_LOCATION_FREEGEOIP__OUT__ ## flow_field_, \
-                SOL_STR_SLICE_STR(value.start + 1, value.end - value.start - 2)); \
-            continue; \
-        } \
-    } while (0)
+    if (sol_json_token_str_eq(&key, json_field_, strlen(json_field_))) { \
+        sol_flow_send_string_slice_packet(mdata->node, \
+            SOL_FLOW_NODE_TYPE_LOCATION_FREEGEOIP__OUT__ ## flow_field_, \
+            SOL_STR_SLICE_STR(value.start + 1, value.end - value.start - 2)); \
+        continue; \
+    }
 
     sol_json_scanner_init(&scanner, response->content.data, response->content.used);
     SOL_JSON_SCANNER_OBJECT_LOOP (&scanner, &token, &key, &value, reason) {
-        JSON_FIELD_TO_FLOW_PORT("ip", IP);
-        JSON_FIELD_TO_FLOW_PORT("country_name", COUNTRY_NAME);
-        JSON_FIELD_TO_FLOW_PORT("country_code", COUNTRY_CODE);
-        JSON_FIELD_TO_FLOW_PORT("city", CITY_NAME);
-        JSON_FIELD_TO_FLOW_PORT("zip_code", ZIP_CODE);
-        JSON_FIELD_TO_FLOW_PORT("time_zone", TIMEZONE);
+        JSON_FIELD_TO_FLOW_PORT("ip", IP)
+        JSON_FIELD_TO_FLOW_PORT("country_name", COUNTRY_NAME)
+        JSON_FIELD_TO_FLOW_PORT("country_code", COUNTRY_CODE)
+        JSON_FIELD_TO_FLOW_PORT("city", CITY_NAME)
+        JSON_FIELD_TO_FLOW_PORT("zip_code", ZIP_CODE)
+        JSON_FIELD_TO_FLOW_PORT("time_zone", TIMEZONE)
 
         if (sol_json_token_str_eq(&key, "latitude", strlen("latitude"))) {
             if (sol_json_token_get_double(&value, &location.lat) < 0)

--- a/src/modules/flow/test/float-generator.c
+++ b/src/modules/flow/test/float-generator.c
@@ -88,8 +88,7 @@ float_generator_open(
         val = sol_vector_append(&mdata->values);
         SOL_NULL_CHECK_GOTO(val, no_memory);
 
-        errno = 0;
-        *val = strtod(it, &tail);
+        *val = sol_util_strtodn(it, &tail, -1, false);
         if (errno) {
             SOL_WRN("Failed do convert option 'sequence' to int %s: %d", it, errno);
             goto error;

--- a/src/modules/flow/test/float-validator.c
+++ b/src/modules/flow/test/float-validator.c
@@ -68,8 +68,7 @@ float_validator_open(
         val = sol_vector_append(&mdata->values);
         SOL_NULL_CHECK_GOTO(val, no_memory);
 
-        errno = 0;
-        *val = strtod(it, &tail);
+        *val = sol_util_strtodn(it, &tail, -1, false);
         if (errno) {
             SOL_WRN("Failed do convert option 'sequence' to double %s: %d", it, errno);
             goto error;

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -81,7 +81,7 @@ sol_util_memdup(const void *data, size_t len)
 }
 
 double
-sol_util_strtodn(const char *nptr, char **endptr, size_t len, bool use_locale)
+sol_util_strtodn(const char *nptr, char **endptr, ssize_t len, bool use_locale)
 {
     char *tmpbuf, *tmpbuf_endptr;
     double value;
@@ -95,6 +95,9 @@ sol_util_strtodn(const char *nptr, char **endptr, size_t len, bool use_locale)
         }
     }
 #endif
+
+    if (len < 0)
+        len = (ssize_t)strlen(nptr);
 
     /* NOTE: Using a copy to ensure trailing \0 and strtod() so we
      * properly parse numbers with large precision.

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -45,7 +45,7 @@
 #include "sol-log.h"
 #include "sol-str-slice.h"
 
-#ifdef HAVE_LOCALE
+#if defined(HAVE_LOCALE) && defined(HAVE_STRTOD_L)
 static locale_t c_locale;
 static void
 clear_c_locale(void)

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -78,13 +78,14 @@
  * @param use_locale if true, then current locale is used, if false
  *        then "C" locale is forced.
  *
- * @param len use at most this amount of bytes of @a nptr.
+ * @param len use at most this amount of bytes of @a nptr. If -1, assumes
+ *        nptr has a trailing NUL and calculate the string length.
  *
  * @return the converted value, if any. The converted value may be @c
  *         NAN, @c INF (positive or negative). See the strtod(3)
  *         documentation for the details.
  */
-double sol_util_strtodn(const char *nptr, char **endptr, size_t len, bool use_locale);
+double sol_util_strtodn(const char *nptr, char **endptr, ssize_t len, bool use_locale);
 
 #define STATIC_ASSERT_LITERAL(_s) ("" _s)
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))


### PR DESCRIPTION
This PR has a bunch of minor fixes, including some low-priority Coverity warnings in the recently-added `freegeoip` module, using the new JSON number parsing routines in the `oicgen.py` script, and using `sol_util_strtodn()` where `strtod()` was used before.