### PR TITLE
Fix for sol-fbp-generator

### DIFF
--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -567,8 +567,11 @@ generate_node_type_assignments(const struct fbp_data *data)
 
     dprintf(fd, "\n");
 
-    for (i = 0; i < data->graph.nodes.len; i++)
-        dprintf(fd, "    nodes[%d].type = %s;\n", i, data->descriptions[i]->symbol);
+    for (i = 0; i < data->graph.nodes.len; i++) {
+        dprintf(fd, "    if (%s->init_type)\n", data->descriptions[i]->symbol);
+        dprintf(fd, "        %s->init_type();\n\n", data->descriptions[i]->symbol);
+        dprintf(fd, "    nodes[%d].type = %s;\n\n", i, data->descriptions[i]->symbol);
+    }
 
     SOL_VECTOR_FOREACH_IDX (&data->declared_fbp_types, dec_type, i) {
         dprintf(fd, "\n    if (!type_%s)\n"


### PR DESCRIPTION
Types that have subflows must call their init_type() function
before being assigned to the node->type.

Signed-off-by: Luiz Ywata <luizg.ywata@intel.com>