### PR TITLE
suite.py: show the failed tests output

### DIFF
--- a/data/scripts/suite.py
+++ b/data/scripts/suite.py
@@ -69,19 +69,30 @@ def run_test_program(task_queue):
 
         task_queue.task_done()
 
+def writeOutput(task, f):
+    f.write("# Running " + task.cmd + "\n")
+    f.write(task.output)
+    f.write("\n")
+
 def print_log(log_file, tasks):
     success_count = 0
     fail_count = 0
+    fail_header = False
 
     f = open(log_file, mode="w+")
 
     for task in tasks:
-        f.write("# Running " + task.cmd + "\n")
-        f.write(task.output)
-        f.write("\n")
+        writeOutput(task, f)
         if task.success:
             success_count += 1
         else:
+            if not fail_header:
+                print("""\
+============================================================================
+Failed tests output
+============================================================================""")
+                fail_header = True
+            writeOutput(task, sys.stdout)
             fail_count += 1
 
     summary = """\
@@ -92,7 +103,7 @@ Testsuite summary
 # SUCCESS: %d
 # FAIL: %d
 ============================================================================
-See %s
+See %s for full output.
 ============================================================================"""
     summary = summary % (len(tasks), success_count, fail_count, log_file)
 

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -48,12 +48,12 @@ test_main(struct test *start, struct test *stop, void (*reset_func)(void), int a
 
     if (argc > 1) {
         pattern = argv[1];
-        printf("Running only tests that match '%s'\n", pattern);
+        fprintf(stderr, "Running only tests that match '%s'\n", pattern);
     }
 
     for (t = start; t < stop; t++) {
         if (!pattern || strstr(t->name, pattern)) {
-            printf("- %s\n", t->name);
+            fprintf(stderr, "- %s\n", t->name);
             t->func();
             if (reset_func)
                 reset_func();
@@ -62,12 +62,12 @@ test_main(struct test *start, struct test *stop, void (*reset_func)(void), int a
     }
 
     if (count == 0) {
-        printf("No tests found!\n");
+        fprintf(stderr, "No tests found!\n");
         return EXIT_FAILURE;
     }
 
     sol_shutdown();
-    printf("OK!\n");
+    fprintf(stderr, "OK!\n");
 
     return 0;
 }


### PR DESCRIPTION
This makes easy to identify the failures in the bots. Changed the test
helper to use stderr and avoid potential ordering issues when reading
the output (assertions in the tests use stderr already).

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>