### PR TITLE
sol-util: implement overflow checks for mul/add operations

### DIFF
--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -47,6 +47,11 @@
 #include "sol-util-linux.h"
 #endif
 
+/** constants used to calculate mul/add operations overflow */
+#define OVERFLOW_TYPE(type) ((type)1 << (sizeof(type) * 4))
+#define OVERFLOW_UINT64 OVERFLOW_TYPE(uint64_t)
+#define OVERFLOW_SIZE_T OVERFLOW_TYPE(size_t)
+
 #define streq(a, b) (strcmp((a), (b)) == 0)
 #define streqn(a, b, n) (strncmp((a), (b), (n)) == 0)
 #define strstartswith(a, b) streqn((a), (b), strlen(b))
@@ -195,6 +200,9 @@ sol_util_size_mul(size_t elem_size, size_t num_elems, size_t *out)
     if (__builtin_mul_overflow(elem_size, num_elems, out))
         return -EOVERFLOW;
 #else
+    if ((elem_size >= OVERFLOW_SIZE_T || num_elems >= OVERFLOW_SIZE_T) &&
+        elem_size > 0 && SIZE_MAX / elem_size < num_elems)
+        return -EOVERFLOW;
     *out = elem_size * num_elems;
 #endif
     return 0;
@@ -207,6 +215,9 @@ sol_util_uint64_mul(const uint64_t a, const uint64_t b, uint64_t *out)
     if (__builtin_mul_overflow(a, b, out))
         return -EOVERFLOW;
 #else
+    if ((a >= OVERFLOW_UINT64 || b >= OVERFLOW_UINT64) &&
+        a > 0 && SIZE_MAX / a < b)
+        return -EOVERFLOW;
     *out = a * b;
 #endif
     return 0;
@@ -219,6 +230,8 @@ sol_util_uint64_add(const uint64_t a, const uint64_t b, uint64_t *out)
     if (__builtin_add_overflow(a, b, out))
         return -EOVERFLOW;
 #else
+    if (a > 0 && b > UINT64_MAX - a)
+        return -EOVERFLOW;
     *out = a + b;
 #endif
     return 0;


### PR DESCRIPTION
This patch implements a overflow check fallback - for cases where
__builtin_mul_overflow() and __builtin_add_overflow() are not available.

The lack of overflow check was resulting in test-json failure - since
we're checking for potential errors on string -> number conversion.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>