### PR TITLE
Only enable locale support if glib have freelocale()

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -227,7 +227,7 @@
 	    "headers": [
 		"<locale.h>"
 	    ],
-	    "fragment": "setlocale(LC_ALL, NULL);"
+	    "fragment": "freelocale(NULL);"
 	},
 	{
 	    "dependency": "icu",


### PR DESCRIPTION
newlocale() and freelocale() are available since glibc 2.10,
on the Intel Galileo SDK we have glibc 2.00.

Signed-off-by: José Roberto de Souza <jose.souza@intel.com>