### PR TITLE
common: Rename 'platform name' to 'board name'

### DIFF
--- a/data/jsons/board_detect.json
+++ b/data/jsons/board_detect.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://solettaproject.github.io/soletta/schemas/platform-detect.schema",
-  "platforms": [
+  "$schema": "http://solettaproject.github.io/soletta/schemas/board-detect.schema",
+  "boards": [
     {
      "name": "intel-galileo-rev-d",
      "validation": [

--- a/data/schemas/board-detect.schema
+++ b/data/schemas/board-detect.schema
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "Soletta's platform detection file",
+  "description": "Soletta's board detection file",
 
   "definitions": {
     "regex_array": {
@@ -28,7 +28,7 @@
       "items": { "$ref": "#/definitions/rule" }
     },
 
-    "platform": {
+    "board": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -46,10 +46,10 @@
   "additionalProperties": false,
   "properties": {
     "$schema": { "type": "string", "format": "uri" }
-    "platforms": {
+    "boards": {
       "type": "array",
-      "items": { "$ref": "#/definitions/platform" }
+      "items": { "$ref": "#/definitions/board" }
     }
   },
-  "required": [ "$schema", "platforms" ]
+  "required": [ "$schema", "boards" ]
 }

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -1,18 +1,17 @@
-config PLATFORM_NAME
-	string "Platform Name"
+config BOARD_NAME
+	string "Board Name"
 	default ""
 	help
-            Some parts of Soletta uses a "platform name" string from
-            sol_platform_get_name() to improve platform
-            behavior. Namely Pin Multiplexer will load modules based
-            on the platform name.
+            Some parts of Soletta uses a "board name" string from
+            'sol_platform_get_board_name()' to improve board behavior.
+            Namely Pin Multiplexer will load modules based on the board name.
 
-            Usually the platform name is detected using either
-            SOL_PLATFORM_NAME environment variable or the rules defined in
-            'platform_detect.json'. Soletta searches for 'platform_detect.json'
-            first at PKGSYSCONFDIR ('/etc/soletta' in most cases) and then at
-            '$PREFIX/share/soletta/', but some platforms such as RIOT may not
-            provide it, then this string is used as a fallback.
+            Usually the board name is detected using either SOL_BOARD_NAME
+            environment variable or the rules defined in 'board_detect.json'.
+            Soletta searches for 'board_detect.json' first at PKGSYSCONFDIR
+            ('/etc/soletta' in most cases) and then at '$PREFIX/share/soletta/',
+            but some platforms such as RIOT may not provide it,
+            then this string is used as a fallback.
 
 config PLATFORM_LINUX
 	bool

--- a/src/lib/common/Makefile
+++ b/src/lib/common/Makefile
@@ -52,7 +52,7 @@ obj-core-$(PLATFORM_CONTIKI) += \
 
 obj-core-$(PLATFORM_LINUX) += \
     sol-platform-linux-common.o \
-    sol-platform-detect.o
+    sol-board-detect.o
 obj-core-$(PLATFORM_LINUX)-extra-cflags += $(SYSTEMD_CFLAGS)
 obj-core-$(PLATFORM_LINUX)-extra-ldflags += $(SYSTEMD_LDFLAGS)
 

--- a/src/lib/common/include/sol-platform.h
+++ b/src/lib/common/include/sol-platform.h
@@ -59,7 +59,7 @@ extern "C" {
  */
 #define CHUNK_MAX_TIME_NS (20 * (NSEC_PER_MSEC))
 
-const char *sol_platform_get_name(void);
+const char *sol_platform_get_board_name(void);
 
 enum sol_platform_state {
     SOL_PLATFORM_STATE_INITIALIZING,

--- a/src/lib/common/sol-board-detect.h
+++ b/src/lib/common/sol-board-detect.h
@@ -34,5 +34,5 @@
 
 #include <stdbool.h>
 
-char *sol_platform_detect(void);
-bool sol_platform_invalid_name(const char *name);
+char *sol_board_detect(void);
+bool sol_board_invalid_name(const char *name);

--- a/src/lib/common/sol-pin-mux.c
+++ b/src/lib/common/sol-pin-mux.c
@@ -150,7 +150,7 @@ sol_pin_mux_init(void)
 {
     sol_log_domain_init_level(SOL_LOG_DOMAIN);
 
-    if (!sol_pin_mux_select_mux(sol_platform_get_name())) {
+    if (!sol_pin_mux_select_mux(sol_platform_get_board_name())) {
         SOL_WRN("Pin Multiplexer found, but failed to be loaded.");
         return -1;
     }

--- a/src/lib/common/sol-platform.c
+++ b/src/lib/common/sol-platform.c
@@ -40,16 +40,16 @@
 #include "sol-macros.h"
 #include "sol-monitors.h"
 #ifdef SOL_PLATFORM_LINUX
-#include "sol-platform-detect.h"
+#include "sol-board-detect.h"
 #endif
 #include "sol-platform.h"
 #include "sol-util.h"
 
-#define SOL_PLATFORM_NAME_ENVVAR "SOL_PLATFORM_NAME"
+#define SOL_BOARD_NAME_ENVVAR "SOL_BOARD_NAME"
 
 SOL_LOG_INTERNAL_DECLARE(_sol_platform_log_domain, "platform");
 
-static char *platform_name = NULL;
+static char *board_name = NULL;
 
 struct service_monitor {
     struct sol_monitors_entry base;
@@ -83,37 +83,37 @@ sol_platform_init(void)
 void
 sol_platform_shutdown(void)
 {
-    free(platform_name);
+    free(board_name);
     sol_monitors_clear(&_ctx.state_monitors);
     sol_monitors_clear(&_ctx.service_monitors);
     sol_platform_impl_shutdown();
 }
 
 SOL_API const char *
-sol_platform_get_name(void)
+sol_platform_get_board_name(void)
 {
-    if (platform_name)
-        return platform_name;
+    if (board_name)
+        return board_name;
 
 #ifdef SOL_PLATFORM_LINUX
-    platform_name = getenv(SOL_PLATFORM_NAME_ENVVAR);
-    if (platform_name && *platform_name != '\0')
-        platform_name = strdup(platform_name);
+    board_name = getenv(SOL_BOARD_NAME_ENVVAR);
+    if (board_name && *board_name != '\0')
+        board_name = strdup(board_name);
     else
-        platform_name = sol_platform_detect();
+        board_name = sol_board_detect();
 
-    if (platform_name && sol_platform_invalid_name(platform_name)) {
-        free(platform_name);
-        platform_name = NULL;
+    if (board_name && sol_board_invalid_name(board_name)) {
+        free(board_name);
+        board_name = NULL;
     }
 #endif
 
-#ifdef PLATFORM_NAME
-    if (!platform_name)
-        platform_name = strdup(PLATFORM_NAME);
+#ifdef BOARD_NAME
+    if (!board_name)
+        board_name = strdup(BOARD_NAME);
 #endif
 
-    return platform_name;
+    return board_name;
 }
 
 SOL_API int

--- a/src/lib/io/Kconfig
+++ b/src/lib/io/Kconfig
@@ -43,9 +43,9 @@ menuconfig USE_PIN_MUX
           as dynamically loadable modules at
           $PREFIX/lib/soletta/modules/pin-mux/<module>.so
 
-          Pin mux modules are used based on the platform-detect logic
-          defined in $PREFIX/share/soletta/platform_detect.json or
-          statically defined PLATFORM_NAME.
+          Pin mux modules are used based on the board-detect logic
+          defined in $PREFIX/share/soletta/board_detect.json or
+          statically defined BOARD_NAME.
 
           If unsure, say Y.
 

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -355,7 +355,7 @@ $(2): $(1)
 endef
 
 $(eval $(call install-resource,$(NODE_TYPE_SCHEMA),$(NODE_TYPE_SCHEMA_DEST)))
-$(eval $(call install-resource,$(PLATFORM_DETECT),$(PLATFORM_DETECT_DEST)))
+$(eval $(call install-resource,$(BOARD_DETECT),$(BOARD_DETECT_DEST)))
 $(eval $(call install-resource,$(GDB_AUTOLOAD_PY),$(GDB_AUTOLOAD_PY_DEST)))
 
 $(MODULES_OK_FILE):

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -82,7 +82,7 @@ samples: $(SOL_LIB_SO) $(SOL_LIB_AR) $(samples-out)
 PHONY += samples
 
 PRE_INSTALL := $(PC_GEN) $(SOL_LIB_SO) $(SOL_LIB_AR) $(bins-out) $(modules-out) $(all-mod-descs)
-PRE_INSTALL += $(NODE_TYPE_SCHEMA_DEST) $(PLATFORM_DETECT_DEST) $(GDB_AUTOLOAD_PY_DEST)
+PRE_INSTALL += $(NODE_TYPE_SCHEMA_DEST) $(BOARD_DETECT_DEST) $(GDB_AUTOLOAD_PY_DEST)
 
 ifneq (,$(strip $(builtin-flows)))
 PRE_GEN += $(FLOW_BUILTINS_DESC)

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -166,20 +166,8 @@ endif
 
 endif #LOG
 
-ifeq (,$(PLATFORM_NAME))
-ifeq (y,$(PLATFORM_LINUX))
-PLATFORM_NAME = linux
-endif
-ifeq (y,$(PLATFORM_RIOTOS))
-PLATFORM_NAME = riotos
-endif
-ifeq (y,$(PLATFORM_CONTIKI))
-PLATFORM_NAME = contiki
-endif
-endif #!PLATFORM_NAME
-
-ifneq (,$(PLATFORM_NAME))
-COMMON_CFLAGS += -DPLATFORM_NAME=\"$(PLATFORM_NAME)\"
+ifneq (,$(BOARD_NAME))
+COMMON_CFLAGS += -DBOARD_NAME=\"$(BOARD_NAME)\"
 endif
 
 ifneq (,$(filter %coverage,$(MAKECMDGOALS)))
@@ -229,8 +217,8 @@ PIN_MUX_BUILTINS_H := $(top_srcdir)src/lib/common/sol-pin-mux-builtins-gen.h
 NODE_TYPE_SCHEMA := $(top_srcdir)data/schemas/node-type-genspec.schema
 NODE_TYPE_SCHEMA_DEST := $(build_flowdatadir)schemas/node-type-genspec.schema
 
-PLATFORM_DETECT := $(top_srcdir)data/jsons/platform_detect.json
-PLATFORM_DETECT_DEST := $(build_datadir)platform_detect.json
+BOARD_DETECT := $(top_srcdir)data/jsons/board_detect.json
+BOARD_DETECT_DEST := $(build_datadir)board_detect.json
 
 FLOW_NODE_TYPE_FIND := $(SCRIPTDIR)sol-flow-node-type-find.py
 FLOW_NODE_TYPE_FIND_IN := $(addsuffix .in,$(FLOW_NODE_TYPE_FIND))


### PR DESCRIPTION
Since is the board name that is expected and not the platform
name. This should avoid misinterpretations that were already happening.

The detection system was automatically setting the board name to
'riotos' when RIOT was found but it should be the name of where RIOT
is supposed to run (or empty if not known) that should be used e.g.
'intel-galileo-rev-d'.

Since there is no demand for a set of board related API's yet, instead
of change 'sol-platform-name-get' to 'sol-board-name-get' and have it
moved to it's on file and header file that would need to be installed, I
decided to name the function 'sol-platform-get-board-name' and keep it
on 'sol-platform' files.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>


============================ Pull Req Note ===============
This was suggested by k-s sometime as a low prio, but since I realized that some misusage was already happening, priority got higher.