### PR TITLE
build: bring back flto flags

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -353,6 +353,13 @@
 	    "type": "pkg-config",
 	    "pkgname": "libcurl",
 	    "atleast-version": "7.32.0"
+	},
+	{
+	    "dependency": "flto",
+	    "type": "ccode",
+            "cflags": {
+                "value": "-flto -ffat-lto-objects"
+            }
 	}
     ]
 }

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -139,6 +139,10 @@ GDB_AUTOLOAD_PY := $(top_srcdir)data/gdb/libsoletta.so-gdb.py
 COMMON_CFLAGS += $(CFLAGS)
 COMMON_LDFLAGS += $(LDFLAGS)
 
+ifneq (,$(filter -O%,$(COMMON_CFLAGS)))
+COMMON_CFLAGS += $(FLTO_CFLAGS)
+endif
+
 ifeq (y,$(LOG))
 ifeq (y,$(MAXIMUM_LOG_LEVEL_CRITICAL))
 MAXIMUM_LOG_LEVEL := 0


### PR DESCRIPTION
This patch re enables the -flto flags based on optimization level
provided flags.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>