### PR TITLE
Reduce glib v2

### DIFF
--- a/src/lib/common/Makefile
+++ b/src/lib/common/Makefile
@@ -20,8 +20,8 @@ obj-log-$(PLATFORM_CONTIKI) += \
 
 obj-core-$(SOL_BUS) += \
     sol-bus.o
-obj-core-$(SOL_BUS)-extra-cflags += $(SYSTEMD_CFLAGS) $(GLIB_CFLAGS)
-obj-core-$(SOL_BUS)-extra-ldflags += $(SYSTEMD_LDFLAGS) $(GLIB_LDFLAGS)
+obj-core-$(SOL_BUS)-extra-cflags += $(SYSTEMD_CFLAGS)
+obj-core-$(SOL_BUS)-extra-ldflags += $(SYSTEMD_LDFLAGS)
 
 obj-core-$(MAINLOOP_GLIB) += \
     sol-mainloop-impl-glib.o

--- a/src/lib/common/sol-bus.c
+++ b/src/lib/common/sol-bus.c
@@ -35,7 +35,6 @@
 #include <stdio.h>
 #include <stdbool.h>
 
-#include <glib.h>
 #include <systemd/sd-bus.h>
 #include <systemd/sd-event.h>
 
@@ -44,11 +43,6 @@
 #include "sol-platform-impl.h"
 #include "sol-util.h"
 #include "sol-vector.h"
-
-struct event_source {
-    GSource gsource;
-    sd_event *event;
-};
 
 struct property_table {
     const struct sol_bus_properties *properties;
@@ -59,7 +53,7 @@ struct property_table {
 };
 
 struct ctx {
-    struct event_source *event_source;
+    struct sol_mainloop_source *mainloop_source;
     sd_bus *bus;
     sd_event_source *ping;
     struct sol_ptr_vector property_tables;
@@ -68,60 +62,88 @@ struct ctx {
 
 static struct ctx _ctx;
 
-static gboolean
-event_prepare(GSource *gsource, gint *timeout)
+struct source_ctx {
+    struct sd_event *event;
+    struct sol_fd *fd_handler;
+};
+
+static bool
+source_prepare(void *data)
 {
-    struct event_source *s = (struct event_source *)gsource;
+    struct source_ctx *s = data;
 
     return sd_event_prepare(s->event) > 0;
 }
 
-static gboolean
-event_check(GSource *gsource)
+static bool
+source_check(void *data)
 {
-    struct event_source *s = (struct event_source *)gsource;
+    struct source_ctx *s = data;
 
     return sd_event_wait(s->event, 0) > 0;
 }
 
-static gboolean
-event_dispatch(GSource *gsource, GSourceFunc cb, gpointer user_data)
+static void
+source_dispatch(void *data)
 {
-    struct event_source *s = (struct event_source *)gsource;
+    struct source_ctx *s = data;
 
-    return sd_event_dispatch(s->event) > 0;
+    sd_event_dispatch(s->event);
 }
 
 static void
-event_finalize(GSource *gsource)
+source_dispose(void *data)
 {
-    struct event_source *s = (struct event_source *)gsource;
+    struct source_ctx *s = data;
 
     sd_event_unref(s->event);
+    sol_fd_del(s->fd_handler);
+
+    free(s);
 }
 
-static GSourceFuncs event_funcs = {
-    .prepare = event_prepare,
-    .check = event_check,
-    .dispatch = event_dispatch,
-    .finalize = event_finalize,
+static const struct sol_mainloop_source_type source_type = {
+    .api_version = SOL_MAINLOOP_SOURCE_TYPE_API_VERSION,
+    .prepare = source_prepare,
+    .check = source_check,
+    .dispatch = source_dispatch,
+    .dispose = source_dispose,
 };
 
-static struct event_source *
+static bool
+on_sd_event_fd(void *data, int fd, unsigned int active_flags)
+{
+    /* just used to wake up main loop */
+    return true;
+}
+
+static struct sol_mainloop_source *
 event_create_source(sd_event *event)
 {
-    struct event_source *s;
+    struct sol_mainloop_source *source;
+    struct source_ctx *ctx;
 
-    s = (struct event_source *)g_source_new(&event_funcs,
-        sizeof(struct event_source));
-    if (!s)
-        return NULL;
+    ctx = malloc(sizeof(*ctx));
+    SOL_NULL_CHECK(ctx, NULL);
 
-    s->event = sd_event_ref(event);
-    g_source_add_unix_fd(&s->gsource, sd_event_get_fd(event),
-        G_IO_IN | G_IO_HUP | G_IO_ERR);
+    ctx->event = sd_event_ref(event);
 
-    return s;
+    ctx->fd_handler = sol_fd_add(sd_event_get_fd(event),
+        SOL_FD_FLAGS_IN | SOL_FD_FLAGS_HUP | SOL_FD_FLAGS_ERR,
+        on_sd_event_fd, ctx);
+    SOL_NULL_CHECK_GOTO(ctx->fd_handler, error_fd);
+
+    source = sol_mainloop_source_new(&source_type, ctx);
+    SOL_NULL_CHECK_GOTO(source, error_source);
+
+    return source;
+
+error_source:
+    sol_fd_del(ctx->fd_handler);
+error_fd:
+    sd_event_unref(ctx->event);
+    free(ctx);
+    return NULL;
 }
 
 static int
@@ -142,18 +164,16 @@ event_attach_mainloop(void)
     int r;
     sd_event *e = NULL;
 
-    if (_ctx.event_source)
+    if (_ctx.mainloop_source)
         return 0;
 
     r = sd_event_default(&e);
     if (r < 0)
         return r;
 
-    _ctx.event_source = event_create_source(e);
-    if (!_ctx.event_source)
+    _ctx.mainloop_source = event_create_source(e);
+    if (!_ctx.mainloop_source)
         goto fail;
-
-    g_source_attach(&_ctx.event_source->gsource, NULL);
 
     sd_event_add_defer(e, &_ctx.ping, _event_mainloop_running, &_ctx);
 
@@ -185,11 +205,14 @@ connect_bus(void)
 {
     int r;
     sd_bus *bus = NULL;
+    struct source_ctx *s;
 
     r = sd_bus_default_system(&bus);
     SOL_INT_CHECK(r, < 0, r);
 
-    r = sd_bus_attach_event(bus, _ctx.event_source->event,
+    s = sol_mainloop_source_get_data(_ctx.mainloop_source);
+
+    r = sd_bus_attach_event(bus, s->event,
         SD_EVENT_PRIORITY_NORMAL);
     SOL_INT_CHECK_GOTO(r, < 0, fail);
 
@@ -210,7 +233,7 @@ fail:
     return r;
 }
 
-/* We attach libsystemd's mainloop to glib on the first time we need to
+/* We attach libsystemd's mainloop to Soletta's on the first time we need to
  * connect to the bus. Any fail on getting connected to the bus means the
  * mainloop terminates.
  */
@@ -222,7 +245,7 @@ sol_bus_get(void (*bus_initialized)(sd_bus *bus))
     if (_ctx.bus)
         return _ctx.bus;
 
-    if (!_ctx.event_source) {
+    if (!_ctx.mainloop_source) {
         r = event_attach_mainloop();
         SOL_INT_CHECK_GOTO(r, < 0, fail);
     }
@@ -266,12 +289,14 @@ sol_bus_close(void)
         _ctx.bus = NULL;
     }
 
-    if (_ctx.event_source) {
+    if (_ctx.mainloop_source) {
+        struct source_ctx *s;
         sd_event_source_unref(_ctx.ping);
-        sd_event_unref(_ctx.event_source->event);
-        g_source_destroy(&_ctx.event_source->gsource);
-        g_source_unref(&_ctx.event_source->gsource);
-        _ctx.event_source = NULL;
+
+        s = sol_mainloop_source_get_data(_ctx.mainloop_source);
+        sd_event_unref(s->event);
+        sol_mainloop_source_del(_ctx.mainloop_source);
+        _ctx.mainloop_source = NULL;
     }
 }
 

--- a/src/lib/common/sol-mainloop-common.c
+++ b/src/lib/common/sol-mainloop-common.c
@@ -38,6 +38,17 @@
 #include "sol-mainloop-impl.h"
 #include "sol-mainloop-common.h"
 
+struct sol_mainloop_source_common {
+    const struct sol_mainloop_source_type *type;
+    const void *data;
+    bool ready;
+    bool remove_me;
+};
+
+static bool source_processing;
+static unsigned source_pending_deletion;
+static struct sol_ptr_vector source_vector = SOL_PTR_VECTOR_INIT;
+
 static bool run_loop;
 
 static bool timeout_processing;
@@ -58,9 +69,12 @@ timeout_compare(const void *data1, const void *data2)
 
 #ifdef PTHREAD
 
+static struct sol_ptr_vector source_v_process = SOL_PTR_VECTOR_INIT;
 static struct sol_ptr_vector timeout_v_process = SOL_PTR_VECTOR_INIT;
 static struct sol_ptr_vector idler_v_process = SOL_PTR_VECTOR_INIT;
 
+#define SOURCE_PROCESS source_v_process
+#define SOURCE_ACUM source_vector
 #define TIMEOUT_PROCESS timeout_v_process
 #define TIMEOUT_ACUM timeout_vector
 #define IDLER_PROCESS idler_v_process
@@ -79,6 +93,8 @@ timeout_vector_update(struct sol_ptr_vector *to, struct sol_ptr_vector *from)
 
 #else  /* !PTHREAD */
 
+#define SOURCE_PROCESS source_vector
+#define SOURCE_ACUM source_vector
 #define TIMEOUT_PROCESS timeout_vector
 #define TIMEOUT_ACUM timeout_vector
 #define IDLER_PROCESS idler_vector
@@ -121,6 +137,15 @@ sol_mainloop_impl_shutdown(void)
     uint16_t i;
 
     sol_mainloop_impl_platform_shutdown();
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&source_vector, ptr, i) {
+        struct sol_mainloop_source_common *source = ptr;
+        source->remove_me = true;
+        if (source->type->dispose)
+            source->type->dispose((void *)source->data);
+        free(ptr);
+    }
+    sol_ptr_vector_clear(&source_vector);
 
     SOL_PTR_VECTOR_FOREACH_IDX (&timeout_vector, ptr, i) {
         free(ptr);
@@ -267,7 +292,7 @@ sol_mainloop_common_idler_process(void)
 }
 
 /* must be called with mainloop lock HELD */
-struct sol_timeout_common *
+static struct sol_timeout_common *
 sol_mainloop_common_timeout_first(void)
 {
     struct sol_timeout_common *timeout;
@@ -279,6 +304,32 @@ sol_mainloop_common_timeout_first(void)
         return timeout;
     }
     return NULL;
+}
+
+static bool sol_mainloop_common_source_get_next_timeout_locked(struct timespec *timeout);
+
+/* must be called with mainloop lock HELD */
+bool
+sol_mainloop_common_timespec_first(struct timespec *ts)
+{
+    struct sol_timeout_common *timeout = sol_mainloop_common_timeout_first();
+    bool r = sol_mainloop_common_source_get_next_timeout_locked(ts);
+
+    if (timeout) {
+        struct timespec now = sol_util_timespec_get_current();
+        struct timespec diff;
+        sol_util_timespec_sub(&timeout->expire, &now, &diff);
+        if (!r || sol_util_timespec_compare(&diff, ts) < 0) {
+            if (diff.tv_sec < 0) {
+                diff.tv_sec = 0;
+                diff.tv_nsec = 0;
+            }
+            *ts = diff;
+            r = true;
+        }
+    }
+
+    return r;
 }
 
 /* must be called with mainloop lock HELD */
@@ -294,6 +345,182 @@ sol_mainloop_common_idler_first(void)
         return idler;
     }
     return NULL;
+}
+
+/* must be called with mainloop lock HELD */
+static inline void
+source_cleanup(void)
+{
+    struct sol_mainloop_source_common *source;
+    uint16_t i;
+
+    if (!source_pending_deletion)
+        return;
+
+    // Walk backwards so deletion doesn't impact the indices.
+    SOL_PTR_VECTOR_FOREACH_REVERSE_IDX (&source_vector, source, i) {
+        if (!source->remove_me)
+            continue;
+
+        sol_ptr_vector_del(&source_vector, i);
+        sol_mainloop_impl_unlock();
+
+        if (source->type->dispose)
+            source->type->dispose((void *)source->data);
+        free(source);
+
+        sol_mainloop_impl_lock();
+        source_pending_deletion--;
+        if (!source_pending_deletion)
+            break;
+    }
+}
+
+bool
+sol_mainloop_common_source_prepare(void)
+{
+    struct sol_mainloop_source_common *source;
+    uint16_t i;
+    bool ready = false;
+
+    sol_mainloop_impl_lock();
+    sol_ptr_vector_steal(&SOURCE_PROCESS, &SOURCE_ACUM);
+    source_processing = true;
+    sol_mainloop_impl_unlock();
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&SOURCE_PROCESS, source, i) {
+        if (!sol_mainloop_common_loop_check())
+            break;
+        if (source->remove_me)
+            continue;
+        if (source->type->prepare) {
+            source->ready = source->type->prepare((void *)source->data);
+            ready |= source->ready;
+        } else
+            source->ready = false;
+    }
+
+    sol_mainloop_impl_lock();
+    sol_ptr_vector_update(&SOURCE_ACUM, &SOURCE_PROCESS);
+    source_cleanup();
+    source_processing = false;
+    sol_mainloop_impl_unlock();
+
+    return ready;
+}
+
+/* must be called with mainloop lock HELD */
+static bool
+sol_mainloop_common_source_get_next_timeout_locked(struct timespec *timeout)
+{
+    bool found = false;
+    struct sol_mainloop_source_common *source;
+    uint16_t i;
+
+    sol_ptr_vector_steal(&SOURCE_PROCESS, &SOURCE_ACUM);
+    source_processing = true;
+    sol_mainloop_impl_unlock();
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&SOURCE_PROCESS, source, i) {
+        struct timespec cur;
+        bool r;
+
+        if (source->remove_me)
+            continue;
+
+        if (!source->type->get_next_timeout)
+            continue;
+
+        r = source->type->get_next_timeout((void *)source->data, &cur);
+        if (r) {
+            if (!found || sol_util_timespec_compare(&cur, timeout) < 0) {
+                if (cur.tv_sec < 0) {
+                    cur.tv_sec = 0;
+                    cur.tv_nsec = 0;
+                }
+                *timeout = cur;
+            }
+            found = true;
+        }
+    }
+
+    sol_mainloop_impl_lock();
+    sol_ptr_vector_update(&SOURCE_ACUM, &SOURCE_PROCESS);
+    source_cleanup();
+    source_processing = false;
+
+    return found;
+}
+
+bool
+sol_mainloop_common_source_get_next_timeout(struct timespec *timeout)
+{
+    bool r;
+
+    sol_mainloop_impl_lock();
+    r = sol_mainloop_common_source_get_next_timeout_locked(timeout);
+    sol_mainloop_impl_unlock();
+
+    return r;
+}
+
+bool
+sol_mainloop_common_source_check(void)
+{
+    struct sol_mainloop_source_common *source;
+    uint16_t i;
+    bool ready = false;
+
+    sol_mainloop_impl_lock();
+    sol_ptr_vector_steal(&SOURCE_PROCESS, &SOURCE_ACUM);
+    source_processing = true;
+    sol_mainloop_impl_unlock();
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&SOURCE_PROCESS, source, i) {
+        if (!sol_mainloop_common_loop_check())
+            break;
+        if (source->remove_me)
+            continue;
+        source->ready |= source->type->check((void *)source->data);
+        ready |= source->ready;
+    }
+
+    sol_mainloop_impl_lock();
+    sol_ptr_vector_update(&SOURCE_ACUM, &SOURCE_PROCESS);
+    source_cleanup();
+    source_processing = false;
+    sol_mainloop_impl_unlock();
+
+    return ready;
+}
+
+void
+sol_mainloop_common_source_dispatch(void)
+{
+    struct sol_mainloop_source_common *source;
+    uint16_t i;
+
+    sol_mainloop_impl_lock();
+    sol_ptr_vector_steal(&SOURCE_PROCESS, &SOURCE_ACUM);
+    source_processing = true;
+    sol_mainloop_impl_unlock();
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&SOURCE_PROCESS, source, i) {
+        if (!sol_mainloop_common_loop_check())
+            break;
+        if (source->remove_me)
+            continue;
+        if (source->ready) {
+            source->type->dispatch((void *)source->data);
+            source->ready = false;
+        }
+    }
+
+    sol_mainloop_impl_lock();
+    sol_ptr_vector_update(&SOURCE_ACUM, &SOURCE_PROCESS);
+    source_cleanup();
+    source_processing = false;
+    sol_mainloop_impl_unlock();
 }
 
 #ifndef SOL_PLATFORM_CONTIKI
@@ -356,6 +583,8 @@ sol_mainloop_impl_timeout_del(void *handle)
 {
     struct sol_timeout_common *timeout = handle;
 
+    SOL_EXP_CHECK(timeout->remove_me == true, false);
+
     sol_mainloop_impl_lock();
 
     timeout->remove_me = true;
@@ -401,6 +630,8 @@ sol_mainloop_impl_idle_del(void *handle)
 {
     struct sol_idler_common *idler = handle;
 
+    SOL_INT_CHECK(idler->status, == idler_deleted, false);
+
     sol_mainloop_impl_lock();
 
     idler->status = idler_deleted;
@@ -411,4 +642,58 @@ sol_mainloop_impl_idle_del(void *handle)
     sol_mainloop_impl_unlock();
 
     return true;
+}
+
+void *
+sol_mainloop_impl_source_new(const struct sol_mainloop_source_type *type, const void *data)
+{
+    int ret;
+    struct sol_mainloop_source_common *source = malloc(sizeof(struct sol_mainloop_source_common));
+
+    SOL_NULL_CHECK(source, NULL);
+
+    sol_mainloop_impl_lock();
+
+    source->type = type;
+    source->data = data;
+    source->remove_me = false;
+    source->ready = false;
+
+    ret = sol_ptr_vector_append(&source_vector, source);
+    SOL_INT_CHECK_GOTO(ret, != 0, clean);
+
+    sol_mainloop_common_main_thread_check_notify();
+    sol_mainloop_impl_unlock();
+
+    return source;
+
+clean:
+    sol_mainloop_impl_unlock();
+    free(source);
+    return NULL;
+}
+
+void
+sol_mainloop_impl_source_del(void *handle)
+{
+    struct sol_mainloop_source_common *source = handle;
+
+    SOL_EXP_CHECK(source->remove_me == true);
+
+    sol_mainloop_impl_lock();
+
+    source->remove_me = true;
+    source_pending_deletion++;
+    if (!source_processing)
+        source_cleanup();
+
+    sol_mainloop_impl_unlock();
+}
+
+void *
+sol_mainloop_impl_source_get_data(const void *handle)
+{
+    const struct sol_mainloop_source_common *source = handle;
+
+    return (void *)source->data;
 }

--- a/src/lib/common/sol-mainloop-common.h
+++ b/src/lib/common/sol-mainloop-common.h
@@ -79,8 +79,13 @@ bool sol_mainloop_common_loop_check(void);
 void sol_mainloop_common_loop_set(bool val);
 void sol_mainloop_common_timeout_process(void);
 void sol_mainloop_common_idler_process(void);
-struct sol_timeout_common *sol_mainloop_common_timeout_first(void);
+bool sol_mainloop_common_timespec_first(struct timespec *ts);
 struct sol_idler_common *sol_mainloop_common_idler_first(void);
+
+bool sol_mainloop_common_source_prepare(void);
+bool sol_mainloop_common_source_get_next_timeout(struct timespec *timeout);
+bool sol_mainloop_common_source_check(void);
+void sol_mainloop_common_source_dispatch(void);
 
 /* thread-related platform specific functions */
 bool sol_mainloop_impl_main_thread_check(void);

--- a/src/lib/common/sol-mainloop-impl-contiki.c
+++ b/src/lib/common/sol-mainloop-impl-contiki.c
@@ -102,21 +102,16 @@ sol_mainloop_impl_platform_shutdown(void)
 static inline clock_time_t
 ticks_until_next_timeout(void)
 {
-    struct sol_timeout_common *timeout;
-    struct timespec now, diff;
+    struct timespec ts;
 
-    timeout = sol_mainloop_common_timeout_first();
-    if (!timeout)
-        return DEFAULT_USLEEP_TIME_TICKS;
-
-    now = sol_util_timespec_get_current();
-    sol_util_timespec_sub(&timeout->expire, &now, &diff);
-
-    if (diff.tv_sec < 0)
+    if (!sol_mainloop_common_timespec_first(&ts))
         return 0;
 
-    return diff.tv_sec * CLOCK_SECOND +
-           (CLOCK_SECOND / NSEC_PER_SEC) * diff.tv_nsec;
+    if (ts.tv_sec < 0)
+        return 0;
+
+    return ts.tv_sec * CLOCK_SECOND +
+           (CLOCK_SECOND / NSEC_PER_SEC) * ts.tv_nsec;
 }
 
 void

--- a/src/lib/common/sol-mainloop-impl-riot.c
+++ b/src/lib/common/sol-mainloop-impl-riot.c
@@ -88,23 +88,17 @@ sol_mainloop_impl_platform_shutdown(void)
 static inline void
 timex_set_until_next_timeout(timex_t *timex)
 {
-    struct sol_timeout_common *timeout;
-    struct timespec now;
-    struct timespec diff;
+    struct timespec ts;
 
-    timeout = sol_mainloop_common_timeout_first();
-    if (!timeout) {
+    if (!sol_mainloop_common_timespec_first(&ts)) {
         *timex = timex_set(0, DEFAULT_USLEEP_TIME);
         return;
     }
 
-    now = sol_util_timespec_get_current();
-    sol_util_timespec_sub(&timeout->expire, &now, &diff);
-
-    if (diff.tv_sec < 0)
+    if (ts.tv_sec < 0)
         *timex = timex_set(0, 0);
     else
-        *timex = timex_set(diff.tv_sec, diff.tv_nsec / NSEC_PER_USEC);
+        *timex = timex_set(ts.tv_sec, ts.tv_nsec / NSEC_PER_USEC);
 }
 
 void

--- a/src/lib/common/sol-mainloop-impl.h
+++ b/src/lib/common/sol-mainloop-impl.h
@@ -60,3 +60,7 @@ bool sol_mainloop_impl_fd_del(void *handle);
 void *sol_mainloop_impl_child_watch_add(uint64_t pid, void (*cb)(void *data, uint64_t pid, int status), const void *data);
 bool sol_mainloop_impl_child_watch_del(void *handle);
 #endif
+
+void *sol_mainloop_impl_source_new(const struct sol_mainloop_source_type *type, const void *data);
+void sol_mainloop_impl_source_del(void *handle);
+void *sol_mainloop_impl_source_get_data(const void *handle);

--- a/src/lib/common/sol-mainloop.c
+++ b/src/lib/common/sol-mainloop.c
@@ -283,6 +283,39 @@ sol_child_watch_del(struct sol_child_watch *handle)
 }
 #endif
 
+SOL_API struct sol_mainloop_source *
+sol_mainloop_source_new(const struct sol_mainloop_source_type *type, const void *data)
+{
+    SOL_NULL_CHECK(type, NULL);
+
+    if (type->api_version != SOL_MAINLOOP_SOURCE_TYPE_API_VERSION) {
+        SOL_WRN("type(%p)->api_version(%hu) != "
+            "SOL_MAINLOOP_SOURCE_TYPE_API_VERSION(%hu)",
+            type, type->api_version,
+            SOL_MAINLOOP_SOURCE_TYPE_API_VERSION);
+        return NULL;
+    }
+
+    SOL_NULL_CHECK(type->check, NULL);
+    SOL_NULL_CHECK(type->dispatch, NULL);
+
+    return sol_mainloop_impl_source_new(type, data);
+}
+
+SOL_API void
+sol_mainloop_source_del(struct sol_mainloop_source *handle)
+{
+    SOL_NULL_CHECK(handle);
+    sol_mainloop_impl_source_del(handle);
+}
+
+SOL_API void *
+sol_mainloop_source_get_data(const struct sol_mainloop_source *handle)
+{
+    SOL_NULL_CHECK(handle, NULL);
+    return sol_mainloop_impl_source_get_data(handle);
+}
+
 SOL_API int
 sol_argc(void)
 {

--- a/src/lib/flow/Makefile
+++ b/src/lib/flow/Makefile
@@ -24,9 +24,7 @@ endif
 obj-flow-$(RESOLVER_CONFFILE) += \
     sol-flow-resolver-conffile.o
 
-obj-flow-$(RESOLVER_CONFFILE)-extra-cflags := $(GLIB_CFLAGS)
 obj-flow-$(FLOW)-extra-cflags += $(def-resolver-flag)
-obj-flow-$(RESOLVER_CONFFILE)-extra-ldflags += $(GLIB_LDFLAGS)
 
 headers-$(FLOW) := \
     include/sol-flow-builder.h \

--- a/src/lib/flow/sol-flow-resolver-conffile.c
+++ b/src/lib/flow/sol-flow-resolver-conffile.c
@@ -32,7 +32,7 @@
 
 #include <assert.h>
 #include <dlfcn.h>
-#include <glib.h>
+#include <limits.h>
 
 #include "sol-conffile.h"
 #include "sol-flow-internal.h"

--- a/src/shared/Makefile
+++ b/src/shared/Makefile
@@ -14,7 +14,5 @@ obj-libshared-$(PLATFORM_LINUX) += \
     sol-conffile.o \
     sol-file-reader.o \
     sol-util-linux.o
-obj-libshared-$(PLATFORM_LINUX)-extra-cflags += $(GLIB_CFLAGS)
-obj-libshared-$(PLATFORM_LINUX)-extra-ldflags += $(GLIB_LDFLAGS)
 
 obj-libshared-y-extra-cflags += -fvisibility=default


### PR DESCRIPTION
This patchset will allow glib usage to be reduced even further.

Changes since v1 (#462):
 * rebased to master, changes mostly due @ibriano's Kconfig/Makefile cleanups.
 * release the lock before calling users's `get_next_timeout()`, done in the same fashion as other loops, we steal the vector and replaces it with a temporary vector with the lock held, then loop in the stolen vector without locks, then take the lock and update the vector. The issue was pointed out by @ulissesf 
 * remove sol-bus dependency on Glib (Makefile)
 * remove sol-bus.c comment mentioning glib integration.