### PR TITLE
sol-util: start using sol-util-impl-$(PLATFORM) v3

### DIFF
--- a/src/shared/Makefile
+++ b/src/shared/Makefile
@@ -13,8 +13,15 @@ obj-libshared-$(FLOW) += \
 obj-libshared-$(PLATFORM_LINUX) += \
     sol-conffile.o \
     sol-file-reader.o \
-    sol-util-linux.o
+    sol-util-linux.o \
+    sol-util-impl-linux.o
 obj-libshared-$(PLATFORM_LINUX)-extra-cflags += $(GLIB_CFLAGS)
 obj-libshared-$(PLATFORM_LINUX)-extra-ldflags += $(GLIB_LDFLAGS)
+
+obj-libshared-$(PLATFORM_RIOTOS) += \
+    sol-util-impl-riot.o
+
+obj-libshared-$(PLATFORM_CONTIKI) += \
+    sol-util-impl-contiki.o
 
 obj-libshared-y-extra-cflags += -fvisibility=default

--- a/src/shared/sol-util-impl-contiki.c
+++ b/src/shared/sol-util-impl-contiki.c
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+
+#include "sol-util-impl.h"
+
+/* Contiki headers */
+#include <contiki.h>
+
+struct timespec
+sol_util_impl_timespec_get_current(void)
+{
+    struct timespec ret;
+    clock_time_t ticks;
+
+    ticks = clock_time();
+    ret.tv_sec = ticks / CLOCK_SECOND;
+    ticks -= ret.tv_sec * CLOCK_SECOND;
+    ret.tv_nsec = (ticks * NSEC_PER_SEC) / CLOCK_SECOND;
+    return ret;
+}
+
+int
+sol_util_impl_timespec_get_realtime(struct timespec *t)
+{
+    errno = ENOSYS;
+    return -1;
+}

--- a/src/shared/sol-util-impl-linux.c
+++ b/src/shared/sol-util-impl-linux.c
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sol-util-impl.h"
+
+struct timespec
+sol_util_impl_timespec_get_current(void)
+{
+    struct timespec t;
+
+    clock_gettime(CLOCK_MONOTONIC, &t);
+    return t;
+}
+int
+sol_util_impl_timespec_get_realtime(struct timespec *t)
+{
+    return clock_gettime(CLOCK_REALTIME, t);
+}

--- a/src/shared/sol-util-impl-riot.c
+++ b/src/shared/sol-util-impl-riot.c
@@ -1,0 +1,72 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+
+#include "sol-util-impl.h"
+
+/* RIOT headers */
+#include <vtimer.h>
+
+#if FEATURE_PERIPH_RTC
+#include <periph/rtc.h>
+#endif
+
+struct timespec
+sol_util_impl_timespec_get_current(void)
+{
+    struct timespec tp;
+    timex_t t;
+
+    vtimer_now(&t);
+    tp.tv_sec = t.seconds;
+    tp.tv_nsec = t.microseconds * 1000;
+    return tp;
+}
+
+int
+sol_util_impl_timespec_get_realtime(struct timespec *t)
+{
+#if FEATURE_PERITH_RTC
+    struct tm rtc;
+    if (rtc_get_time(&rtc) != 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    t.tv_sec = mktime(&rtc);
+    t.tv_nsec = 0;
+    return 0;
+#else
+    errno = ENOSYS;
+    return -1;
+#endif
+}

--- a/src/shared/sol-util-impl.h
+++ b/src/shared/sol-util-impl.h
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "sol-util.h"
+
+struct timespec sol_util_impl_timespec_get_current(void);
+int sol_util_impl_timespec_get_realtime(struct timespec *t);

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -39,9 +39,10 @@
 #include <locale.h>
 #endif
 
-#include "sol-util.h"
 #include "sol-log.h"
 #include "sol-str-slice.h"
+#include "sol-util.h"
+#include "sol-util-impl.h"
 
 #if defined(HAVE_LOCALE) && defined(HAVE_STRTOD_L)
 static locale_t c_locale;
@@ -179,81 +180,17 @@ sol_util_strtodn(const char *nptr, char **endptr, ssize_t len, bool use_locale)
     return value;
 }
 
-#ifdef SOL_PLATFORM_CONTIKI
-#include <contiki.h>
-
 struct timespec
 sol_util_timespec_get_current(void)
 {
-    struct timespec ret;
-    clock_time_t ticks;
-
-    ticks = clock_time();
-    ret.tv_sec = ticks / CLOCK_SECOND;
-    ticks -= ret.tv_sec * CLOCK_SECOND;
-    ret.tv_nsec = (ticks * NSEC_PER_SEC) / CLOCK_SECOND;
-    return ret;
+    return sol_util_impl_timespec_get_current();
 }
-#elif defined(SOL_PLATFORM_RIOT) && SOL_PLATFORM_RIOT
-#include <vtimer.h>
-
-struct timespec
-sol_util_timespec_get_current(void)
-{
-    struct timespec tp;
-    timex_t t;
-    vtimer_now(&t);
-    tp.tv_sec = t.seconds;
-    tp.tv_nsec = t.microseconds * 1000;
-    return tp;
-}
-#else
-struct timespec
-sol_util_timespec_get_current(void)
-{
-    struct timespec t;
-
-    clock_gettime(CLOCK_MONOTONIC, &t);
-    return t;
-}
-#endif
-
-#ifdef SOL_PLATFORM_CONTIKI
-int
-sol_util_timespec_get_realtime(struct timespec *t)
-{
-    errno = ENOSYS;
-    return -1;
-}
-#elif defined(SOL_PLATFORM_RIOT) && SOL_PLATFORM_RIOT
-#if FEATURE_PERIPH_RTC
-#include <periph/rtc.h>
-#endif
 
 int
 sol_util_timespec_get_realtime(struct timespec *t)
 {
-#if FEATURE_PERITH_RTC
-    struct tm rtc;
-    if (rtc_get_time(&rtc) != 0) {
-        errno = EINVAL;
-        return -1;
-    }
-    t.tv_sec = mktime(&rtc);
-    t.tv_nsec = 0;
-    return 0;
-#else
-    errno = ENOSYS;
-    return -1;
-#endif
+    return sol_util_impl_timespec_get_realtime(t);
 }
-#else
-int
-sol_util_timespec_get_realtime(struct timespec *t)
-{
-    return clock_gettime(CLOCK_REALTIME, t);
-}
-#endif
 
 char *
 sol_util_strerror(int errnum, char *buf, size_t buflen)


### PR DESCRIPTION
Differences from v2:
- maintain util on libshared.mod instead of creating util.mod

Differences from v1:
- fixed kbuild makefile

Since we were using a lot of platform #ifdefs in sol-util.c

Signed-off-by: Ricardo de Almeida Gonzaga <ricardo.gonzaga@intel.com>