### PR TITLE
Fix conf file options requirement.

### DIFF
--- a/src/lib/flow/sol-flow-resolver-conffile.c
+++ b/src/lib/flow/sol-flow-resolver-conffile.c
@@ -270,12 +270,14 @@ resolver_conffile_resolve_by_id(const char *id,
         }
     }
 
-    r = sol_flow_node_named_options_init_from_strv(named_opts, tmp_type, opts_strv);
-    if (r < 0)
-        goto end;
+    if (opts_strv) {
+        r = sol_flow_node_named_options_init_from_strv(named_opts, tmp_type, opts_strv);
+        if (r < 0)
+            goto end;
+    }
 
     *node_type = tmp_type;
-
+    r = 0;
 end:
     return r;
 }


### PR DESCRIPTION
Not all nodes requires options. If one creates a conf file with the following entry:

/* Section of a conf file */
{
 "name": "MyBtn"
 "type": "gtk/pushbutton"
}

The sol-fbp-runner would exit with an error code, because it could not
find the options for MyBtn.

Signed-off-by: Guilherme Iscaro de Godoy <guilherme.iscaro@intel.com>

@cmarcelo Could you please take a look?