### PR TITLE
build: bring back -fsanitize=address|undefined flags

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -17,6 +17,26 @@ config ENABLE_DYNAMIC_MODULES
 	bool
 	default n
 
+config CC_SANITIZE
+	bool "Compiler sanitize"
+	depends on HAVE_SANITIZE_UNDEFINED || HAVE_SANITIZE_ADDRESS
+	default y
+
+choice CC_SANITIZE_TYPE
+	prompt "Compiler sanitize type"
+	depends on CC_SANITIZE
+	default CC_SANITIZE_UNDEFINED if HAVE_SANITIZE_UNDEFINED
+	default CC_SANITIZE_ADDRESS if HAVE_SANITIZE_ADDRESS
+
+config CC_SANITIZE_UNDEFINED
+	bool "undefined"
+	depends on HAVE_SANITIZE_UNDEFINED
+
+config CC_SANITIZE_ADDRESS
+	bool "address"
+	depends on HAVE_SANITIZE_ADDRESS
+endchoice
+
 config SHARED_LIBRARY
     bool "Build shared library"
     default y

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -353,6 +353,20 @@
 	    "type": "pkg-config",
 	    "pkgname": "libcurl",
 	    "atleast-version": "7.32.0"
+	},
+	{
+	    "dependency": "sanitize_undefined",
+	    "type": "ccode",
+            "cflags": {
+                "value": "-fsanitize=undefined"
+            }
+	},
+	{
+	    "dependency": "sanitize_address",
+	    "type": "ccode",
+            "cflags": {
+                "value": "-fsanitize=address"
+            }
 	}
     ]
 }

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -139,6 +139,15 @@ GDB_AUTOLOAD_PY := $(top_srcdir)data/gdb/libsoletta.so-gdb.py
 COMMON_CFLAGS += $(CFLAGS)
 COMMON_LDFLAGS += $(LDFLAGS)
 
+ifeq (y,$(CC_SANITIZE))
+ifeq (y,$(CC_SANITIZE_UNDEFINED))
+COMMON_CFLAGS += $(SANITIZE_UNDEFINED_CFLAGS)
+endif
+ifeq (y,$(CC_SANITIZE_ADDRESS))
+COMMON_CFLAGS += $(SANITIZE_ADDRESS_CFLAGS)
+endif
+endif
+
 ifeq (y,$(LOG))
 ifeq (y,$(MAXIMUM_LOG_LEVEL_CRITICAL))
 MAXIMUM_LOG_LEVEL := 0


### PR DESCRIPTION
This patch brings back the -fsanitize flags. It adds the CC_SANITIZE
item to Kconfig and the sanitize type dependent to it. The default (like
previously with autotools) is -fsanitize=undefined, unless disabled or
non supported.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>