### PR TITLE
Fix conf file options requirement.

### DIFF
--- a/src/lib/flow/sol-flow-resolver-conffile.c
+++ b/src/lib/flow/sol-flow-resolver-conffile.c
@@ -249,7 +249,7 @@ resolver_conffile_resolve_by_id(const char *id,
     const struct sol_flow_node_type *tmp_type;
     const char **opts_strv = NULL;
     const char *type_name;
-    int r;
+    int r = 0;
 
     /* TODO: replace strv in sol_conffile interface with something
     * that holds line/column number information for each entry. */
@@ -270,12 +270,14 @@ resolver_conffile_resolve_by_id(const char *id,
         }
     }
 
-    r = sol_flow_node_named_options_init_from_strv(named_opts, tmp_type, opts_strv);
-    if (r < 0)
-        goto end;
+    if (opts_strv) {
+        r = sol_flow_node_named_options_init_from_strv(named_opts, tmp_type, opts_strv);
+        if (r < 0)
+            goto end;
+    } else
+        *named_opts = (struct sol_flow_node_named_options){};
 
     *node_type = tmp_type;
-
 end:
     return r;
 }


### PR DESCRIPTION
Not all nodes requires options. If one creates a conf file with the following entry:

/* Section of a conf file */
{
 "name": "MyBtn"
 "type": "gtk/pushbutton"
}

The sol-fbp-runner would exit with an error code, because it could not
find the options for MyBtn.

Signed-off-by: Guilherme Iscaro de Godoy <guilherme.iscaro@intel.com>