### PR TITLE
Check if glibc have newer locale functions

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -228,6 +228,14 @@
 	    "fragment": "setlocale(LC_ALL, NULL);"
 	},
 	{
+	    "dependency": "newlocale",
+	    "type": "ccode",
+	    "headers": [
+		"<locale.h>"
+	    ],
+	    "fragment": "freelocale(NULL);"
+	},
+	{
 	    "dependency": "icu",
 	    "type": "pkg-config",
 	    "pkgname": "icu-uc icu-i18n",

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -43,7 +43,7 @@
 #include "sol-log.h"
 #include "sol-str-slice.h"
 
-#if defined(HAVE_LOCALE) && defined(HAVE_STRTOD_L)
+#if defined(HAVE_NEWLOCALE) && defined(HAVE_STRTOD_L)
 static locale_t c_locale;
 static void
 clear_c_locale(void)
@@ -84,7 +84,7 @@ sol_util_strtodn(const char *nptr, char **endptr, ssize_t len, bool use_locale)
     char *tmpbuf, *tmpbuf_endptr;
     double value;
 
-#if defined(HAVE_LOCALE) && defined(HAVE_STRTOD_L)
+#if defined(HAVE_NEWLOCALE) && defined(HAVE_STRTOD_L)
     if (!use_locale) {
         if (!init_c_locale()) {
             /* not great, but a best effort to convert something */
@@ -107,7 +107,7 @@ sol_util_strtodn(const char *nptr, char **endptr, ssize_t len, bool use_locale)
     tmpbuf = strndupa(nptr, len);
 
     errno = 0;
-#ifdef HAVE_LOCALE
+#ifdef HAVE_NEWLOCALE
     if (!use_locale) {
 #ifdef HAVE_STRTOD_L
         value = strtod_l(tmpbuf, &tmpbuf_endptr, c_locale);


### PR DESCRIPTION
On 'json: add number parsing.'[b9dc3ad4] we started to use freelocale()
and newlocale() that are functions only available on glibc 2.10 or newer
but in our Galileo SDK the available version is 2.10.

Signed-off-by: José Roberto de Souza <jose.souza@intel.com>