### PR TITLE
Fill buffer

### DIFF
--- a/src/lib/comms/sol-network-linux.c
+++ b/src/lib/comms/sol-network-linux.c
@@ -52,6 +52,7 @@
 #include "sol-missing.h"
 #include "sol-network.h"
 #include "sol-util.h"
+#include "sol-util-linux.h"
 
 SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "network");
 
@@ -294,7 +295,7 @@ _netlink_request(int event)
     if (sendmsg(network->nl_socket, (struct msghdr *)&msg, 0) <= 0)
         SOL_WRN("Failed on send message to get the links");
 
-    while ((n = read(network->nl_socket, buffer_receive, sizeof(buffer_receive))) > 0) {
+    while ((n = sol_util_fill_buffer(network->nl_socket, buffer_receive, sizeof(buffer_receive), NULL)) > 0) {
         for (h = (struct nlmsghdr *)buffer_receive; NLMSG_OK(h, n); h = NLMSG_NEXT(h, n)) {
             if (h->nlmsg_type == NLMSG_DONE)
                 return;

--- a/src/lib/io/sol-uart-linux.c
+++ b/src/lib/io/sol-uart-linux.c
@@ -44,6 +44,7 @@
 #include "sol-mainloop.h"
 #include "sol-uart.h"
 #include "sol-util.h"
+#include "sol-util-linux.h"
 
 SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "uart");
 
@@ -78,7 +79,7 @@ uart_rx_callback(void *data, int fd, unsigned int active_flags)
     }
     if (active_flags & SOL_FD_FLAGS_IN) {
         unsigned char buf[1];
-        int status = read(uart->fd, buf, sizeof(buf));
+        int status = sol_util_fill_buffer(uart->fd, (char *)buf, sizeof(buf), NULL);
         if (status > 0)
             uart->async.rx_cb((void *)uart->async.rx_user_data, uart, buf[0]);
     }

--- a/src/modules/flow/keyboard/Kconfig
+++ b/src/modules/flow/keyboard/Kconfig
@@ -1,3 +1,4 @@
 config FLOW_NODE_TYPE_KEYBOARD
 	tristate "Node type: keyboard"
+	depends on PLATFORM_LINUX
 	default m

--- a/src/modules/flow/keyboard/keyboard.c
+++ b/src/modules/flow/keyboard/keyboard.c
@@ -47,6 +47,7 @@
 #include "sol-mainloop.h"
 #include "sol-vector.h"
 #include "sol-util.h"
+#include "sol-util-linux.h"
 
 struct keyboard_common_data {
     struct sol_flow_node *node;
@@ -227,12 +228,13 @@ keyboard_on_event(void *data, int fd, unsigned int cond)
 
     if (cond & SOL_FD_FLAGS_IN) {
         unsigned char buf[8];
-        int r = read(STDIN_FILENO, buf, sizeof(buf));
+        size_t size;
+        int r = sol_util_fill_buffer(STDIN_FILENO, (char *)buf, sizeof(buf), &size);
         if (r < 0) {
             SOL_WRN("could not read stdin: %s", sol_util_strerrora(errno));
             cond |= SOL_FD_FLAGS_ERR;
-        } else if (r > 0) {
-            mdata->on_code(mdata, buf, r);
+        } else if (size > 0) {
+            mdata->on_code(mdata, buf, size);
         }
     }
 

--- a/src/shared/sol-util-linux.c
+++ b/src/shared/sol-util-linux.c
@@ -123,11 +123,11 @@ ssize_t
 sol_util_fill_buffer(const int fd, char *buffer, const size_t buffer_size, size_t *size_read)
 {
     ssize_t size;
+    size_t bytes_read = 0;
     unsigned int retry = 0;
 
-    *size_read = 0;
     do {
-        size = read(fd, buffer + *size_read, buffer_size - *size_read);
+        size = read(fd, buffer + bytes_read, buffer_size - bytes_read);
         if (size < 0) {
             retry++;
             if (retry >= SOL_UTIL_MAX_READ_ATTEMPTS)
@@ -140,8 +140,11 @@ sol_util_fill_buffer(const int fd, char *buffer, const size_t buffer_size, size_
         }
 
         retry = 0; //We only count consecutive failures
-        *size_read += (size_t)size;
-    } while (size && *size_read < buffer_size);
+        bytes_read += (size_t)size;
+    } while (size && bytes_read < buffer_size);
+
+    if (size_read)
+        *size_read = bytes_read;
 
     return size;
 }


### PR DESCRIPTION
Using `sol_util_fill_buffer()` instead of raw `read()` on many applicable places. I've tried to not just blindly replace, but definitely review must take into account my lack of familiarity with the code (iow, I may have screwed everything up). One special doubt is about 'keyboard' - as `sol_util_fill_buffer()` is linux only, I made it depend on linux - however, I'm not sure about it. If opposed, I see no problem on dropping that patch.
All patches are separated by file touched - but I can squash them.