### PR TITLE
Fix memory leaks on http-client

### DIFF
--- a/src/lib/comms/sol-http-client-impl-curl.c
+++ b/src/lib/comms/sol-http-client-impl-curl.c
@@ -52,12 +52,13 @@ void sol_http_client_shutdown(void);
 static struct {
     CURLM *multi;
     struct sol_timeout *multi_perform_timeout;
+    struct sol_ptr_vector connections;
     long timeout_ms;
-    unsigned int fds;
     int ref;
 } global = {
     .timeout_ms = 100,
-    .ref = 0
+    .ref = 0,
+    .connections = SOL_PTR_VECTOR_INIT,
 };
 
 struct connection {
@@ -73,22 +74,24 @@ struct connection {
     bool pending_error_cb;
 };
 
-static bool
-cleanup_multi_cb(void *data)
+static void
+destroy_connection(struct connection *c)
 {
-    CURLM *multi = data;
+    curl_multi_remove_handle(global.multi, c->curl);
+    curl_easy_cleanup(c->curl);
 
-    if (global.fds)
-        return true;
+    sol_buffer_fini(&c->buffer);
+    sol_arena_del(c->arena);
 
-    curl_multi_cleanup(multi);
-    curl_global_cleanup();
-    return false;
+    free(c);
 }
 
 void
 sol_http_client_shutdown(void)
 {
+    struct connection *c;
+    unsigned int i;
+
     if (!global.ref)
         return;
     global.ref--;
@@ -100,11 +103,15 @@ sol_http_client_shutdown(void)
         global.multi_perform_timeout = NULL;
     }
 
-    /* Cleanup in an idler as there might be easy handles in the flight. */
-    if (!sol_idle_add(cleanup_multi_cb, global.multi)) {
-        SOL_WRN("Could defer cURL cleanup");
-        return;
+    SOL_PTR_VECTOR_FOREACH_IDX (&global.connections, c, i) {
+        destroy_connection(c);
     }
+
+    sol_ptr_vector_clear(&global.connections);
+
+    curl_multi_cleanup(global.multi);
+    curl_global_cleanup();
+
     global.multi = NULL;
 }
 
@@ -276,15 +283,9 @@ error_cb(void *data)
 
     call_connection_finish_cb(connection);
 
-    curl_multi_remove_handle(global.multi, connection->curl);
-    curl_easy_cleanup(connection->curl);
+    destroy_connection(connection);
 
-    sol_buffer_fini(&connection->buffer);
-    sol_arena_del(connection->arena);
-
-    free(connection);
-
-    global.fds--;
+    sol_ptr_vector_remove(&global.connections, connection);
 
     return false;
 }
@@ -364,7 +365,6 @@ open_socket_cb(void *clientp, curlsocktype purpose, struct curl_sockaddr *addr)
         return -1;
     }
 
-    global.fds++;
     return fd;
 }
 
@@ -449,6 +449,8 @@ perform_multi(CURL *curl, struct sol_arena *arena,
         curl_multi_remove_handle(global.multi, connection->curl);
         goto free_buffer;
     }
+
+    sol_ptr_vector_append(&global.connections, connection);
 
     return true;
 

--- a/src/lib/datatypes/include/sol-vector.h
+++ b/src/lib/datatypes/include/sol-vector.h
@@ -153,6 +153,8 @@ int sol_ptr_vector_set(struct sol_ptr_vector *pv, uint16_t i, void *ptr);
 
 int sol_ptr_vector_insert_sorted(struct sol_ptr_vector *pv, void *ptr, int (*compare_cb)(const void *data1, const void *data2));
 
+int sol_ptr_vector_remove(struct sol_ptr_vector *pv, const void *ptr);
+
 static inline int
 sol_ptr_vector_del(struct sol_ptr_vector *pv, uint16_t i)
 {

--- a/src/lib/datatypes/sol-vector.c
+++ b/src/lib/datatypes/sol-vector.c
@@ -215,3 +215,18 @@ sol_ptr_vector_set(struct sol_ptr_vector *pv, uint16_t i, void *ptr)
     *data = ptr;
     return 0;
 }
+
+SOL_API int
+sol_ptr_vector_remove(struct sol_ptr_vector *pv, const void *ptr)
+{
+    unsigned int i;
+    void *p;
+
+    SOL_PTR_VECTOR_FOREACH_REVERSE_IDX (pv, p, i) {
+        if (ptr == p) {
+            sol_ptr_vector_del(pv, i);
+            return 0;
+        }
+    }
+    return -ENODATA;
+}


### PR DESCRIPTION
This series also introduces sol_ptr_vector_remove() which removes a pointer from a sol_ptr_vector as this seems to be a common operation.

The strategy for fixing the memory leak is keeping references to the existing connections, and using the procedure recommended in the curl_multi_cleanup(3) man page for cleaning them up:

> Cleans  up  and  removes  a whole multi stack. It does not free or touch any individual
> easy handles in any way - they still need to be closed individually,  using  the  usual
> curl_easy_cleanup(3) way. The order of cleaning up should be:
> 1 - curl_multi_remove_handle(3) before any easy handles are cleaned up
> 2 -  curl_easy_cleanup(3)  can now be called independently since the easy handle is no
>   longer connected to the multi handle
> 3 - curl_multi_cleanup(3) should be called when all easy handles are removed
