### PR TITLE
build: add headers-m support

### DIFF
--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -141,12 +141,13 @@ parse-sample = \
 	$(eval samples-out      += $(sample-$(1)-out)) \
 
 clean-control = $(eval headers-y:=) $(eval obj-y:=) $(eval obj-m:=) $(eval bin-y:=) \
-		$(eval test-y:=) $(eval test-internal-y:=) $(eval sample-y:=)
+		$(eval test-y:=) $(eval test-internal-y:=) $(eval sample-y:=) $(eval headers-m:=)
 
 inc-subdirs = \
 	$(foreach subdir,$(SUBDIRS), $(clean-control) \
 		$(eval -include $(subdir)Makefile) \
 		$(call extra-headers,$(addprefix $(subdir),$(headers-y))) \
+		$(call extra-headers,$(addprefix $(subdir),$(headers-m))) \
 		$(eval curr-builtins        := $(subst .mod,,$(filter %.mod,$(obj-y)))) \
 		$(eval builtins             += $(curr-builtins)) \
 		$(foreach buin,$(curr-builtins), \


### PR DESCRIPTION
It seems we've missed the headers-m identification/parsing, this patch
adds that and fixes issues with flower-power module.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>