### PR TITLE
Reduce glib v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,11 @@ for in-depth information, the summary of environment variables to use:
 
 	make CFLAGS="-O0 -ggdb3" # disable optimizations
 
+Users of `GMainLoop` (ie: gtk, libsoup) should use the function
+`sol_glib_integration()` from the header file `sol-glib-integration.h`
+to make sure they will work with Soletta, regardless of how libsoletta
+was compiled.
+
 #### POSIX (kconfig: Core library -> Mainloop -> posix)
 
 If GLib is too big then you can use a simpler implementation based

--- a/src/lib/common/Makefile
+++ b/src/lib/common/Makefile
@@ -84,6 +84,9 @@ headers-y := \
     include/sol-types.h \
     sol-common-buildopts.h.in
 
+headers-$(PLATFORM_LINUX) += \
+    include/sol-glib-integration.h
+
 headers-$(USE_PIN_MUX) += \
     include/sol-pin-mux-modules.h
 

--- a/src/lib/common/Makefile
+++ b/src/lib/common/Makefile
@@ -20,8 +20,8 @@ obj-log-$(PLATFORM_CONTIKI) += \
 
 obj-core-$(SOL_BUS) += \
     sol-bus.o
-obj-core-$(SOL_BUS)-extra-cflags += $(SYSTEMD_CFLAGS) $(GLIB_CFLAGS)
-obj-core-$(SOL_BUS)-extra-ldflags += $(SYSTEMD_LDFLAGS) $(GLIB_LDFLAGS)
+obj-core-$(SOL_BUS)-extra-cflags += $(SYSTEMD_CFLAGS)
+obj-core-$(SOL_BUS)-extra-ldflags += $(SYSTEMD_LDFLAGS)
 
 obj-core-$(MAINLOOP_GLIB) += \
     sol-mainloop-impl-glib.o

--- a/src/lib/common/include/sol-glib-integration.h
+++ b/src/lib/common/include/sol-glib-integration.h
@@ -1,0 +1,457 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file sol-glib-integration.h
+ *
+ * This file is to be included by GMainLoop users. It will make sure
+ * Glib's main loop is usable with Soletta in the case of Soletta
+ * being compiled with glib as mainloop or any other such as POSIX.
+ *
+ * Include this file and call sol_glib_integration().
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <glib.h>
+#include <sol-mainloop.h>
+#include <sol-log.h>
+#include <sol-vector.h>
+
+static gboolean
+_sol_glib_integration_gsource_prepare(GSource *source, gint *timeout)
+{
+    return FALSE;
+}
+
+static gboolean
+_sol_glib_integration_gsource_check(GSource *source)
+{
+    return FALSE;
+}
+
+static gboolean
+_sol_glib_integration_gsource_dispatch(GSource *source, GSourceFunc cb, gpointer user_data)
+{
+    return TRUE;
+}
+
+static GSourceFuncs _sol_glib_integration_gsource_funcs = {
+    .prepare = _sol_glib_integration_gsource_prepare,
+    .check = _sol_glib_integration_gsource_check,
+    .dispatch = _sol_glib_integration_gsource_dispatch,
+};
+
+static gboolean
+_sol_glib_integration_gsource_cb(gpointer user_data)
+{
+    return TRUE;
+}
+
+struct _sol_glib_integration_fd_handler {
+    struct sol_fd *watch;
+    struct _sol_glib_integration_source_data *mdata;
+    int fd;
+    gushort events;
+};
+
+static void
+_sol_glib_integration_fd_handler_del(struct _sol_glib_integration_fd_handler *h)
+{
+    sol_fd_del(h->watch);
+    free(h);
+}
+
+struct _sol_glib_integration_source_data {
+    GSource gsource;
+    struct sol_ptr_vector handlers;
+    GPollFD *fds;
+    gint n_fds;
+    gint n_poll;
+    gint timeout;
+    gint max_prio;
+};
+
+static unsigned int
+_sol_glib_integration_gpoll_events_to_fd_flags(gushort gpoll_events)
+{
+    unsigned int sol_flags = 0;
+
+    if (gpoll_events & G_IO_IN) sol_flags |= SOL_FD_FLAGS_IN;
+    if (gpoll_events & G_IO_OUT) sol_flags |= SOL_FD_FLAGS_OUT;
+    if (gpoll_events & G_IO_PRI) sol_flags |= SOL_FD_FLAGS_PRI;
+    if (gpoll_events & G_IO_ERR) sol_flags |= SOL_FD_FLAGS_ERR;
+    if (gpoll_events & G_IO_HUP) sol_flags |= SOL_FD_FLAGS_HUP;
+    if (gpoll_events & G_IO_NVAL) sol_flags |= SOL_FD_FLAGS_NVAL;
+
+    return sol_flags;
+}
+
+static gushort
+_sol_glib_integration_fd_flags_to_gpoll_events(unsigned int sol_flags)
+{
+    gushort glib_flags = 0;
+
+    if (sol_flags & SOL_FD_FLAGS_IN) glib_flags |= G_IO_IN;
+    if (sol_flags & SOL_FD_FLAGS_OUT) glib_flags |= G_IO_OUT;
+    if (sol_flags & SOL_FD_FLAGS_PRI) glib_flags |= G_IO_PRI;
+    if (sol_flags & SOL_FD_FLAGS_ERR) glib_flags |= G_IO_ERR;
+    if (sol_flags & SOL_FD_FLAGS_HUP) glib_flags |= G_IO_HUP;
+    if (sol_flags & SOL_FD_FLAGS_NVAL) glib_flags |= G_IO_NVAL;
+
+    return glib_flags;
+}
+
+static GPollFD *
+_sol_glib_integration_source_gpollfd_find(struct _sol_glib_integration_source_data *mdata, int fd)
+{
+    gint i;
+
+    for (i = 0; i < mdata->n_poll; i++) {
+        GPollFD *gpfd = mdata->fds + i;
+        if (gpfd->fd == fd)
+            return gpfd;
+    }
+
+    return NULL;
+}
+
+static struct _sol_glib_integration_fd_handler *
+_sol_glib_integration_source_fd_handler_data_find(struct _sol_glib_integration_source_data *mdata, int fd)
+{
+    uint16_t i;
+    struct _sol_glib_integration_fd_handler *h;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&mdata->handlers, h, i) {
+        if (h->fd == fd)
+            return h;
+    }
+
+    return NULL;
+}
+
+static bool
+_sol_glib_integration_on_source_fd(void *data, int fd, unsigned int active_flags)
+{
+    struct _sol_glib_integration_fd_handler *h = data;
+    GPollFD *gpfd = _sol_glib_integration_source_gpollfd_find(h->mdata, fd);
+
+    SOL_NULL_CHECK(gpfd, true);
+    gpfd->revents = _sol_glib_integration_fd_flags_to_gpoll_events(active_flags);
+
+    return true;
+}
+
+static void
+_sol_glib_integration_source_fd_handlers_adjust(struct _sol_glib_integration_source_data *mdata)
+{
+    uint16_t i;
+    struct _sol_glib_integration_fd_handler *h;
+
+    // 1 - cleanup fd handlers that are not needed or changed
+    // Walk backwards so deletion doesn't impact the indices.
+    SOL_PTR_VECTOR_FOREACH_REVERSE_IDX (&mdata->handlers, h, i) {
+        GPollFD *gpfd = _sol_glib_integration_source_gpollfd_find(mdata, h->fd);
+
+        if (gpfd && gpfd->events == h->events)
+            continue;
+
+        if (gpfd)
+            SOL_DBG("glib fd=%d, changed events %#x -> %#x", h->fd, h->events, gpfd->events);
+        else
+            SOL_DBG("glib fd=%d is not needed anymore", h->fd);
+        _sol_glib_integration_fd_handler_del(h);
+        sol_ptr_vector_del(&mdata->handlers, i);
+    }
+
+    // 2 - create fd handlers for new or changed fds
+    for (i = 0; i < (uint16_t)mdata->n_poll; i++) {
+        const GPollFD *gpfd = mdata->fds + i;
+        unsigned int flags;
+        int r;
+
+        h = _sol_glib_integration_source_fd_handler_data_find(mdata, gpfd->fd);
+        if (h)
+            continue;
+
+        h = malloc(sizeof(struct _sol_glib_integration_fd_handler));
+        SOL_NULL_CHECK(h);
+
+        h->fd = gpfd->fd;
+        h->events = gpfd->events;
+        h->mdata = mdata;
+
+        flags = _sol_glib_integration_gpoll_events_to_fd_flags(gpfd->events);
+
+        h->watch = sol_fd_add(gpfd->fd,
+            flags, _sol_glib_integration_on_source_fd, h);
+        SOL_NULL_CHECK_GOTO(h->watch, watch_failed);
+
+        r = sol_ptr_vector_append(&mdata->handlers, h);
+        SOL_INT_CHECK_GOTO(r, < 0, append_failed);
+
+        SOL_DBG("glib fd=%d monitoring events %#x", h->fd, h->events);
+        continue;
+
+append_failed:
+        sol_fd_del(h->watch);
+watch_failed:
+        free(h);
+        return;
+    }
+}
+
+static bool
+_sol_glib_integration_source_acquire(struct _sol_glib_integration_source_data *mdata)
+{
+    GMainContext *ctx = g_source_get_context(&mdata->gsource);
+    gboolean r = g_main_context_acquire(ctx);
+
+    /* NOTE: not doing wait() here, should we? */
+    if (!r)
+        SOL_WRN("couldn't acquire glib's context.");
+
+    return r;
+}
+
+static void
+_sol_glib_integration_source_release(struct _sol_glib_integration_source_data *mdata)
+{
+    GMainContext *ctx = g_source_get_context(&mdata->gsource);
+
+    g_main_context_release(ctx);
+}
+
+static inline unsigned int
+_sol_glib_integration_align_power2(unsigned int u)
+{
+    unsigned int left_zeros;
+
+    if (u == 1)
+        return 1;
+    if ((left_zeros = __builtin_clz(u - 1)) < 1)
+        return 0;
+    return 1 << ((sizeof(u) * 8) - left_zeros);
+}
+
+static bool
+_sol_glib_integration_source_prepare(void *data)
+{
+    struct _sol_glib_integration_source_data *mdata = data;
+    GMainContext *ctx = g_source_get_context(&mdata->gsource);
+    bool ready;
+    gint req_n_fds;
+
+    if (!_sol_glib_integration_source_acquire(mdata))
+        return false;
+
+    ready = g_main_context_prepare(ctx, &mdata->max_prio);
+
+    /* NOTE: this shouldn't require a loop, but gmain.c does it, so we mimic
+     * such behavior here.
+     */
+    do {
+        size_t byte_size;
+        void *tmp;
+
+        mdata->n_poll = g_main_context_query(ctx,
+            mdata->max_prio, &mdata->timeout, mdata->fds, mdata->n_fds);
+        req_n_fds = _sol_glib_integration_align_power2(mdata->n_poll);
+
+        if (req_n_fds == mdata->n_fds)
+            break;
+
+        /* NOTE: not using sol_util_size_mul() since sol-util.h is not
+         * installed and this file is to be compiled by soletta's
+         * users.
+         */
+        byte_size = req_n_fds * sizeof(GPollFD);
+        tmp = realloc(mdata->fds, byte_size);
+        if (byte_size > 0) {
+            SOL_NULL_CHECK_GOTO(tmp, failed);
+            memset(tmp, 0, byte_size);
+        }
+
+        mdata->fds = tmp;
+        mdata->n_fds = req_n_fds;
+    } while (1);
+
+    _sol_glib_integration_source_release(mdata);
+
+    _sol_glib_integration_source_fd_handlers_adjust(mdata);
+
+    return ready;
+
+failed:
+    _sol_glib_integration_source_release(mdata);
+    return false;
+}
+
+static bool
+_sol_glib_integration_source_get_next_timeout(void *data, struct timespec *ts)
+{
+    struct _sol_glib_integration_source_data *mdata = data;
+
+    if (mdata->timeout < 0)
+        return false;
+
+    /* NOTE: not using sol_util_timespec_from_msec() since sol-util.h
+     * is not installed and this file is to be compiled by soletta's
+     * users.
+     */
+    ts->tv_sec = mdata->timeout / 1000ULL;
+    ts->tv_nsec = (mdata->timeout % 1000ULL) * 1000000ULL;
+    return true;
+}
+
+static bool
+_sol_glib_integration_source_check(void *data)
+{
+    struct _sol_glib_integration_source_data *mdata = data;
+    GMainContext *ctx = g_source_get_context(&mdata->gsource);
+    bool ready;
+
+    if (!_sol_glib_integration_source_acquire(mdata))
+        return false;
+
+    ready = g_main_context_check(ctx,
+        mdata->max_prio, mdata->fds, mdata->n_poll);
+
+    _sol_glib_integration_source_release(mdata);
+
+    return ready;
+}
+
+static void
+_sol_glib_integration_source_dispatch(void *data)
+{
+    struct _sol_glib_integration_source_data *mdata = data;
+    GMainContext *ctx = g_source_get_context(&mdata->gsource);
+
+    if (!_sol_glib_integration_source_acquire(mdata))
+        return;
+
+    g_main_context_dispatch(ctx);
+
+    _sol_glib_integration_source_release(mdata);
+}
+
+static void
+_sol_glib_integration_source_dispose(void *data)
+{
+    struct _sol_glib_integration_source_data *mdata = data;
+    GMainContext *ctx = g_source_get_context(&mdata->gsource);
+    uint16_t i;
+    struct _sol_glib_integration_fd_handler *h;
+
+    SOL_PTR_VECTOR_FOREACH_REVERSE_IDX (&mdata->handlers, h, i) {
+        _sol_glib_integration_fd_handler_del(h);
+    }
+    sol_ptr_vector_clear(&mdata->handlers);
+
+    free(mdata->fds);
+
+    g_source_destroy(&mdata->gsource);
+    g_source_unref(&mdata->gsource);
+
+    g_main_context_unref(ctx);
+}
+
+static const struct sol_mainloop_source_type _sol_glib_integration_source_type = {
+    .api_version = SOL_MAINLOOP_SOURCE_TYPE_API_VERSION,
+    .prepare = _sol_glib_integration_source_prepare,
+    .get_next_timeout = _sol_glib_integration_source_get_next_timeout,
+    .check = _sol_glib_integration_source_check,
+    .dispatch = _sol_glib_integration_source_dispatch,
+    .dispose = _sol_glib_integration_source_dispose
+};
+
+static bool
+sol_glib_integration(void)
+{
+    GMainContext *ctx;
+    GSource *gsource;
+    struct sol_mainloop_source *msource;
+    struct _sol_glib_integration_source_data *mdata;
+    guint id;
+
+    /* no need to integrate if we're called from glib */
+    if (g_main_depth()) {
+        SOL_DBG("already running with glib");
+        return true;
+    }
+
+    ctx = g_main_context_default();
+
+    /* convention: we add a GSource with 'sol_init' as user_data to
+     * mark Soletta was integrated with Glib.
+     *
+     * it is a dummy gsource that does nothing other than exist to hold
+     * this mark.
+     */
+    gsource = g_main_context_find_source_by_user_data(ctx, sol_init);
+    if (gsource)
+        return true;
+
+    gsource = g_source_new(&_sol_glib_integration_gsource_funcs,
+        sizeof(struct _sol_glib_integration_source_data));
+    SOL_NULL_CHECK(gsource, false);
+    g_source_set_callback(gsource,
+        _sol_glib_integration_gsource_cb, sol_init, NULL);
+
+    id = g_source_attach(gsource, ctx);
+    SOL_INT_CHECK_GOTO(id, == 0, failed_gsource);
+
+    mdata = (struct _sol_glib_integration_source_data *)gsource;
+    sol_ptr_vector_init(&mdata->handlers);
+    mdata->fds = NULL;
+    mdata->n_fds = 0;
+    mdata->n_poll = 0;
+    mdata->timeout = -1;
+    mdata->max_prio = 0;
+
+    msource = sol_mainloop_source_new(&_sol_glib_integration_source_type, gsource);
+    SOL_NULL_CHECK_GOTO(msource, failed_mainloop_source);
+
+    g_main_context_ref(ctx);
+    SOL_DBG("glib's mainloop is now integrated");
+
+    return true;
+
+failed_mainloop_source:
+    g_source_destroy(gsource);
+failed_gsource:
+    g_source_unref(gsource);
+    SOL_WRN("failed to integrate glib's mainloop");
+    return false;
+}

--- a/src/lib/common/sol-bus.c
+++ b/src/lib/common/sol-bus.c
@@ -35,7 +35,6 @@
 #include <stdio.h>
 #include <stdbool.h>
 
-#include <glib.h>
 #include <systemd/sd-bus.h>
 #include <systemd/sd-event.h>
 
@@ -44,11 +43,6 @@
 #include "sol-platform-impl.h"
 #include "sol-util.h"
 #include "sol-vector.h"
-
-struct event_source {
-    GSource gsource;
-    sd_event *event;
-};
 
 struct property_table {
     const struct sol_bus_properties *properties;
@@ -59,7 +53,7 @@ struct property_table {
 };
 
 struct ctx {
-    struct event_source *event_source;
+    struct sol_mainloop_source *mainloop_source;
     sd_bus *bus;
     sd_event_source *ping;
     struct sol_ptr_vector property_tables;
@@ -68,60 +62,88 @@ struct ctx {
 
 static struct ctx _ctx;
 
-static gboolean
-event_prepare(GSource *gsource, gint *timeout)
+struct source_ctx {
+    struct sd_event *event;
+    struct sol_fd *fd_handler;
+};
+
+static bool
+source_prepare(void *data)
 {
-    struct event_source *s = (struct event_source *)gsource;
+    struct source_ctx *s = data;
 
     return sd_event_prepare(s->event) > 0;
 }
 
-static gboolean
-event_check(GSource *gsource)
+static bool
+source_check(void *data)
 {
-    struct event_source *s = (struct event_source *)gsource;
+    struct source_ctx *s = data;
 
     return sd_event_wait(s->event, 0) > 0;
 }
 
-static gboolean
-event_dispatch(GSource *gsource, GSourceFunc cb, gpointer user_data)
+static void
+source_dispatch(void *data)
 {
-    struct event_source *s = (struct event_source *)gsource;
+    struct source_ctx *s = data;
 
-    return sd_event_dispatch(s->event) > 0;
+    sd_event_dispatch(s->event);
 }
 
 static void
-event_finalize(GSource *gsource)
+source_dispose(void *data)
 {
-    struct event_source *s = (struct event_source *)gsource;
+    struct source_ctx *s = data;
 
     sd_event_unref(s->event);
+    sol_fd_del(s->fd_handler);
+
+    free(s);
 }
 
-static GSourceFuncs event_funcs = {
-    .prepare = event_prepare,
-    .check = event_check,
-    .dispatch = event_dispatch,
-    .finalize = event_finalize,
+static const struct sol_mainloop_source_type source_type = {
+    .api_version = SOL_MAINLOOP_SOURCE_TYPE_API_VERSION,
+    .prepare = source_prepare,
+    .check = source_check,
+    .dispatch = source_dispatch,
+    .dispose = source_dispose,
 };
 
-static struct event_source *
+static bool
+on_sd_event_fd(void *data, int fd, unsigned int active_flags)
+{
+    /* just used to wake up main loop */
+    return true;
+}
+
+static struct sol_mainloop_source *
 event_create_source(sd_event *event)
 {
-    struct event_source *s;
+    struct sol_mainloop_source *source;
+    struct source_ctx *ctx;
 
-    s = (struct event_source *)g_source_new(&event_funcs,
-        sizeof(struct event_source));
-    if (!s)
-        return NULL;
+    ctx = malloc(sizeof(*ctx));
+    SOL_NULL_CHECK(ctx, NULL);
 
-    s->event = sd_event_ref(event);
-    g_source_add_unix_fd(&s->gsource, sd_event_get_fd(event),
-        G_IO_IN | G_IO_HUP | G_IO_ERR);
+    ctx->event = sd_event_ref(event);
 
-    return s;
+    ctx->fd_handler = sol_fd_add(sd_event_get_fd(event),
+        SOL_FD_FLAGS_IN | SOL_FD_FLAGS_HUP | SOL_FD_FLAGS_ERR,
+        on_sd_event_fd, ctx);
+    SOL_NULL_CHECK_GOTO(ctx->fd_handler, error_fd);
+
+    source = sol_mainloop_source_new(&source_type, ctx);
+    SOL_NULL_CHECK_GOTO(source, error_source);
+
+    return source;
+
+error_source:
+    sol_fd_del(ctx->fd_handler);
+error_fd:
+    sd_event_unref(ctx->event);
+    free(ctx);
+    return NULL;
 }
 
 static int
@@ -142,18 +164,16 @@ event_attach_mainloop(void)
     int r;
     sd_event *e = NULL;
 
-    if (_ctx.event_source)
+    if (_ctx.mainloop_source)
         return 0;
 
     r = sd_event_default(&e);
     if (r < 0)
         return r;
 
-    _ctx.event_source = event_create_source(e);
-    if (!_ctx.event_source)
+    _ctx.mainloop_source = event_create_source(e);
+    if (!_ctx.mainloop_source)
         goto fail;
-
-    g_source_attach(&_ctx.event_source->gsource, NULL);
 
     sd_event_add_defer(e, &_ctx.ping, _event_mainloop_running, &_ctx);
 
@@ -185,11 +205,14 @@ connect_bus(void)
 {
     int r;
     sd_bus *bus = NULL;
+    struct source_ctx *s;
 
     r = sd_bus_default_system(&bus);
     SOL_INT_CHECK(r, < 0, r);
 
-    r = sd_bus_attach_event(bus, _ctx.event_source->event,
+    s = sol_mainloop_source_get_data(_ctx.mainloop_source);
+
+    r = sd_bus_attach_event(bus, s->event,
         SD_EVENT_PRIORITY_NORMAL);
     SOL_INT_CHECK_GOTO(r, < 0, fail);
 
@@ -210,7 +233,7 @@ fail:
     return r;
 }
 
-/* We attach libsystemd's mainloop to glib on the first time we need to
+/* We attach libsystemd's mainloop to Soletta's on the first time we need to
  * connect to the bus. Any fail on getting connected to the bus means the
  * mainloop terminates.
  */
@@ -222,7 +245,7 @@ sol_bus_get(void (*bus_initialized)(sd_bus *bus))
     if (_ctx.bus)
         return _ctx.bus;
 
-    if (!_ctx.event_source) {
+    if (!_ctx.mainloop_source) {
         r = event_attach_mainloop();
         SOL_INT_CHECK_GOTO(r, < 0, fail);
     }
@@ -266,12 +289,14 @@ sol_bus_close(void)
         _ctx.bus = NULL;
     }
 
-    if (_ctx.event_source) {
+    if (_ctx.mainloop_source) {
+        struct source_ctx *s;
         sd_event_source_unref(_ctx.ping);
-        sd_event_unref(_ctx.event_source->event);
-        g_source_destroy(&_ctx.event_source->gsource);
-        g_source_unref(&_ctx.event_source->gsource);
-        _ctx.event_source = NULL;
+
+        s = sol_mainloop_source_get_data(_ctx.mainloop_source);
+        sd_event_unref(s->event);
+        sol_mainloop_source_del(_ctx.mainloop_source);
+        _ctx.mainloop_source = NULL;
     }
 }
 

--- a/src/lib/common/sol-mainloop-common.c
+++ b/src/lib/common/sol-mainloop-common.c
@@ -38,6 +38,17 @@
 #include "sol-mainloop-impl.h"
 #include "sol-mainloop-common.h"
 
+struct sol_mainloop_source_common {
+    const struct sol_mainloop_source_type *type;
+    const void *data;
+    bool ready;
+    bool remove_me;
+};
+
+static bool source_processing;
+static unsigned source_pending_deletion;
+static struct sol_ptr_vector source_vector = SOL_PTR_VECTOR_INIT;
+
 static bool run_loop;
 
 static bool timeout_processing;
@@ -58,9 +69,12 @@ timeout_compare(const void *data1, const void *data2)
 
 #ifdef PTHREAD
 
+static struct sol_ptr_vector source_v_process = SOL_PTR_VECTOR_INIT;
 static struct sol_ptr_vector timeout_v_process = SOL_PTR_VECTOR_INIT;
 static struct sol_ptr_vector idler_v_process = SOL_PTR_VECTOR_INIT;
 
+#define SOURCE_PROCESS source_v_process
+#define SOURCE_ACUM source_vector
 #define TIMEOUT_PROCESS timeout_v_process
 #define TIMEOUT_ACUM timeout_vector
 #define IDLER_PROCESS idler_v_process
@@ -79,6 +93,8 @@ timeout_vector_update(struct sol_ptr_vector *to, struct sol_ptr_vector *from)
 
 #else  /* !PTHREAD */
 
+#define SOURCE_PROCESS source_vector
+#define SOURCE_ACUM source_vector
 #define TIMEOUT_PROCESS timeout_vector
 #define TIMEOUT_ACUM timeout_vector
 #define IDLER_PROCESS idler_vector
@@ -267,7 +283,7 @@ sol_mainloop_common_idler_process(void)
 }
 
 /* must be called with mainloop lock HELD */
-struct sol_timeout_common *
+static struct sol_timeout_common *
 sol_mainloop_common_timeout_first(void)
 {
     struct sol_timeout_common *timeout;
@@ -279,6 +295,32 @@ sol_mainloop_common_timeout_first(void)
         return timeout;
     }
     return NULL;
+}
+
+static bool sol_mainloop_common_source_get_next_timeout_locked(struct timespec *timeout);
+
+/* must be called with mainloop lock HELD */
+bool
+sol_mainloop_common_timespec_first(struct timespec *ts)
+{
+    struct sol_timeout_common *timeout = sol_mainloop_common_timeout_first();
+    bool r = sol_mainloop_common_source_get_next_timeout_locked(ts);
+
+    if (timeout) {
+        struct timespec now = sol_util_timespec_get_current();
+        struct timespec diff;
+        sol_util_timespec_sub(&timeout->expire, &now, &diff);
+        if (!r || sol_util_timespec_compare(&diff, ts) < 0) {
+            if (diff.tv_sec < 0) {
+                diff.tv_sec = 0;
+                diff.tv_nsec = 0;
+            }
+            *ts = diff;
+            r = true;
+        }
+    }
+
+    return r;
 }
 
 /* must be called with mainloop lock HELD */
@@ -295,6 +337,200 @@ sol_mainloop_common_idler_first(void)
     }
     return NULL;
 }
+
+/* must be called with mainloop lock HELD */
+static inline void
+source_cleanup(void)
+{
+    struct sol_mainloop_source_common *source;
+    uint16_t i;
+
+    if (!source_pending_deletion)
+        return;
+
+    // Walk backwards so deletion doesn't impact the indices.
+    SOL_PTR_VECTOR_FOREACH_REVERSE_IDX (&source_vector, source, i) {
+        if (!source->remove_me)
+            continue;
+
+        sol_ptr_vector_del(&source_vector, i);
+        sol_mainloop_impl_unlock();
+
+        if (source->type->dispose)
+            source->type->dispose((void *)source->data);
+        free(source);
+
+        sol_mainloop_impl_lock();
+        source_pending_deletion--;
+        if (!source_pending_deletion)
+            break;
+    }
+}
+
+bool
+sol_mainloop_common_source_prepare(void)
+{
+    struct sol_mainloop_source_common *source;
+    uint16_t i;
+    bool ready = false;
+
+    sol_mainloop_impl_lock();
+    sol_ptr_vector_steal(&SOURCE_PROCESS, &SOURCE_ACUM);
+    source_processing = true;
+    sol_mainloop_impl_unlock();
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&SOURCE_PROCESS, source, i) {
+        if (!sol_mainloop_common_loop_check())
+            break;
+        if (source->remove_me)
+            continue;
+        if (source->type->prepare) {
+            source->ready = source->type->prepare((void *)source->data);
+            ready |= source->ready;
+        } else
+            source->ready = false;
+    }
+
+    sol_mainloop_impl_lock();
+    sol_ptr_vector_update(&SOURCE_ACUM, &SOURCE_PROCESS);
+    source_cleanup();
+    source_processing = false;
+    sol_mainloop_impl_unlock();
+
+    return ready;
+}
+
+/* must be called with mainloop lock HELD */
+static bool
+sol_mainloop_common_source_get_next_timeout_locked(struct timespec *timeout)
+{
+    bool found = false;
+    struct sol_mainloop_source_common *source;
+    uint16_t i;
+
+    sol_ptr_vector_steal(&SOURCE_PROCESS, &SOURCE_ACUM);
+    source_processing = true;
+    sol_mainloop_impl_unlock();
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&SOURCE_PROCESS, source, i) {
+        struct timespec cur;
+        bool r;
+
+        if (source->remove_me)
+            continue;
+
+        if (!source->type->get_next_timeout)
+            continue;
+
+        r = source->type->get_next_timeout((void *)source->data, &cur);
+        if (r) {
+            if (!found || sol_util_timespec_compare(&cur, timeout) < 0) {
+                if (cur.tv_sec < 0) {
+                    cur.tv_sec = 0;
+                    cur.tv_nsec = 0;
+                }
+                *timeout = cur;
+            }
+            found = true;
+        }
+    }
+
+    sol_mainloop_impl_lock();
+    sol_ptr_vector_update(&SOURCE_ACUM, &SOURCE_PROCESS);
+    source_cleanup();
+    source_processing = false;
+
+    return found;
+}
+
+bool
+sol_mainloop_common_source_get_next_timeout(struct timespec *timeout)
+{
+    bool r;
+
+    sol_mainloop_impl_lock();
+    r = sol_mainloop_common_source_get_next_timeout_locked(timeout);
+    sol_mainloop_impl_unlock();
+
+    return r;
+}
+
+bool
+sol_mainloop_common_source_check(void)
+{
+    struct sol_mainloop_source_common *source;
+    uint16_t i;
+    bool ready = false;
+
+    sol_mainloop_impl_lock();
+    sol_ptr_vector_steal(&SOURCE_PROCESS, &SOURCE_ACUM);
+    source_processing = true;
+    sol_mainloop_impl_unlock();
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&SOURCE_PROCESS, source, i) {
+        if (!sol_mainloop_common_loop_check())
+            break;
+        if (source->remove_me)
+            continue;
+        source->ready |= source->type->check((void *)source->data);
+        ready |= source->ready;
+    }
+
+    sol_mainloop_impl_lock();
+    sol_ptr_vector_update(&SOURCE_ACUM, &SOURCE_PROCESS);
+    source_cleanup();
+    source_processing = false;
+    sol_mainloop_impl_unlock();
+
+    return ready;
+}
+
+void
+sol_mainloop_common_source_dispatch(void)
+{
+    struct sol_mainloop_source_common *source;
+    uint16_t i;
+
+    sol_mainloop_impl_lock();
+    sol_ptr_vector_steal(&SOURCE_PROCESS, &SOURCE_ACUM);
+    source_processing = true;
+    sol_mainloop_impl_unlock();
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&SOURCE_PROCESS, source, i) {
+        if (!sol_mainloop_common_loop_check())
+            break;
+        if (source->remove_me)
+            continue;
+        if (source->ready) {
+            source->type->dispatch((void *)source->data);
+            source->ready = false;
+        }
+    }
+
+    sol_mainloop_impl_lock();
+    sol_ptr_vector_update(&SOURCE_ACUM, &SOURCE_PROCESS);
+    source_cleanup();
+    source_processing = false;
+    sol_mainloop_impl_unlock();
+}
+
+// to be called after threads are finished.
+void
+sol_mainloop_common_source_shutdown(void)
+{
+    struct sol_mainloop_source_common *source;
+    uint16_t i;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&source_vector, source, i) {
+        source->remove_me = true;
+        if (source->type->dispose)
+            source->type->dispose((void *)source->data);
+        free(source);
+    }
+
+    sol_ptr_vector_clear(&source_vector);
+}
+
 
 #ifndef SOL_PLATFORM_CONTIKI
 void
@@ -356,6 +592,8 @@ sol_mainloop_impl_timeout_del(void *handle)
 {
     struct sol_timeout_common *timeout = handle;
 
+    SOL_EXP_CHECK(timeout->remove_me == true, false);
+
     sol_mainloop_impl_lock();
 
     timeout->remove_me = true;
@@ -401,6 +639,8 @@ sol_mainloop_impl_idle_del(void *handle)
 {
     struct sol_idler_common *idler = handle;
 
+    SOL_INT_CHECK(idler->status, == idler_deleted, false);
+
     sol_mainloop_impl_lock();
 
     idler->status = idler_deleted;
@@ -411,4 +651,58 @@ sol_mainloop_impl_idle_del(void *handle)
     sol_mainloop_impl_unlock();
 
     return true;
+}
+
+void *
+sol_mainloop_impl_source_new(const struct sol_mainloop_source_type *type, const void *data)
+{
+    int ret;
+    struct sol_mainloop_source_common *source = malloc(sizeof(struct sol_mainloop_source_common));
+
+    SOL_NULL_CHECK(source, NULL);
+
+    sol_mainloop_impl_lock();
+
+    source->type = type;
+    source->data = data;
+    source->remove_me = false;
+    source->ready = false;
+
+    ret = sol_ptr_vector_append(&source_vector, source);
+    SOL_INT_CHECK_GOTO(ret, != 0, clean);
+
+    sol_mainloop_common_main_thread_check_notify();
+    sol_mainloop_impl_unlock();
+
+    return source;
+
+clean:
+    sol_mainloop_impl_unlock();
+    free(source);
+    return NULL;
+}
+
+void
+sol_mainloop_impl_source_del(void *handle)
+{
+    struct sol_mainloop_source_common *source = handle;
+
+    SOL_EXP_CHECK(source->remove_me == true);
+
+    sol_mainloop_impl_lock();
+
+    source->remove_me = true;
+    source_pending_deletion++;
+    if (!source_processing)
+        source_cleanup();
+
+    sol_mainloop_impl_unlock();
+}
+
+void *
+sol_mainloop_impl_source_get_data(const void *handle)
+{
+    const struct sol_mainloop_source_common *source = handle;
+
+    return (void *)source->data;
 }

--- a/src/lib/common/sol-mainloop-common.h
+++ b/src/lib/common/sol-mainloop-common.h
@@ -79,8 +79,14 @@ bool sol_mainloop_common_loop_check(void);
 void sol_mainloop_common_loop_set(bool val);
 void sol_mainloop_common_timeout_process(void);
 void sol_mainloop_common_idler_process(void);
-struct sol_timeout_common *sol_mainloop_common_timeout_first(void);
+bool sol_mainloop_common_timespec_first(struct timespec *ts);
 struct sol_idler_common *sol_mainloop_common_idler_first(void);
+
+bool sol_mainloop_common_source_prepare(void);
+bool sol_mainloop_common_source_get_next_timeout(struct timespec *timeout);
+bool sol_mainloop_common_source_check(void);
+void sol_mainloop_common_source_dispatch(void);
+void sol_mainloop_common_source_shutdown(void);
 
 /* thread-related platform specific functions */
 bool sol_mainloop_impl_main_thread_check(void);

--- a/src/lib/common/sol-mainloop-impl-contiki.c
+++ b/src/lib/common/sol-mainloop-impl-contiki.c
@@ -93,6 +93,8 @@ sol_mainloop_impl_platform_shutdown(void)
     void *ptr;
     uint16_t i;
 
+    sol_mainloop_common_source_shutdown();
+
     SOL_PTR_VECTOR_FOREACH_IDX (&event_handler_vector, ptr, i) {
         free(ptr);
     }
@@ -102,21 +104,16 @@ sol_mainloop_impl_platform_shutdown(void)
 static inline clock_time_t
 ticks_until_next_timeout(void)
 {
-    struct sol_timeout_common *timeout;
-    struct timespec now, diff;
+    struct timespec ts;
 
-    timeout = sol_mainloop_common_timeout_first();
-    if (!timeout)
-        return DEFAULT_USLEEP_TIME_TICKS;
-
-    now = sol_util_timespec_get_current();
-    sol_util_timespec_sub(&timeout->expire, &now, &diff);
-
-    if (diff.tv_sec < 0)
+    if (!sol_mainloop_common_timespec_first(&ts))
         return 0;
 
-    return diff.tv_sec * CLOCK_SECOND +
-           (CLOCK_SECOND / NSEC_PER_SEC) * diff.tv_nsec;
+    if (ts.tv_sec < 0)
+        return 0;
+
+    return ts.tv_sec * CLOCK_SECOND +
+           (CLOCK_SECOND / NSEC_PER_SEC) * ts.tv_nsec;
 }
 
 void

--- a/src/lib/common/sol-mainloop-impl-riot.c
+++ b/src/lib/common/sol-mainloop-impl-riot.c
@@ -83,28 +83,23 @@ sol_mainloop_impl_platform_init(void)
 void
 sol_mainloop_impl_platform_shutdown(void)
 {
+    sol_mainloop_common_source_shutdown();
 }
 
 static inline void
 timex_set_until_next_timeout(timex_t *timex)
 {
-    struct sol_timeout_common *timeout;
-    struct timespec now;
-    struct timespec diff;
+    struct timespec ts;
 
-    timeout = sol_mainloop_common_timeout_first();
-    if (!timeout) {
+    if (!sol_mainloop_common_timespec_first(&ts)) {
         *timex = timex_set(0, DEFAULT_USLEEP_TIME);
         return;
     }
 
-    now = sol_util_timespec_get_current();
-    sol_util_timespec_sub(&timeout->expire, &now, &diff);
-
-    if (diff.tv_sec < 0)
+    if (ts.tv_sec < 0)
         *timex = timex_set(0, 0);
     else
-        *timex = timex_set(diff.tv_sec, diff.tv_nsec / NSEC_PER_USEC);
+        *timex = timex_set(ts.tv_sec, ts.tv_nsec / NSEC_PER_USEC);
 }
 
 void

--- a/src/lib/common/sol-mainloop-impl.h
+++ b/src/lib/common/sol-mainloop-impl.h
@@ -60,3 +60,7 @@ bool sol_mainloop_impl_fd_del(void *handle);
 void *sol_mainloop_impl_child_watch_add(uint64_t pid, void (*cb)(void *data, uint64_t pid, int status), const void *data);
 bool sol_mainloop_impl_child_watch_del(void *handle);
 #endif
+
+void *sol_mainloop_impl_source_new(const struct sol_mainloop_source_type *type, const void *data);
+void sol_mainloop_impl_source_del(void *handle);
+void *sol_mainloop_impl_source_get_data(const void *handle);

--- a/src/lib/common/sol-mainloop.c
+++ b/src/lib/common/sol-mainloop.c
@@ -283,6 +283,39 @@ sol_child_watch_del(struct sol_child_watch *handle)
 }
 #endif
 
+SOL_API struct sol_mainloop_source *
+sol_mainloop_source_new(const struct sol_mainloop_source_type *type, const void *data)
+{
+    SOL_NULL_CHECK(type, NULL);
+
+    if (type->api_version != SOL_MAINLOOP_SOURCE_TYPE_API_VERSION) {
+        SOL_WRN("type(%p)->api_version(%hu) != "
+            "SOL_MAINLOOP_SOURCE_TYPE_API_VERSION(%hu)",
+            type, type->api_version,
+            SOL_MAINLOOP_SOURCE_TYPE_API_VERSION);
+        return NULL;
+    }
+
+    SOL_NULL_CHECK(type->check, NULL);
+    SOL_NULL_CHECK(type->dispatch, NULL);
+
+    return sol_mainloop_impl_source_new(type, data);
+}
+
+SOL_API void
+sol_mainloop_source_del(struct sol_mainloop_source *handle)
+{
+    SOL_NULL_CHECK(handle);
+    sol_mainloop_impl_source_del(handle);
+}
+
+SOL_API void *
+sol_mainloop_source_get_data(const struct sol_mainloop_source *handle)
+{
+    SOL_NULL_CHECK(handle, NULL);
+    return sol_mainloop_impl_source_get_data(handle);
+}
+
 SOL_API int
 sol_argc(void)
 {

--- a/src/lib/flow/Makefile
+++ b/src/lib/flow/Makefile
@@ -24,9 +24,7 @@ endif
 obj-flow-$(RESOLVER_CONFFILE) += \
     sol-flow-resolver-conffile.o
 
-obj-flow-$(RESOLVER_CONFFILE)-extra-cflags := $(GLIB_CFLAGS)
 obj-flow-$(FLOW)-extra-cflags += $(def-resolver-flag)
-obj-flow-$(RESOLVER_CONFFILE)-extra-ldflags += $(GLIB_LDFLAGS)
 
 headers-$(FLOW) := \
     include/sol-flow-builder.h \

--- a/src/lib/flow/sol-flow-resolver-conffile.c
+++ b/src/lib/flow/sol-flow-resolver-conffile.c
@@ -32,7 +32,7 @@
 
 #include <assert.h>
 #include <dlfcn.h>
-#include <glib.h>
+#include <limits.h>
 
 #include "sol-conffile.h"
 #include "sol-flow-internal.h"

--- a/src/modules/flow/gtk/Kconfig
+++ b/src/modules/flow/gtk/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_GTK
 	tristate "Node type: gtk"
-	depends on HAVE_GTK && HAVE_GLIB && MAINLOOP_GLIB
+	depends on HAVE_GTK && HAVE_GLIB
 	default m

--- a/src/modules/flow/gtk/gtk.c
+++ b/src/modules/flow/gtk/gtk.c
@@ -39,6 +39,7 @@
 
 SOL_LOG_INTERNAL_DECLARE(_gtk_log_domain, "flow-gtk");
 
+#include "sol-glib-integration.h"
 #include "sol-mainloop.h"
 #include "sol-util.h"
 #include "sol-vector.h"
@@ -67,6 +68,9 @@ static void
 init(void)
 {
     SOL_LOG_INTERNAL_INIT_ONCE;
+
+    if (!sol_glib_integration())
+        return;
 
     gtk_state = &_gtk_state;
     gtk_state->window = window_new();

--- a/src/shared/Makefile
+++ b/src/shared/Makefile
@@ -15,7 +15,5 @@ obj-libshared-$(PLATFORM_LINUX) += \
     sol-file-reader.o \
     sol-util-linux.o \
     sol-iio.o
-obj-libshared-$(PLATFORM_LINUX)-extra-cflags += $(GLIB_CFLAGS)
-obj-libshared-$(PLATFORM_LINUX)-extra-ldflags += $(GLIB_LDFLAGS)
 
 obj-libshared-y-extra-cflags += -fvisibility=default

--- a/src/test/.gitignore
+++ b/src/test/.gitignore
@@ -27,3 +27,4 @@
 /test-vector
 /test-mainloop-threads
 /test-mainloop-threads-sol-run
+/test-mainloop-glib-integration

--- a/src/test/Kconfig
+++ b/src/test/Kconfig
@@ -60,6 +60,11 @@ config TEST_MAINLOOP_THREADS_SOL_RUN
 	depends on PTHREAD && MAINLOOP_POSIX
 	default y
 
+config TEST_MAINLOOP_GLIB_INTEGRATION
+	bool "mainloop glib integration"
+	depends on LINUX && HAVE_GLIB
+	default y
+
 config TEST_MONITORS
 	bool "monitors"
 	default y

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -37,6 +37,11 @@ test-$(TEST_MAINLOOP_THREADS_SOL_RUN) += test-mainloop-threads-sol-run
 test-test-mainloop-threads-sol-run-$(TEST_MAINLOOP_THREADS_SOL_RUN) := test-mainloop-threads-sol-run.c
 test-test-mainloop-threads-sol-run-$(TEST_MAINLOOP_THREADS_SOL_RUN)-extra-ldflags += $(PTHREAD_H_LDFLAGS)
 
+test-$(TEST_MAINLOOP_GLIB_INTEGRATION) += test-mainloop-glib-integration
+test-test-mainloop-glib-integration-$(TEST_MAINLOOP_GLIB_INTEGRATION) := test-mainloop-glib-integration.c
+test-test-mainloop-glib-integration-$(TEST_MAINLOOP_GLIB_INTEGRATION)-extra-cflags += $(GLIB_CFLAGS)
+test-test-mainloop-glib-integration-$(TEST_MAINLOOP_GLIB_INTEGRATION)-extra-ldflags += $(GLIB_LDFLAGS)
+
 test-$(TEST_MONITORS) += test-monitors
 test-test-monitors-$(TEST_MONITORS) := test.c test-monitors.c
 

--- a/src/test/test-mainloop-glib-integration.c
+++ b/src/test/test-mainloop-glib-integration.c
@@ -1,0 +1,175 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <glib-unix.h>
+
+#include "sol-glib-integration.h"
+#include "sol-platform-linux.h"
+
+#include "test.h"
+
+static bool did_idle = false;
+static bool did_timeout = false;
+static bool did_fd = false;
+static int pfd[2];
+static struct sol_platform_linux_fork_run *fork_run;
+
+static void
+check_done(void)
+{
+    if (did_idle && did_timeout && did_fd)
+        sol_quit();
+}
+
+static gboolean
+on_idle(gpointer data)
+{
+    did_idle = true;
+    SOL_DBG("did idle");
+    check_done();
+    return false;
+}
+
+static gboolean
+on_timeout(gpointer data)
+{
+    did_timeout = true;
+    SOL_DBG("did timeout");
+    check_done();
+    return false;
+}
+
+static gboolean
+on_fd(gint fd, GIOCondition cond, gpointer data)
+{
+    did_fd = true;
+    SOL_DBG("did fd=%d, cond=%#x", fd, cond);
+    check_done();
+    return false;
+}
+
+static bool
+on_watchdog(void *data)
+{
+    SOL_WRN("watchdog expired - mainloop integration failed");
+    sol_quit_with_code(EXIT_FAILURE);
+    return false;
+}
+
+static void
+on_fork(void *data)
+{
+    char c = 0xff;
+
+    while (write(pfd[1], &c, 1) < 0)
+        ;
+}
+
+static void
+on_child_exit(void *data, uint64_t pid, int status)
+{
+    fork_run = NULL;
+}
+
+static void
+startup(void)
+{
+    guint id;
+
+    if (pipe2(pfd, O_CLOEXEC) < 0) {
+        SOL_WRN("pipe()");
+        goto error;
+    }
+
+    if (!sol_glib_integration()) {
+        SOL_WRN("sol_glib_integration()");
+        goto error;
+    }
+
+    fork_run = sol_platform_linux_fork_run(on_fork, on_child_exit, NULL);
+    if (!fork_run) {
+        SOL_WRN("sol_platform_linux_fork_run()");
+        goto error;
+    }
+
+    id = g_idle_add(on_idle, NULL);
+    if (id == 0) {
+        SOL_WRN("g_idle_add()");
+        goto error;
+    }
+
+    id = g_timeout_add(100, on_timeout, NULL);
+    if (id == 0) {
+        SOL_WRN("g_timeout_add()");
+        goto error;
+    }
+
+    id = g_unix_fd_add(pfd[0], G_IO_IN, on_fd, NULL);
+    if (id == 0) {
+        SOL_WRN("g_unix_fd_add()");
+        goto error;
+    }
+
+    sol_timeout_add(5000, on_watchdog, NULL);
+    return;
+
+error:
+    sol_quit_with_code(EXIT_FAILURE);
+    return;
+}
+
+static void
+shutdown(void)
+{
+    if (!did_idle)
+        SOL_WRN("failed to do idle");
+    if (!did_timeout)
+        SOL_WRN("failed to do timeout");
+    if (!did_fd)
+        SOL_WRN("failed to do fd");
+
+    if (fork_run)
+        sol_platform_linux_fork_run_stop(fork_run);
+
+    if (pfd[0] > 0) {
+        close(pfd[0]);
+        close(pfd[1]);
+    }
+
+    if (!did_idle || !did_timeout || !did_fd)
+        exit(EXIT_FAILURE);
+}
+
+SOL_MAIN_DEFAULT(startup, shutdown);


### PR DESCRIPTION
This patchset will allow glib usage to be reduced even further.

Changes since v2 (#477):
 * `sol-mainloop.h` now documents `struct sol_mainloop_source_type` members in separated lines, similar to `sol-worker-thread.h` as requested by @ulissesf 
 * `sol-mainloop-impl-posix.c:fd_process()`:
   * `sources_ready` implies in non-block `ppoll()`, thus set `use_ts=true` with a zero-timeout
   * call `sol_mainloop_common_source_prepare()` before `fd_prepare()`, this allows source's prepare to create `struct sol_fd` to listen to its internal file descriptors before soletta prepares its own `pollfds` array.
   * only call `sol_mainloop_common_source_check()` once at the end, do not interleave it with own callback dispatches;
   * call `sol_mainloop_common_source_dispatch()` if `sol_mainloop_common_source_check() || sources_ready`. 
 * added `sol_mainloop_common_source_shutdown()` and changed the code to call it after threads are finished and before fd/idler/timeouts are destroyed, this allows sources to delete their own `struct sol_fd` at their type's `dispose()`
 * added `sol-glib-integration.h` and `sol_glib_integration()`, with test;
 * gtk now uses `sol_glib_integration()` and can be used with posix mainloop!

Changes since v1 (#462):
 * rebased to master, changes mostly due @ibriano's Kconfig/Makefile cleanups.
 * release the lock before calling users's `get_next_timeout()`, done in the same fashion as other loops, we steal the vector and replaces it with a temporary vector with the lock held, then loop in the stolen vector without locks, then take the lock and update the vector. The issue was pointed out by @ulissesf 
 * remove sol-bus dependency on Glib (Makefile)
 * remove sol-bus.c comment mentioning glib integration.