### PR TITLE
modules/flower-power: make packet API more flexible

### DIFF
--- a/src/modules/flow/flower-power/include/sol-flower-power.h
+++ b/src/modules/flow/flower-power/include/sol-flower-power.h
@@ -56,7 +56,7 @@ struct sol_flow_packet *sol_flower_power_new_packet(const struct sol_flower_powe
 struct sol_flow_packet *sol_flower_power_new_packet_components(const char *id, const char *timestamp, struct sol_drange *fertilizer, struct sol_drange *light, struct sol_drange *temperature, struct sol_drange *water);
 
 int sol_flower_power_get_packet(const struct sol_flow_packet *packet, struct sol_flower_power_data *fpd);
-int sol_flower_power_get_packet_components(const struct sol_flow_packet *packet, char **id, char **timestamp, struct sol_drange *fertilizer, struct sol_drange *light, struct sol_drange *temperature, struct sol_drange *water);
+int sol_flower_power_get_packet_components(const struct sol_flow_packet *packet, const char **id, const char **timestamp, struct sol_drange *fertilizer, struct sol_drange *light, struct sol_drange *temperature, struct sol_drange *water);
 
 int sol_flower_power_send_packet(struct sol_flow_node *src, uint16_t src_port, const struct sol_flower_power_data *fpd);
 int sol_flower_power_send_packet_components(struct sol_flow_node *src, uint16_t src_port, char *id, char *timestamp, struct sol_drange *fertilizer, struct sol_drange *light, struct sol_drange *temperature, struct sol_drange *water);


### PR DESCRIPTION
When creating a new packet passing components, some components
can be passed as NULL and default measures will be used in this case.

Remove redundant checks on function that create a new packet
given a flower power data struct.

@otaviobp : I've talked to ceolin about the possible
issue with packet getter, but it seems to be behaving
just like all the other packet types.

If memory was alloced for strings, they would need to be
freed by getter() users... It wouldn't be nice.

Also, for our cases, these pointers are used in the same
scope where packet is got. If later usage is required,
user is responsible for duplicating it.

Same is done for error packet (it gives a pointer for
an error msg that stop existing when packet dies).

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>