### PR TITLE
Build Contiki without config V2

### DIFF
--- a/src/lib/common/sol-missing.h
+++ b/src/lib/common/sol-missing.h
@@ -120,6 +120,10 @@ memmem(const void *haystack, size_t haystacklen, const void *needle, size_t need
 #define I2C_RDRW_IOCTL_MAX_MSGS 42
 #endif
 
+#ifndef SSIZE_MAX
+#define SSIZE_MAX LONG_MAX
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/flow/Kconfig
+++ b/src/lib/flow/Kconfig
@@ -9,7 +9,7 @@ config JAVASCRIPT
 
 config NODE_DESCRIPTION
 	bool "Node description support"
-	depends on FLOW
+	depends on FLOW && FEATURE_RUNNABLE_PROGRAMS
 	default y
 	help
             Add node description support to enable runtime introspection.
@@ -23,7 +23,7 @@ config RESOLVER_CONFFILE
 
 config INSPECTOR
 	bool "Inspector"
-	depends on FLOW
+	depends on FLOW && FEATURE_RUNNABLE_PROGRAMS
 	default y
 
 menu "Node Types"

--- a/src/lib/flow/Kconfig
+++ b/src/lib/flow/Kconfig
@@ -4,7 +4,7 @@ config FLOW
 
 config JAVASCRIPT
 	bool "Javascript support"
-	depends on FLOW
+	depends on FLOW && PLATFORM_LINUX
 	default y
 
 config NODE_DESCRIPTION

--- a/src/modules/flow/converter/string-format.c
+++ b/src/modules/flow/converter/string-format.c
@@ -46,6 +46,8 @@
 #include <math.h>
 #include <stdio.h>
 
+#include "sol-missing.h"
+
 #include "string-format.h"
 
 #define SF_MIN(x, y) (((x) > (y)) ? (y) : (x))

--- a/src/modules/flow/converter/string-format.c
+++ b/src/modules/flow/converter/string-format.c
@@ -48,8 +48,8 @@
 
 #include "string-format.h"
 
-#define MIN(x, y) (((x) > (y)) ? (y) : (x))
-#define MAX(x, y) (((x) > (y)) ? (x) : (y))
+#define SF_MIN(x, y) (((x) > (y)) ? (y) : (x))
+#define SF_MAX(x, y) (((x) > (y)) ? (x) : (y))
 
 struct format_spec_data {
     ssize_t width;
@@ -632,9 +632,9 @@ insert_thousands_grouping(
     }
 
     while ((l = group_generator_next(&groupgen)) > 0) {
-        l = MIN(l, MAX(MAX(remaining, min_width), 1));
-        n_zeros = MAX(0, l - remaining);
-        n_chars = MAX(0, MIN(remaining, l));
+        l = SF_MIN(l, SF_MAX(SF_MAX(remaining, min_width), 1));
+        n_zeros = SF_MAX(0, l - remaining);
+        n_chars = SF_MAX(0, SF_MIN(remaining, l));
 
         /* Use n_zero zero's and n_chars chars */
         /* Count only, don't do anything. */
@@ -661,9 +661,9 @@ insert_thousands_grouping(
     if (!loop_broken) {
         /* We left the loop without using a break statement. */
 
-        l = MAX(MAX(remaining, min_width), 1);
-        n_zeros = MAX(0, l - remaining);
-        n_chars = MAX(0, MIN(remaining, l));
+        l = SF_MAX(SF_MAX(remaining, min_width), 1);
+        n_zeros = SF_MAX(0, l - remaining);
+        n_chars = SF_MAX(0, SF_MIN(remaining, l));
 
         /* Use n_zero zero's and n_chars chars */
         count += (use_separator ? thousands_sep_len : 0) + n_zeros + n_chars;

--- a/src/modules/flow/keyboard/Kconfig
+++ b/src/modules/flow/keyboard/Kconfig
@@ -1,3 +1,4 @@
 config FLOW_NODE_TYPE_KEYBOARD
 	tristate "Node type: keyboard"
+	depends on PLATFORM_LINUX
 	default m

--- a/src/modules/flow/magnetometer/Kconfig
+++ b/src/modules/flow/magnetometer/Kconfig
@@ -1,3 +1,4 @@
 config FLOW_NODE_TYPE_MAGNETOMETER
 	tristate "Node type: magnetometer"
+	depends on USE_I2C
 	default m

--- a/src/modules/flow/max31855/Kconfig
+++ b/src/modules/flow/max31855/Kconfig
@@ -1,3 +1,4 @@
 config FLOW_NODE_TYPE_MAX31855
 	tristate "Node type: max31855"
+	depends on USE_SPI
 	default m

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -41,6 +41,7 @@
 
 #include "sol-util.h"
 #include "sol-log.h"
+#include "sol-missing.h"
 #include "sol-str-slice.h"
 
 #if defined(HAVE_NEWLOCALE) && defined(HAVE_STRTOD_L)

--- a/tools/build/Kconfig.contiki
+++ b/tools/build/Kconfig.contiki
@@ -1,3 +1,4 @@
 config CONTIKI
     def_bool y
     select FEATURE_HW_GPIO
+    select FEATURE_FLOW


### PR DESCRIPTION
Changes from V1:
* Removed 'Disable sanitizer on RIOT and Contiki'  we will solve this in another way
* Added 3 more patches, to enable build on a real device using newlib.
  * Only build flow Javascript support on Linux
  * Converter: Rename MIN and MAX macros
  * Contiki: Fix undeclared SSIZE_MAX