### PR TITLE
build: add warning message support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,11 @@ warning: $(KCONFIG_GEN)
 $(warning-targets)
 else
 all: $(PRE_GEN) $(SOL_LIB_SO) $(SOL_LIB_AR) $(bins-out) $(modules-out)
+default_target: all
 endif # HAVE_KCONFIG_CONFIG
 endif # NOT_FOUND
 
 $(KCONFIG_CONFIG): $(KCONFIG_GEN)
 
-.DEFAULT_GOAL = all
+.DEFAULT_GOAL = default_target
 .PHONY = $(PHONY) all

--- a/src/modules/flow/string/Makefile
+++ b/src/modules/flow/string/Makefile
@@ -1,10 +1,11 @@
 obj-$(FLOW_NODE_TYPE_STRING) += string.mod
 obj-string-$(FLOW_NODE_TYPE_STRING) := string.json
 
-ifdef HAVE_ICU
+ifeq (y,$(HAVE_ICU))
 obj-string-$(FLOW_NODE_TYPE_STRING) += string-icu.o
 else
 obj-string-$(FLOW_NODE_TYPE_STRING) += string-ascii.o
+warning-msg := "You're building the string nodes module without i18n support -- some nodes will only act properly on pure ASCII input, not the intended utf-8 for Soletta. Please re-configure after you have ICU development packages installed to get the intended string nodes behavior."
 endif
 
 obj-string-$(FLOW_NODE_TYPE_STRING)-extra-cflags += $(LOCALE_CFLAGS) $(ICU_CFLAGS)

--- a/src/modules/flow/string/string-ascii.c
+++ b/src/modules/flow/string/string-ascii.c
@@ -30,10 +30,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-//FIXME: change to build system warning, not compile time
-
-#warning "You're building the string nodes module without i18n support -- some nodes will only act properly on pure ASCII input, not the intended utf-8 for Soletta. Please re-configure after you have ICU development packages installed to get the intended string nodes behavior."
-
 #include <ctype.h>
 #include <errno.h>
 

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -140,14 +140,23 @@ parse-sample = \
 	$(eval $(1)-deps        := $(subst .mod,,$(sample-$(1)-y-deps))) \
 	$(eval samples-out      += $(sample-$(1)-out)) \
 
+parse-warnings = \
+	$(if $(2), \
+		$(eval all-warnings            += $(1)bs-warnings) \
+		$(eval $(1)bs-warnings-msg += $(2)) \
+	) \
+
 clean-control = $(eval headers-y:=) $(eval obj-y:=) $(eval obj-m:=) $(eval bin-y:=) \
-		$(eval test-y:=) $(eval test-internal-y:=) $(eval sample-y:=) $(eval headers-m:=)
+		$(eval test-y:=) $(eval test-internal-y:=) $(eval sample-y:=) $(eval headers-m:=) \
+		$(eval warning-msg:=) $(eval warning-msg-y:=) $(eval warning-msg-m:=)
 
 inc-subdirs = \
 	$(foreach subdir,$(SUBDIRS), $(clean-control) \
 		$(eval -include $(subdir)Makefile) \
+		$(eval warnings             := $(warning-msg) $(warning-msg-y) $(warning-msg-m)) \
 		$(call extra-headers,$(addprefix $(subdir),$(headers-y))) \
 		$(call extra-headers,$(addprefix $(subdir),$(headers-m))) \
+		$(call parse-warnings,$(subdir),$(warnings)) \
 		$(eval curr-builtins        := $(subst .mod,,$(filter %.mod,$(obj-y)))) \
 		$(eval builtins             += $(curr-builtins)) \
 		$(foreach buin,$(curr-builtins), \
@@ -192,6 +201,23 @@ $(eval $(call inc-subdirs))
 $(eval $(call extra-bins))
 
 PRE_GEN += $(all-gen-hdrs) $(all-dest-hdr) $(all-dest-bin)
+
+define make-warning
+$(1): all
+	$(Q)echo "     [!]   "$($(1)-msg)
+
+default_target: $(1)
+PHONY += $(1)
+endef
+$(foreach wrn,$(all-warnings),$(eval $(call make-warning,$(wrn))))
+
+define make-warning-header
+$(all-warnings): warning-header
+warning-header: all
+	$(Q)echo -e "\n*** ATTENTION:"
+PHONY += warning-header
+endef
+$(if $(all-warnings),$(eval $(call make-warning-header,$(wrn))))
 
 define make-extra-header
 $($(1)-dest): $(1)


### PR DESCRIPTION
This patch introduces a mechanism to inform the user about missing
features or possible misbehaving features based on target system's
configuration.

The first feature's user is the string flow module, this module
implements an ascii fallback case the target system doesn't provide ICU.

We support the following formats:
warning-msg := "an arbitrary message"
warning-msg-$(CONFIG_OPTION) := "another arbitrary message"

Where warning-msg-$(CONFIG_OPTION) may expand either to warning-msg-y or warning-msg-m.

See: https://github.com/solettaproject/soletta/issues/463

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>