### PR TITLE
Build bring back flto flags v3

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -382,6 +382,13 @@
             "ldflags": {
                 "value": "-lubsan"
             }
+	},
+	{
+	    "dependency": "flto",
+	    "type": "ccode",
+            "cflags": {
+                "value": "-flto -ffat-lto-objects"
+            }
 	}
     ]
 }

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -375,6 +375,13 @@
             "cflags": {
                 "value": "-fsanitize=address"
             }
+	},
+	{
+	    "dependency": "libubsan",
+	    "type": "ccode",
+            "ldflags": {
+                "value": "-lubsan"
+            }
 	}
     ]
 }

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -146,6 +146,8 @@ endif
 ifeq (y,$(CC_SANITIZE_ADDRESS))
 COMMON_CFLAGS += $(SANITIZE_ADDRESS_CFLAGS)
 endif
+
+COMMON_LDFLAGS += $(LIBUBSAN_LDFLAGS)
 endif
 
 ifeq (y,$(LOG))

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -150,6 +150,10 @@ endif
 COMMON_LDFLAGS += $(LIBUBSAN_LDFLAGS)
 endif
 
+ifneq (,$(shell echo $(COMMON_CFLAGS) | grep -e "-O[s12345\ ]"))
+COMMON_CFLAGS += $(FLTO_CFLAGS)
+endif
+
 ifeq (y,$(LOG))
 ifeq (y,$(MAXIMUM_LOG_LEVEL_CRITICAL))
 MAXIMUM_LOG_LEVEL := 0


### PR DESCRIPTION
## Changes
v2:
   + handle only -O[s12345\ ]

v3: 
   + added new patch: 	"build: [sanitizer] add -lubsan"

## Rationale
This patch re enables the -flto flags based on optimization level
provided flags.

Signed-off-by: Leandro Dorileo leandro.maciel.dorileo@intel.com