### PR TITLE
Fix issues in freeing memory after calling sol_flow_send_packet

### DIFF
--- a/data/scripts/sol-flow-node-type-stub-gen.py
+++ b/data/scripts/sol-flow-node-type-stub-gen.py
@@ -276,16 +276,11 @@ send_%(name)s_packet(struct sol_flow_node *src, uint16_t src_port
                      /* TODO: args to create a new packet */)
 {
     struct sol_flow_packet *packet;
-    int ret;
 
     packet = packet_new_%(name)s(/* TODO: args */);
     SOL_NULL_CHECK(packet, -ENOMEM);
 
-    ret = sol_flow_send_packet(src, src_port, packet);
-    if (ret != 0)
-        sol_flow_packet_del(packet);
-
-    return ret;
+    return sol_flow_send_packet(src, src_port, packet);
 }
 
 """ % {

--- a/src/lib/flow/sol-flow.c
+++ b/src/lib/flow/sol-flow.c
@@ -224,6 +224,7 @@ sol_flow_send_packet(struct sol_flow_node *src, uint16_t src_port, struct sol_fl
 {
     struct sol_flow_node *parent;
     struct sol_flow_node_container_type *parent_type;
+    int ret;
 
     SOL_FLOW_NODE_CHECK_GOTO(src, err);
     parent = src->parent;
@@ -239,7 +240,11 @@ sol_flow_send_packet(struct sol_flow_node *src, uint16_t src_port, struct sol_fl
      * reduce indirection. */
     SOL_FLOW_NODE_TYPE_IS_CONTAINER_CHECK_GOTO(parent, err);
     parent_type = (struct sol_flow_node_container_type *)parent->type;
-    return parent_type->send(parent, src, src_port, packet);
+
+    ret = parent_type->send(parent, src, src_port, packet);
+    if (ret != 0)
+        sol_flow_packet_del(packet);
+    return ret;
 
 err:
     sol_flow_packet_del(packet);

--- a/src/modules/flow/flower-power/flower-power.c
+++ b/src/modules/flow/flower-power/flower-power.c
@@ -198,16 +198,11 @@ sol_flower_power_send_packet(struct sol_flow_node *src,
     uint16_t src_port, const struct sol_flower_power_data *fpd)
 {
     struct sol_flow_packet *packet;
-    int ret;
 
     packet = sol_flower_power_new_packet(fpd);
     SOL_NULL_CHECK(packet, -ENOMEM);
 
-    ret = sol_flow_send_packet(src, src_port, packet);
-    if (ret != 0)
-        sol_flow_packet_del(packet);
-
-    return ret;
+    return sol_flow_send_packet(src, src_port, packet);
 }
 
 SOL_API int
@@ -217,17 +212,12 @@ sol_flower_power_send_packet_components(struct sol_flow_node *src,
     struct sol_drange *temperature, struct sol_drange *water)
 {
     struct sol_flow_packet *packet;
-    int ret;
 
     packet = sol_flower_power_new_packet_components(id, timestamp,
         fertilizer, light, temperature, water);
     SOL_NULL_CHECK(packet, -ENOMEM);
 
-    ret = sol_flow_send_packet(src, src_port, packet);
-    if (ret != 0)
-        sol_flow_packet_del(packet);
-
-    return ret;
+    return sol_flow_send_packet(src, src_port, packet);
 }
 
 struct http_get_data {


### PR DESCRIPTION
Documentation states that sol_flow_send_packet is responsable in releasing
packet memory. But in a few places method sol_flow_packet_del was called
if sol_flow_send_packet returns a non zero value.

And, as far as I could get, sol_flow_send_packet was not releasing memory if
parent->send method was failing.

I am not familiar with sol-flow code, but as far as I could trace, the only
implementation of parent->send method was located in sol-flow-static, and when
send was returning a non zero value, the packet memory was not being released.