### PR TITLE
Fix memory leaks on http-client v2

### DIFF
--- a/src/lib/datatypes/include/sol-vector.h
+++ b/src/lib/datatypes/include/sol-vector.h
@@ -153,6 +153,8 @@ int sol_ptr_vector_set(struct sol_ptr_vector *pv, uint16_t i, void *ptr);
 
 int sol_ptr_vector_insert_sorted(struct sol_ptr_vector *pv, void *ptr, int (*compare_cb)(const void *data1, const void *data2));
 
+int sol_ptr_vector_remove(struct sol_ptr_vector *pv, const void *ptr);
+
 static inline int
 sol_ptr_vector_del(struct sol_ptr_vector *pv, uint16_t i)
 {

--- a/src/lib/datatypes/sol-vector.c
+++ b/src/lib/datatypes/sol-vector.c
@@ -215,3 +215,18 @@ sol_ptr_vector_set(struct sol_ptr_vector *pv, uint16_t i, void *ptr)
     *data = ptr;
     return 0;
 }
+
+SOL_API int
+sol_ptr_vector_remove(struct sol_ptr_vector *pv, const void *ptr)
+{
+    uint16_t i;
+    void *p;
+
+    SOL_PTR_VECTOR_FOREACH_REVERSE_IDX (pv, p, i) {
+        if (ptr == p) {
+            sol_ptr_vector_del(pv, i);
+            return 0;
+        }
+    }
+    return -ENODATA;
+}


### PR DESCRIPTION
Changes from v1:
- Fixed review comments;

Original message:

This series also introduces sol_ptr_vector_remove() which removes a pointer from a sol_ptr_vector as this seems to be a common operation.

The strategy for fixing the memory leak is keeping references to the existing connections, and using the procedure recommended in the curl_multi_cleanup(3) man page for cleaning them up:

Cleans up and removes a whole multi stack. It does not free or touch any individual
easy handles in any way - they still need to be closed individually, using the usual
curl_easy_cleanup(3) way. The order of cleaning up should be:
1 - curl_multi_remove_handle(3) before any easy handles are cleaned up
2 - curl_easy_cleanup(3) can now be called independently since the easy handle is no
longer connected to the multi handle
3 - curl_multi_cleanup(3) should be called when all easy handles are removed