### PR TITLE
Buffer review

### DIFF
--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -79,9 +79,11 @@ extern "C" {
 struct sol_buffer {
     void *data;
     size_t reserved, used;
+    bool fixed_size;
 };
 
-#define SOL_BUFFER_EMPTY (struct sol_buffer){.data = NULL, .reserved = 0, .used = 0 }
+#define SOL_BUFFER_INIT_EMPTY (struct sol_buffer){.data = NULL, .reserved = 0, .used = 0, .fixed_size = false }
+#define SOL_BUFFER_INIT_FIXED(data_, size_) (struct sol_buffer){.data = data_, .reserved = size_, .used = 0, .fixed_size = true }
 
 static inline void
 sol_buffer_init(struct sol_buffer *buf)
@@ -90,6 +92,17 @@ sol_buffer_init(struct sol_buffer *buf)
     buf->data = NULL;
     buf->reserved = 0;
     buf->used = 0;
+    buf->fixed_size = false;
+}
+
+static inline void
+sol_buffer_init_fixed_size(struct sol_buffer *buf, void *data, size_t data_size)
+{
+    assert(buf);
+    buf->data = data;
+    buf->reserved = data_size;
+    buf->used = 0;
+    buf->fixed_size = true;
 }
 
 static inline void
@@ -98,6 +111,16 @@ sol_buffer_fini(struct sol_buffer *buf)
     if (!buf)
         return;
     free(buf->data);
+    buf->data = NULL;
+    buf->used = 0;
+    buf->reserved = 0;
+}
+
+static inline void
+sol_buffer_fini_nofree(struct sol_buffer *buf)
+{
+    if (!buf)
+        return;
     buf->data = NULL;
     buf->used = 0;
     buf->reserved = 0;

--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -137,6 +137,14 @@ int sol_buffer_ensure(struct sol_buffer *buf, size_t min_size);
  * an extra NUL byte so the buffer can be used as a cstr. */
 int sol_buffer_set_slice(struct sol_buffer *buf, const struct sol_str_slice slice);
 
+static inline struct sol_str_slice
+sol_buffer_get_slice(const struct sol_buffer *buf)
+{
+    if (!buf)
+        return SOL_STR_SLICE_STR(NULL, 0);
+    return SOL_STR_SLICE_STR(buf->data, buf->used);
+}
+
 /* Appends the 'slice' into 'buf', reallocating if necessary. */
 int sol_buffer_append_slice(struct sol_buffer *buf, const struct sol_str_slice slice);
 

--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -35,6 +35,7 @@
 #include <assert.h>
 
 #include <sol-str-slice.h>
+#include <stdarg.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -138,6 +139,21 @@ int sol_buffer_set_slice(struct sol_buffer *buf, const struct sol_str_slice slic
 
 /* Appends the 'slice' into 'buf', reallocating if necessary. */
 int sol_buffer_append_slice(struct sol_buffer *buf, const struct sol_str_slice slice);
+
+/* append the formatted string to buffer, including trailing \0 */
+int sol_buffer_append_vprintf(struct sol_buffer *buf, const char *fmt, va_list args);
+static inline int sol_buffer_append_printf(struct sol_buffer *buf, const char *fmt, ...) SOL_ATTR_PRINTF(2, 3);
+static inline int
+sol_buffer_append_printf(struct sol_buffer *buf, const char *fmt, ...)
+{
+    va_list args;
+    int r;
+
+    va_start(args, fmt);
+    r = sol_buffer_append_vprintf(buf, fmt, args);
+    va_end(args);
+    return r;
+}
 
 /**
  * @}

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -44,6 +44,7 @@ sol_buffer_resize(struct sol_buffer *buf, size_t new_size)
     char *new_data;
 
     SOL_NULL_CHECK(buf, -EINVAL);
+    SOL_EXP_CHECK(buf->fixed_size, -EPERM);
 
     if (buf->reserved == new_size)
         return 0;
@@ -60,13 +61,19 @@ sol_buffer_resize(struct sol_buffer *buf, size_t new_size)
 SOL_API int
 sol_buffer_ensure(struct sol_buffer *buf, size_t min_size)
 {
+    int err;
+
     SOL_NULL_CHECK(buf, -EINVAL);
 
     if (min_size >= SIZE_MAX - 1)
         return -EINVAL;
     if (buf->reserved >= min_size)
         return 0;
-    return sol_buffer_resize(buf, align_power2(min_size + 1));
+
+    err = sol_buffer_resize(buf, align_power2(min_size + 1));
+    if (err == -EPERM)
+        return -ENOMEM;
+    return err;
 }
 
 SOL_API int

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -33,6 +33,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 #include "sol-buffer.h"
 #include "sol-log.h"
@@ -109,4 +110,27 @@ sol_buffer_append_slice(struct sol_buffer *buf, const struct sol_str_slice slice
     sol_str_slice_copy((char *)buf->data + buf->used, slice);
     buf->used += slice.len;
     return 0;
+}
+
+SOL_API int
+sol_buffer_append_vprintf(struct sol_buffer *buf, const char *fmt, va_list args)
+{
+    SOL_NULL_CHECK(buf, -EINVAL);
+    SOL_NULL_CHECK(fmt, -EINVAL);
+
+    do {
+        size_t space = buf->reserved - buf->used;
+        char *p = (char *)buf->data + buf->used;
+        ssize_t done = vsnprintf(p, space, fmt, args);
+        if (done < 0)
+            return -errno;
+        else if ((size_t)done >= space) {
+            int r = sol_buffer_ensure(buf, buf->used + done + 1);
+            if (r < 0)
+                return r;
+        } else {
+            buf->used += done;
+            return 0;
+        }
+    } while (1);
 }

--- a/src/lib/flow/sol-flow-parser.c
+++ b/src/lib/flow/sol-flow-parser.c
@@ -279,7 +279,7 @@ append_node_options(
     const struct sol_flow_node_type *type,
     struct sol_flow_node_named_options *named_opts)
 {
-    struct sol_buffer key = SOL_BUFFER_EMPTY, value = SOL_BUFFER_EMPTY;
+    struct sol_buffer key = SOL_BUFFER_INIT_EMPTY, value = SOL_BUFFER_INIT_EMPTY;
     struct sol_flow_node_named_options result;
     struct sol_flow_node_named_options_member *m;
     struct sol_fbp_meta *meta;
@@ -604,8 +604,8 @@ build_flow(struct parse_state *state)
     struct sol_fbp_exported_port *ep;
     struct sol_fbp_option *opt;
     struct sol_flow_node_type *type = NULL;
-    struct sol_buffer src_port_buf = SOL_BUFFER_EMPTY, dst_port_buf = SOL_BUFFER_EMPTY;
-    struct sol_buffer opt_name_buf = SOL_BUFFER_EMPTY;
+    struct sol_buffer src_port_buf = SOL_BUFFER_INIT_EMPTY, dst_port_buf = SOL_BUFFER_INIT_EMPTY;
+    struct sol_buffer opt_name_buf = SOL_BUFFER_INIT_EMPTY;
     int i, err = 0;
 
     fbp_error = sol_fbp_parse(state->input, &state->graph);

--- a/src/lib/flow/sol-flow-static.c
+++ b/src/lib/flow/sol-flow-static.c
@@ -412,7 +412,7 @@ teardown_flow_data(
 static int
 flow_node_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
 {
-    struct sol_buffer opts_buf = SOL_BUFFER_EMPTY;
+    struct sol_buffer opts_buf = SOL_BUFFER_INIT_EMPTY;
     struct flow_static_type *type;
     struct flow_static_data *fsd;
     const struct sol_flow_static_node_spec *spec;

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -220,7 +220,7 @@ sol_util_size_mul(size_t elem_size, size_t num_elems, size_t *out)
     return 0;
 }
 
-static inline uint64_t
+static inline int
 sol_util_uint64_mul(const uint64_t a, const uint64_t b, uint64_t *out)
 {
 #ifdef HAVE_BUILTIN_MUL_OVERFLOW
@@ -235,7 +235,7 @@ sol_util_uint64_mul(const uint64_t a, const uint64_t b, uint64_t *out)
     return 0;
 }
 
-static inline uint64_t
+static inline int
 sol_util_uint64_add(const uint64_t a, const uint64_t b, uint64_t *out)
 {
 #ifdef HAVE_BUILTIN_ADD_OVERFLOW

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -221,6 +221,20 @@ sol_util_size_mul(size_t elem_size, size_t num_elems, size_t *out)
 }
 
 static inline int
+sol_util_size_add(const size_t a, const size_t b, size_t *out)
+{
+#ifdef HAVE_BUILTIN_ADD_OVERFLOW
+    if (__builtin_add_overflow(a, b, out))
+        return -EOVERFLOW;
+#else
+    if (a > 0 && b > SIZE_MAX - a)
+        return -EOVERFLOW;
+    *out = a + b;
+#endif
+    return 0;
+}
+
+static inline int
 sol_util_uint64_mul(const uint64_t a, const uint64_t b, uint64_t *out)
 {
 #ifdef HAVE_BUILTIN_MUL_OVERFLOW

--- a/src/test/test-buffer.c
+++ b/src/test/test-buffer.c
@@ -178,6 +178,30 @@ test_append_slice(void)
     free(backend);
 }
 
+DEFINE_TEST(test_append_printf);
+
+static void
+test_append_printf(void)
+{
+    struct sol_buffer buf;
+    int err;
+
+    sol_buffer_init(&buf);
+    err = sol_buffer_append_printf(&buf, "[%03d]", 1);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_STR_EQ(buf.data, "[001]");
+
+    err = sol_buffer_append_printf(&buf, "'%s'", "This is a longer string, bla bla bla, bla bla bla");
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_STR_EQ(buf.data, "[001]'This is a longer string, bla bla bla, bla bla bla'");
+
+    err = sol_buffer_append_printf(&buf, ".");
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_STR_EQ(buf.data, "[001]'This is a longer string, bla bla bla, bla bla bla'.");
+
+    sol_buffer_fini(&buf);
+}
+
 DEFINE_TEST(test_fixed_size);
 
 static void

--- a/src/test/test-buffer.c
+++ b/src/test/test-buffer.c
@@ -173,6 +173,10 @@ test_append_slice(void)
     ASSERT_STR_NE(buf.data, backend);
     ASSERT_STR_EQ(buf.data, expected_str);
 
+    slice = sol_buffer_get_slice(&buf);
+    ASSERT_INT_EQ(slice.len, buf.used);
+    ASSERT_STR_EQ(slice.data, buf.data);
+
     sol_buffer_fini(&buf);
 
     free(backend);


### PR DESCRIPTION
This series reviews `sol-buffer.h` so it's better and easier to use.

I plan to wait #490 to be merged and change that and more APIs to use `struct sol_buffer` instead of manually manipulating buffers, that is error prone.