### PR TITLE
Fix make check fbp issues v2

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -370,6 +370,13 @@
             }
 	},
 	{
+	    "dependency": "no_sanitize",
+	    "type": "ccode",
+            "cflags": {
+                "value": "-fno-sanitize=all"
+            }
+	},
+	{
 	    "dependency": "sanitize_address",
 	    "type": "ccode",
             "cflags": {

--- a/src/lib/flow/sol-flow-parser.c
+++ b/src/lib/flow/sol-flow-parser.c
@@ -386,8 +386,9 @@ append_node_options(
     }
 
     if (!failed) {
-        memcpy(result.members, named_opts->members,
-            named_opts->count * sizeof(struct sol_flow_node_named_options_member));
+        if (named_opts->count)
+            memcpy(result.members, named_opts->members,
+                named_opts->count * sizeof(struct sol_flow_node_named_options_member));
         *named_opts = result;
         r = 0;
     } else {

--- a/src/modules/flow/converter/converter.c
+++ b/src/modules/flow/converter/converter.c
@@ -1851,7 +1851,7 @@ irange_compose(struct sol_flow_node *node, void *data, uint16_t port, uint16_t c
 
     mdata->port_has_value |= 1 << idx;
 
-    tmp = mdata->output_value & ~(0xff << (idx * CHAR_BIT));
+    tmp = mdata->output_value & ~(0xffu << (idx * CHAR_BIT));
     tmp |= in_val << (idx * CHAR_BIT);
     mdata->output_value = tmp;
 

--- a/src/modules/flow/int/int.c
+++ b/src/modules/flow/int/int.c
@@ -782,7 +782,7 @@ validate_shift(const struct sol_flow_packet *packet)
 static int
 shift_left_func(int in0, int in1)
 {
-    return in0 << in1;
+    return (unsigned) in0 << in1;
 }
 
 static int
@@ -792,8 +792,12 @@ shift_left_process(struct sol_flow_node *node, void *data, uint16_t port, uint16
 
     if (port == SOL_FLOW_NODE_TYPE_INT_SHIFT_LEFT__IN__SHIFT)
         r = validate_shift(packet);
-    if (r < 0)
+
+    if (r < 0) {
+        sol_flow_send_error_packet(node, r, "Error, invalid numeric types for a shift left operation.");
         return r;
+    }
+
     return two_port_process(node, data, port, SOL_FLOW_NODE_TYPE_INT_SHIFT_LEFT__OUT__OUT, packet, shift_left_func);
 }
 

--- a/src/modules/flow/int/int.json
+++ b/src/modules/flow/int/int.json
@@ -421,7 +421,7 @@
       "in_ports": [
         {
           "data_type": "int",
-          "description": "Value to be shifted",
+          "description": "Value to be shifted (it's assumed to be unsigned)",
           "methods": {
             "process": "shift_right_process"
           },

--- a/src/test-fbp/bitwise-int.fbp
+++ b/src/test-fbp/bitwise-int.fbp
@@ -35,6 +35,7 @@ all_zero(constant/int:value=0x00000000)
 one(constant/int:value=1)
 min_int(constant/int:value=0x80000000)
 max_int(constant/int:value=0x7fffffff)
+minus_one(constant/int:value=-1)
 
 input1 OUT -> IN[0] and(int/bitwise-and)
 input2 OUT -> IN[1] and
@@ -64,6 +65,10 @@ one OUT -> SHIFT shiftl
 shiftl OUT -> IN[0] cmp_expected_shiftl(int/equal)
 all_zero OUT -> IN[1] cmp_expected_shiftl
 cmp_expected_shiftl OUT -> RESULT test_int_bitwise_shift_left(test/result)
+
+min_int OUT -> IN shiftl_error(int/shift-left)
+minus_one OUT -> SHIFT shiftl_error
+shiftl_error ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS test_int_bitwise_shift_left_error(test/result)
 
 all_one OUT -> IN shiftr(int/shift-right)
 one OUT -> SHIFT shiftr

--- a/src/test-fbp/console-error.fbp
+++ b/src/test-fbp/console-error.fbp
@@ -31,5 +31,7 @@
 _(file/reader:path="file_that_doesnt_exists") ERROR -> IN c(console)
 _(constant/int:value=1) OUT -> INTERVAL _(timer) OUT -> QUIT _(app/quit)
 
+## TEST-SKIP-VALGRIND Timer was expiring at the wrong time because of valgrind.
+
 ## TEST-OUTPUT
 # c #02 (error) - Could not load "file_that_doesnt_exists": No such file or directory

--- a/src/thirdparty/Makefile
+++ b/src/thirdparty/Makefile
@@ -7,3 +7,7 @@ obj-javascript-$(JAVASCRIPT)-extra-cflags := \
 	-Wno-float-equal \
 	-Wno-format-nonliteral \
 	-Wno-suggest-attribute=noreturn
+
+ifneq (,$(NO_SANITIZE_CFLAGS))
+	obj-javascript-$(JAVASCRIPT)-extra-cflags += $(NO_SANITIZE_CFLAGS)
+endif

--- a/tools/run-fbp-tests
+++ b/tools/run-fbp-tests
@@ -69,7 +69,7 @@ def collect_tests(tests):
             result.append(t)
     return result
 
-def get_expected(t):
+def get_expected(t, args):
     code = 0
     out = None
     skip = None
@@ -87,6 +87,12 @@ def get_expected(t):
 
         if cmd == "TEST-EXPECTS-ERROR":
             code = 1
+        elif cmd == "TEST-SKIP-VALGRIND":
+            if args.valgrind:
+                if len(splitted) > 2:
+                    skip = splitted[2]
+                else:
+                    skip = ""
         elif cmd == "TEST-SKIP":
             if len(splitted) > 2:
                 skip = splitted[2]
@@ -152,7 +158,7 @@ if __name__ == "__main__":
         dir = os.path.dirname(t)
         file = os.path.basename(t)
 
-        expected_out, expected_code, skip, is_regex = get_expected(t)
+        expected_out, expected_code, skip, is_regex = get_expected(t, args)
         if skip is not None:
             print("SKIPPED running %s: %s" % (t, skip))
             skipped += 1


### PR DESCRIPTION
Differences from v1:
- Added a test for a wrong shift operation
- Removed curl from valgrind ignore file
- Fixed a bunch of thigns found by address sanitizer
- don't set -fno-sanitizer if compiler doesn't support it
- rework "TEST-SKIP-VALGRIND" 