### PR TITLE
Enable flow on RIOT by default

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -102,7 +102,7 @@ source "src/samples/common/Kconfig"
 
 config FLOW_SAMPLES
 	bool "Flow samples"
-	depends on FLOW
+	depends on FLOW_SUPPORT
 	default y
 
 config FLOW_FBP_GENERATOR_SAMPLES

--- a/src/lib/common/include/sol-mainloop.h
+++ b/src/lib/common/include/sol-mainloop.h
@@ -37,6 +37,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/lib/common/sol-mainloop.c
+++ b/src/lib/common/sol-mainloop.c
@@ -72,7 +72,7 @@ extern int sol_platform_init(void);
 extern void sol_platform_shutdown(void);
 extern int sol_blob_init(void);
 extern void sol_blob_shutdown(void);
-#ifdef FLOW
+#ifdef FLOW_SUPPORT
 extern int sol_flow_init(void);
 extern void sol_flow_shutdown(void);
 #endif
@@ -118,7 +118,7 @@ sol_init(void)
     if (r < 0)
         goto blob_error;
 
-#ifdef FLOW
+#ifdef FLOW_SUPPORT
     r = sol_flow_init();
     if (r < 0)
         goto flow_error;
@@ -137,7 +137,7 @@ sol_init(void)
 #ifdef NETWORK
 comms_error:
 #endif
-#ifdef FLOW
+#ifdef FLOW_SUPPORT
     sol_flow_shutdown();
 flow_error:
 #endif
@@ -212,7 +212,7 @@ sol_shutdown(void)
 #ifdef NETWORK
     sol_comms_shutdown();
 #endif
-#ifdef FLOW
+#ifdef FLOW_SUPPORT
     sol_flow_shutdown();
 #endif
     sol_blob_shutdown();

--- a/src/lib/flow/Kconfig
+++ b/src/lib/flow/Kconfig
@@ -18,7 +18,7 @@ config NODE_DESCRIPTION
 
 config RESOLVER_CONFFILE
 	bool "Resolver conffile"
-	depends on NODE_DESCRIPTION
+	depends on NODE_DESCRIPTION && FEATURE_FILESYSTEM
 	default y
 
 config INSPECTOR

--- a/src/lib/flow/Kconfig
+++ b/src/lib/flow/Kconfig
@@ -1,15 +1,15 @@
-config FLOW
+config FLOW_SUPPORT
 	bool "Flow support"
 	default y
 
 config JAVASCRIPT
 	bool "Javascript support"
-	depends on FLOW && PLATFORM_LINUX
+	depends on FLOW_SUPPORT && PLATFORM_LINUX
 	default y
 
 config NODE_DESCRIPTION
 	bool "Node description support"
-	depends on FLOW && FEATURE_RUNNABLE_PROGRAMS
+	depends on FLOW_SUPPORT && FEATURE_RUNNABLE_PROGRAMS
 	default y
 	help
             Add node description support to enable runtime introspection.
@@ -23,11 +23,11 @@ config RESOLVER_CONFFILE
 
 config INSPECTOR
 	bool "Inspector"
-	depends on FLOW && FEATURE_RUNNABLE_PROGRAMS
+	depends on FLOW_SUPPORT && FEATURE_RUNNABLE_PROGRAMS
 	default y
 
 menu "Node Types"
-	depends on FLOW
+	depends on FLOW_SUPPORT
 source "src/modules/flow/accelerometer/Kconfig"
 source "src/modules/flow/aio/Kconfig"
 source "src/modules/flow/app/Kconfig"

--- a/src/lib/flow/Makefile
+++ b/src/lib/flow/Makefile
@@ -1,6 +1,6 @@
-obj-$(FLOW) += flow.mod
+obj-$(FLOW_SUPPORT) += flow.mod
 
-obj-flow-$(FLOW) := \
+obj-flow-$(FLOW_SUPPORT) := \
     sol-flow-node-options.o \
     sol-flow-packet.o \
     sol-flow-simplectype.o \
@@ -24,9 +24,9 @@ endif
 obj-flow-$(RESOLVER_CONFFILE) += \
     sol-flow-resolver-conffile.o
 
-obj-flow-$(FLOW)-extra-cflags += $(def-resolver-flag)
+obj-flow-$(FLOW_SUPPORT)-extra-cflags += $(def-resolver-flag)
 
-headers-$(FLOW) := \
+headers-$(FLOW_SUPPORT) := \
     include/sol-flow-builder.h \
     include/sol-flow.h \
     include/sol-flow-inspector.h \

--- a/src/lib/flow/sol-flow-node-options.c
+++ b/src/lib/flow/sol-flow-node-options.c
@@ -228,7 +228,7 @@ irange_parse(const char *value, struct sol_flow_node_named_options_member *m)
 
     LINEAR_VALUES_RECAP(INT32_MAX, INT32_MIN);
 
-    SOL_DBG("irange opt ends up as min=%d, max=%d, step=%d, val=%d\n",
+    SOL_DBG("irange opt ends up as min=%"PRId32", max=%"PRId32", step=%"PRId32", val=%"PRId32"\n",
         ret->min, ret->max, ret->step, ret->val);
 
     free(buf);
@@ -374,8 +374,8 @@ rgb_parse(const char *value, struct sol_flow_node_named_options_member *m)
         break;
     }
 
-    SOL_DBG("rgb opt ends up as red=%d, green=%d, blue=%d "
-        "red_max=%d, green_max=%d, blue_max=%d\n",
+    SOL_DBG("rgb opt ends up as red=%"PRIu32", green=%"PRIu32", blue=%"PRIu32" "
+        "red_max=%"PRIu32", green_max=%"PRIu32", blue_max=%"PRIu32"\n",
         ret->red, ret->green, ret->blue,
         ret->red_max, ret->green_max, ret->blue_max);
 

--- a/src/lib/io/sol-i2c-riot.c
+++ b/src/lib/io/sol-i2c-riot.c
@@ -256,7 +256,7 @@ i2c_read_reg_multiple_timeout_cb(void *data)
 {
     struct sol_i2c *i2c = data;
     uint8_t i;
-    size_t ret;
+    size_t ret = 0;
 
     i2c_acquire(i2c->dev);
     for (i = 0; i < i2c->async.times; i++) {
@@ -371,7 +371,7 @@ sol_i2c_pending_cancel(struct sol_i2c *i2c, struct sol_i2c_pending *pending)
     SOL_NULL_CHECK(i2c);
     SOL_NULL_CHECK(pending);
 
-    if (i2c->async.timeout == (struct sol_i2c_pending *)pending) {
+    if (i2c->async.timeout == (struct sol_timeout *)pending) {
         sol_timeout_del(i2c->async.timeout);
         i2c->async.dispatch(i2c);
         i2c->async.timeout = NULL;

--- a/src/modules/flow/app/app.c
+++ b/src/modules/flow/app/app.c
@@ -122,7 +122,7 @@ quit_with_code_process(struct sol_flow_node *node, void *data, uint16_t port, ui
 static int
 quit_with_error_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
 {
-    int32_t in_value;
+    int in_value;
     int r;
 
     r = sol_flow_packet_get_error(packet, &in_value, NULL);

--- a/src/modules/flow/console/console.c
+++ b/src/modules/flow/console/console.c
@@ -90,7 +90,7 @@ console_in_process(struct sol_flow_node *node, void *data, uint16_t port, uint16
         uint32_t red, green, blue;
         int r = sol_flow_packet_get_rgb_components(packet, &red, &green, &blue);
         SOL_INT_CHECK(r, < 0, r);
-        fprintf(mdata->fp, "%s(%d, %d, %d) (rgb)%s\n",
+        fprintf(mdata->fp, "%s(%"PRIu32", %"PRIu32", %"PRIu32") (rgb)%s\n",
             mdata->prefix ? mdata->prefix : "",
             red, green, blue,
             mdata->suffix ? mdata->suffix : "");

--- a/src/modules/flow/converter/string-format.c
+++ b/src/modules/flow/converter/string-format.c
@@ -366,7 +366,7 @@ static int
 int32_to_char(int32_t input,
     char **p_output)
 {
-    int r = asprintf(p_output, "%c", input);
+    int r = asprintf(p_output, "%c", (int)input);
 
     SOL_INT_CHECK(r, < 0, -EINVAL);
 
@@ -451,10 +451,10 @@ int32_to_binary_string(int32_t input,
 
     switch (base) {
     case 16:
-        FORMAT_EVAL("%s%s%x", input);
+        FORMAT_EVAL("%s%s%"PRIx32, input);
         break;
     case 8:
-        FORMAT_EVAL("%s%s%o", input);
+        FORMAT_EVAL("%s%s%"PRIo32, input);
         break;
     case 2:
         to_bin = byte_to_binary(input);

--- a/src/modules/flow/file/Kconfig
+++ b/src/modules/flow/file/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_FILE
 	tristate "Node type: file"
-	depends on PTHREAD
+	depends on FEATURE_FILESYSTEM && WORKER_THREAD
 	default m

--- a/src/modules/flow/float/float.c
+++ b/src/modules/flow/float/float.c
@@ -791,27 +791,27 @@ wave_generator_trapezoidal_open(struct sol_flow_node *node,
         return -EDOM;
     }
     if (opts->ticks_inc.val < 1) {
-        SOL_ERR("Trapezoidal wave generator's ticks_inc value (%d) cannot"
+        SOL_ERR("Trapezoidal wave generator's ticks_inc value (%"PRId32") cannot"
             " be less than 1)", opts->ticks_inc.val);
         return -EDOM;
     }
     if (opts->ticks_dec.val < 1) {
-        SOL_ERR("Trapezoidal wave generator's ticks_dec value (%d) cannot"
+        SOL_ERR("Trapezoidal wave generator's ticks_dec value (%"PRId32") cannot"
             " be less than 1)", opts->ticks_dec.val);
         return -EDOM;
     }
     if (opts->tick_start.val < 0) {
-        SOL_ERR("Trapezoidal wave generator's tick_start value (%d) cannot"
+        SOL_ERR("Trapezoidal wave generator's tick_start value (%"PRId32") cannot"
             " be less than 0)", opts->tick_start.val);
         return -EDOM;
     }
     if (opts->ticks_at_max.val < 0) {
-        SOL_ERR("Trapezoidal wave generator's ticks_at_max value (%d) cannot"
+        SOL_ERR("Trapezoidal wave generator's ticks_at_max value (%"PRId32") cannot"
             " be less than 0)", opts->ticks_at_max.val);
         return -EDOM;
     }
     if (opts->ticks_at_min.val < 0) {
-        SOL_ERR("Trapezoidal wave generator's ticks_at_min value (%d) cannot"
+        SOL_ERR("Trapezoidal wave generator's ticks_at_min value (%"PRId32") cannot"
             " be less than 0)", opts->ticks_at_min.val);
         return -EDOM;
     }
@@ -931,12 +931,12 @@ wave_generator_sinusoidal_open(struct sol_flow_node *node,
         return -EDOM;
     }
     if (opts->ticks_per_period.val < 1) {
-        SOL_ERR("Sinusoidal wave generator's ticks_per_period value (%d) cannot"
+        SOL_ERR("Sinusoidal wave generator's ticks_per_period value (%"PRId32") cannot"
             " be less than 1)", opts->ticks_per_period.val);
         return -EDOM;
     }
     if (opts->tick_start.val < 0) {
-        SOL_ERR("Sinusoidal wave generator's tick_start value (%d) cannot"
+        SOL_ERR("Sinusoidal wave generator's tick_start value (%"PRId32") cannot"
             " be less than 0)", opts->tick_start.val);
         return -EDOM;
     }

--- a/src/modules/flow/flower-power/Kconfig
+++ b/src/modules/flow/flower-power/Kconfig
@@ -1,6 +1,6 @@
 config FLOW_NODE_TYPE_FLOWER_POWER
 	tristate "Node type: flower-power"
-	depends on FLOW && HTTP_CLIENT
+	depends on HTTP_CLIENT
 	default y
 	help
 		Parrot Flower Power is a wireless plant monitor that measures

--- a/src/modules/flow/freegeoip/Kconfig
+++ b/src/modules/flow/freegeoip/Kconfig
@@ -1,6 +1,6 @@
 config FLOW_NODE_TYPE_FREEGEOIP
 	tristate "Node type: freegeoip"
-	depends on FLOW && HTTP_CLIENT
+	depends on HTTP_CLIENT
 	default y
 	help
 		Uses the free FreeGeoip service to obtain the location of

--- a/src/modules/flow/fs/Kconfig
+++ b/src/modules/flow/fs/Kconfig
@@ -1,3 +1,4 @@
 config FLOW_NODE_TYPE_FS
 	tristate "Node type: fs"
+	depends on FEATURE_FILESYSTEM
 	default m

--- a/src/modules/flow/gtk/Kconfig
+++ b/src/modules/flow/gtk/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_GTK
 	tristate "Node type: gtk"
-	depends on HAVE_GTK && HAVE_GLIB
+	depends on LINUX && HAVE_GTK && HAVE_GLIB
 	default m

--- a/src/modules/flow/gyroscope/Kconfig
+++ b/src/modules/flow/gyroscope/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_GYROSCOPE
 	tristate "Node type: gyroscope"
-	depends on PLATFORM_LINUX && USE_I2C
+	depends on USE_I2C
 	default m

--- a/src/modules/flow/int/int.c
+++ b/src/modules/flow/int/int.c
@@ -188,7 +188,7 @@ inrange_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t 
 // =============================================================================
 
 struct irange_min_max_data {
-    int val[2];
+    int32_t val[2];
     int (*func) (int var0, int var1);
     uint16_t port;
     bool val_initialized[2];
@@ -232,7 +232,7 @@ static int
 min_max_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
 {
     struct irange_min_max_data *mdata = data;
-    int *result;
+    int32_t *result;
     int r;
 
     r = sol_flow_packet_get_irange_value(packet, &mdata->val[port]);
@@ -1049,7 +1049,7 @@ irange_map_process(struct sol_flow_node *node, void *data, uint16_t port, uint16
 {
     struct irange_map_data *mdata = data;
     struct sol_irange in_value;
-    int32_t out_value;
+    int32_t out_value = 0;
     int r;
 
     r = sol_flow_packet_get_irange(packet, &in_value);

--- a/src/modules/flow/led-strip/lpd8806.c
+++ b/src/modules/flow/led-strip/lpd8806.c
@@ -148,7 +148,7 @@ pixel_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t co
     SOL_INT_CHECK(r, < 0, r);
 
     if (in_value.val >= mdata->pixel_count) {
-        SOL_WRN("Invalid pixel %d. Expected pixel ranging from 0 to %d", in_value.val, mdata->pixel_count - 1);
+        SOL_WRN("Invalid pixel %d. Expected pixel ranging from 0 to %d", (int)in_value.val, mdata->pixel_count - 1);
         return -EINVAL;
     }
 

--- a/src/modules/flow/network/network.c
+++ b/src/modules/flow/network/network.c
@@ -32,6 +32,7 @@
 
 #include <errno.h>
 #include <limits.h>
+#include <sys/types.h>
 #include <regex.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/modules/flow/piezo-speaker/piezo-speaker.c
+++ b/src/modules/flow/piezo-speaker/piezo-speaker.c
@@ -314,7 +314,7 @@ tune_parse(struct piezo_speaker_data *mdata, const char *tune)
     if (*pos != TUNE_FIELD_SEPARATOR || i != mdata->num_entries) {
         if (!i) goto _format_err;
         SOL_WRN("Bad format for speaker tune string (%s)"
-            " -- less beat (%d) than note (%d) entries."
+            " -- less beat (%d) than note (%"PRId32") entries."
             " The notes array length is being shrunk to match the beats",
             tune, i, mdata->num_entries);
         mdata->num_entries = i;
@@ -329,7 +329,7 @@ tune_parse(struct piezo_speaker_data *mdata, const char *tune)
         goto _format_err;
     if (mdata->tempo_ms * 1000 > INT32_MAX / 9) {
         SOL_WRN("Bad format for speaker tune string (%s)"
-            " -- base tempo too high %" PRId32 " ms (max is %d ms)"
+            " -- base tempo too high %" PRId32 " ms (max is %"PRId32" ms)"
             " -- we can't apply a new tune",
             tune, mdata->tempo_ms, INT32_MAX / 9000);
         return -EINVAL;

--- a/src/modules/flow/string/Makefile
+++ b/src/modules/flow/string/Makefile
@@ -1,8 +1,12 @@
 obj-$(FLOW_NODE_TYPE_STRING) += string.mod
 obj-string-$(FLOW_NODE_TYPE_STRING) := string.json
 
+ifdef LINUX
 ifdef HAVE_ICU
 obj-string-$(FLOW_NODE_TYPE_STRING) += string-icu.o
+else
+obj-string-$(FLOW_NODE_TYPE_STRING) += string-ascii.o
+endif
 else
 obj-string-$(FLOW_NODE_TYPE_STRING) += string-ascii.o
 endif

--- a/src/modules/flow/string/string-ascii.c
+++ b/src/modules/flow/string/string-ascii.c
@@ -295,7 +295,7 @@ struct string_split_data {
     struct sol_vector substrings;
     char *string;
     char *separator;
-    int index, max_split;
+    int32_t index, max_split;
 };
 
 static int
@@ -312,11 +312,11 @@ string_split_open(struct sol_flow_node *node,
     opts = (const struct sol_flow_node_type_string_split_options *)options;
 
     if (opts->index.val < 0) {
-        SOL_WRN("Index (%d) must be a non-negative value", opts->index.val);
+        SOL_WRN("Index (%"PRId32") must be a non-negative value", opts->index.val);
         return -EINVAL;
     }
     if (opts->max_split.val < 0) {
-        SOL_WRN("Max split (%d) must be a non-negative value",
+        SOL_WRN("Max split (%"PRId32") must be a non-negative value",
             opts->max_split.val);
         return -EINVAL;
     }
@@ -369,7 +369,7 @@ calculate_substrings(struct string_split_data *mdata,
 static int
 send_substring(struct string_split_data *mdata, struct sol_flow_node *node)
 {
-    int len;
+    int32_t len;
     struct sol_str_slice *sub_slice;
 
     if (!(mdata->string && mdata->separator))
@@ -405,7 +405,7 @@ set_string_index(struct sol_flow_node *node,
     SOL_INT_CHECK(r, < 0, r);
 
     if (in_value < 0) {
-        SOL_WRN("Index (%d) must be a non-negative value", in_value);
+        SOL_WRN("Index (%"PRId32") must be a non-negative value", in_value);
         return -EINVAL;
     }
     mdata->index = in_value;
@@ -428,7 +428,7 @@ set_max_split(struct sol_flow_node *node,
     SOL_INT_CHECK(r, < 0, r);
 
     if (in_value < 0) {
-        SOL_WRN("Max split (%d) must be a non-negative value", in_value);
+        SOL_WRN("Max split (%"PRId32") must be a non-negative value", in_value);
         return -EINVAL;
     }
     mdata->max_split = in_value;

--- a/src/modules/flow/string/string-ascii.c
+++ b/src/modules/flow/string/string-ascii.c
@@ -32,7 +32,9 @@
 
 //FIXME: change to build system warning, not compile time
 
+#ifdef LINUX
 #warning "You're building the string nodes module without i18n support -- some nodes will only act properly on pure ASCII input, not the intended utf-8 for Soletta. Please re-configure after you have ICU development packages installed to get the intended string nodes behavior."
+#endif
 
 #include <ctype.h>
 #include <errno.h>

--- a/src/modules/flow/switcher/switcher.c
+++ b/src/modules/flow/switcher/switcher.c
@@ -76,7 +76,8 @@ switcher_open(struct sol_flow_node *node, void *data, const struct sol_flow_node
 static int
 switcher_set_index(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
 {
-    int r, in_value;
+    int32_t in_value;
+    int r;
 
     r = sol_flow_packet_get_irange_value(packet, &in_value);
     SOL_INT_CHECK(r, < 0, r);

--- a/src/modules/flow/udev/Kconfig
+++ b/src/modules/flow/udev/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_UDEV
 	tristate "Node type: udev"
-	depends on HAVE_UDEV
+	depends on LINUX && HAVE_UDEV
 	default m

--- a/src/shared/Makefile
+++ b/src/shared/Makefile
@@ -4,7 +4,7 @@ obj-libshared-y := \
     sol-monitors.o \
     sol-util.o
 
-obj-libshared-$(FLOW) += \
+obj-libshared-$(FLOW_SUPPORT) += \
     sol-fbp-graph.o \
     sol-fbp-internal-log.o \
     sol-fbp-internal-scanner.o \

--- a/src/test/Kconfig
+++ b/src/test/Kconfig
@@ -13,17 +13,17 @@ config TEST_COAP
 
 config TEST_FBP
 	bool "fbp"
-	depends on FLOW
+	depends on FLOW_SUPPORT
 	default y
 
 config TEST_FBP_SCANNER
 	bool "fbp scanner"
-	depends on FLOW
+	depends on FLOW_SUPPORT
 	default y
 
 config TEST_FLOW
 	bool "flow"
-	depends on FLOW
+	depends on FLOW_SUPPORT
 	default y
 
 config TEST_FLOW_BUILDER

--- a/tools/build/Kconfig.features
+++ b/tools/build/Kconfig.features
@@ -39,3 +39,6 @@ config FEATURE_HW_I2C
 
 config FEATURE_FLOW
     bool
+
+config FEATURE_FILESYSTEM
+    bool

--- a/tools/build/Kconfig.linux
+++ b/tools/build/Kconfig.linux
@@ -14,3 +14,4 @@ config LINUX
     select FEATURE_COAP
     select FEATURE_HTTP_CLIENT if HAVE_LIBCURL
     select FEATURE_FLOW
+    select FEATURE_FILESYSTEM

--- a/tools/build/Kconfig.riot
+++ b/tools/build/Kconfig.riot
@@ -7,3 +7,4 @@ config RIOT
     select FEATURE_HW_UART
     select FEATURE_HW_I2C
     select FEATURE_NETWORK
+    select FEATURE_FLOW


### PR DESCRIPTION
Enable flow, and the necessary fixes to make that happen with alldefconfig.

Changes since v1:
 - Rebased, some changes gone since Ze's patch-set included them already.