### PR TITLE
Buffer review v2

### DIFF
--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -160,6 +160,14 @@ sol_buffer_get_slice(const struct sol_buffer *buf)
     return SOL_STR_SLICE_STR(buf->data, buf->used);
 }
 
+static inline struct sol_str_slice
+sol_buffer_get_slice_at(const struct sol_buffer *buf, size_t pos)
+{
+    if (!buf || buf->used < pos)
+        return SOL_STR_SLICE_STR(NULL, 0);
+    return SOL_STR_SLICE_STR((char *)buf->data + pos, buf->used - pos);
+}
+
 /* Appends the 'slice' into 'buf', reallocating if necessary. */
 int sol_buffer_append_slice(struct sol_buffer *buf, const struct sol_str_slice slice);
 

--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -152,6 +152,14 @@ int sol_buffer_ensure(struct sol_buffer *buf, size_t min_size);
  * an extra NUL byte so the buffer can be used as a cstr. */
 int sol_buffer_set_slice(struct sol_buffer *buf, const struct sol_str_slice slice);
 
+static inline struct sol_str_slice
+sol_buffer_get_slice(const struct sol_buffer *buf)
+{
+    if (!buf)
+        return SOL_STR_SLICE_STR(NULL, 0);
+    return SOL_STR_SLICE_STR(buf->data, buf->used);
+}
+
 /* Appends the 'slice' into 'buf', reallocating if necessary. */
 int sol_buffer_append_slice(struct sol_buffer *buf, const struct sol_str_slice slice);
 

--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -35,6 +35,7 @@
 #include <assert.h>
 
 #include <sol-str-slice.h>
+#include <stdarg.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -153,6 +154,21 @@ int sol_buffer_set_slice(struct sol_buffer *buf, const struct sol_str_slice slic
 
 /* Appends the 'slice' into 'buf', reallocating if necessary. */
 int sol_buffer_append_slice(struct sol_buffer *buf, const struct sol_str_slice slice);
+
+/* append the formatted string to buffer, including trailing \0 */
+int sol_buffer_append_vprintf(struct sol_buffer *buf, const char *fmt, va_list args);
+static inline int sol_buffer_append_printf(struct sol_buffer *buf, const char *fmt, ...) SOL_ATTR_PRINTF(2, 3);
+static inline int
+sol_buffer_append_printf(struct sol_buffer *buf, const char *fmt, ...)
+{
+    va_list args;
+    int r;
+
+    va_start(args, fmt);
+    r = sol_buffer_append_vprintf(buf, fmt, args);
+    va_end(args);
+    return r;
+}
 
 /**
  * @}

--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -189,6 +189,14 @@ sol_buffer_get_slice_at(const struct sol_buffer *buf, size_t pos)
 /* Appends the 'slice' into 'buf', reallocating if necessary. */
 int sol_buffer_append_slice(struct sol_buffer *buf, const struct sol_str_slice slice);
 
+/* Insert the 'slice' into 'buf' at position 'pos', reallocating if necessary.
+ *
+ * If pos == buf->end, then the behavior is the same as
+ * sol_buffer_append_slice() and a trailing '\0' is
+ * guaranteed.
+ */
+int sol_buffer_insert_slice(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice);
+
 /* append the formatted string to buffer, including trailing \0 */
 int sol_buffer_append_vprintf(struct sol_buffer *buf, const char *fmt, va_list args);
 static inline int sol_buffer_append_printf(struct sol_buffer *buf, const char *fmt, ...) SOL_ATTR_PRINTF(2, 3);

--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -212,6 +212,24 @@ sol_buffer_append_printf(struct sol_buffer *buf, const char *fmt, ...)
     return r;
 }
 
+/* insert the formatted string into the buffer at given position.  If
+ * position == buf->pos, then the behavior is the same as
+ * sol_buffer_append_vprintf().
+ */
+int sol_buffer_insert_vprintf(struct sol_buffer *buf, size_t pos, const char *fmt, va_list args);
+static inline int sol_buffer_insert_printf(struct sol_buffer *buf, size_t pos, const char *fmt, ...) SOL_ATTR_PRINTF(3, 4);
+static inline int
+sol_buffer_insert_printf(struct sol_buffer *buf, size_t pos, const char *fmt, ...)
+{
+    va_list args;
+    int r;
+
+    va_start(args, fmt);
+    r = sol_buffer_insert_vprintf(buf, pos, fmt, args);
+    va_end(args);
+    return r;
+}
+
 /**
  * @}
  */

--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -142,6 +142,24 @@ sol_buffer_fini(struct sol_buffer *buf)
     buf->capacity = 0;
 }
 
+static inline void *
+sol_buffer_at(const struct sol_buffer *buf, size_t pos)
+{
+    if (!buf)
+        return NULL;
+    if (pos > buf->used)
+        return NULL;
+    return (char *)buf->data + pos;
+}
+
+static inline void *
+sol_buffer_at_end(const struct sol_buffer *buf)
+{
+    if (!buf)
+        return NULL;
+    return (char *)buf->data + buf->used;
+}
+
 int sol_buffer_resize(struct sol_buffer *buf, size_t new_size);
 
 /* Ensure that 'buf' has at least the given 'min_size'. It may
@@ -165,7 +183,7 @@ sol_buffer_get_slice_at(const struct sol_buffer *buf, size_t pos)
 {
     if (!buf || buf->used < pos)
         return SOL_STR_SLICE_STR(NULL, 0);
-    return SOL_STR_SLICE_STR((char *)buf->data + pos, buf->used - pos);
+    return SOL_STR_SLICE_STR(sol_buffer_at(buf,  pos), buf->used - pos);
 }
 
 /* Appends the 'slice' into 'buf', reallocating if necessary. */

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -86,6 +86,8 @@ sol_buffer_set_slice(struct sol_buffer *buf, const struct sol_str_slice slice)
     SOL_NULL_CHECK(buf, -EINVAL);
 
     /* Extra room for the ending NUL-byte. */
+    if (slice.len >= SIZE_MAX - 1)
+        return -EOVERFLOW;
     err = sol_buffer_ensure(buf, slice.len + 1);
     if (err < 0)
         return err;
@@ -98,13 +100,19 @@ sol_buffer_set_slice(struct sol_buffer *buf, const struct sol_str_slice slice)
 SOL_API int
 sol_buffer_append_slice(struct sol_buffer *buf, const struct sol_str_slice slice)
 {
+    size_t new_size;
     int err;
 
     SOL_NULL_CHECK(buf, -EINVAL);
 
+    err = sol_util_size_add(buf->used, slice.len, &new_size);
+    if (err < 0)
+        return err;
+
     /* Extra room for the ending NUL-byte. */
-    /* FIXME: len+used might overflow! */
-    err = sol_buffer_ensure(buf, slice.len + buf->used + 1);
+    if (new_size >= SIZE_MAX - 1)
+        return -EOVERFLOW;
+    err = sol_buffer_ensure(buf, new_size + 1);
     if (err < 0)
         return err;
 
@@ -126,7 +134,17 @@ sol_buffer_append_vprintf(struct sol_buffer *buf, const char *fmt, va_list args)
         if (done < 0)
             return -errno;
         else if ((size_t)done >= space) {
-            int r = sol_buffer_ensure(buf, buf->used + done + 1);
+            int r;
+            size_t new_size;
+
+            r = sol_util_size_add(buf->used, done, &new_size);
+            if (r < 0)
+                return r;
+
+            /* Extra room for the ending NUL-byte. */
+            if (new_size >= SIZE_MAX - 1)
+                return -EOVERFLOW;
+            r = sol_buffer_ensure(buf, new_size + 1);
             if (r < 0)
                 return r;
         } else {

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -33,6 +33,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 #include "sol-buffer.h"
 #include "sol-log.h"
@@ -110,4 +111,27 @@ sol_buffer_append_slice(struct sol_buffer *buf, const struct sol_str_slice slice
     sol_str_slice_copy((char *)buf->data + buf->used, slice);
     buf->used += slice.len;
     return 0;
+}
+
+SOL_API int
+sol_buffer_append_vprintf(struct sol_buffer *buf, const char *fmt, va_list args)
+{
+    SOL_NULL_CHECK(buf, -EINVAL);
+    SOL_NULL_CHECK(fmt, -EINVAL);
+
+    do {
+        size_t space = buf->capacity - buf->used;
+        char *p = (char *)buf->data + buf->used;
+        ssize_t done = vsnprintf(p, space, fmt, args);
+        if (done < 0)
+            return -errno;
+        else if ((size_t)done >= space) {
+            int r = sol_buffer_ensure(buf, buf->used + done + 1);
+            if (r < 0)
+                return r;
+        } else {
+            buf->used += done;
+            return 0;
+        }
+    } while (1);
 }

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -189,3 +189,28 @@ sol_buffer_append_vprintf(struct sol_buffer *buf, const char *fmt, va_list args)
         }
     } while (1);
 }
+
+SOL_API int
+sol_buffer_insert_vprintf(struct sol_buffer *buf, size_t pos, const char *fmt, va_list args)
+{
+    char *s;
+    ssize_t len;
+    struct sol_str_slice slice;
+    int r;
+
+    SOL_NULL_CHECK(buf, -EINVAL);
+    SOL_NULL_CHECK(fmt, -EINVAL);
+    SOL_INT_CHECK(pos, > buf->used, -EINVAL);
+
+    if (pos == buf->used)
+        return sol_buffer_append_vprintf(buf, fmt, args);
+
+    len = vasprintf(&s, fmt, args);
+    if (len < 0)
+        return -errno;
+
+    slice = SOL_STR_SLICE_STR(s, len);
+    r = sol_buffer_insert_slice(buf, pos, slice);
+    free(s);
+    return r;
+}

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -100,6 +100,7 @@ sol_buffer_set_slice(struct sol_buffer *buf, const struct sol_str_slice slice)
 SOL_API int
 sol_buffer_append_slice(struct sol_buffer *buf, const struct sol_str_slice slice)
 {
+    char *p;
     size_t new_size;
     int err;
 
@@ -116,7 +117,9 @@ sol_buffer_append_slice(struct sol_buffer *buf, const struct sol_str_slice slice
     if (err < 0)
         return err;
 
-    sol_str_slice_copy((char *)buf->data + buf->used, slice);
+    p = sol_buffer_at_end(buf);
+    memcpy(p, slice.data, slice.len);
+    p[slice.len] = '\0';
     buf->used += slice.len;
     return 0;
 }
@@ -129,7 +132,7 @@ sol_buffer_append_vprintf(struct sol_buffer *buf, const char *fmt, va_list args)
 
     do {
         size_t space = buf->capacity - buf->used;
-        char *p = (char *)buf->data + buf->used;
+        char *p = sol_buffer_at_end(buf);
         ssize_t done = vsnprintf(p, space, fmt, args);
         if (done < 0)
             return -errno;

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -125,6 +125,39 @@ sol_buffer_append_slice(struct sol_buffer *buf, const struct sol_str_slice slice
 }
 
 SOL_API int
+sol_buffer_insert_slice(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice)
+{
+    char *p;
+    size_t new_size;
+    int err;
+
+    SOL_NULL_CHECK(buf, -EINVAL);
+    SOL_INT_CHECK(pos, > buf->used, -EINVAL);
+
+    if (pos == buf->used)
+        return sol_buffer_append_slice(buf, slice);
+
+    err = sol_util_size_add(buf->used, slice.len, &new_size);
+    if (err < 0)
+        return err;
+
+    /* Extra room for the ending NUL-byte. */
+    if (new_size >= SIZE_MAX - 1)
+        return -EOVERFLOW;
+    err = sol_buffer_ensure(buf, new_size + 1);
+    if (err < 0)
+        return err;
+
+    p = sol_buffer_at(buf, pos);
+    memmove(p + slice.len, p, buf->used - pos);
+    memcpy(p, slice.data, slice.len);
+    buf->used += slice.len;
+    p = sol_buffer_at_end(buf);
+    p[0] = '\0';
+    return 0;
+}
+
+SOL_API int
 sol_buffer_append_vprintf(struct sol_buffer *buf, const char *fmt, va_list args)
 {
     SOL_NULL_CHECK(buf, -EINVAL);

--- a/src/lib/flow/sol-flow-parser.c
+++ b/src/lib/flow/sol-flow-parser.c
@@ -279,7 +279,7 @@ append_node_options(
     const struct sol_flow_node_type *type,
     struct sol_flow_node_named_options *named_opts)
 {
-    struct sol_buffer key = SOL_BUFFER_EMPTY, value = SOL_BUFFER_EMPTY;
+    struct sol_buffer key = SOL_BUFFER_INIT_EMPTY, value = SOL_BUFFER_INIT_EMPTY;
     struct sol_flow_node_named_options result;
     struct sol_flow_node_named_options_member *m;
     struct sol_fbp_meta *meta;
@@ -605,8 +605,8 @@ build_flow(struct parse_state *state)
     struct sol_fbp_exported_port *ep;
     struct sol_fbp_option *opt;
     struct sol_flow_node_type *type = NULL;
-    struct sol_buffer src_port_buf = SOL_BUFFER_EMPTY, dst_port_buf = SOL_BUFFER_EMPTY;
-    struct sol_buffer opt_name_buf = SOL_BUFFER_EMPTY;
+    struct sol_buffer src_port_buf = SOL_BUFFER_INIT_EMPTY, dst_port_buf = SOL_BUFFER_INIT_EMPTY;
+    struct sol_buffer opt_name_buf = SOL_BUFFER_INIT_EMPTY;
     int i, err = 0;
 
     fbp_error = sol_fbp_parse(state->input, &state->graph);

--- a/src/lib/flow/sol-flow-static.c
+++ b/src/lib/flow/sol-flow-static.c
@@ -412,7 +412,7 @@ teardown_flow_data(
 static int
 flow_node_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
 {
-    struct sol_buffer opts_buf = SOL_BUFFER_EMPTY;
+    struct sol_buffer opts_buf = SOL_BUFFER_INIT_EMPTY;
     struct flow_static_type *type;
     struct flow_static_data *fsd;
     const struct sol_flow_static_node_spec *spec;

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -220,7 +220,7 @@ sol_util_size_mul(size_t elem_size, size_t num_elems, size_t *out)
     return 0;
 }
 
-static inline uint64_t
+static inline int
 sol_util_uint64_mul(const uint64_t a, const uint64_t b, uint64_t *out)
 {
 #ifdef HAVE_BUILTIN_MUL_OVERFLOW
@@ -235,7 +235,7 @@ sol_util_uint64_mul(const uint64_t a, const uint64_t b, uint64_t *out)
     return 0;
 }
 
-static inline uint64_t
+static inline int
 sol_util_uint64_add(const uint64_t a, const uint64_t b, uint64_t *out)
 {
 #ifdef HAVE_BUILTIN_ADD_OVERFLOW

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -221,6 +221,20 @@ sol_util_size_mul(size_t elem_size, size_t num_elems, size_t *out)
 }
 
 static inline int
+sol_util_size_add(const size_t a, const size_t b, size_t *out)
+{
+#ifdef HAVE_BUILTIN_ADD_OVERFLOW
+    if (__builtin_add_overflow(a, b, out))
+        return -EOVERFLOW;
+#else
+    if (a > 0 && b > SIZE_MAX - a)
+        return -EOVERFLOW;
+    *out = a + b;
+#endif
+    return 0;
+}
+
+static inline int
 sol_util_uint64_mul(const uint64_t a, const uint64_t b, uint64_t *out)
 {
 #ifdef HAVE_BUILTIN_MUL_OVERFLOW

--- a/src/test/test-buffer.c
+++ b/src/test/test-buffer.c
@@ -178,6 +178,30 @@ test_append_slice(void)
     free(backend);
 }
 
+DEFINE_TEST(test_append_printf);
+
+static void
+test_append_printf(void)
+{
+    struct sol_buffer buf;
+    int err;
+
+    sol_buffer_init(&buf);
+    err = sol_buffer_append_printf(&buf, "[%03d]", 1);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_STR_EQ(buf.data, "[001]");
+
+    err = sol_buffer_append_printf(&buf, "'%s'", "This is a longer string, bla bla bla, bla bla bla");
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_STR_EQ(buf.data, "[001]'This is a longer string, bla bla bla, bla bla bla'");
+
+    err = sol_buffer_append_printf(&buf, ".");
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_STR_EQ(buf.data, "[001]'This is a longer string, bla bla bla, bla bla bla'.");
+
+    sol_buffer_fini(&buf);
+}
+
 DEFINE_TEST(test_memory_not_owned);
 
 static void

--- a/src/test/test-buffer.c
+++ b/src/test/test-buffer.c
@@ -177,6 +177,10 @@ test_append_slice(void)
     ASSERT_INT_EQ(slice.len, buf.used);
     ASSERT_STR_EQ(slice.data, buf.data);
 
+    slice = sol_buffer_get_slice_at(&buf, 2);
+    ASSERT_INT_EQ(slice.len, buf.used - 2);
+    ASSERT_STR_EQ(slice.data, (char *)buf.data + 2);
+
     sol_buffer_fini(&buf);
 
     free(backend);

--- a/src/test/test-buffer.c
+++ b/src/test/test-buffer.c
@@ -173,6 +173,10 @@ test_append_slice(void)
     ASSERT_STR_NE(buf.data, backend);
     ASSERT_STR_EQ(buf.data, expected_str);
 
+    slice = sol_buffer_get_slice(&buf);
+    ASSERT_INT_EQ(slice.len, buf.used);
+    ASSERT_STR_EQ(slice.data, buf.data);
+
     sol_buffer_fini(&buf);
 
     free(backend);

--- a/src/test/test-buffer.c
+++ b/src/test/test-buffer.c
@@ -241,6 +241,30 @@ test_append_printf(void)
     sol_buffer_fini(&buf);
 }
 
+DEFINE_TEST(test_insert_printf);
+
+static void
+test_insert_printf(void)
+{
+    struct sol_buffer buf;
+    int err;
+
+    sol_buffer_init(&buf);
+    err = sol_buffer_insert_printf(&buf, 0, "'%s'", "This is a longer string, bla bla bla, bla bla bla");
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_STR_EQ(buf.data, "'This is a longer string, bla bla bla, bla bla bla'");
+
+    err = sol_buffer_insert_printf(&buf, 0, "[%03d]", 1);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_STR_EQ(buf.data, "[001]'This is a longer string, bla bla bla, bla bla bla'");
+
+    err = sol_buffer_insert_printf(&buf, strlen("[001]"), " ### ");
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_STR_EQ(buf.data, "[001] ### 'This is a longer string, bla bla bla, bla bla bla'");
+
+    sol_buffer_fini(&buf);
+}
+
 DEFINE_TEST(test_memory_not_owned);
 
 static void

--- a/src/test/test-buffer.c
+++ b/src/test/test-buffer.c
@@ -57,7 +57,7 @@ DEFINE_TEST(test_resize);
 static void
 test_resize(void)
 {
-    struct sol_buffer buf = SOL_BUFFER_EMPTY;
+    struct sol_buffer buf = SOL_BUFFER_INIT_EMPTY;
     const int size = 1024;
     char *buf_data;
     int i;
@@ -87,7 +87,7 @@ DEFINE_TEST(test_ensure);
 static void
 test_ensure(void)
 {
-    struct sol_buffer buf = SOL_BUFFER_EMPTY;
+    struct sol_buffer buf = SOL_BUFFER_INIT_EMPTY;
     const int size = 1024;
     char *buf_data;
     int i;
@@ -176,6 +176,47 @@ test_append_slice(void)
     sol_buffer_fini(&buf);
 
     free(backend);
+}
+
+DEFINE_TEST(test_memory_not_owned);
+
+static void
+test_memory_not_owned(void)
+{
+    struct sol_buffer buf;
+    struct sol_str_slice slice;
+    char backend[10];
+    int err;
+
+    sol_buffer_init_flags(&buf, backend, sizeof(backend), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
+
+    err = sol_buffer_ensure(&buf, 0);
+    ASSERT_INT_EQ(err, 0);
+
+    err = sol_buffer_ensure(&buf, sizeof(backend));
+    ASSERT_INT_EQ(err, 0);
+
+    err = sol_buffer_ensure(&buf, sizeof(backend) * 2);
+    ASSERT_INT_EQ(err, -ENOMEM);
+
+    err = sol_buffer_resize(&buf, 0);
+    ASSERT_INT_EQ(err, -EPERM);
+
+    slice = sol_str_slice_from_str("test");
+    err = sol_buffer_append_slice(&buf, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_STR_EQ(buf.data, "test");
+
+    slice = sol_str_slice_from_str("other");
+    err = sol_buffer_append_slice(&buf, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_STR_EQ(buf.data, "testother");
+
+    slice = sol_str_slice_from_str("OVERFLOW");
+    err = sol_buffer_append_slice(&buf, slice);
+    ASSERT_INT_EQ(err, -ENOMEM);
+
+    sol_buffer_fini(&buf);
 }
 
 

--- a/src/test/test-buffer.c
+++ b/src/test/test-buffer.c
@@ -186,6 +186,37 @@ test_append_slice(void)
     free(backend);
 }
 
+DEFINE_TEST(test_insert_slice);
+
+static void
+test_insert_slice(void)
+{
+    struct sol_buffer buf;
+    struct sol_str_slice slice;
+    int err;
+
+    sol_buffer_init(&buf);
+    slice = sol_str_slice_from_str("World");
+    err = sol_buffer_insert_slice(&buf, 0, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("World"));
+    ASSERT_STR_EQ(buf.data, "World");
+
+    slice = sol_str_slice_from_str("Hello");
+    err = sol_buffer_insert_slice(&buf, 0, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("HelloWorld"));
+    ASSERT_STR_EQ(buf.data, "HelloWorld");
+
+    slice = sol_str_slice_from_str(" -*- ");
+    err = sol_buffer_insert_slice(&buf, strlen("Hello"), slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("Hello -*- World"));
+    ASSERT_STR_EQ(buf.data, "Hello -*- World");
+
+    sol_buffer_fini(&buf);
+}
+
 DEFINE_TEST(test_append_printf);
 
 static void


### PR DESCRIPTION
Changes since v1 (#517):
 * changed from `bool fized_size` to `enum sol_buffer_flags`;
 * renamed `reserved` to `capacity` member to allow a nice flag name;
 * removed the `sol_buffer_fini_nofree()`, it's handled by a flag now;
 * added `sol_buffer_at()` and `sol_buffer_at_end()`;
 * added `sol_buffer_insert_slice()` to insert a slice at a given position;
 * added `sol_buffer_insert_printf()` to insert a formatted string at a given position;
 * added `sol_buffer_get_slice_at()`