### PR TITLE
string-icu: Memory issues

### DIFF
--- a/src/modules/flow/string/string-icu.c
+++ b/src/modules/flow/string/string-icu.c
@@ -283,6 +283,7 @@ string_concat(struct sol_flow_node *node,
 fail_sz:
     free(dest);
 fail_to_utf8:
+    free(final);
     sol_flow_send_error_packet(node, -errno, u_errorName(err));
     return -errno;
 }
@@ -770,11 +771,12 @@ string_change_case(struct sol_flow_node *node,
 
     return r;
 
-fail_to_utf8:
 fail_case_func:
     free(u_lower);
+fail_to_utf8:
 fail_from_utf8:
     free(u_orig);
+    free(final);
     sol_flow_send_error_packet(node, -errno, u_errorName(err));
     return -errno;
 }


### PR DESCRIPTION
Possible double free on string_change_case();
Memory leak on string_concat() and string_change_case().

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>