### PR TITLE
Build duktape cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ targets.
 
  * [General Information](#general-information)
  * [Building from Source](#building-from-source)
+   * [Submodules](#submodules)
+       * [Duktape](#duktape)
+   * [Building](#building)
  * [Debug](#debug)
  * [Libraries](#libraries)
   * [Common](#common)
@@ -47,6 +50,40 @@ is based on Glib's GMainLoop, while some smaller OS have their own
 implementation, see [main loops](#main-loops) documentaion.
 
 ## Building from Source
+
+#### Submodules
+**Soletta Project** uses git submodule to include external sources into
+its source tree (currently we have a single one). The submodules are handled
+as an optional dependency and can be built as an external source code where
+the source code can be cloned out-of-tree.
+
+We have introduced in the source tree the script
+```data/scripts/git-init-submodules.py``` to handle the submodules. This
+script does some special tricks when handling with submodules, it knows
+about some extra variables introduced to .gitmodule file like: handling
+sparsecheckout, shallow checkouts based on ```branch``` variable and also
+generates the sparse rules file based on ```sparserules``` variable.
+
+Since the script wraps git submodule the configured modules can be initialized,
+de-initialized and so on as a regular git submodule, we recommend using our
+script because it provides the extra features we have introduced.
+
+###### Duktape
+As mentioned in the previous section **Soletta Project** includes some git
+submodules, Duktape - an embeddable Javascript engine - is one of them.
+
+> Warning: we strongly recommend using the **Soleta's** Duktape submodule -
+see previous section.
+
+To build **Soletta** with Duktape support you either initialize its git submodule
+or set the ```DUKTAPE_SRC``` environment variable to point to Duktape source
+code - we're interested in duktape.c and duktape.h files so make sure to
+set the variable pointing to ```src/``` directory - not the root source dir.
+
+We have specific version requirements so make sure to clone the proper version
+if not using submodule.
+
+#### Building
 
 The build system is based on linux kernel's kconfig. To configure it
 with default configuration values run:

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -1,387 +1,387 @@
 {
-    "definitions" : {
-        "PKGNAME": "soletta",
-        "VERSION_MAJOR": 0,
-        "VERSION_MINOR": 0,
-        "VERSION_RELEASE": 1,
-        "VERSION": "{VERSION_MAJOR}.{VERSION_MINOR}.{VERSION_RELEASE}",
-        "DESTDIR": "/",
-        "SYSCONF": "/etc/",
-        "LIBDIR": "{PREFIX}/lib/",
-        "DATADIR": "{PREFIX}/share/",
-        "BINDIR": "{PREFIX}/bin/",
-        "INCLUDEDIR": "{PREFIX}/include/",
-        "SOL_DATADIR": "{DATADIR}/{PKGNAME}/",
-        "SOL_INCLUDEDIR": "{INCLUDEDIR}/{PKGNAME}/",
-        "MODULESDIR": "{LIBDIR}/{PKGNAME}/modules/",
-        "SOL_FLOW_DATADIR": "{SOL_DATADIR}/flow/",
-        "DESCDIR": "{SOL_FLOW_DATADIR}/descriptions/",
-        "SCHEMADIR": "{SOL_FLOW_DATADIR}/schema/",
-        "PCDIR": "{LIBDIR}/pkgconfig/",
-        "PKGSYSCONFDIR": "{SYSCONF}/{PKGNAME}/",
-        "FLOWMODULESDIR": "{MODULESDIR}/flow/",
-        "PINMUXDIR": "{MODULESDIR}/pin-mux/",
-        "LINUXMICROMODULESDIR": "{MODULESDIR}/linux-micro/"
+  "definitions": {
+    "PKGNAME": "soletta",
+    "VERSION_MAJOR": 0,
+    "VERSION_MINOR": 0,
+    "VERSION_RELEASE": 1,
+    "VERSION": "{VERSION_MAJOR}.{VERSION_MINOR}.{VERSION_RELEASE}",
+    "DESTDIR": "/",
+    "SYSCONF": "/etc/",
+    "LIBDIR": "{PREFIX}/lib/",
+    "DATADIR": "{PREFIX}/share/",
+    "BINDIR": "{PREFIX}/bin/",
+    "INCLUDEDIR": "{PREFIX}/include/",
+    "SOL_DATADIR": "{DATADIR}/{PKGNAME}/",
+    "SOL_INCLUDEDIR": "{INCLUDEDIR}/{PKGNAME}/",
+    "MODULESDIR": "{LIBDIR}/{PKGNAME}/modules/",
+    "SOL_FLOW_DATADIR": "{SOL_DATADIR}/flow/",
+    "DESCDIR": "{SOL_FLOW_DATADIR}/descriptions/",
+    "SCHEMADIR": "{SOL_FLOW_DATADIR}/schema/",
+    "PCDIR": "{LIBDIR}/pkgconfig/",
+    "PKGSYSCONFDIR": "{SYSCONF}/{PKGNAME}/",
+    "FLOWMODULESDIR": "{MODULESDIR}/flow/",
+    "PINMUXDIR": "{MODULESDIR}/pin-mux/",
+    "LINUXMICROMODULESDIR": "{MODULESDIR}/linux-micro/"
+  },
+  "pre-dependencies": [
+    {
+      "dependency": "gnu_source",
+      "type": "ccode",
+      "headers": [
+        "<string.h>"
+      ],
+      "fragment": "strndupa(0,0);",
+      "cflags": {
+        "comment": "append to COMMON_CFLAGS so it's used for further checks",
+        "append_to": "COMMON_CFLAGS",
+        "value": "-D_GNU_SOURCE=1"
+      }
     },
-    "pre-dependencies": [
-	{
-	    "dependency": "gnu_source",
-	    "type": "ccode",
-	    "headers": [
-		"<string.h>"
-            ],
-            "fragment": "strndupa(0,0);",
-            "cflags": {
-                "comment": "append to COMMON_CFLAGS so it's used for further checks",
-                "append_to": "COMMON_CFLAGS",
-                "value": "-D_GNU_SOURCE=1"
-            }
-	},
-	{
-	    "dependency": "ldl",
-	    "type": "ccode",
-	    "headers": [
-		"<dlfcn.h>"
-            ],
-            "fragment": "dlopen(0,0);",
-            "ldflags": {
-                "comment": "append to COMMON_LDFLAGS so it's used for further checks, and else where in the build system",
-                "append_to": "COMMON_LDFLAGS",
-                "value": "-ldl"
-            }
-	},
-	{
-	    "dependency": "lib_math",
-	    "type": "ccode",
-	    "headers": [
-		"<math.h>"
-            ],
-            "fragment": "isinf(0);",
-            "ldflags": {
-                "append_to": "COMMON_LDFLAGS",
-                "value": "-lm"
-            }
-	},
-	{
-	    "dependency": "check_cflags",
-	    "type": "cflags",
-	    "cflags": [
-                "-pipe",
-                "-Wall",
-                "-W",
-                "-Wextra",
-                "-Wundef",
-                "-Wformat=2",
-                "-Wlogical-op",
-                "-Wsign-compare",
-                "-Wformat-security",
-                "-Wmissing-include-dirs",
-                "-Wformat-nonliteral",
-                "-Wold-style-definition",
-                "-Wpointer-arith",
-                "-Winit-self",
-                "-Wdeclaration-after-statement",
-                "-Wfloat-equal",
-                "-Wmissing-prototypes",
-                "-Wstrict-prototypes",
-                "-Wredundant-decls",
-                "-Wmissing-declarations",
-                "-Wmissing-noreturn",
-                "-Wno-unused-parameter",
-                "-Wshadow",
-                "-Wendif-labels",
-                "-Wstrict-aliasing=3",
-                "-Wwrite-strings",
-                "-Wno-long-long",
-                "-Wno-missing-field-initializers",
-                "-Wno-override-init",
-                "-Wnested-externs",
-                "-Wchar-subscripts",
-                "-Wtype-limits",
-                "-Wuninitialized",
-                "-fno-common",
-                "-fdiagnostics-show-option",
-                "-fvisibility=hidden",
-                "-ffunction-sections",
-                "-fdata-sections",
-                "-fno-asynchronous-unwind-tables"
-            ],
-            "comment": "append to COMMON_CFLAGS so it's used for further checks",
-            "append_to": "COMMON_CFLAGS"
-	},
-	{
-	    "dependency": "check_ldflags",
-	    "type": "ldflags",
-	    "ldflags": [
-                "-Wl,--gc-sections"
-            ],
-            "append_to": "COMMON_LDFLAGS"
-	}
-    ],
-    "dependencies": [
-	{
-	    "dependency": "check",
-	    "type": "pkg-config",
-	    "pkgname": "check"
-	},
-	{
-	    "dependency": "glib",
-	    "type": "pkg-config",
-	    "pkgname": "glib-2.0"
-	},
-	{
-	    "dependency": "gtk",
-	    "type": "pkg-config",
-	    "pkgname": "gtk+-3.0"
-	},
-	{
-	    "dependency": "systemd",
-	    "type": "pkg-config",
-	    "pkgname": "libsystemd",
-	    "atleast-version": "221"
-	},
-	{
-	    "dependency": "udev",
-	    "type": "pkg-config",
-	    "pkgname": "libudev"
-	},
-	{
-	    "dependency": "sd_dbus",
-	    "type": "ccode",
-	    "headers": [
-		"<systemd/sd-bus.h>"
-	    ]
-	},
-	{
-	    "dependency": "sys_auxv_h",
-	    "type": "ccode",
-	    "headers": [
-		"<sys/auxv.h>"
-	    ],
-	    "fragment": "getauxval(AT_EXECFN);"
-	},
-	{
-	    "dependency": "decl_dladdr",
-	    "type": "ccode",
-	    "headers": [
-		"<dlfcn.h>"
-	    ],
-	    "fragment": "dladdr(0, 0);"
-	},
-	{
-	    "dependency": "pthread_h",
-	    "type": "ccode",
-	    "headers": [
-		"<pthread.h>"
-	    ],
-            "ldflags": {
-                "value": "-lpthread"
-            }
-	},
-	{
-	    "dependency": "linux",
-	    "type": "ccode",
-	    "headers": [
-		"<linux/ioctl.h>"
-	    ]
-	},
-	{
-	    "dependency": "riotos",
-	    "type": "ccode",
-	    "fragment": "#ifndef RIOT_CPU\n#error \"No RIOT_CPU defined\"\n#endif\n"
-	},
-	{
-	    "dependency": "contiki",
-	    "type": "ccode",
-	    "headers": [
-		"<contiki.h>"
-	    ]
-	},
-	{
-	    "dependency": "dlfcn_h",
-	    "type": "ccode",
-	    "headers": [
-		"<dlfcn.h>"
-	    ]
-	},
-	{
-	    "dependency": "socket",
-	    "type": "ccode",
-	    "headers": [
-		"<sys/socket.h>"
-	    ]
-	},
-	{
-	    "dependency": "accept4",
-	    "type": "ccode",
-	    "headers": [
-		"<sys/socket.h>"
-	    ],
-	    "fragment": "accept4(0, 0, 0, 0);"
-	},
-	{
-	    "dependency": "locale",
-	    "type": "ccode",
-	    "headers": [
-		"<locale.h>"
-	    ],
-	    "fragment": "setlocale(LC_ALL, NULL);"
-	},
-	{
-	    "dependency": "newlocale",
-	    "type": "ccode",
-	    "headers": [
-		"<locale.h>"
-	    ],
-	    "fragment": "newlocale(LC_ALL_MASK, NULL, NULL);"
-	},
-	{
-	    "dependency": "icu",
-	    "type": "pkg-config",
-	    "pkgname": "icu-uc icu-i18n",
-	    "atleast-version": "52.1"
-	},
-	{
-	    "dependency": "isatty",
-	    "type": "ccode",
-	    "headers": [
-		"<unistd.h>"
-	    ],
-	    "fragment": "isatty(0);"
-	},
-	{
-	    "dependency": "ppoll",
-	    "type": "ccode",
-	    "headers": [
-		"<poll.h>"
-	    ],
-	    "fragment": "ppoll(0, 0, 0, 0);"
-	},
-	{
-	    "dependency": "decl_strndupa",
-	    "type": "ccode",
-	    "headers": [
-		"<string.h>"
-	    ],
-	    "fragment": "strndupa(0, 0);"
-	},
-	{
-	    "dependency": "builtin_mul_overflow",
-	    "type": "ccode",
-	    "fragment": "__builtin_mul_overflow(0ULL, 0ULL, (unsigned long long *)0);"
-	},
-	{
-	    "dependency": "builtin_add_overflow",
-	    "type": "ccode",
-	    "fragment": "__builtin_add_overflow(0ULL, 0ULL, (unsigned long long *)0);"
-	},
-	{
-	    "dependency": "decl_memmem",
-	    "type": "ccode",
-	    "headers": [
-		"<string.h>"
-	    ],
-	    "fragment": "memmem(0, 0, 0, 0);"
-	},
-	{
-	    "dependency": "decl_ifla_inet6_addr_gen_mode",
-	    "type": "ccode",
-	    "headers": [
-		"<netinet/in.h>",
-		"<netinet/ether.h>",
-                "<linux/rtnetlink.h>",
-		"<net/if.h>",
-                "<linux/if_link.h>",
-		"<linux/if_addr.h>"
-	    ],
-	    "fragment": "int v = IFLA_INET6_ADDR_GEN_MODE;"
-	},
-	{
-	    "dependency": "strtod_l",
-	    "type": "ccode",
-	    "headers": [
-		"<stdlib.h>"
-	    ],
-	    "fragment": "strtod_l(0, 0, 0);"
-	},
-	{
-	    "dependency": "valgrind",
-	    "type": "exec",
-	    "exec": "valgrind"
-	},
-	{
-	    "dependency": "doxygen",
-	    "type": "exec",
-	    "exec": "doxygen"
-	},
-	{
-	    "dependency": "bzip2",
-	    "type": "exec",
-	    "exec": "bzip2"
-	},
-	{
-	    "dependency": "tar",
-	    "type": "exec",
-	    "exec": "tar"
-	},
-	{
-	    "dependency": "lcov",
-	    "type": "exec",
-	    "exec": "lcov"
-	},
-	{
-	    "dependency": "genhtml",
-	    "type": "exec",
-	    "exec": "genhtml"
-	},
-	{
-	    "dependency": "chrpath",
-	    "type": "exec",
-	    "exec": "chrpath",
-	    "required": true
-	},
-	{
-	    "dependency": "jsonschema",
-	    "type": "python",
-	    "pkgname": "jsonschema",
-	    "required": true
-	},
-	{
-	    "dependency": "graphviz",
-	    "type": "exec",
-	    "exec": "dot"
-	},
-	{
-	    "dependency": "imagemagick",
-	    "type": "exec",
-	    "exec": "convert"
-	},
-	{
-	    "dependency": "libcurl",
-	    "type": "pkg-config",
-	    "pkgname": "libcurl",
-	    "atleast-version": "7.32.0"
-	},
-	{
-	    "dependency": "sanitize_undefined",
-	    "type": "ccode",
-            "cflags": {
-                "value": "-fsanitize=undefined"
-            }
-	},
-	{
-	    "dependency": "no_sanitize",
-	    "type": "ccode",
-            "cflags": {
-                "value": "-fno-sanitize=all"
-            }
-	},
-	{
-	    "dependency": "sanitize_address",
-	    "type": "ccode",
-            "cflags": {
-                "value": "-fsanitize=address"
-            }
-	}
-    ]
+    {
+      "dependency": "ldl",
+      "type": "ccode",
+      "headers": [
+        "<dlfcn.h>"
+      ],
+      "fragment": "dlopen(0,0);",
+      "ldflags": {
+        "comment": "append to COMMON_LDFLAGS so it's used for further checks, and else where in the build system",
+        "append_to": "COMMON_LDFLAGS",
+        "value": "-ldl"
+      }
+    },
+    {
+      "dependency": "lib_math",
+      "type": "ccode",
+      "headers": [
+        "<math.h>"
+      ],
+      "fragment": "isinf(0);",
+      "ldflags": {
+        "append_to": "COMMON_LDFLAGS",
+        "value": "-lm"
+      }
+    },
+    {
+      "dependency": "check_cflags",
+      "type": "cflags",
+      "cflags": [
+        "-pipe",
+        "-Wall",
+        "-W",
+        "-Wextra",
+        "-Wundef",
+        "-Wformat=2",
+        "-Wlogical-op",
+        "-Wsign-compare",
+        "-Wformat-security",
+        "-Wmissing-include-dirs",
+        "-Wformat-nonliteral",
+        "-Wold-style-definition",
+        "-Wpointer-arith",
+        "-Winit-self",
+        "-Wdeclaration-after-statement",
+        "-Wfloat-equal",
+        "-Wmissing-prototypes",
+        "-Wstrict-prototypes",
+        "-Wredundant-decls",
+        "-Wmissing-declarations",
+        "-Wmissing-noreturn",
+        "-Wno-unused-parameter",
+        "-Wshadow",
+        "-Wendif-labels",
+        "-Wstrict-aliasing=3",
+        "-Wwrite-strings",
+        "-Wno-long-long",
+        "-Wno-missing-field-initializers",
+        "-Wno-override-init",
+        "-Wnested-externs",
+        "-Wchar-subscripts",
+        "-Wtype-limits",
+        "-Wuninitialized",
+        "-fno-common",
+        "-fdiagnostics-show-option",
+        "-fvisibility=hidden",
+        "-ffunction-sections",
+        "-fdata-sections",
+        "-fno-asynchronous-unwind-tables"
+      ],
+      "comment": "append to COMMON_CFLAGS so it's used for further checks",
+      "append_to": "COMMON_CFLAGS"
+    },
+    {
+      "dependency": "check_ldflags",
+      "type": "ldflags",
+      "ldflags": [
+        "-Wl,--gc-sections"
+      ],
+      "append_to": "COMMON_LDFLAGS"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependency": "check",
+      "type": "pkg-config",
+      "pkgname": "check"
+    },
+    {
+      "dependency": "glib",
+      "type": "pkg-config",
+      "pkgname": "glib-2.0"
+    },
+    {
+      "dependency": "gtk",
+      "type": "pkg-config",
+      "pkgname": "gtk+-3.0"
+    },
+    {
+      "dependency": "systemd",
+      "type": "pkg-config",
+      "pkgname": "libsystemd",
+      "atleast-version": "221"
+    },
+    {
+      "dependency": "udev",
+      "type": "pkg-config",
+      "pkgname": "libudev"
+    },
+    {
+      "dependency": "sd_dbus",
+      "type": "ccode",
+      "headers": [
+        "<systemd/sd-bus.h>"
+      ]
+    },
+    {
+      "dependency": "sys_auxv_h",
+      "type": "ccode",
+      "headers": [
+        "<sys/auxv.h>"
+      ],
+      "fragment": "getauxval(AT_EXECFN);"
+    },
+    {
+      "dependency": "decl_dladdr",
+      "type": "ccode",
+      "headers": [
+        "<dlfcn.h>"
+      ],
+      "fragment": "dladdr(0, 0);"
+    },
+    {
+      "dependency": "pthread_h",
+      "type": "ccode",
+      "headers": [
+        "<pthread.h>"
+      ],
+      "ldflags": {
+        "value": "-lpthread"
+      }
+    },
+    {
+      "dependency": "linux",
+      "type": "ccode",
+      "headers": [
+        "<linux/ioctl.h>"
+      ]
+    },
+    {
+      "dependency": "riotos",
+      "type": "ccode",
+      "fragment": "#ifndef RIOT_CPU\n#error \"No RIOT_CPU defined\"\n#endif\n"
+    },
+    {
+      "dependency": "contiki",
+      "type": "ccode",
+      "headers": [
+        "<contiki.h>"
+      ]
+    },
+    {
+      "dependency": "dlfcn_h",
+      "type": "ccode",
+      "headers": [
+        "<dlfcn.h>"
+      ]
+    },
+    {
+      "dependency": "socket",
+      "type": "ccode",
+      "headers": [
+        "<sys/socket.h>"
+      ]
+    },
+    {
+      "dependency": "accept4",
+      "type": "ccode",
+      "headers": [
+        "<sys/socket.h>"
+      ],
+      "fragment": "accept4(0, 0, 0, 0);"
+    },
+    {
+      "dependency": "locale",
+      "type": "ccode",
+      "headers": [
+        "<locale.h>"
+      ],
+      "fragment": "setlocale(LC_ALL, NULL);"
+    },
+    {
+      "dependency": "newlocale",
+      "type": "ccode",
+      "headers": [
+        "<locale.h>"
+      ],
+      "fragment": "newlocale(LC_ALL_MASK, NULL, NULL);"
+    },
+    {
+      "dependency": "icu",
+      "type": "pkg-config",
+      "pkgname": "icu-uc icu-i18n",
+      "atleast-version": "52.1"
+    },
+    {
+      "dependency": "isatty",
+      "type": "ccode",
+      "headers": [
+        "<unistd.h>"
+      ],
+      "fragment": "isatty(0);"
+    },
+    {
+      "dependency": "ppoll",
+      "type": "ccode",
+      "headers": [
+        "<poll.h>"
+      ],
+      "fragment": "ppoll(0, 0, 0, 0);"
+    },
+    {
+      "dependency": "decl_strndupa",
+      "type": "ccode",
+      "headers": [
+        "<string.h>"
+      ],
+      "fragment": "strndupa(0, 0);"
+    },
+    {
+      "dependency": "builtin_mul_overflow",
+      "type": "ccode",
+      "fragment": "__builtin_mul_overflow(0ULL, 0ULL, (unsigned long long *)0);"
+    },
+    {
+      "dependency": "builtin_add_overflow",
+      "type": "ccode",
+      "fragment": "__builtin_add_overflow(0ULL, 0ULL, (unsigned long long *)0);"
+    },
+    {
+      "dependency": "decl_memmem",
+      "type": "ccode",
+      "headers": [
+        "<string.h>"
+      ],
+      "fragment": "memmem(0, 0, 0, 0);"
+    },
+    {
+      "dependency": "decl_ifla_inet6_addr_gen_mode",
+      "type": "ccode",
+      "headers": [
+        "<netinet/in.h>",
+        "<netinet/ether.h>",
+        "<linux/rtnetlink.h>",
+        "<net/if.h>",
+        "<linux/if_link.h>",
+        "<linux/if_addr.h>"
+      ],
+      "fragment": "int v = IFLA_INET6_ADDR_GEN_MODE;"
+    },
+    {
+      "dependency": "strtod_l",
+      "type": "ccode",
+      "headers": [
+        "<stdlib.h>"
+      ],
+      "fragment": "strtod_l(0, 0, 0);"
+    },
+    {
+      "dependency": "valgrind",
+      "type": "exec",
+      "exec": "valgrind"
+    },
+    {
+      "dependency": "doxygen",
+      "type": "exec",
+      "exec": "doxygen"
+    },
+    {
+      "dependency": "bzip2",
+      "type": "exec",
+      "exec": "bzip2"
+    },
+    {
+      "dependency": "tar",
+      "type": "exec",
+      "exec": "tar"
+    },
+    {
+      "dependency": "lcov",
+      "type": "exec",
+      "exec": "lcov"
+    },
+    {
+      "dependency": "genhtml",
+      "type": "exec",
+      "exec": "genhtml"
+    },
+    {
+      "dependency": "chrpath",
+      "type": "exec",
+      "exec": "chrpath",
+      "required": true
+    },
+    {
+      "dependency": "jsonschema",
+      "type": "python",
+      "pkgname": "jsonschema",
+      "required": true
+    },
+    {
+      "dependency": "graphviz",
+      "type": "exec",
+      "exec": "dot"
+    },
+    {
+      "dependency": "imagemagick",
+      "type": "exec",
+      "exec": "convert"
+    },
+    {
+      "dependency": "libcurl",
+      "type": "pkg-config",
+      "pkgname": "libcurl",
+      "atleast-version": "7.32.0"
+    },
+    {
+      "dependency": "sanitize_undefined",
+      "type": "ccode",
+      "cflags": {
+        "value": "-fsanitize=undefined"
+      }
+    },
+    {
+      "dependency": "no_sanitize",
+      "type": "ccode",
+      "cflags": {
+        "value": "-fno-sanitize=all"
+      }
+    },
+    {
+      "dependency": "sanitize_address",
+      "type": "ccode",
+      "cflags": {
+        "value": "-fsanitize=address"
+      }
+    }
+  ]
 }

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -382,6 +382,18 @@
       "cflags": {
         "value": "-fsanitize=address"
       }
+    },
+    {
+      "dependency": "duktape_src",
+      "type": "filesystem",
+      "files": [
+        "duktape.c",
+        "duktape.h"
+      ],
+      "path": {
+        "in-tree": "{TOP_SRCDIR}/src/thirdparty/duktape/src/",
+        "out-of-tree": "{DUKTAPE_SRC}"
+      }
     }
   ]
 }

--- a/src/lib/flow/Kconfig
+++ b/src/lib/flow/Kconfig
@@ -4,7 +4,7 @@ config FLOW_SUPPORT
 
 config JAVASCRIPT
 	bool "Javascript support"
-	depends on FLOW_SUPPORT && PLATFORM_LINUX
+	depends on FLOW_SUPPORT && PLATFORM_LINUX && HAVE_DUKTAPE_SRC
 	default y
 
 config NODE_DESCRIPTION

--- a/src/thirdparty/Makefile
+++ b/src/thirdparty/Makefile
@@ -1,7 +1,7 @@
 obj-$(JAVASCRIPT) := javascript.mod
 
 obj-javascript-$(JAVASCRIPT) := \
-	duktape/src/duktape.o
+	$(DUKTAPE_SRC_PATH)/duktape.o
 
 obj-javascript-$(JAVASCRIPT)-extra-cflags := \
 	-Wno-float-equal \

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -57,8 +57,19 @@ extra-headers = \
 		) \
 	) \
 
+artifact-path = $(foreach curr,$(1), \
+			$(if $(filter $(abspath $(top_srcdir))%,$(abspath $(1))), \
+				$(addprefix $(2),$(curr)), \
+				$(curr) \
+			) \
+		 ) \
+
+object-path = $(if $(filter $(abspath $(top_srcdir))%,$(abspath $(1))), \
+			$(subst $(top_srcdir)src/,$(build_stagedir),$(1)), \
+			$(addprefix $(build_stagedir)$(subst $(top_srcdir)src/,,$(2)),$(notdir $(1))))
+
 parse-common-module = \
-	$(eval artifacts    := $(addprefix $(2),$(obj-$(1)-$(3)))) \
+	$(eval artifacts    := $(call artifact-path,$(obj-$(1)-$(3)),$(2))) \
 	$(eval mod-headers  := $(addprefix $(2),$(headers-$(1)-$(3)))) \
 	$(call extra-headers,$(mod-headers)) \
 	$(call gen-artifact,$(1),$(filter %.json,$(artifacts))) \
@@ -69,7 +80,7 @@ parse-common-module = \
 	$(eval $(1)-bs      += $(if $(wildcard $(2)/Kconfig),$(addprefix $(2),Kconfig))) \
 	$(eval $(1)-hdrs    := $(filter %.h,$(artifacts))) \
 	$(foreach obj,$(mod-objs), \
-		$(eval dest-obj        := $(subst $(top_srcdir)src/,$(build_stagedir),$(obj))) \
+		$(eval dest-obj        := $(call object-path,$(obj),$(2))) \
 		$(eval $(dest-obj)-src := $(subst .o,.c,$(obj))) \
 		$(eval $(1)-srcs       := $($(dest-obj)-src)) \
 	        $(eval $(1)-objs       += $(dest-obj)) \

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -297,7 +297,7 @@ $(SOL_LIB_SO): $(SOL_LIB_AR) $(builtin-objs)
 $(DEPENDENCY_CACHE): $(MODULES_OK_FILE)
 	$(Q)$(PYTHON) $(DEPENDENCY_SCRIPT) --compiler="$(TARGETCC)" --cflags="$(DEP_RESOLVER_CFLAGS)" \
 		--ldflags="$(DEP_RESOLVER_LDFLAGS)" --prefix="$(PREFIX)" --cache="$(DEPENDENCY_CACHE)" \
-		--pkg-config="$(PKG_CONFIG)"
+		--pkg-config="$(PKG_CONFIG)" --makefile-gen
 
 $(KCONFIG_GEN): $(DEPENDENCY_CACHE)
 	$(Q)$(PYTHON) $(DEPENDENCY_SCRIPT) --compiler="$(TARGETCC)" --cflags="$(DEP_RESOLVER_CFLAGS)" \

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -305,7 +305,7 @@ $(SOL_LIB_SO): $(SOL_LIB_AR) $(builtin-objs)
 	$(Q)$(TARGETCC) -shared $(builtin-objs) $(sort $(builtin-ldflags)) $(LIB_LDFLAGS) -o $(@).$(VERSION)
 	$(Q)$(LN) -fs $(notdir $(@).$(VERSION)) $(@)
 
-$(DEPENDENCY_CACHE): $(MODULES_OK_FILE)
+$(DEPENDENCY_CACHE):
 	$(Q)$(PYTHON) $(DEPENDENCY_SCRIPT) --compiler="$(TARGETCC)" --cflags="$(DEP_RESOLVER_CFLAGS)" \
 		--ldflags="$(DEP_RESOLVER_LDFLAGS)" --prefix="$(PREFIX)" --cache="$(DEPENDENCY_CACHE)" \
 		--pkg-config="$(PKG_CONFIG)" --makefile-gen
@@ -373,9 +373,6 @@ endef
 $(eval $(call install-resource,$(NODE_TYPE_SCHEMA),$(NODE_TYPE_SCHEMA_DEST)))
 $(eval $(call install-resource,$(BOARD_DETECT),$(BOARD_DETECT_DEST)))
 $(eval $(call install-resource,$(GDB_AUTOLOAD_PY),$(GDB_AUTOLOAD_PY_DEST)))
-
-$(MODULES_OK_FILE):
-	$(Q)$(PYTHON) $(SUBMODULE_SCRIPT) || (false)
 
 $(FLOW_OIC_GEN): $(FLOW_OIC_GEN_SCRIPT)
 	$(Q)echo "     "GEN"   "$(@)

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -121,7 +121,7 @@ TEMPLATE_SCRIPT := $(SCRIPTDIR)template.py
 
 # flags and comp. helpers
 HEADERDIRS := $(addprefix $(top_srcdir),src/shared src/lib/common)
-HEADERDIRS += $(addprefix $(top_srcdir),src/thirdparty/duktape/src)
+HEADERDIRS += $(DUKTAPE_SRC_PATH)
 HEADERDIRS += $(addprefix $(top_srcdir),src/lib/flow src/lib/comms/)
 HEADERDIRS += $(addprefix $(top_srcdir),$(KCONFIG_INCLUDE)generated/)
 HEADERDIRS += $(build_includedir)

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -292,8 +292,6 @@ DOXYGEN_GENERATED = \
 	doc/doxygen/latex \
 	doc/doxygen/man
 
-SUBMODULE_SCRIPT := $(SCRIPTDIR)git-init-submodules.py
-
 ## oic flow
 FLOW_OIC_GEN := $(flow-dir)oic/oic.json $(flow-dir)oic/oic.c
 FLOW_OIC_SPEC_DIR := $(top_srcdir)data/oic
@@ -313,8 +311,6 @@ warning-targets = all check check-fbp check-valgrind check-fbp-valgrind check-st
 		pre-install post-install install doc cheat-sheet samples doxygen: warning
 
 PACKAGE_DOCNAME := "soletta"-$(VERSION)-doc
-
-MODULES_OK_FILE := $(top_srcdir).git/modules-ok
 
 kconfig-targets := config nconfig menuconfig xconfig gconfig oldconfig localmodconfig localyesconfig \
 		silentoldconfig defconfig savedefconfig allnoconfig allyesconfig allmodconfig alldefconfig \


### PR DESCRIPTION
## Rationale

This series does:
   - remove the submodule initialization from build system;
   - avoid failing if duktape is not present - we simply disable it;
   - add a mechanism to provide DUKTAPE_SRC variable so we can do external duktape clones and use it from there - this is a distro building requirement, namely clear linux;

Besides the feature set of changes the series also brings a patch to fix an -gen.h installation bug;