### PR TITLE
IIO Address

### DIFF
--- a/src/lib/io/include/sol-i2c.h
+++ b/src/lib/io/include/sol-i2c.h
@@ -309,6 +309,30 @@ uint8_t sol_i2c_bus_get(const struct sol_i2c *i2c);
  */
 void sol_i2c_pending_cancel(struct sol_i2c *i2c, struct sol_i2c_pending *pending);
 
+#ifdef SOL_PLATFORM_LINUX
+
+/**
+ * Create a new i2c device.
+ *
+ * Iterates through @a relative_dir on '/sys/devices/' looking
+ * for 'i2c-X' dir and add @a dev_name @dev_number to its 'new_device' file.
+ *
+ * @param relative_dir bus on '/sys/devices' where to add new i2c device.
+ * @param dev_name name of device. Usually is the one its driver expects
+ * @param dev_number number of device on bus. Usually a string on the form '0xYY'
+ * @param result_path resulting path of new device. It's a convenience to
+ * retrieve new device path. Note that the device dir may take some time
+ * to appear on sysfs - it may be necessary to wait some time before trying to
+ * access it. Needs to be PATH_MAX long in order to fit the path.
+ * @param write_status result of write operation to 'new_device' file.
+ * A value of -EINVAL means that write failed, but *maybe* the device already exists.
+ *
+ * @return false if could not try to write to 'new_device' file,
+ * true if could; in this case, @a write_status contain the status of writing
+ */
+bool sol_i2c_create_device(const char *address, const char *dev_name, const char *dev_number, char *result_path, int *write_status);
+#endif
+
 /**
  * @}
  */

--- a/src/modules/flow/iio/Kconfig
+++ b/src/modules/flow/iio/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_IIO
 	tristate "Node type: iio"
-	depends on FLOW && PLATFORM_LINUX
+	depends on PLATFORM_LINUX
 	default m

--- a/src/modules/flow/iio/iio.json
+++ b/src/modules/flow/iio/iio.json
@@ -28,8 +28,8 @@
       "options": {
        "members": [
          {
-           "data_type": "int",
-           "description": "IIO device number",
+           "data_type": "string",
+           "description": "IIO device identifier. If it's an integer value, will be interpreted as IIO device id. If it's a string starting with '/', will be interpreted as absolute path of IIO device on sysfs. If it's on the form 'i2c/X-YYYY', will evaluate to an i2c device on sysfs, where X is the bus number and YYYY is the device number, eg, 7-0069, for device 0x69 on bus 7. If it's on the form 'create,i2c,<rel_path>,<devnumber>,<devname>', where rel_path is the path of bus relative to '/sys/devices', them it will attempt to create an IIO device on that i2c bus and use it.",
            "name": "iio_device"
          },
          {

--- a/src/shared/sol-iio.h
+++ b/src/shared/sol-iio.h
@@ -151,6 +151,30 @@ bool sol_iio_device_start_buffer(struct sol_iio_device *device);
  */
 int sol_iio_resolve_device_address(const char *address);
 
+/**
+ * Create device based on address information.
+ *
+ * Address is a combination on the for <bus_type>,<rel_path>,<devnumber>,<devname>
+ * @a bus_type is the bus type, supported values are: i2c
+ * @a rel_path is the relative path for device on '/sys/devices',
+ * like 'platform/80860F41:05'
+ * @a devnumber is device number on bus, like 0xA4
+ * @a devname is device name, the one recognized by its driver
+ * If successful, will return on @cb the device number obtained. If device
+ * number is -1, it was not possible to create the device. If device already
+ * exists, will just return its IIO id on @a cb.
+ *
+ * @param address on format specified above
+ * @param cb callback to be called after device creation. It contains IIO
+ * device id, or -1 if unsuccessful
+ * @param data user data to be passed to callback
+ *
+ * @return to if attempt to create device was successful, false othewise. Note
+ * that to really know if device was created, besides return, one needs to check
+ * callback device_id.
+ */
+bool sol_iio_create_device_address(const char *address, void (*cb)(void *data, int device_id), const void *data);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/shared/sol-iio.h
+++ b/src/shared/sol-iio.h
@@ -136,6 +136,21 @@ bool sol_iio_device_trigger_now(struct sol_iio_device *device);
  */
 bool sol_iio_device_start_buffer(struct sol_iio_device *device);
 
+/**
+ * Attempts to find IIO device id from an address.
+ *
+ * Address can be an absolute path (starting with '/') pointing to sysfs
+ * dir of device. Alternatively, it can be i2c/X-YYYY, for i2c device,
+ * where X is the bus number and YYYY is the device number, eg, 7-0069
+ * for device 0x69 on bus 7. If it doesn't start with '/' or 'i2c/' then
+ * it will search for it on contents of 'name' file of IIO devices.
+ *
+ * @param address of device.
+ *
+ * @return IIO device id or -1 if could not find device id
+ */
+int sol_iio_resolve_device_address(const char *address);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/shared/sol-util-linux.h
+++ b/src/shared/sol-util-linux.h
@@ -34,8 +34,10 @@
 
 #include "sol-macros.h"
 
+#include <dirent.h>
 #include <sys/types.h>
 #include <stdarg.h>
+#include <stdbool.h>
 
 #define CHUNK_SIZE 4096
 #define SOL_UTIL_MAX_READ_ATTEMPTS 10
@@ -49,3 +51,4 @@ char *sol_util_load_file_string(const char *filename, size_t *size) SOL_ATTR_WAR
 int sol_util_get_rootdir(char *out, size_t size) SOL_ATTR_WARN_UNUSED_RESULT;
 int sol_util_fd_set_flag(int fd, int flag) SOL_ATTR_WARN_UNUSED_RESULT;
 ssize_t sol_util_fill_buffer(const int fd, char *buffer, const size_t buffer_size, size_t *size_read);
+bool sol_util_iterate_dir(const char *path, bool (*iterate_dir_cb)(void *data, const char *dir_path, struct dirent *ent), const void *data);


### PR DESCRIPTION
A tentative to address iio devices other than its id. Accepting name, absolute path on sysfs and for i2c, a relative path or even instructions to create the device.
I'm specially concerned about the instructions: it's a relative simple comma-separated string, that I started using for tests and survived to final form of this patch, reason: not sure what other format use (json?) that kept things simple. Last commit on this series (the one which changes the node) have examples of strings on its message. It's simple, but you, strings...