### PR TITLE
Add USE_ICU

### DIFF
--- a/src/modules/flow/string/Kconfig
+++ b/src/modules/flow/string/Kconfig
@@ -1,3 +1,9 @@
+# This is the solely user of ICU. If gets wider use, move up in the hierarchy.
+config USE_ICU
+	bool "Use ICU library"
+	depends on HAVE_ICU
+	default y
+
 config FLOW_NODE_TYPE_STRING
 	tristate "Node type: string"
 	default y

--- a/src/modules/flow/string/Makefile
+++ b/src/modules/flow/string/Makefile
@@ -1,14 +1,10 @@
 obj-$(FLOW_NODE_TYPE_STRING) += string.mod
 obj-string-$(FLOW_NODE_TYPE_STRING) := string.json
 
-ifdef LINUX
-ifdef HAVE_ICU
+ifdef USE_ICU
 obj-string-$(FLOW_NODE_TYPE_STRING) += string-icu.o string-replace-icu.o
 else
 obj-string-$(FLOW_NODE_TYPE_STRING) += string-ascii.o string-replace-ascii.o
-endif
-else
-obj-string-$(FLOW_NODE_TYPE_STRING) += string-ascii.o
 endif
 
 obj-string-$(FLOW_NODE_TYPE_STRING)-extra-cflags += $(LOCALE_CFLAGS) $(ICU_CFLAGS)

--- a/src/modules/flow/string/string-ascii.c
+++ b/src/modules/flow/string/string-ascii.c
@@ -43,8 +43,10 @@
 #include <locale.h>
 #endif
 
+#include "sol-flow-internal.h"
+
 #include "string-gen.h"
-#include "string.h"
+#include "string-ascii.h"
 
 struct string_data {
     int32_t n;

--- a/src/modules/flow/string/string-ascii.h
+++ b/src/modules/flow/string/string-ascii.h
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "sol-flow.h"
+
+char *string_replace(struct sol_flow_node *node, char *value, char *change_from, char *change_to, size_t max_count);

--- a/src/modules/flow/string/string-icu.c
+++ b/src/modules/flow/string/string-icu.c
@@ -37,8 +37,10 @@
 #include <unicode/utypes.h>
 #include <unicode/uchar.h>
 
+#include "sol-flow-internal.h"
+
 #include "string-gen.h"
-#include "string.h"
+#include "string-icu.h"
 
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 

--- a/src/modules/flow/string/string-icu.h
+++ b/src/modules/flow/string/string-icu.h
@@ -32,15 +32,10 @@
 
 #pragma once
 
-#include "sol-log.h"
-#include "sol-flow.h"
-#include "sol-flow-internal.h"
-#include "sol-util.h"
+#include <unicode/uchar.h>
 
-#ifdef HAVE_ICU
+#include "sol-flow.h"
+
 UChar *string_replace(struct sol_flow_node *node, UChar *value, UChar *change_from, UChar *change_to, size_t max_count);
 
 int icu_str_from_utf8(const char *utf_str, UChar **ret_icu_str, UErrorCode *ret_icu_err);
-#else
-char *string_replace(struct sol_flow_node *node, char *value, char *change_from, char *change_to, size_t max_count);
-#endif

--- a/src/modules/flow/string/string-replace-ascii.c
+++ b/src/modules/flow/string/string-replace-ascii.c
@@ -46,7 +46,9 @@
 #include <string.h>
 #include <sys/types.h>
 
-#include "string.h"
+#include "sol-util.h"
+
+#include "string-ascii.h"
 
 #define FAST_COUNT 0
 #define FAST_SEARCH 1

--- a/src/modules/flow/string/string-replace-icu.c
+++ b/src/modules/flow/string/string-replace-icu.c
@@ -50,7 +50,10 @@
 #include <unicode/utypes.h>
 #include <unicode/uchar.h>
 
-#include "string.h"
+#include "sol-log.h"
+#include "sol-util.h"
+
+#include "string-icu.h"
 
 #define FAST_COUNT 0
 #define FAST_SEARCH 1


### PR DESCRIPTION
First patch is kind of independent, but touches the string module, so it's here.

I'm not sure `USE_ICU` is in the right place, though.

@glima @dorileo @ibriano thoughts?

Glima told me the replace functions are implemented in a separate C file because they have a different license from the rest of the project. Otherwise we would probably inline them in `string-ascii.c` and `string-icu.c`.