### PR TITLE
Remove get_ports_counts() from sol_flow_node_type

### DIFF
--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -767,19 +767,6 @@ static void
     "name_c": data["name_c"],
     })
 
-    if in_ports_names or out_ports_names:
-        first_port = in_ports_names[0] if in_ports_names else out_ports_names[0]
-        outfile.write("    if (%s.packet_type == NULL) {\n" % (first_port))
-
-    for port, d_type in zip(in_ports_names, in_data_types):
-        outfile.write("        %s.packet_type = %s;\n"  % (port, packet_type_from_data_type(d_type)))
-
-    for port, d_type in zip(out_ports_names, out_data_types):
-        outfile.write("        %s.packet_type = %s;\n"  % (port, packet_type_from_data_type(d_type)))
-
-    if in_ports_names or out_ports_names:
-        outfile.write("    }\n")
-
     outfile.write("""\
     if (ports_in_count)
         *ports_in_count = %(ports_in_count)d;
@@ -799,6 +786,16 @@ static void
 """ % {
     "name_c": data["name_c"],
     })
+
+    if in_ports_names or out_ports_names:
+        all_ports_names = in_ports_names + out_ports_names
+        all_ports_types = in_data_types + out_data_types
+        outfile.write("    if (%s.packet_type == NULL) {\n" % (all_ports_names[0]))
+
+        for port, d_type in zip(all_ports_names, all_ports_types):
+            packet_type = packet_type_from_data_type(d_type)
+            outfile.write("        %s.packet_type = %s;\n"  % (port, packet_type))
+        outfile.write("    }\n")
 
     if "init_type" in methods:
         outfile.write("    %s();\n" % methods.get("init_type"))

--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -759,26 +759,6 @@ static const struct sol_flow_port_type_out *
     "get_ports": out_ports_get_port
     })
 
-    outfile.write("""\
-static void
-%(name_c)s_get_ports_counts_internal(const struct sol_flow_node_type *type, uint16_t *ports_in_count, uint16_t *ports_out_count)
-{
-""" % {
-    "name_c": data["name_c"],
-    })
-
-    outfile.write("""\
-    if (ports_in_count)
-        *ports_in_count = %(ports_in_count)d;
-    if (ports_out_count)
-        *ports_out_count = %(ports_out_count)d;
-}
-""" % {
-    "name_c": data["name_c"],
-    "ports_in_count": in_ports_count,
-    "ports_out_count": out_ports_count,
-    })
-
     outfile.write("""
 static void
 %(name_c)s_init_type_internal(void)
@@ -999,7 +979,6 @@ static const %(node_type)s %(name_c)s = {%(node_base_type_access_open)s
     .init_type = %(name_c)s_init_type_internal,
     .open = %(open)s,
     .close = %(close)s,
-    .get_ports_counts = %(name_c)s_get_ports_counts_internal,
 """ % {
     "node_type": node_type,
     "node_base_type_access_open": node_base_type_access_open,
@@ -1013,13 +992,21 @@ static const %(node_type)s %(name_c)s = {%(node_base_type_access_open)s
 
     if in_ports_names:
         outfile.write("""\
+    .ports_in_count = %(count)d,
     .get_port_in = %(name_c)s_get_port_in_internal,
-""" % {"name_c": data["name_c"]})
+""" % {
+    "name_c": data["name_c"],
+    "count": in_ports_count,
+    })
 
     if out_ports_names:
         outfile.write("""\
+    .ports_out_count = %(count)d,
     .get_port_out = %(name_c)s_get_port_out_internal,
-""" % {"name_c": data["name_c"]})
+""" % {
+    "name_c": data["name_c"],
+    "count": out_ports_count,
+    })
 
     outfile.write("""\
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED

--- a/src/bin/sol-fbp-runner/runner.c
+++ b/src/bin/sol-fbp-runner/runner.c
@@ -180,7 +180,8 @@ attach_simulation_nodes(struct runner *r)
     bool found;
     char *node_name;
 
-    r->root_type->get_ports_counts(r->root_type, &in_count, &out_count);
+    in_count = r->root_type->ports_in_count;
+    out_count = r->root_type->ports_out_count;
 
     if (in_count == 0 && out_count == 0)
         return 0;

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -347,7 +347,9 @@ struct sol_flow_node_type {
     const void *type_data; /**< pointer to per-type user data */
     const void *default_options;
 
-    void (*get_ports_counts)(const struct sol_flow_node_type *type, uint16_t *ports_in_count, uint16_t *ports_out_count); /**< member function to get the number of input/output ports of the node */
+    uint16_t ports_in_count;
+    uint16_t ports_out_count;
+
     const struct sol_flow_port_type_in *(*get_port_in)(const struct sol_flow_node_type *type, uint16_t port); /**< member function to get the array of the node's input ports */
     const struct sol_flow_port_type_out *(*get_port_out)(const struct sol_flow_node_type *type, uint16_t port); /**< member function to get the array of the node's output ports */
 

--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -703,7 +703,7 @@ sol_flow_builder_connect_by_index(struct sol_flow_builder *builder, const char *
 {
     struct sol_flow_static_node_spec *src_node_spec, *dst_node_spec;
     int r;
-    uint16_t src, dst, ports_in_count, ports_out_count;
+    uint16_t src, dst;
 
     SOL_NULL_CHECK(builder, -EINVAL);
 
@@ -721,19 +721,15 @@ sol_flow_builder_connect_by_index(struct sol_flow_builder *builder, const char *
         return r;
 
     /* check if port index is inside ports range */
-    src_node_spec->type->get_ports_counts(src_node_spec->type, NULL,
-        &ports_out_count);
-    if (src_port_index >= ports_out_count) {
+    if (src_port_index >= src_node_spec->type->ports_out_count) {
         SOL_WRN("Output port index %d out of ports range (count = %d).",
-            src_port_index, ports_out_count);
+            src_port_index, src_node_spec->type->ports_out_count);
         return -EINVAL;
     }
 
-    dst_node_spec->type->get_ports_counts(dst_node_spec->type, &ports_in_count,
-        NULL);
-    if (dst_port_index >= ports_in_count) {
+    if (dst_port_index >= dst_node_spec->type->ports_in_count) {
         SOL_WRN("Input port index %d out of ports range (count = %d).",
-            src_port_index, ports_in_count);
+            src_port_index, dst_node_spec->type->ports_in_count);
         return -EINVAL;
     }
 

--- a/src/lib/flow/sol-flow-js.c
+++ b/src/lib/flow/sol-flow-js.c
@@ -882,17 +882,6 @@ flow_js_port_out_disconnect(struct sol_flow_node *node, void *data, uint16_t por
         type->ports_in.len * PORTS_IN_METHODS_LENGTH, PORTS_OUT_METHODS_LENGTH, PORTS_OUT_DISCONNECT_INDEX);
 }
 
-static void
-flow_js_get_ports_counts(const struct sol_flow_node_type *type, uint16_t *ports_in_count, uint16_t *ports_out_count)
-{
-    const struct flow_js_type *js_type = (struct flow_js_type *)type;
-
-    if (ports_in_count)
-        *ports_in_count = js_type->ports_in.len;
-    if (ports_out_count)
-        *ports_out_count = js_type->ports_out.len;
-}
-
 static const struct sol_flow_port_type_in *
 flow_js_get_port_in(const struct sol_flow_node_type *type, uint16_t port)
 {
@@ -1299,7 +1288,6 @@ flow_js_type_init(struct flow_js_type *type, const char *buf, size_t len)
             .data_size = sizeof(struct flow_js_data),
             .open = flow_js_open,
             .close = flow_js_close,
-            .get_ports_counts = flow_js_get_ports_counts,
             .get_port_in = flow_js_get_port_in,
             .get_port_out = flow_js_get_port_out,
             .dispose_type = flow_dispose_type,
@@ -1309,6 +1297,9 @@ flow_js_type_init(struct flow_js_type *type, const char *buf, size_t len)
 
     if (!setup_ports(type, buf, len))
         return false;
+
+    type->base.ports_in_count = type->ports_in.len;
+    type->base.ports_out_count = type->ports_out.len;
 
     js_content_buf = strndup(buf, len);
     SOL_NULL_CHECK(js_content_buf, false);

--- a/src/lib/flow/sol-flow-simplectype.c
+++ b/src/lib/flow/sol-flow-simplectype.c
@@ -187,17 +187,6 @@ simplectype_destroy_description(struct sol_flow_node_type *type)
 #endif
 }
 
-static void
-simplectype_get_ports_counts(const struct sol_flow_node_type *type, uint16_t *ports_in_count, uint16_t *ports_out_count)
-{
-    const struct simplectype_type_data *type_data = type->type_data;
-
-    if (ports_in_count)
-        *ports_in_count = type_data->ports_in.len;
-    if (ports_out_count)
-        *ports_out_count = type_data->ports_out.len;
-}
-
 static const struct sol_flow_port_type_in *
 simplectype_get_port_in(const struct sol_flow_node_type *type, uint16_t port)
 {
@@ -412,7 +401,9 @@ simplectype_new_full_inner(const char *name, size_t private_data_size, uint16_t 
     type_data->ports_in = ports_in;
     type_data->ports_out = ports_out;
 
-    type->get_ports_counts = simplectype_get_ports_counts;
+    type->ports_in_count = ports_in.len;
+    type->ports_out_count = ports_out.len;
+
     type->get_port_in = simplectype_get_port_in;
     type->get_port_out = simplectype_get_port_out;
     type->open = simplectype_open;

--- a/src/lib/flow/sol-flow.c
+++ b/src/lib/flow/sol-flow.c
@@ -103,7 +103,6 @@ sol_flow_node_init(struct sol_flow_node *node, struct sol_flow_node *parent, con
 
     SOL_NULL_CHECK(type, -EINVAL);
     SOL_NULL_CHECK(node, -EINVAL);
-    SOL_NULL_CHECK(type->get_ports_counts, -EINVAL);
 
     SOL_FLOW_NODE_TYPE_API_CHECK(type, SOL_FLOW_NODE_TYPE_API_VERSION, -EINVAL);
 

--- a/src/test/test-flow-builder.c
+++ b/src/test/test-flow-builder.c
@@ -141,15 +141,19 @@ static const struct sol_flow_port_type_out *test_ports_out[] = {
 static void
 test_node_get_ports_counts(const struct sol_flow_node_type *type, uint16_t *ports_in_count, uint16_t *ports_out_count)
 {
-    if (!test_port_in.packet_type) {
-        test_port_in.packet_type = SOL_FLOW_PACKET_TYPE_EMPTY;
-        test_port_out.packet_type = SOL_FLOW_PACKET_TYPE_EMPTY;
-    }
-
     if (ports_in_count)
         *ports_in_count = ARRAY_SIZE(test_ports_in);
     if (ports_out_count)
         *ports_out_count = ARRAY_SIZE(test_ports_out);
+}
+
+static void
+test_node_init_type(void)
+{
+    if (!test_port_in.packet_type) {
+        test_port_in.packet_type = SOL_FLOW_PACKET_TYPE_EMPTY;
+        test_port_out.packet_type = SOL_FLOW_PACKET_TYPE_EMPTY;
+    }
 }
 
 static const struct sol_flow_port_type_in *
@@ -187,6 +191,8 @@ static const struct sol_flow_node_type_description test_node_description = {
 
 static const struct sol_flow_node_type test_node_type = {
     .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
+
+    .init_type = test_node_init_type,
 
     .get_ports_counts = test_node_get_ports_counts,
     .get_port_in = test_node_get_port_in,

--- a/src/test/test-flow-builder.c
+++ b/src/test/test-flow-builder.c
@@ -139,15 +139,6 @@ static const struct sol_flow_port_type_out *test_ports_out[] = {
 };
 
 static void
-test_node_get_ports_counts(const struct sol_flow_node_type *type, uint16_t *ports_in_count, uint16_t *ports_out_count)
-{
-    if (ports_in_count)
-        *ports_in_count = ARRAY_SIZE(test_ports_in);
-    if (ports_out_count)
-        *ports_out_count = ARRAY_SIZE(test_ports_out);
-}
-
-static void
 test_node_init_type(void)
 {
     if (!test_port_in.packet_type) {
@@ -194,7 +185,8 @@ static const struct sol_flow_node_type test_node_type = {
 
     .init_type = test_node_init_type,
 
-    .get_ports_counts = test_node_get_ports_counts,
+    .ports_in_count = ARRAY_SIZE(test_ports_in),
+    .ports_out_count = ARRAY_SIZE(test_ports_out),
     .get_port_in = test_node_get_port_in,
     .get_port_out = test_node_get_port_out,
     .options_size = sizeof(struct sol_flow_node_options),
@@ -426,7 +418,6 @@ ports_can_be_exported(void)
 {
     struct sol_flow_builder *builder;
     struct sol_flow_node_type *type;
-    uint16_t count_in = 0, count_out = 0;
     int ret;
 
     const char *in_name = "EXPORTED_IN";
@@ -447,9 +438,8 @@ ports_can_be_exported(void)
     type = sol_flow_builder_get_node_type(builder);
     ASSERT(type);
 
-    type->get_ports_counts(type, &count_in, &count_out);
-    ASSERT_INT_EQ(count_in, 1);
-    ASSERT_INT_EQ(count_out, 1);
+    ASSERT_INT_EQ(type->ports_in_count, 1);
+    ASSERT_INT_EQ(type->ports_out_count, 1);
 
     ASSERT(type->description);
 

--- a/src/test/test-flow-parser.c
+++ b/src/test/test-flow-parser.c
@@ -138,15 +138,19 @@ static const struct sol_flow_port_type_out *test_ports_out[] = {
 static void
 test_node_get_ports_counts(const struct sol_flow_node_type *type, uint16_t *ports_in_count, uint16_t *ports_out_count)
 {
-    if (!test_port_in.packet_type) {
-        test_port_in.packet_type = SOL_FLOW_PACKET_TYPE_EMPTY;
-        test_port_out.packet_type = SOL_FLOW_PACKET_TYPE_EMPTY;
-    }
-
     if (ports_in_count)
         *ports_in_count = ARRAY_SIZE(test_ports_in);
     if (ports_out_count)
         *ports_out_count = ARRAY_SIZE(test_ports_out);
+}
+
+static void
+test_node_init_type(void)
+{
+    if (!test_port_in.packet_type) {
+        test_port_in.packet_type = SOL_FLOW_PACKET_TYPE_EMPTY;
+        test_port_out.packet_type = SOL_FLOW_PACKET_TYPE_EMPTY;
+    }
 }
 
 static const struct sol_flow_port_type_in *
@@ -217,6 +221,8 @@ static const struct sol_flow_node_type test_node_type = {
 
     .options_size = sizeof(struct test_node_options),
     .default_options = &default_opts,
+
+    .init_type = test_node_init_type,
 
     .get_ports_counts = test_node_get_ports_counts,
     .get_port_in = test_node_get_port_in,

--- a/src/test/test-flow-parser.c
+++ b/src/test/test-flow-parser.c
@@ -136,15 +136,6 @@ static const struct sol_flow_port_type_out *test_ports_out[] = {
 };
 
 static void
-test_node_get_ports_counts(const struct sol_flow_node_type *type, uint16_t *ports_in_count, uint16_t *ports_out_count)
-{
-    if (ports_in_count)
-        *ports_in_count = ARRAY_SIZE(test_ports_in);
-    if (ports_out_count)
-        *ports_out_count = ARRAY_SIZE(test_ports_out);
-}
-
-static void
 test_node_init_type(void)
 {
     if (!test_port_in.packet_type) {
@@ -224,7 +215,8 @@ static const struct sol_flow_node_type test_node_type = {
 
     .init_type = test_node_init_type,
 
-    .get_ports_counts = test_node_get_ports_counts,
+    .ports_in_count = ARRAY_SIZE(test_ports_in),
+    .ports_out_count = ARRAY_SIZE(test_ports_out),
     .get_port_in = test_node_get_port_in,
     .get_port_out = test_node_get_port_out,
 
@@ -432,7 +424,6 @@ exported_ports(void)
 {
     struct sol_flow_parser *parser;
     struct sol_flow_node_type *type;
-    uint16_t count_in = 0, count_out = 0;
 
     static const char input[] =
         "OUTPORT=a.OUT1:OUTPUT_PORT\n"
@@ -445,9 +436,8 @@ exported_ports(void)
     type = sol_flow_parse_string(parser, input, NULL);
     ASSERT(type);
 
-    type->get_ports_counts(type, &count_in, &count_out);
-    ASSERT_INT_EQ(count_in, 1);
-    ASSERT_INT_EQ(count_out, 1);
+    ASSERT_INT_EQ(type->ports_in_count, 1);
+    ASSERT_INT_EQ(type->ports_out_count, 1);
 
     ASSERT(type->description);
 

--- a/src/test/test-flow.c
+++ b/src/test/test-flow.c
@@ -227,6 +227,15 @@ static const struct sol_flow_port_type_out *test_ports_out[] = {
 static void
 test_node_get_ports_counts(const struct sol_flow_node_type *type, uint16_t *ports_in_count, uint16_t *ports_out_count)
 {
+    if (ports_in_count)
+        *ports_in_count = ARRAY_SIZE(test_ports_in);
+    if (ports_out_count)
+        *ports_out_count = ARRAY_SIZE(test_ports_out);
+}
+
+static void
+test_node_init_type(void)
+{
     if (!test_port_in.packet_type) {
         test_port_in.packet_type = SOL_FLOW_PACKET_TYPE_EMPTY;
         test_port_out.packet_type = SOL_FLOW_PACKET_TYPE_EMPTY;
@@ -235,11 +244,6 @@ test_node_get_ports_counts(const struct sol_flow_node_type *type, uint16_t *port
         test_port_any_in.packet_type = SOL_FLOW_PACKET_TYPE_ANY;
         test_port_any_out.packet_type = SOL_FLOW_PACKET_TYPE_ANY;
     }
-
-    if (ports_in_count)
-        *ports_in_count = ARRAY_SIZE(test_ports_in);
-    if (ports_out_count)
-        *ports_out_count = ARRAY_SIZE(test_ports_out);
 }
 
 static const struct sol_flow_port_type_in *
@@ -262,6 +266,8 @@ static const struct sol_flow_node_type test_node_type = {
 
     .open = test_node_open,
     .close = test_node_close,
+
+    .init_type = test_node_init_type,
 
     .get_ports_counts = test_node_get_ports_counts,
     .get_port_in = test_node_get_port_in,

--- a/src/test/test-flow.c
+++ b/src/test/test-flow.c
@@ -225,15 +225,6 @@ static const struct sol_flow_port_type_out *test_ports_out[] = {
 };
 
 static void
-test_node_get_ports_counts(const struct sol_flow_node_type *type, uint16_t *ports_in_count, uint16_t *ports_out_count)
-{
-    if (ports_in_count)
-        *ports_in_count = ARRAY_SIZE(test_ports_in);
-    if (ports_out_count)
-        *ports_out_count = ARRAY_SIZE(test_ports_out);
-}
-
-static void
 test_node_init_type(void)
 {
     if (!test_port_in.packet_type) {
@@ -269,7 +260,8 @@ static const struct sol_flow_node_type test_node_type = {
 
     .init_type = test_node_init_type,
 
-    .get_ports_counts = test_node_get_ports_counts,
+    .ports_in_count = ARRAY_SIZE(test_ports_in),
+    .ports_out_count = ARRAY_SIZE(test_ports_out),
     .get_port_in = test_node_get_port_in,
     .get_port_out = test_node_get_port_out,
 };


### PR DESCRIPTION
We know the sizes upfront and our design implies that these values won't change for an existing type, so set them sooner in a more convenient way. As a bonus, fix a longstanding TODO item.