### PR TITLE
Improvements to runner simulation

### DIFF
--- a/src/bin/sol-fbp-runner/runner.c
+++ b/src/bin/sol-fbp-runner/runner.c
@@ -154,9 +154,9 @@ struct map {
 static const struct map input_nodes[] = {
     { &SOL_FLOW_PACKET_TYPE_IRANGE, "gtk/spinbutton", "OUT" },
     { &SOL_FLOW_PACKET_TYPE_DRANGE, "gtk/slider", "OUT" },
-    { &SOL_FLOW_PACKET_TYPE_ANY, "gtk/toggle", "OUT" },
-    { &SOL_FLOW_PACKET_TYPE_EMPTY, "gtk/toggle", "OUT" },
-    { &SOL_FLOW_PACKET_TYPE_BOOLEAN, "gtk/pushbutton", "OUT" },
+    { &SOL_FLOW_PACKET_TYPE_ANY, "gtk/pushbutton", "PRESSED" },
+    { &SOL_FLOW_PACKET_TYPE_EMPTY, "gtk/pushbutton", "PRESSED" },
+    { &SOL_FLOW_PACKET_TYPE_BOOLEAN, "gtk/toggle", "OUT" },
     { &SOL_FLOW_PACKET_TYPE_RGB, "gtk/rgb-editor", "OUT" },
     { &SOL_FLOW_PACKET_TYPE_BYTE, "gtk/byte-editor", "OUT" },
 };
@@ -164,6 +164,7 @@ static const struct map input_nodes[] = {
 static const struct map output_nodes[] = {
     { &SOL_FLOW_PACKET_TYPE_IRANGE, "gtk/label", "IN" },
     { &SOL_FLOW_PACKET_TYPE_DRANGE, "gtk/label", "IN" },
+    { &SOL_FLOW_PACKET_TYPE_EMPTY, "gtk/label", "IN" },
     { &SOL_FLOW_PACKET_TYPE_STRING, "gtk/label", "IN" },
     { &SOL_FLOW_PACKET_TYPE_BOOLEAN, "gtk/led", "IN" },
 };

--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -907,8 +907,10 @@ sol_flow_builder_get_node_type(struct sol_flow_builder *builder)
     desc = &type_data->desc;
 
     /* TODO: ensure no repeated connections in connect() */
-    qsort(builder->conns.data, builder->conns.len,
-        sizeof(struct sol_flow_static_conn_spec), compare_conns);
+    if (builder->conns.len > 1) {
+        qsort(builder->conns.data, builder->conns.len,
+            sizeof(struct sol_flow_static_conn_spec), compare_conns);
+    }
 
     if (builder->options_description.len > 0) {
         opts = calloc(1, sizeof(*opts));

--- a/src/modules/flow/gtk/gtk.json
+++ b/src/modules/flow/gtk/gtk.json
@@ -84,7 +84,7 @@
     },
     {
       "category": "input/sw",
-      "description": "Emulates a pushbutton providing boolean packets",
+      "description": "Emulates a pushbutton that automatically goes up when released",
       "methods": {
         "close": "gtk_pushbutton_close",
         "open": "gtk_pushbutton_open"
@@ -95,6 +95,16 @@
           "data_type": "boolean",
           "description": "TRUE when pushed and FALSE when released.",
           "name": "OUT"
+        },
+        {
+          "data_type": "empty",
+          "description": "Send an empty packet when the button is pushed.",
+          "name": "PRESSED"
+        },
+        {
+          "data_type": "empty",
+          "description": "Send an empty packet when the button is released.",
+          "name": "RELEASED"
         }
       ],
       "private_data_type": "gtk_common_data",

--- a/src/modules/flow/gtk/gtk.json
+++ b/src/modules/flow/gtk/gtk.json
@@ -242,8 +242,10 @@
           {
             "data_type": "int",
             "default": {
-              "max": 100,
-              "min": 0
+              "val": 0,
+              "max": "INT32_MAX",
+              "min": "INT32_MIN",
+              "step": 1
             },
             "description": "Spinbutton's range",
             "name": "range"

--- a/src/modules/flow/gtk/gtk.json
+++ b/src/modules/flow/gtk/gtk.json
@@ -43,7 +43,7 @@
         "open": "gtk_label_open"
       },
       "name": "gtk/label",
-      "private_data_type": "gtk_common_data",
+      "private_data_type": "gtk_label_data",
       "url": "http://solettaproject.org/doc/latest/node_types/gtk/label.html"
     },
     {

--- a/src/modules/flow/gtk/label.c
+++ b/src/modules/flow/gtk/label.c
@@ -52,9 +52,13 @@ gtk_label_in_process(struct sol_flow_node *node,
     const struct sol_flow_packet *packet)
 {
     struct gtk_common_data *mdata = data;
+    struct gtk_label_data *label_data = data;
 
     if (sol_flow_packet_get_type(packet) == SOL_FLOW_PACKET_TYPE_EMPTY) {
-        gtk_label_set_text(GTK_LABEL(mdata->widget), "[empty]");
+        char buf[32];
+        label_data->empty_count++;
+        snprintf(buf, sizeof(buf), "[empty %d]", label_data->empty_count);
+        gtk_label_set_text(GTK_LABEL(mdata->widget), buf);
     } else if (sol_flow_packet_get_type(packet) == SOL_FLOW_PACKET_TYPE_STRING) {
         const char *in_value;
         int r = sol_flow_packet_get_string(packet, &in_value);

--- a/src/modules/flow/gtk/label.h
+++ b/src/modules/flow/gtk/label.h
@@ -32,6 +32,11 @@
 
 #include "common.h"
 
+struct gtk_label_data {
+    struct gtk_common_data base;
+    unsigned int empty_count;
+};
+
 DEFINE_DEFAULT_HEADER(label);
 
 int gtk_label_in_process(struct sol_flow_node *node,

--- a/src/modules/flow/gtk/pushbutton.c
+++ b/src/modules/flow/gtk/pushbutton.c
@@ -40,6 +40,8 @@ on_pushbutton_pressed(GtkButton *button, gpointer data)
 
     sol_flow_send_boolean_packet(mdata->node,
         SOL_FLOW_NODE_TYPE_GTK_PUSHBUTTON__OUT__OUT, true);
+    sol_flow_send_empty_packet(mdata->node,
+        SOL_FLOW_NODE_TYPE_GTK_PUSHBUTTON__OUT__PRESSED);
 }
 
 static void
@@ -49,6 +51,8 @@ on_pushbutton_released(GtkButton *button, gpointer data)
 
     sol_flow_send_boolean_packet(mdata->node,
         SOL_FLOW_NODE_TYPE_GTK_PUSHBUTTON__OUT__OUT, false);
+    sol_flow_send_empty_packet(mdata->node,
+        SOL_FLOW_NODE_TYPE_GTK_PUSHBUTTON__OUT__RELEASED);
 }
 
 static int

--- a/src/samples/flow/gtk-gallery/gtk-gallery.fbp
+++ b/src/samples/flow/gtk-gallery/gtk-gallery.fbp
@@ -49,3 +49,4 @@ byte_editor(gtk/byte-editor) OUT -> IN byte_editor_output(gtk/label)
 rgb_editor(gtk/rgb-editor) OUT -> IN rgb_editor_output(gtk/led:rgb=0|0|0)
 
 pushbutton(gtk/pushbutton) OUT -> IN pushbutton_output(gtk/led)
+pushbutton PRESSED -> IN pushbutton_pressed_output(gtk/label)

--- a/src/samples/flow/gtk-gallery/gtk-gallery.fbp
+++ b/src/samples/flow/gtk-gallery/gtk-gallery.fbp
@@ -38,7 +38,7 @@ toggle OUT -> IN toggle_output2(gtk/led:rgb=255|0|0)
 
 slider(gtk/slider) OUT -> IN slider_output(gtk/label)
 
-spinbutton(gtk/spinbutton:range=step:1|max:INT32_MAX|val:30|min:30) OUT -> IN spinbutton_output(gtk/label)
+spinbutton(gtk/spinbutton:range=step:1|max:INT32_MAX|val:42|min:30) OUT -> IN spinbutton_output(gtk/label)
 
 pwm_editor(gtk/pwm-editor) ENABLED -> ENABLED pwm_viewer(gtk/pwm-viewer)
 pwm_editor DUTY_CYCLE -> DUTY_CYCLE pwm_viewer


### PR DESCRIPTION
The flag `-s` can be used in `sol-fbp-runner` to create simulation nodes for exported ports in a FBP. It currently uses GTK node types.

This PR fixes a series of small issues identified in those node types, and fine tune the node types we use and the presentation of the simulator.