### PR TITLE
dependencies: Check libudev minimum version

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -143,7 +143,8 @@
 	{
 	    "dependency": "udev",
 	    "type": "pkg-config",
-	    "pkgname": "libudev"
+	    "pkgname": "libudev",
+	    "atleast-version": "204"
 	},
 	{
 	    "dependency": "sd_dbus",


### PR DESCRIPTION
Related to issue #415.

The node type udev requires an API modified in libudev 183.
This patch adds a check for libudev 204, the oldest version
I managed to test with.

Signed-off-by: Anselmo L. S. Melo <anselmo.melo@intel.com>