### PR TITLE
IIO Address v2

### DIFF
--- a/src/lib/io/include/sol-i2c.h
+++ b/src/lib/io/include/sol-i2c.h
@@ -37,6 +37,7 @@
 #include <sys/types.h>
 
 #include <sol-macros.h>
+#include <sol-buffer.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -308,6 +309,29 @@ uint8_t sol_i2c_bus_get(const struct sol_i2c *i2c);
  * @param pending the operation handle
  */
 void sol_i2c_pending_cancel(struct sol_i2c *i2c, struct sol_i2c_pending *pending);
+
+#ifdef SOL_PLATFORM_LINUX
+
+/**
+ * Create a new i2c device.
+ *
+ * Iterates through @a relative_dir on '/sys/devices/' looking
+ * for 'i2c-X' dir and add @a dev_name @dev_number to its 'new_device' file.
+ *
+ * @param relative_dir bus on '/sys/devices' where to add new i2c device.
+ * @param dev_name name of device. Usually is the one its driver expects.
+ * @param dev_number number of device on bus.
+ * @param result_path resulting path of new device. It's a convenience to
+ * retrieve new device path. Note that the device dir may take some time
+ * to appear on sysfs - it may be necessary to wait some time before trying to
+ * access it.
+ *
+ * @return a positive value if everything was ok. A negative one if some error
+ * happened. Watch out for -EEXIST return: it means that device could not be
+ * created because it already exists.
+ */
+int sol_i2c_create_device(const char *address, const char *dev_name, unsigned int dev_number, struct sol_buffer *result_path);
+#endif
 
 /**
  * @}

--- a/src/lib/io/sol-i2c-linux.c
+++ b/src/lib/io/sol-i2c-linux.c
@@ -47,10 +47,12 @@
 #include <linux/i2c.h>
 #endif
 
+#include <dirent.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdint.h>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 #include <errno.h>
 
 #define SOL_LOG_DOMAIN &_log_domain
@@ -64,6 +66,16 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "i2c");
 #ifdef WORKER_THREAD
 #include "sol-worker-thread.h"
 #endif
+
+#define SYSFS_DEVICES_PATH_RAW "/sys/devices/%s"
+#define SYSFS_I2C_NEW_DEVICE "%s/%s/new_device"
+
+struct i2c_create_device {
+    struct sol_buffer *result_path;
+    unsigned int dev_number;
+    const char *dev_name;
+    int result;
+};
 
 struct sol_i2c {
     int dev;
@@ -961,4 +973,92 @@ sol_i2c_pending_cancel(struct sol_i2c *i2c, struct sol_i2c_pending *pending)
 #endif
         SOL_WRN("Invalid I2C pending handle.");
     }
+}
+
+static bool
+create_device_iter_cb(void *data, const char *dir_path, struct dirent *ent)
+{
+    struct i2c_create_device *result = data;
+    char path[PATH_MAX];
+    int r;
+    struct stat st;
+
+    if (strstartswith(ent->d_name, "i2c-")) {
+        r = snprintf(path, sizeof(path), SYSFS_I2C_NEW_DEVICE, dir_path,
+            ent->d_name);
+        if (r > 0) {
+            /* There should be only one i2c-X dir. If we fail to write to its
+             * new_device file, we lost */
+            result->result = sol_util_write_file(path, "%s %d",
+                result->dev_name, result->dev_number);
+            if (result->result < 0) {
+                SOL_WRN("Could not write to [%s]: %s", path,
+                    sol_util_strerrora(errno));
+            }
+
+            r = snprintf(path, PATH_MAX, "%s/%s/%s-00%X",
+                dir_path, ent->d_name, ent->d_name + strlen("i2c-"),
+                result->dev_number);
+            if (r < 0 || r >= PATH_MAX) {
+                SOL_WRN("Could not write resulting device path");
+                result->result = -EINVAL;
+                return true;
+            }
+
+            if (result->result == -EINVAL) {
+                /* Device may happen to exist. Check it. */
+                if (!stat(path, &st)) {
+                    result->result = -EEXIST;
+                }
+            }
+
+            if (result->result_path) {
+                r = sol_buffer_append_printf(result->result_path,
+                    "%s", path);
+                if (r < 0) {
+                    SOL_WRN("Could not write resulting device path to buffer");
+                    result->result = r;
+                }
+            }
+            return true;
+        }
+    }
+
+    return false;
+}
+
+SOL_API int
+sol_i2c_create_device(const char *address, const char *dev_name, unsigned int dev_number, struct sol_buffer *result_path)
+{
+    char path[PATH_MAX], real_path[PATH_MAX];
+    int len;
+    struct i2c_create_device result;
+
+    SOL_NULL_CHECK(address, -EINVAL);
+    SOL_NULL_CHECK(dev_name, -EINVAL);
+
+    result.dev_name = dev_name;
+    result.dev_number = dev_number;
+    result.result_path = result_path;
+
+    len = snprintf(path, sizeof(path), SYSFS_DEVICES_PATH_RAW, address);
+    if (len < 0 || len >= PATH_MAX) {
+        SOL_WRN("Could not create sysfs bus path");
+        return -EINVAL;
+    }
+
+    /* Validate if path points do '/sys/devices', to avoid some '../' trickery */
+    if (realpath(path, real_path)) {
+        if (!strstartswith(real_path, "/sys/devices")) {
+            SOL_WRN("Invalid relative path [%s]", address);
+            return -EINVAL;
+        }
+    }
+
+    if (!sol_util_iterate_dir(real_path, create_device_iter_cb, &result)) {
+        SOL_WRN("Could not find suitable i2c dir on device sysfs [%s]", real_path);
+        return -ENOENT;
+    }
+
+    return result.result;
 }

--- a/src/modules/flow/iio/Kconfig
+++ b/src/modules/flow/iio/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_IIO
 	tristate "Node type: iio"
-	depends on FLOW && PLATFORM_LINUX
+	depends on PLATFORM_LINUX
 	default m

--- a/src/modules/flow/iio/iio.json
+++ b/src/modules/flow/iio/iio.json
@@ -28,8 +28,8 @@
       "options": {
        "members": [
          {
-           "data_type": "int",
-           "description": "IIO device number",
+           "data_type": "string",
+           "description": "IIO device identifier. It's a space separated list of commands. For commands, if it's an integer value, will be interpreted as IIO device id. If it's a string starting with '/', will be interpreted as absolute path of IIO device on sysfs. If it's on the form 'i2c/X-YYYY', will evaluate to an i2c device on sysfs, where X is the bus number and YYYY is the device number, eg, 7-0069, for device 0x69 on bus 7. If it's on the form 'create,i2c,<rel_path>,<devnumber>,<devname>', where rel_path is the path of bus relative to '/sys/devices', them it will attempt to create an IIO device on that i2c bus and use it.",
            "name": "iio_device"
          },
          {

--- a/src/modules/flow/iio/nodes.c
+++ b/src/modules/flow/iio/nodes.c
@@ -39,12 +39,17 @@
 #include <sol-iio.h>
 
 struct gyroscope_data {
+    struct sol_iio_config config;
+    struct sol_direction_vector scale;
+    struct sol_direction_vector offset;
     struct sol_flow_node *node;
     struct sol_iio_device *device;
     struct sol_iio_channel *channel_x;
     struct sol_iio_channel *channel_y;
     struct sol_iio_channel *channel_z;
     bool buffer_enabled : 1;
+    bool use_device_default_scale : 1;
+    bool use_device_default_offset : 1;
 };
 
 static void
@@ -80,37 +85,20 @@ error:
     SOL_WRN("%s", errmsg);
 }
 
-static int
-gyroscope_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
+static void
+create_device_cb(void *data, int device_id)
 {
     struct gyroscope_data *mdata = data;
-    const struct sol_flow_node_type_iio_gyroscope_options *opts;
-    struct sol_iio_config config;
     struct sol_iio_channel_config channel_config = SOL_IIO_CHANNEL_CONFIG_INIT;
 
-    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_IIO_GYROSCOPE_OPTIONS_API_VERSION,
-        -EINVAL);
-    opts = (const struct sol_flow_node_type_iio_gyroscope_options *)options;
-
-    mdata->buffer_enabled = opts->buffer_size.val > -1;
-
-    config.api_version = SOL_IIO_CONFIG_API_VERSION;
-    config.trigger_name = opts->iio_trigger_name;
-    config.buffer_size = opts->buffer_size.val;
-    config.sampling_frequency = opts->sampling_frequency.val;
-    if (mdata->buffer_enabled) {
-        config.sol_iio_reader_cb = reader_cb;
-        config.data = mdata;
-    }
-
-    mdata->device = sol_iio_open(opts->iio_device.val, &config);
-    SOL_NULL_CHECK(mdata->device, -EINVAL);
+    mdata->device = sol_iio_open(device_id, &mdata->config);
+    SOL_NULL_CHECK(mdata->device);
 
 #define ADD_CHANNEL(_axis) \
-    if (!opts->use_device_default_scale) \
-        channel_config.scale = opts->scale._axis; \
-    if (!opts->use_device_default_offset) \
-        channel_config.offset = opts->offset._axis; \
+    if (!mdata->use_device_default_scale) \
+        channel_config.scale = mdata->scale._axis; \
+    if (!mdata->use_device_default_offset) \
+        channel_config.offset = mdata->offset._axis; \
     mdata->channel_ ## _axis = sol_iio_add_channel(mdata->device, "in_anglvel_" # _axis, &channel_config); \
     SOL_NULL_CHECK_GOTO(mdata->channel_ ## _axis, error);
 
@@ -121,16 +109,48 @@ gyroscope_open(struct sol_flow_node *node, void *data, const struct sol_flow_nod
 #undef ADD_CHANNEL
 
     sol_iio_device_start_buffer(mdata->device);
-    mdata->node = node;
 
-    return 0;
+    return;
 
 error:
-    SOL_WRN("Could not open create iio/gyroscope node. Failed to open IIO device %d",
-        opts->iio_device.val);
+    SOL_WRN("Could not create iio/gyroscope node. Failed to open IIO device %d",
+        device_id);
     sol_iio_close(mdata->device);
+}
 
-    return -EINVAL;
+static int
+gyroscope_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
+{
+    struct gyroscope_data *mdata = data;
+    const struct sol_flow_node_type_iio_gyroscope_options *opts;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_IIO_GYROSCOPE_OPTIONS_API_VERSION,
+        -EINVAL);
+    opts = (const struct sol_flow_node_type_iio_gyroscope_options *)options;
+
+    mdata->node = node;
+
+    mdata->buffer_enabled = opts->buffer_size.val > -1;
+
+    mdata->config.api_version = SOL_IIO_CONFIG_API_VERSION;
+    mdata->config.trigger_name = opts->iio_trigger_name;
+    mdata->config.buffer_size = opts->buffer_size.val;
+    mdata->config.sampling_frequency = opts->sampling_frequency.val;
+    if (mdata->buffer_enabled) {
+        mdata->config.sol_iio_reader_cb = reader_cb;
+        mdata->config.data = mdata;
+    }
+    mdata->use_device_default_scale = opts->use_device_default_scale;
+    mdata->use_device_default_offset = opts->use_device_default_offset;
+    mdata->scale = opts->scale;
+    mdata->offset = opts->offset;
+
+    if (!sol_iio_address_device(opts->iio_device, create_device_cb, mdata)) {
+        SOL_WRN("Could not create iio/gyroscope node. Failed to open IIO device %s",
+            opts->iio_device);
+    }
+
+    return 0;
 }
 
 static void

--- a/src/samples/flow/iio/gyroscope.fbp
+++ b/src/samples/flow/iio/gyroscope.fbp
@@ -29,8 +29,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # Print iio gyroscope reading each second
+# iio_device: will first try any device whose name is 'l3g4200d'. If fails,
+# will try to create it using the 'create' command. If it fails, tries
+# IIO device whose id is '0'.
 
-gyro(iio/gyroscope:iio_device=0,buffer_size=20)
+gyro(iio/gyroscope:iio_device="l3g4200d create,i2c,platform/80860F41:05,0x69,l3g4200d 0",buffer_size=20)
 timer(timer)
 
 timer OUT -> TICK gyro OUT -> IN _(console)

--- a/src/shared/sol-iio.c
+++ b/src/shared/sol-iio.c
@@ -51,6 +51,10 @@
 
 #include "sol-iio.h"
 
+#ifdef USE_I2C
+#include <sol-i2c.h>
+#endif
+
 struct sol_iio_device {
     char *trigger_name;
     void (*reader_cb)(void *data, struct sol_iio_device *device);
@@ -85,10 +89,27 @@ struct sol_iio_channel {
     char name[]; /* Must be last. Memory trick in place. */
 };
 
+struct resolve_name_path_data {
+    const char *name;
+    int id;
+};
+
+struct create_and_resolve_path_data {
+    struct sol_str_slice slice;
+    struct sol_vector commands;
+    struct sol_buffer path;
+    char *addresses;
+    void (*cb)(void *data, int device_id);
+    const void *data;
+    int command_index;
+};
+
 #define DEVICE_PATH "/dev/iio:device%d"
 #define SYSFS_DEVICES_PATH "/sys/bus/iio/devices"
+#define SYSFS_DEVICE_PATH "/sys/bus/iio/devices/%s"
 
 #define DEVICE_NAME_PATH SYSFS_DEVICES_PATH "/iio:device%d/name"
+#define DEVICE_NAME_PATH_BY_DEVICE_DIR SYSFS_DEVICES_PATH "/%s/name"
 
 #define BUFFER_ENABLE_DEVICE_PATH SYSFS_DEVICES_PATH "/iio:device%d/buffer/enable"
 #define BUFFER_LENGHT_DEVICE_PATH SYSFS_DEVICES_PATH "/iio:device%d/buffer/length"
@@ -111,6 +132,14 @@ struct sol_iio_channel {
 #define SAMPLING_FREQUENCY_DEVICE_PATH SYSFS_DEVICES_PATH "/iio:device%d/sampling_frequency"
 #define SAMPLING_FREQUENCY_BUFFER_PATH SYSFS_DEVICES_PATH "/iio:device%d/buffer/sampling_frequency"
 #define SAMPLING_FREQUENCY_TRIGGER_PATH SYSFS_DEVICES_PATH "/trigger%d/sampling_frequency"
+
+#define I2C_DEVICES_PATH "/sys/bus/i2c/devices/%u-%04u/"
+
+#define REL_PATH_IDX 2
+#define DEV_NUMBER_IDX 3
+#define DEV_NAME_IDX 4
+
+static bool create_or_resolve_device_address_dispatch(void *data);
 
 static bool
 craft_filename_path(char *path, size_t size, const char *base, ...)
@@ -1085,6 +1114,309 @@ sol_iio_device_start_buffer(struct sol_iio_device *device)
     SOL_PTR_VECTOR_FOREACH_IDX (&device->channels, channel, i) {
         channel->offset_in_buffer = calc_channel_offset_in_buffer(channel);
     }
+
+    return true;
+}
+
+static bool
+resolve_name_path_cb(void *data, const char *dir_path, struct dirent *ent)
+{
+    struct resolve_name_path_data *result = data;
+    char path[PATH_MAX], *name;
+    int len;
+
+    if (strstartswith(ent->d_name, "iio:device")) {
+        if (craft_filename_path(path, sizeof(path),
+            DEVICE_NAME_PATH_BY_DEVICE_DIR, ent->d_name)) {
+
+            len = sol_util_read_file(path, "%ms", &name);
+            if (len > 0) {
+                if (streq(name, result->name)) {
+                    result->id = atoi(ent->d_name + strlen("iio:device"));
+                    free(name);
+                    return true;
+                }
+                free(name);
+            }
+        }
+    }
+
+    return false;
+}
+
+static int
+resolve_name_path(const char *name)
+{
+    struct resolve_name_path_data data = { .id = -1, .name = name };
+
+    sol_util_iterate_dir(SYSFS_DEVICES_PATH, resolve_name_path_cb, &data);
+
+    return data.id;
+}
+
+struct resolve_absolute_path_data {
+    char *path;
+    int id;
+};
+
+static bool
+resolve_absolute_path_cb(void *data, const char *dir_path, struct dirent *ent)
+{
+    struct resolve_absolute_path_data *result = data;
+    char path[PATH_MAX], real_path[PATH_MAX];
+
+    if (craft_filename_path(path, sizeof(path),
+        SYSFS_DEVICE_PATH, ent->d_name)) {
+
+        if (realpath(path, real_path)) {
+            if (strstartswith(real_path, result->path)) {
+                result->id = atoi(ent->d_name + strlen("iio:device"));
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+static int
+resolve_absolute_path(const char *address)
+{
+    char real_path[PATH_MAX];
+    struct resolve_absolute_path_data result = { .id = -1 };
+
+    if (realpath(address, real_path)) {
+        result.path = real_path;
+        sol_util_iterate_dir(SYSFS_DEVICES_PATH, resolve_absolute_path_cb, &result);
+    }
+
+    return result.id;
+}
+
+static int
+resolve_i2c_path(const char *address)
+{
+    unsigned int bus, device;
+    char path[PATH_MAX], real_path[PATH_MAX];
+    struct resolve_absolute_path_data result = { .id = -1 };
+
+    if (sscanf(address, "%u-%u", &bus, &device) != 2) {
+        SOL_WRN("Unexpected i2c address format. Got [%s], expected X-YYYY,"
+            " where X is bus number and YYYY is device address", address);
+        return -1;
+    }
+
+    if (craft_filename_path(path, sizeof(path), I2C_DEVICES_PATH, bus, device)) {
+        /* Idea: check if there's a symbolic link on iio/devices to the same
+         * destination as the i2c dir */
+        if (realpath(path, real_path)) {
+            result.path = real_path;
+            sol_util_iterate_dir(SYSFS_DEVICES_PATH, resolve_absolute_path_cb, &result);
+        }
+    }
+
+    return result.id;
+}
+
+static int
+check_device_id(int id)
+{
+    char path[PATH_MAX];
+    struct stat st;
+
+    if (craft_filename_path(path, sizeof(path), DEVICE_NAME_PATH, id)) {
+        if (!stat(path, &st))
+            return id;
+    }
+
+    return -1;
+}
+
+static int
+resolve_device_address(const char *address)
+{
+    char *end_ptr;
+    int i;
+
+    SOL_NULL_CHECK(address, -1);
+
+    if (strstartswith(address, "/"))
+        return resolve_absolute_path(address);
+
+    if (strstartswith(address, "i2c/"))
+        return resolve_i2c_path(address + strlen("i2c/"));
+
+    errno = 0;
+    i = strtol(address, &end_ptr, 0);
+    if (!errno && *end_ptr == '\0')
+        return check_device_id(i);
+
+    return resolve_name_path(address);
+}
+
+static void
+create_and_resolver_data_del(struct create_and_resolve_path_data *data)
+{
+    sol_vector_clear(&data->commands);
+    sol_buffer_fini(&data->path);
+    free(data->addresses);
+    free(data);
+}
+
+static char *
+sol_slice_to_str(const struct sol_str_slice *slice)
+{
+    char *result = calloc(1, slice->len + 1);
+
+    SOL_NULL_CHECK(result, NULL);
+
+    memcpy(result, slice->data, slice->len);
+
+    return result;
+}
+
+/* This ifdef is here to avoid warnings by not having I2C support.
+ * It'll probably be extended for other supported hardware */
+#ifdef USE_I2C
+static bool
+create_and_resolve_path_timeout_cb(void *data)
+{
+    struct create_and_resolve_path_data *dispatcher_data = data;
+    int r;
+
+    r = resolve_absolute_path((char *)dispatcher_data->path.data);
+    if (r > -1) {
+        dispatcher_data->cb((void *)dispatcher_data->data, r);
+        create_and_resolver_data_del(dispatcher_data);
+    } else
+        create_or_resolve_device_address_dispatch(dispatcher_data);
+
+    return false;
+}
+#endif
+
+static bool
+create_device_address(struct sol_str_slice *command, struct create_and_resolve_path_data *dispatcher_data)
+{
+    char *rel_path = NULL, *dev_number_s = NULL, *dev_name = NULL;
+    bool ret = false;
+    struct sol_vector instructions = SOL_VECTOR_INIT(struct sol_str_slice);
+
+    if (strstartswith(command->data, "create,i2c,")) {
+#ifndef USE_I2C
+        SOL_WRN("No support for i2c");
+        goto end;
+#else
+        unsigned int dev_number;
+        char *end_ptr;
+        int r;
+
+        instructions = sol_util_str_split(*command, ",", 5);
+
+        if (instructions.len < 5) {
+            SOL_WRN("Invalid create device path. Expected 'create,i2c,<rel_path>,"
+                "<devnumber>,<devname>'");
+            goto end;
+        }
+
+        rel_path = sol_slice_to_str(sol_vector_get(&instructions, REL_PATH_IDX));
+        SOL_NULL_CHECK_GOTO(rel_path, end);
+
+        dev_number_s = sol_slice_to_str(sol_vector_get(&instructions, DEV_NUMBER_IDX));
+        SOL_NULL_CHECK_GOTO(dev_number_s, end);
+
+        errno = 0;
+        dev_number = strtoul(dev_number_s, &end_ptr, 0);
+        if (errno || *end_ptr != '\0')
+            goto end;
+
+        dev_name = sol_slice_to_str(sol_vector_get(&instructions, DEV_NAME_IDX));
+        SOL_NULL_CHECK_GOTO(dev_name, end);
+
+        r = sol_i2c_create_device(rel_path, dev_name, dev_number,
+            &dispatcher_data->path);
+
+        if (r >= 0 || r == -EEXIST) {
+            /* Giving some time to sysfs update. Maybe listen for udev events? */
+            if (sol_timeout_add(1000, create_and_resolve_path_timeout_cb, dispatcher_data)) {
+                ret = true;
+            }
+        } else {
+            goto end;
+        }
+#endif
+    }
+
+end:
+    free(rel_path);
+    free(dev_number_s);
+    free(dev_name);
+    sol_vector_clear(&instructions);
+
+    return ret;
+}
+
+static bool
+create_or_resolve_device_address_dispatch(void *data)
+{
+    struct create_and_resolve_path_data *dispatcher_data = data;
+    struct sol_str_slice *command;
+    int r = -1;
+
+    do {
+        command = sol_vector_get(&dispatcher_data->commands, dispatcher_data->command_index++);
+        if (!command) {
+            SOL_WRN("Could not create or resolve device address using any of commands");
+            dispatcher_data->cb((void *)dispatcher_data->data, -1);
+            create_and_resolver_data_del(dispatcher_data);
+
+            return false;
+        }
+
+        SOL_DBG("IIO device creation/resolving dispatching command: %.*s",
+            SOL_STR_SLICE_PRINT(*command));
+
+        if (strstartswith(command->data, "create,")) {
+            if (create_device_address(command, dispatcher_data)) {
+                /* As this is an async call, lets wait it's answer */
+                return false;
+            }
+        } else {
+            char *command_s = sol_slice_to_str(command);
+            if (command_s) {
+                r = resolve_device_address(command_s);
+                if (r > -1) {
+                    dispatcher_data->cb((void *)dispatcher_data->data, r);
+                    create_and_resolver_data_del(dispatcher_data);
+                }
+                free(command_s);
+            }
+        }
+    } while (r < 0);
+
+    return false;
+}
+
+bool
+sol_iio_address_device(const char *commands, void (*cb)(void *data, int device_id), const void *data)
+{
+    struct create_and_resolve_path_data *dispatcher_data;
+
+    SOL_NULL_CHECK(commands, false);
+    SOL_NULL_CHECK(cb, false);
+
+    dispatcher_data = calloc(1, sizeof(struct create_and_resolve_path_data));
+    SOL_NULL_CHECK(dispatcher_data, false);
+
+    sol_buffer_init(&dispatcher_data->path);
+    dispatcher_data->cb = cb;
+    dispatcher_data->data = data;
+
+    dispatcher_data->addresses = strdup(commands);
+    dispatcher_data->slice = sol_str_slice_from_str(dispatcher_data->addresses);
+    dispatcher_data->commands = sol_util_str_split(dispatcher_data->slice, " ", 0);
+
+    sol_idle_add(create_or_resolve_device_address_dispatch, dispatcher_data);
 
     return true;
 }

--- a/src/shared/sol-iio.h
+++ b/src/shared/sol-iio.h
@@ -136,6 +136,48 @@ bool sol_iio_device_trigger_now(struct sol_iio_device *device);
  */
 bool sol_iio_device_start_buffer(struct sol_iio_device *device);
 
+/**
+ * Address an IIO device from a list of commands to find them.
+ *
+ * IIO devices may exist on sysfs after being plugged, or need to be
+ * explicitly created if, for instance, they use I2C or SPI interfaces.
+ * This function provides a way of addressing an IIO device to get its IIO
+ * id from a series of space separated @a commands. Commands are processed
+ * from left to right and processing stops on first command that worked.
+ * A provided callback will be called with IIO device id or -1 if no command
+ * resolved to an IIO device.
+ *
+ * There are essentially five commands. It can be an absolute path
+ * (starting with '/') pointing to sysfs dir of device. Alternatively,
+ * it can be @c i2c/X-YYYY, for i2c device, where @a X is the bus number and
+ * @a YYYY is the device number, eg, @c 7-0069 for device 0x69 on bus 7.
+ * If its a raw number, will be interpreted as IIO device id and this function
+ * will only check the id. It can also be device name, as it appears on
+ * 'name' file on sysfs.
+ * Finally, it can describe a command to @a create an IIO device. In this case,
+ * command is a combination on the form
+ * <tt> <bus_type>,<rel_path>,<devnumber>,<devname> </tt>
+ *
+ * @arg @a bus_type is the bus type, supported values are: i2c
+ * @arg @a rel_path is the relative path for device on '/sys/devices',
+ * like 'platform/80860F41:05'
+ * @arg @a devnumber is device number on bus, like 0xA4
+ * @arg @a devname is device name, the one recognized by its driver
+ *
+ * If device already exists, will just return its IIO id on @a cb.
+ *
+ * @param commands space separated commands on format specified above. e.g. <tt>
+ * l3g4200d create,i2c,platform/80860F41:05,0x69,l33g4200d </tt>
+ * @param cb callback to be called after device resolution. It contains IIO
+ * device id, or -1 if unsuccessful
+ * @param data user data to be passed to callback
+ *
+ * @return @a true if attempt to resolve device was successful, @a false
+ * othewise. Note that to really know if device was resolved, besides return,
+ * one needs to check callback device_id.
+ */
+bool sol_iio_address_device(const char *commands, void (*cb)(void *data, int device_id), const void *data);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/shared/sol-util-file.c
+++ b/src/shared/sol-util-file.c
@@ -34,12 +34,14 @@
 #include "sol-missing.h"
 #include "sol-mainloop.h"
 #include "sol-log.h"
+#include "sol-util.h"
 
 #include <dlfcn.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <libgen.h>
 #include <limits.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -365,4 +367,48 @@ sol_util_fd_set_flag(int fd, int flag)
         return -errno;
 
     return 0;
+}
+
+bool
+sol_util_iterate_dir(const char *path, bool (*iterate_dir_cb)(void *data, const char *dir_path, struct dirent *ent), const void *data)
+{
+    DIR *dir;
+    struct dirent *ent, *res;
+    int success;
+    long name_max;
+    size_t len;
+    bool result = false;
+
+    SOL_NULL_CHECK(path, false);
+    SOL_NULL_CHECK(iterate_dir_cb, false);
+
+    /* See readdir_r(3) */
+    name_max = pathconf(path, _PC_NAME_MAX);
+    if (name_max == -1)
+        name_max = 255;
+    len = offsetof(struct dirent, d_name) + name_max + 1;
+    ent = malloc(len);
+    SOL_NULL_CHECK(ent, false);
+
+    dir = opendir(path);
+    if (!dir) {
+        SOL_WRN("Could not open dir [%s] to iterate: %s", path,
+            sol_util_strerrora(errno));
+        return false;
+    }
+
+    success = readdir_r(dir, ent, &res);
+    while (success == 0 && res) {
+        if (iterate_dir_cb((void *)data, path, res)) {
+            result = true;
+            break;
+        }
+
+        success = readdir_r(dir, ent, &res);
+    }
+
+    free(ent);
+    closedir(dir);
+
+    return result;
 }

--- a/src/shared/sol-util-file.h
+++ b/src/shared/sol-util-file.h
@@ -34,8 +34,10 @@
 
 #include "sol-macros.h"
 
+#include <dirent.h>
 #include <sys/types.h>
 #include <stdarg.h>
+#include <stdbool.h>
 
 #define CHUNK_SIZE 4096
 #define SOL_UTIL_MAX_READ_ATTEMPTS 10
@@ -49,3 +51,4 @@ char *sol_util_load_file_string(const char *filename, size_t *size) SOL_ATTR_WAR
 int sol_util_get_rootdir(char *out, size_t size) SOL_ATTR_WARN_UNUSED_RESULT;
 int sol_util_fd_set_flag(int fd, int flag) SOL_ATTR_WARN_UNUSED_RESULT;
 ssize_t sol_util_fill_buffer(const int fd, char *buffer, const size_t buffer_size, size_t *size_read);
+bool sol_util_iterate_dir(const char *path, bool (*iterate_dir_cb)(void *data, const char *dir_path, struct dirent *ent), const void *data);


### PR DESCRIPTION
v2:
Now accepts a list of 'commands' to create a device.
Commits of 'resolving' and 'creation' squashed, as now they are treated inside of command list
Sample updated to show this feature.
i2c api accepts `dev_number` as a number.
i2c api returns -EEXIST when device already exists. No more combination of boolean return and int to find out the truth.

A tentative to address iio devices other than its id. Accepting name, absolute path on sysfs and for i2c, a relative path or even instructions to create the device.
I'm specially concerned about the instructions: it's a relative simple comma-separated string, that I started using for tests and survived to final form of this patch, reason: not sure what other format use (json?) that kept things simple. Last commit on this series (the one which changes the node) have examples of strings on its message. It's simple, but you, strings...