### PR TITLE
sol-iio: Make creation of sysfs triggers more reliable

### DIFF
--- a/src/shared/sol-iio.c
+++ b/src/shared/sol-iio.c
@@ -241,23 +241,29 @@ set_current_trigger(struct sol_iio_device *device, const char *trigger_name)
 static bool
 create_sysfs_trigger(struct sol_iio_device *device)
 {
-    int len, id, i;
+    int len, id, i, tries = 10;
     char *trigger_name;
     bool result = false;
 
-    /* TODO check available trigger indice instead of using a random one */
-    /* Create new trigger */
     id = rand();
-    i = sol_util_write_file(SYSFS_TRIGGER_SYSFS_ADD_TRIGGER, "%d", id);
-    if (i < 0) {
+    do {
+        i = sol_util_write_file(SYSFS_TRIGGER_SYSFS_ADD_TRIGGER, "%d", id);
         if (i == -ENOENT) {
             SOL_WRN("No 'iio_sysfs_tigger' under '/sys/bus/iio/devices'."
                 " Missing 'modprobe iio-trig-sysfs'?");
             return false;
         }
 
+        /* If EINVAL, we try again. If not, give up */
+        if (i < 0 && i != -EINVAL)
+            goto error;
+
+        if (i < 0)
+            id = rand();
+    } while (i < 0 && tries--);
+
+    if (i < 0)
         goto error;
-    }
 
     /* Set device current trigger */
     len = asprintf(&trigger_name, "sysfstrig%d", id);


### PR DESCRIPTION
Still guessing a number, but re-trying in case trigger name already
exists.
Not going on a deterministic order because we may end up failing many
times before creating a trigger - e.g., creating ten new triggers
starting from '1' will end up with 45 failed tries.
Even we save a global 'last trigger id', we could conflict with existing
ones.
Using normal rand() as this is *not* cryptography related.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>