### PR TITLE
Build general improvements v4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,7 @@ endif
 # basic variable definitions
 include $(top_srcdir)tools/build/Makefile.vars
 
-# soletta rules themselves
-include $(top_srcdir)tools/build/Makefile.rules
+include $(top_srcdir)tools/build/Makefile.common
 
 # kconfig interface rules
 ifeq (help, $(filter help,$(MAKECMDGOALS)))
@@ -33,25 +32,26 @@ ifeq (,$(filter $(dep-avoid-targets),$(MAKECMDGOALS)))
 -include ${all-objs:.o=.o.dep}
 endif
 
-include $(top_srcdir)tools/build/Makefile.targets
-
 ifneq (,$(NOT_FOUND))
 warning:
 	$(Q)echo -e "The following (required) dependencies were not met:\n"
 	$(Q)echo -e "$(NOT_FOUND)"
 	$(Q)echo -e "If you've just installed it, run: make reconf"
 	$(Q)echo -e "For more information/options, run: make help"
-	$(Q)false
 $(warning-targets)
 else
 ifeq ($(HAVE_KCONFIG_CONFIG),)
-warning: $(KCONFIG_GEN)
+warning:
 	$(Q)echo "You need a config file first. Please run a config target, e.g.: make menuconfig"
 	$(Q)echo "For a quick default config run: make alldefconfig"
 	$(Q)echo "For more information/options run: make help"
-	$(Q)false
 $(warning-targets)
 else
+# soletta rules themselves
+include $(top_srcdir)tools/build/Makefile.rules
+
+include $(top_srcdir)tools/build/Makefile.targets
+
 all: $(PRE_GEN) $(SOL_LIB_SO) $(SOL_LIB_AR) $(bins-out) $(modules-out)
 endif # HAVE_KCONFIG_CONFIG
 endif # NOT_FOUND

--- a/tools/build/Makefile.common
+++ b/tools/build/Makefile.common
@@ -1,0 +1,44 @@
+$(DEPENDENCY_CACHE):
+	$(Q)$(PYTHON) $(DEPENDENCY_SCRIPT) --compiler="$(TARGETCC)" --cflags="$(DEP_RESOLVER_CFLAGS)" \
+		--ldflags="$(DEP_RESOLVER_LDFLAGS)" --prefix="$(PREFIX)" --cache="$(DEPENDENCY_CACHE)" \
+		--pkg-config="$(PKG_CONFIG)" --makefile-gen
+
+$(KCONFIG_GEN): $(DEPENDENCY_CACHE)
+	$(Q)$(PYTHON) $(DEPENDENCY_SCRIPT) --compiler="$(TARGETCC)" --cflags="$(DEP_RESOLVER_CFLAGS)" \
+		--ldflags="$(DEP_RESOLVER_LDFLAGS)" --prefix="$(PREFIX)" --cache="$(DEPENDENCY_CACHE)" \
+		--pkg-config="$(PKG_CONFIG)" --kconfig-gen
+
+$(MAKEFILE_GEN): $(DEPENDENCY_CACHE) $(KCONFIG_CONFIG)
+	$(Q)$(PYTHON) $(DEPENDENCY_SCRIPT) --compiler="$(TARGETCC)" --cflags="$(DEP_RESOLVER_CFLAGS)" \
+		--ldflags="$(DEP_RESOLVER_LDFLAGS)" --prefix="$(PREFIX)" --cache="$(DEPENDENCY_CACHE)" \
+		--pkg-config="$(PKG_CONFIG)" --definitions-header="$(DEFINITIONS_H)" --makefile-gen
+
+reconf: $(DEPENDENCY_SCRIPT)
+	$(Q)echo "[re]running dependency-resolver..."
+	$(Q)$(RM) -f $(DEPENDENCY_FILES)
+	$(Q)$(RM) $(DEPENDENCY_CACHE)
+	$(Q) V=1 $(PYTHON) $(DEPENDENCY_SCRIPT) --compiler=$(TARGETCC) --cflags="$(DEP_RESOLVER_CFLAGS)" \
+		--ldflags="$(DEP_RESOLVER_LDFLAGS)" --prefix="$(PREFIX)" --definitions-header="$(DEFINITIONS_H)" \
+		--cache="$(DEPENDENCY_CACHE)" --kconfig-gen --makefile-gen
+
+PHONY += reconf
+
+# common build targets
+define clean-resource
+	$(Q)echo "   "CLEAN"   "$(1)
+	$(Q)$(RM) -Rf $(1)
+
+endef
+
+cleanup-files := $(tests-out) $(CLEANUP_GEN) $(kconfig-clean-objs)
+cleanup-files += $(BUILDDIR) $(CHEAT_SHEET_INDEX_HTML) $(DOXYGEN_GENERATED)
+
+clean:
+	$(foreach curr,$(wildcard $(cleanup-files)),$(call clean-resource,$(curr)))
+
+PHONY += clean
+
+distclean: clean
+	$(Q)$(RM) -Rf .config* $(DEPENDENCY_FILES) $(KCONFIG_INCLUDE) $(DEPENDENCY_CACHE)
+
+PHONY += distclean

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -420,4 +420,5 @@ $(FLOW_NODE_TYPE_FIND): $(FLOW_NODE_TYPE_FIND_IN) $(KCONFIG_CONFIG) $(MAKEFILE_G
 		--template=$(FLOW_NODE_TYPE_FIND_IN) --output=$(FLOW_NODE_TYPE_FIND)
 
 $(KCONFIG_AUTOHEADER): $(KCONFIG_CONFIG)
-	$(MAKE) -f $(top_srcdir)Makefile silentoldconfig
+	$(Q)mkdir -p $(KCONFIG_INCLUDE)config $(KCONFIG_INCLUDE)generated
+	$(Q)$(obj)/conf -s --silentoldconfig Kconfig

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -321,31 +321,6 @@ $(SOL_LIB_SO): $(SOL_LIB_AR) $(builtin-objs)
 	$(Q)$(TARGETCC) -shared $(builtin-objs) $(sort $(builtin-ldflags)) $(LIB_LDFLAGS) -o $(@).$(VERSION)
 	$(Q)$(LN) -fs $(notdir $(@).$(VERSION)) $(@)
 
-$(DEPENDENCY_CACHE):
-	$(Q)$(PYTHON) $(DEPENDENCY_SCRIPT) --compiler="$(TARGETCC)" --cflags="$(DEP_RESOLVER_CFLAGS)" \
-		--ldflags="$(DEP_RESOLVER_LDFLAGS)" --prefix="$(PREFIX)" --cache="$(DEPENDENCY_CACHE)" \
-		--pkg-config="$(PKG_CONFIG)" --makefile-gen
-
-$(KCONFIG_GEN): $(DEPENDENCY_CACHE)
-	$(Q)$(PYTHON) $(DEPENDENCY_SCRIPT) --compiler="$(TARGETCC)" --cflags="$(DEP_RESOLVER_CFLAGS)" \
-		--ldflags="$(DEP_RESOLVER_LDFLAGS)" --prefix="$(PREFIX)" --cache="$(DEPENDENCY_CACHE)" \
-		--pkg-config="$(PKG_CONFIG)" --kconfig-gen
-
-$(MAKEFILE_GEN): $(DEPENDENCY_CACHE) $(KCONFIG_CONFIG)
-	$(Q)$(PYTHON) $(DEPENDENCY_SCRIPT) --compiler="$(TARGETCC)" --cflags="$(DEP_RESOLVER_CFLAGS)" \
-		--ldflags="$(DEP_RESOLVER_LDFLAGS)" --prefix="$(PREFIX)" --cache="$(DEPENDENCY_CACHE)" \
-		--pkg-config="$(PKG_CONFIG)" --definitions-header="$(DEFINITIONS_H)" --makefile-gen
-
-reconf: $(DEPENDENCY_SCRIPT)
-	$(Q)echo "[re]running dependency-resolver..."
-	$(Q)$(RM) -f $(DEPENDENCY_FILES)
-	$(Q)$(RM) $(DEPENDENCY_CACHE)
-	$(Q) V=1 $(PYTHON) $(DEPENDENCY_SCRIPT) --compiler=$(TARGETCC) --cflags="$(DEP_RESOLVER_CFLAGS)" \
-		--ldflags="$(DEP_RESOLVER_LDFLAGS)" --prefix="$(PREFIX)" --definitions-header="$(DEFINITIONS_H)" \
-		--cache="$(DEPENDENCY_CACHE)" --kconfig-gen --makefile-gen
-
-PHONY += reconf
-
 # generators
 define make-gen
 $($(1)-hdr) $($(1)-src) $($(1)-desc): $(1) $(NODE_TYPE_GEN_SCRIPT)
@@ -443,26 +418,6 @@ $(FLOW_NODE_TYPE_FIND): $(FLOW_NODE_TYPE_FIND_IN) $(KCONFIG_CONFIG) $(MAKEFILE_G
 	$(Q)echo "     "GEN"   "$(FLOW_NODE_TYPE_FIND)
 	$(Q)$(PYTHON) $(TEMPLATE_SCRIPT) --context-files $(KCONFIG_CONFIG) $(MAKEFILE_GEN) \
 		--template=$(FLOW_NODE_TYPE_FIND_IN) --output=$(FLOW_NODE_TYPE_FIND)
-
-# common build targets
-define clean-resource
-	$(Q)echo "   "CLEAN"   "$(1)
-	$(Q)$(RM) -Rf $(1)
-
-endef
-
-cleanup-files := $(tests-out) $(CLEANUP_GEN) $(kconfig-clean-objs)
-cleanup-files += $(BUILDDIR) $(CHEAT_SHEET_INDEX_HTML) $(DOXYGEN_GENERATED)
-
-clean:
-	$(foreach curr,$(wildcard $(cleanup-files)),$(call clean-resource,$(curr)))
-
-PHONY += clean
-
-distclean: clean
-	$(Q)$(RM) -Rf .config* $(DEPENDENCY_FILES) $(KCONFIG_INCLUDE) $(DEPENDENCY_CACHE)
-
-PHONY += distclean
 
 $(KCONFIG_AUTOHEADER): $(KCONFIG_CONFIG)
 	$(MAKE) -f $(top_srcdir)Makefile silentoldconfig

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -306,7 +306,7 @@ PC_GEN := $(build_pcdir)soletta.pc
 PC_GEN_IN := $(top_srcdir)pc/soletta.pc.in
 
 PRE_GEN := $(HEADER_GEN) $(KCONFIG_AUTOHEADER) $(KCONFIG_CONFIG) $(BSDEPS)
-PRE_GEN += $(NODE_TYPE_GEN_SCRIPT)
+PRE_GEN += $(NODE_TYPE_GEN_SCRIPT) $(PC_GEN)
 
 CLEANUP_GEN := $(FLOW_OIC_GEN) $(HEADER_GEN)
 

--- a/tools/check-license.sh
+++ b/tools/check-license.sh
@@ -40,7 +40,7 @@ function die() {
 DIFF_LIST=$(mktemp /tmp/sol-tmp.XXXX)
 
 PATTERNS=".*\.*\([ch]\|py\|h\.in\|py\.in\|fbp\|sh\|json\|COPYING\|calc\-lib\-size\|generate\-svg\-from\-all\-fbps\)$"
-IGNORE="data\/oic\/\|data\/jsons\/\|.*\.ac"
+IGNORE="data\/oic\/\|data\/jsons\/\|.*\.ac|.*Makefile.*"
 
 trap "rm -f $DIFF_LIST" EXIT
 
@@ -72,7 +72,7 @@ if [ ! -s "$DIFF_LIST" ]; then
         BASE_COMMIT="HEAD~1"
     fi
     echo "Working directory is clean, checking commit changes since $BASE_COMMIT"
-    git diff --diff-filter=ACMR --oneline --name-only $BASE_COMMIT HEAD | grep --color=never '^.*\.[ch]' > $DIFF_LIST
+    git diff --diff-filter=ACMR --oneline --name-only $BASE_COMMIT HEAD | grep --color=never '^.*\.[ch]$' > $DIFF_LIST
 fi
 
 for f in $(cat $DIFF_LIST); do


### PR DESCRIPTION
## Changes
  + v2 (since #572):
     - added patch: **	check-license: ignore makefiles**;
     - added patch: **	build: generate soletta.pc on build time**;
  + v3 (since #573):
     - changed the Makefile ignore rule in: **check-license: ignore makefiles**;
  + v4 (since #574):
     - changed patch: **check-license: ignore makefiles** to really fix the issue with check-license.sh on tree, it was considering Makefile.common case the grep was ```.*\.[ch]``` not ```.*\.[ch]$```;
     - upstream rebased;

**PS**: Since this series has got an ack in the previous version I'm sending this version simply to shoot the build bots and have one last check;