### PR TITLE
build: build/gen everything out of src dir

### DIFF
--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -384,6 +384,7 @@ $(LINUX_MICRO_BUILTINS_H): $(BUILTINS_SCRIPT) $(KCONFIG_CONFIG)
 
 $(FLOW_BUILTINS_H): $(BUILTINS_SCRIPT) $(KCONFIG_CONFIG)
 	$(Q)echo "     "GEN"   "$(@)
+	$(Q)$(MKDIR) -p $(dir $(FLOW_BUILTINS_H))
 	$(Q)$(PYTHON) $(BUILTINS_SCRIPT) \
 		--output=$@ \
 		--array="static const void *SOL_FLOW_BUILTIN_NODE_TYPE_ALL[]" \
@@ -394,6 +395,7 @@ $(FLOW_BUILTINS_H): $(BUILTINS_SCRIPT) $(KCONFIG_CONFIG)
 
 $(PIN_MUX_BUILTINS_H): $(BUILTINS_SCRIPT) $(KCONFIG_CONFIG)
 	$(Q)echo "     "GEN"   "$(@)
+	$(Q)$(MKDIR) -p $(dir $(PIN_MUX_BUILTINS_H))
 	$(Q)$(PYTHON) $(BUILTINS_SCRIPT) \
                 --output=$@ \
                 --array="static const struct sol_pin_mux *SOL_PIN_MUX_BUILTINS_ALL[]" \

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -226,8 +226,8 @@ SAMPLE_LDFLAGS := $(BIN_LDFLAGS)
 # generators
 ## headers
 LINUX_MICRO_BUILTINS_H := $(top_srcdir)src/lib/common/sol-platform-linux-micro-builtins-gen.h
-FLOW_BUILTINS_H := $(top_srcdir)src/lib/flow/sol-flow-builtins-gen.h
-PIN_MUX_BUILTINS_H := $(top_srcdir)src/lib/common/sol-pin-mux-builtins-gen.h
+FLOW_BUILTINS_H := $(build_stagedir)lib/flow/sol-flow-builtins-gen.h
+PIN_MUX_BUILTINS_H := $(build_stagedir)lib/common/sol-pin-mux-builtins-gen.h
 
 NODE_TYPE_SCHEMA := $(top_srcdir)data/schemas/node-type-genspec.schema
 NODE_TYPE_SCHEMA_DEST := $(build_flowdatadir)schemas/node-type-genspec.schema
@@ -235,8 +235,8 @@ NODE_TYPE_SCHEMA_DEST := $(build_flowdatadir)schemas/node-type-genspec.schema
 BOARD_DETECT := $(top_srcdir)data/jsons/board_detect.json
 BOARD_DETECT_DEST := $(build_datadir)board_detect.json
 
-FLOW_NODE_TYPE_FIND := $(SCRIPTDIR)sol-flow-node-type-find.py
-FLOW_NODE_TYPE_FIND_IN := $(addsuffix .in,$(FLOW_NODE_TYPE_FIND))
+FLOW_NODE_TYPE_FIND := $(build_bindir)sol-flow-node-type-find.py
+FLOW_NODE_TYPE_FIND_IN := $(SCRIPTDIR)sol-flow-node-type-find.py.in
 
 FLOW_BUILTINS_DESC := $(build_descdir)builtins.json
 
@@ -259,8 +259,9 @@ HEADER_GEN += $(FLOW_BUILTINS_H)
 ## scripts
 BUILTINS_SCRIPT := $(SCRIPTDIR)sol-builtins-gen.py
 
-NODE_TYPE_GEN_SCRIPT := $(SCRIPTDIR)sol-flow-node-type-gen.py
-NODE_TYPE_GEN_SCRIPT_IN := $(addsuffix .in,$(SCRIPTDIR)sol-flow-node-type-gen.py)
+NODE_TYPE_GEN_SCRIPT := $(build_bindir)sol-flow-node-type-gen.py
+NODE_TYPE_GEN_SCRIPT_IN := $(SCRIPTDIR)sol-flow-node-type-gen.py.in
+
 NODE_TYPE_STUB_GEN_SCRIPT := $(SCRIPTDIR)sol-flow-node-type-stub-gen.py
 NODE_TYPE_STUB_GEN_TEST := $(top_srcdir)src/test-stub-gen/dummy.json
 NODE_TYPE_STUB_GEN_DIR := $(build_stagedir)dummy/
@@ -310,8 +311,7 @@ PRE_GEN += $(NODE_TYPE_GEN_SCRIPT) $(PC_GEN)
 
 CLEANUP_GEN := $(FLOW_OIC_GEN) $(HEADER_GEN)
 
-EXTRA_BINS := $(FLOW_NODE_TYPE_FIND)
-EXTRA_BINS += $(addprefix $(SCRIPTDIR),sol-flow-node-type-gen.py sol-flow-node-type-validate.py)
+EXTRA_BINS := $(addprefix $(SCRIPTDIR),sol-flow-node-type-validate.py)
 
 warning-targets = all check check-fbp check-valgrind check-fbp-valgrind check-stub coverage run-coverage \
 		pre-install post-install install doc cheat-sheet samples doxygen: warning


### PR DESCRIPTION
We don't want to have anything being built or generated inside the src
dir, this patch removes all the remaining resources being generated
there.

The only remaining resource being generated in the source dir is the
oic.json - which in my option should remain there.

See: https://github.com/solettaproject/soletta/issues/561

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>