### PR TITLE
sol-conffile: Remove quotes from strings

### DIFF
--- a/src/lib/parsers/include/sol-json.h
+++ b/src/lib/parsers/include/sol-json.h
@@ -193,6 +193,17 @@ sol_json_token_str_eq(const struct sol_json_token *token, const char *str, unsig
 #define SOL_JSON_TOKEN_STR_LITERAL_EQ(token_, str_) \
     sol_json_token_str_eq(token_, str_, sizeof(str_) - 1)
 
+static inline void
+sol_json_token_remove_quotes(struct sol_json_token *token)
+{
+    if (sol_json_token_get_size(token) < 3)
+        return;
+    if (*token->start == '"')
+        token->start++;
+    if (*(token->end - 1) == '"')
+        token->end--;
+}
+
 /**
  * Get the numeric value of the given token as an 64 bits unsigned integer.
  *

--- a/src/modules/flow/flower-power/flower-power.c
+++ b/src/modules/flow/flower-power/flower-power.c
@@ -315,21 +315,21 @@ generate_token_cb(void *data, struct sol_http_response *response)
     sol_json_scanner_init(&scanner, response->content.data,
         response->content.used);
     SOL_JSON_SCANNER_OBJECT_LOOP (&scanner, &token, &key, &value, reason) {
-        size_t token_size;
+        size_t value_size, token_size;
 
         if (!SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "access_token"))
             continue;
 
-        /* value is between double quotes */
-        token_size = value.end - value.start + auth_len - 1;
+        sol_json_token_remove_quotes(&value);
+        value_size = sol_json_token_get_size(&value);
+        token_size = value_size + auth_len + 1;
 
         free(mdata->token);
         mdata->token = malloc(token_size);
         SOL_NULL_CHECK(mdata->token);
 
         strcpy(mdata->token, AUTH_START);
-        memcpy(mdata->token + auth_len, value.start + 1,
-            value.end - value.start - 2);
+        memcpy(mdata->token + auth_len, value.start, value_size);
         *(mdata->token + token_size - 1) = '\0';
 
         return;
@@ -534,15 +534,17 @@ http_get_cb(void *data, struct sol_http_response *response)
                     }
                 } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key,
                     "location_identifier")) {
-                    id = strndupa(value.start + 1, value.end - value.start - 2);
+                    sol_json_token_remove_quotes(&value);
+                    id = strndupa(value.start, sol_json_token_get_size(&value));
                     if (!id) {
                         SOL_WRN("Failed to get id");
                         goto error;
                     }
                 } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key,
                     "last_sample_upload")) {
-                    timestamp = strndupa(value.start + 1,
-                        value.end - value.start - 2);
+                    sol_json_token_remove_quotes(&value);
+                    timestamp = strndupa(value.start,
+                        sol_json_token_get_size(&value));
                     if (!timestamp) {
                         SOL_WRN("Failed to get timestamp");
                         goto error;
@@ -580,8 +582,9 @@ http_get_cb(void *data, struct sol_http_response *response)
                             }
                         } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key,
                             "battery_end_of_life_date_utc")) {
-                            battery_end_of_life = strndupa(value.start + 1,
-                                value.end - value.start - 2);
+                            sol_json_token_remove_quotes(&value);
+                            battery_end_of_life = strndupa(value.start,
+                                sol_json_token_get_size(&value));
                             if (!battery_end_of_life) {
                                 SOL_WRN("Failed to get battery end of life");
                                 goto error;
@@ -590,15 +593,17 @@ http_get_cb(void *data, struct sol_http_response *response)
                     }
                 } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key,
                     "sensor_serial")) {
-                    id = strndupa(value.start + 1, value.end - value.start - 2);
+                    sol_json_token_remove_quotes(&value);
+                    id = strndupa(value.start, sol_json_token_get_size(&value));
                     if (!id) {
                         SOL_WRN("Failed to get id");
                         goto error;
                     }
                 } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key,
                     "last_upload_datetime_utc")) {
-                    timestamp = strndupa(value.start + 1,
-                        value.end - value.start - 2);
+                    sol_json_token_remove_quotes(&value);
+                    timestamp = strndupa(value.start,
+                        sol_json_token_get_size(&value));
                     if (!timestamp) {
                         SOL_WRN("Failed to get timestamp");
                         goto error;

--- a/src/shared/sol-conffile.c
+++ b/src/shared/sol-conffile.c
@@ -93,14 +93,18 @@ sol_conffile_set_entry_options(struct sol_conffile_entry *entry, struct sol_json
     SOL_JSON_SCANNER_OBJECT_LOOP (&scanner, &token, &key, &value, reason) {
         int key_len, value_len;
         char *tmp;
-        key_len = sol_json_token_get_size(&key) - 2; // remove quotes from the key.
-        value_len = sol_json_token_get_size(&value); // do not remove quotes from the value. (not everything is a string here)
+
+        sol_json_token_remove_quotes(&key);
+        key_len = sol_json_token_get_size(&key);
+        sol_json_token_remove_quotes(&value);
+        value_len = sol_json_token_get_size(&value);
+
         if (!key_len || !value_len) {
             reason = SOL_JSON_LOOP_REASON_INVALID;
             break;
         }
 
-        if (asprintf(&tmp, "%.*s=%.*s", key_len, key.start + 1, value_len, value.start) <= 0) {
+        if (asprintf(&tmp, "%.*s=%.*s", key_len, key.start, value_len, value.start) <= 0) {
             SOL_WRN("Couldn't allocate memory for the config file, ignoring options.");
             return -ENOMEM;
             break;

--- a/src/test-fbp/test-json-confguration.fbp
+++ b/src/test-fbp/test-json-confguration.fbp
@@ -32,5 +32,5 @@ _(constant/int:value=4) OUT -> IN _(TestConsole)
 _(constant/int:value=1) OUT -> INTERVAL _(timer) OUT -> QUIT _(app/quit)
 
 ## TEST-OUTPUT
-# "-=-=- soletta -=-=-"4 (integer range)
+# -=-=- soletta -=-=-4 (integer range)
 


### PR DESCRIPTION
When an options is a string, the quotes should be
removed from it.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>