### PR TITLE
datatypes/vector: fix memset arithmetics

### DIFF
--- a/src/lib/datatypes/sol-vector.c
+++ b/src/lib/datatypes/sol-vector.c
@@ -93,7 +93,7 @@ sol_vector_append_n(struct sol_vector *v, uint16_t n)
     }
 
     new_elems = (unsigned char *)v->data + (v->elem_size * (v->len - n));
-    memset(new_elems, 0, v->elem_size * n);
+    memset(new_elems, 0, (size_t)v->elem_size * n);
 
     return new_elems;
 }


### PR DESCRIPTION
Issue reported by coverity:

Suspicious implicit sign extension: "n" with type "unsigned short"
(16 bits, unsigned) is promoted in "v->elem_size * n" to type "int"
(32 bits, signed), then sign-extended to type "unsigned long" (64 bits,
unsigned). If "v->elem_size * n" is greater than 0x7FFFFFFF, the
upper bits of the result will all be 1.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>