### PR TITLE
build: add Requires.private to soletta.pc

### DIFF
--- a/data/scripts/dependency-resolver.py
+++ b/data/scripts/dependency-resolver.py
@@ -181,6 +181,9 @@ def handle_pkgconfig_check(args, conf, context):
         if ldflags_stat:
             context.add_cond_makefile_var("%s_LDFLAGS" % dep, ldflags)
 
+        if cflags_stat or ldflags_stat:
+            context.add_cond_makefile_var("%s_REQUIRES_PRIVATE" % dep, pkg)
+
     success = (cflags_stat or ldflags_stat) and ver_match
     have_var = "y" if success else "n"
     context.add_kconfig("HAVE_%s" % dep, "bool", have_var)
@@ -406,7 +409,7 @@ type_handlers = {
 
 def format_makefile_var(items):
     output = ""
-    for k,v in items:
+    for k,v in sorted(items):
         if not v or not v["value"]: continue
         output += "%s %s %s\n" % (k, v["attrib"], v["value"])
     return output

--- a/data/scripts/template.py
+++ b/data/scripts/template.py
@@ -103,6 +103,11 @@ def load_context(files):
         handle.read_string(content)
         dc = handle["context"]
         result = dict(list(result.items()) + list(dc.items()))
+
+    # also consider env vars in the context
+    for k,v in os.environ.items():
+        result[k] = v
+
     return result
 
 def try_subst(verbatim):

--- a/pc/soletta.pc.in
+++ b/pc/soletta.pc.in
@@ -11,3 +11,4 @@ Description: SOLETTA io library
 Version: {{@VERSION@}}
 Libs: -L${libdir} -lsoletta
 Cflags: -I${includedir}/soletta
+Requires.private: {{@requires-private@}}

--- a/src/lib/common/Makefile
+++ b/src/lib/common/Makefile
@@ -74,6 +74,17 @@ obj-core-$(PTHREAD)-extra-ldflags += $(PTHREAD_H_LDFLAGS)
 obj-core-$(USE_PIN_MUX) += \
     sol-pin-mux.o
 
+requires-private-$(MAINLOOP_GLIB) += \
+    $(GLIB_REQUIRES_PRIVATE)
+
+requires-private-$(SOL_BUS) += \
+    $(SYSTEMD_REQUIRES_PRIVATE)
+
+requires-private-$(PLATFORM_SYSTEMD) += \
+    $(SYSTEMD_REQUIRES_PRIVATE) \
+    $(UDEV_REQUIRES_PRIVATE)
+
+
 headers-y := \
     include/sol-log.h \
     include/sol-macros.h \

--- a/src/lib/comms/Makefile
+++ b/src/lib/comms/Makefile
@@ -24,6 +24,9 @@ obj-networking-$(HTTP_CLIENT) += \
 obj-networking-$(HTTP_CLIENT)-extra-ldflags += \
     $(LIBCURL_LDFLAGS)
 
+requires-private-$(HTTP_CLIENT) := \
+    $(LIBCURL_REQUIRES_PRIVATE)
+
 headers-networking-$(NETWORK) += \
     include/sol-network.h
 

--- a/src/modules/flow/gtk/Makefile
+++ b/src/modules/flow/gtk/Makefile
@@ -5,3 +5,6 @@ obj-gtk-$(FLOW_NODE_TYPE_GTK) += pwm-viewer.o rgb-editor.o slider.o
 obj-gtk-$(FLOW_NODE_TYPE_GTK) += spinbutton.o toggle.o window.o
 obj-gtk-$(FLOW_NODE_TYPE_GTK)-extra-cflags += $(GTK_CFLAGS) $(GLIB_CFLAGS)
 obj-gtk-$(FLOW_NODE_TYPE_GTK)-extra-ldflags += $(GTK_LDFLAGS) $(GLIB_LDFLAGS)
+
+requires-private-$(FLOW_NODE_TYPE_GTK) := \
+    $(GTK_REQUIRES_PRIVATE)

--- a/src/modules/flow/string/Makefile
+++ b/src/modules/flow/string/Makefile
@@ -32,3 +32,7 @@ endif
 
 obj-string-$(FLOW_NODE_TYPE_STRING)-extra-cflags += $(LOCALE_CFLAGS) $(ICU_CFLAGS) $(LIBPCRE_CFLAGS)
 obj-string-$(FLOW_NODE_TYPE_STRING)-extra-ldflags += $(LOCALE_LDFLAGS) $(ICU_LDFLAGS) $(LIBPCRE_LDFLAGS)
+
+requires-private-$(FLOW_NODE_TYPE_STRING) := \
+    $(ICU_REQUIRES_PRIVATE) \
+    $(LIBPCRE_LDFLAGS)

--- a/src/modules/flow/udev/Makefile
+++ b/src/modules/flow/udev/Makefile
@@ -2,3 +2,6 @@ obj-$(FLOW_NODE_TYPE_UDEV) += udev.mod
 obj-udev-$(FLOW_NODE_TYPE_UDEV) := udev.json udev.o
 obj-udev-$(FLOW_NODE_TYPE_UDEV)-extra-cflags += $(UDEV_CFLAGS)
 obj-udev-$(FLOW_NODE_TYPE_UDEV)-extra-ldflags += $(UDEV_LDFLAGS)
+
+requires-private-$(FLOW_NODE_TYPE_UDEV) := \
+    $(UDEV_REQUIRES_PRIVATE)

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -212,7 +212,9 @@ inc-subdirs = \
 			$(call parse-sample,$(sample),$(subdir)) \
 		) \
 		$(clean-control) \
-	)
+	) \
+	$(eval requires-private := $(sort $(requires-private-y) $(requires-private-m))) \
+	export requires-private
 
 extra-bins = \
 	$(foreach bin,$(EXTRA_BINS), \

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -39,6 +39,7 @@ all-hdr :=
 all-dest-bin :=
 all-mod-descs :=
 
+requires-private :=
 module-types := flow linux-micro pin-mux
 
 # vars to distinguish the modules types


### PR DESCRIPTION
This patch introduces a new private-requires-y and private-requires-m
variables to declare which pkg dependencies we're using, with that we
can add that to our distributed soletta.pc file.

For that we're also considering env vars in the template parser so we
can easily export&get useful information while processing template
files.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>