### PR TITLE
Make it possible for the user to disable libpcre dependency lookup.

### DIFF
--- a/src/modules/flow/string/Kconfig
+++ b/src/modules/flow/string/Kconfig
@@ -1,7 +1,15 @@
-# This is the solely user of ICU. If gets wider use, move up in the hierarchy.
+# This is the solely user of ICU. If gets wider use, move up in the
+# hierarchy.
 config USE_ICU
 	bool "Use ICU library"
 	depends on HAVE_ICU
+	default y
+
+# This is the solely user of LIBPCRE. If gets wider use, move up in
+# the hierarchy.
+config USE_LIBPCRE
+	bool "Use LIBPCRE library"
+	depends on HAVE_LIBPCRE
 	default y
 
 config FLOW_NODE_TYPE_STRING

--- a/src/modules/flow/string/Makefile
+++ b/src/modules/flow/string/Makefile
@@ -16,14 +16,14 @@
 #  nodes have a different license than the others, we kept them split
 #  like that.
 
-ifeq (,$(HAVE_LIBPCRE))
+ifeq (,$(USE_LIBPCRE))
 warning-msg := "You're building the string nodes module without Perl regular expressions support. That way, the string module will still be built, but the regular expression nodes will be made useless -- any input packet on them only issue an error output packet. Please re-configure after you have LIBPCRE development packages installed to get the intended string nodes behavior.\n\n"
 endif
 
 obj-$(FLOW_NODE_TYPE_STRING) += string.mod
 obj-string-$(FLOW_NODE_TYPE_STRING) := string.json string-regexp.o
 
-ifeq (y,$(HAVE_ICU))
+ifeq (y,$(USE_ICU))
 obj-string-$(FLOW_NODE_TYPE_STRING) += string-icu.o string-replace-icu.o
 else
 obj-string-$(FLOW_NODE_TYPE_STRING) += string-ascii.o string-replace-ascii.o

--- a/src/modules/flow/string/string-regexp.c
+++ b/src/modules/flow/string/string-regexp.c
@@ -33,7 +33,7 @@
 #include <ctype.h>
 #include <errno.h>
 
-#ifdef HAVE_LIBPCRE
+#ifdef USE_LIBPCRE
 #include <pcre.h>
 #endif
 
@@ -42,7 +42,7 @@
 #include "string-gen.h"
 #include "string-regexp.h"
 
-#ifdef HAVE_LIBPCRE
+#ifdef USE_LIBPCRE
 static struct sol_vector
 string_regexp_search_and_split(struct string_regexp_search_data *mdata)
 {
@@ -237,7 +237,7 @@ string_regexp_search(struct sol_flow_node *node,
     uint16_t conn_id,
     const struct sol_flow_packet *packet)
 {
-#ifdef HAVE_LIBPCRE
+#ifdef USE_LIBPCRE
     struct string_regexp_search_data *mdata = data;
     const char *in_value;
     int r;
@@ -271,7 +271,7 @@ set_string_regexp_pattern(struct sol_flow_node *node,
     uint16_t conn_id,
     const struct sol_flow_packet *packet)
 {
-#ifdef HAVE_LIBPCRE
+#ifdef USE_LIBPCRE
     struct string_regexp_search_data *mdata = data;
     const char *in_value;
     int r;
@@ -306,7 +306,7 @@ set_string_regexp_index(struct sol_flow_node *node,
     uint16_t conn_id,
     const struct sol_flow_packet *packet)
 {
-#ifdef HAVE_LIBPCRE
+#ifdef USE_LIBPCRE
     struct string_regexp_search_data *mdata = data;
     int32_t in_value;
     int r;
@@ -336,7 +336,7 @@ set_string_regexp_max_match(struct sol_flow_node *node,
     uint16_t conn_id,
     const struct sol_flow_packet *packet)
 {
-#ifdef HAVE_LIBPCRE
+#ifdef USE_LIBPCRE
     struct string_regexp_search_data *mdata = data;
     int32_t in_value;
     int r;


### PR DESCRIPTION
Also move HAVE_ICU usage back to USE_ICU.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>

As requested by Caio, who is dealing with with builds for small OSes and still has no easy way of skipping these (host) dependency auto-detections.