### PR TITLE
build: make sure we've kconfig/conf built

### DIFF
--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -447,6 +447,6 @@ $(FLOW_NODE_TYPE_FIND): $(FLOW_NODE_TYPE_FIND_IN) $(KCONFIG_CONFIG) $(MAKEFILE_G
 	$(Q)$(PYTHON) $(TEMPLATE_SCRIPT) --context-files $(KCONFIG_CONFIG) $(MAKEFILE_GEN) \
 		--template=$(FLOW_NODE_TYPE_FIND_IN) --output=$(FLOW_NODE_TYPE_FIND)
 
-$(KCONFIG_AUTOHEADER): $(KCONFIG_CONFIG)
+$(KCONFIG_AUTOHEADER): $(KCONFIG_CONFIG) $(obj)/conf
 	$(Q)mkdir -p $(KCONFIG_INCLUDE)config $(KCONFIG_INCLUDE)generated
 	$(Q)$(obj)/conf -s --silentoldconfig Kconfig


### PR DESCRIPTION
Since we're now calling kconfig/conf the rule should make sure it's
built. This patch does that by implicitly declaring it as its dependency.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>