### PR TITLE
build: sol_config.h should be regenerated with .config-cache

### DIFF
--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -447,6 +447,6 @@ $(FLOW_NODE_TYPE_FIND): $(FLOW_NODE_TYPE_FIND_IN) $(KCONFIG_CONFIG) $(MAKEFILE_G
 	$(Q)$(PYTHON) $(TEMPLATE_SCRIPT) --context-files $(KCONFIG_CONFIG) $(MAKEFILE_GEN) \
 		--template=$(FLOW_NODE_TYPE_FIND_IN) --output=$(FLOW_NODE_TYPE_FIND)
 
-$(KCONFIG_AUTOHEADER): $(KCONFIG_CONFIG) $(obj)/conf
+$(KCONFIG_AUTOHEADER): $(DEPENDENCY_CACHE) $(KCONFIG_CONFIG) $(obj)/conf
 	$(Q)mkdir -p $(KCONFIG_INCLUDE)config $(KCONFIG_INCLUDE)generated
 	$(Q)$(obj)/conf -s --silentoldconfig Kconfig


### PR DESCRIPTION
If .config-cache was regenerated the sol_config.h should be as well. A
common test case is, make:

$ make alldefconfig && make

add new dependencies to dependencies.json then:
$ make reconf

sol_config.h should be regenerated. This patch fixes the issue.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>