### PR TITLE
build: split static and shared lib build

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -12,9 +12,22 @@ config BASE_OS
 source "tools/build/Kconfig.$BASE_OS"
 
 menu "Basic"
+choice LIB_OUTPUT
+	prompt "Soletta library output"
+	default SHARED_LIBRARY
+
+config SHARED_LIBRARY
+	bool "Shared"
+	depends on FEATURE_DYNAMIC_LINKER
+
+config STATIC_LIBRARY
+	bool "Static"
+endchoice
+
 # backward compatibility with autotools vars
 config ENABLE_DYNAMIC_MODULES
 	bool
+	depends on SHARED_LIBRARY
 	default n
 
 config CC_SANITIZE
@@ -36,11 +49,6 @@ config CC_SANITIZE_ADDRESS
 	bool "address"
 	depends on HAVE_SANITIZE_ADDRESS
 endchoice
-
-config SHARED_LIBRARY
-    bool "Build shared library"
-    default y
-    depends on FEATURE_DYNAMIC_LINKER
 
 config MODULES
 	bool "Enable loadable module support"

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ include $(top_srcdir)tools/build/Makefile.rules
 
 include $(top_srcdir)tools/build/Makefile.targets
 
-default_target: $(PRE_GEN) $(SOL_LIB_SO) $(SOL_LIB_AR) $(bins-out) $(modules-out)
+default_target: $(PRE_GEN) $(SOL_LIB_OUTPUT) $(bins-out) $(modules-out)
 all: default_target
 endif # HAVE_KCONFIG_CONFIG
 endif # NOT_FOUND

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -264,7 +264,7 @@ endef
 $(foreach bin,$(EXTRA_BINS),$(eval $(call make-extra-bin,$(bin))))
 
 define make-bin
-$(bin-$(1)-out): $(SOL_LIB_SO) $(bin-$(1)-srcs) $(call find-deps,$(1))
+$(bin-$(1)-out): $(SOL_LIB_OUTPUT) $(bin-$(1)-srcs) $(call find-deps,$(1))
 	$(Q)echo "     "BIN"   "$$@
 	$(Q)$(MKDIR) -p $(dir $(bin-$(1)-out))
 	$(Q)$(TARGETCC) $(BIN_CFLAGS) $(bin-$(1)-cflags) $(filter-out %.h,$(bin-$(1)-srcs)) -o $(bin-$(1)-out) $(BIN_LDFLAGS) $(bin-$(1)-ldflags) $(sort $(builtin-ldflags))
@@ -275,7 +275,7 @@ sample-out = $(if $(filter %.o,$(sample-$(1)-out)), -c -o $(sample-$(1)-out),-o 
 sample-src = $(filter-out %.json,$(filter-out %.h,$(sample-$(1)-srcs)))
 
 define make-sample
-$(sample-$(1)-out): $(SOL_LIB_SO) $(sample-$(1)-srcs) $(call find-deps,$(1))
+$(sample-$(1)-out): $(SOL_LIB_OUTPUT) $(sample-$(1)-srcs) $(call find-deps,$(1))
 	$(Q)echo "     "SMP"   "$$@
 	$(Q)$(MKDIR) -p $(dir $(sample-$(1)-out))
 	$(Q)$(TARGETCC) $(SAMPLE_CFLAGS) $(sample-$(1)-cflags) $(sample-$(1)-includedir) $(sample-src) \
@@ -284,16 +284,21 @@ $(sample-$(1)-out): $(SOL_LIB_SO) $(sample-$(1)-srcs) $(call find-deps,$(1))
 endef
 $(foreach sample,$(samples),$(eval $(call make-sample,$(sample))))
 
+ifeq (y,$(STATIC_LIBRARY))
+use-builtin-ldflags = $(sort $(builtin-ldflags))
+use-builtin-cflags = $(sort $(builtin-cflags))
+endif
+
 define make-test
-$(test-$(1)-out): $(SOL_LIB_SO) $(test-$(1)-srcs) $(call find-deps,$(1))
+$(test-$(1)-out): $(SOL_LIB_OUTPUT) $(test-$(1)-srcs) $(call find-deps,$(1))
 	$(Q)echo "     "TST"   "$$@
-	$(Q)$(TARGETCC) $(TEST_CFLAGS) $(test-$(1)-cflags) $(filter-out %.h,$(test-$(1)-srcs)) \
-	$(call find-deps,$(1)) -o $$@ $(TEST_LDFLAGS) $(test-$(1)-ldflags)
+	$(Q)$(TARGETCC) $(TEST_CFLAGS) $(test-$(1)-cflags) $(use-builtin-cflags) $(filter-out %.h,$(test-$(1)-srcs)) \
+	$(call find-deps,$(1)) -o $$@ $(TEST_LDFLAGS) $(test-$(1)-ldflags) $(use-builtin-ldflags)
 endef
 $(foreach curr,$(tests),$(eval $(call make-test,$(curr))))
 
 define make-test-internal
-$(test-$(1)-out): $(SOL_LIB_SO) $(test-$(1)-srcs) $(call find-deps,$(1))
+$(test-$(1)-out): $(SOL_LIB_OUTPUT) $(test-$(1)-srcs) $(call find-deps,$(1))
 	$(Q)echo "     "TST"   "$$@
 	$(Q)$(TARGETCC) $(TEST_INT_CFLAGS) $(test-$(1)-cflags) $(filter-out %.h,$(test-$(1)-srcs)) \
 	$(builtin-objs) $(call find-deps,$(1)) -o $$@ $(sort $(builtin-ldflags)) $(TEST_INT_LDFLAGS) $(test-$(1)-ldflags)
@@ -321,13 +326,15 @@ $(foreach buin,$(builtins), \
 	$(foreach obj,$($(buin)-objs), $(eval $(call make-object,$(obj),$(buin)))) \
 )
 
+ifeq (y,$(SHARED_LIBRARY))
 define make-mod-so
-$($(1)-out): $(SOL_LIB_SO) $($(1)-objs) $(call find-deps,$(1)) $($(1)-bs)
+$($(1)-out): $(SOL_LIB_OUTPUT) $($(1)-objs) $(call find-deps,$(1)) $($(1)-bs)
 	$(Q)echo "     "MOD"   "$$@
 	$(Q)$(MKDIR) -p $(dir $($(1)-out))
 	$(Q)$(TARGETCC) $(MOD_CFLAGS) $(sort $($(1)-cflags)) $($(1)-objs) -shared -o $($(1)-out) $(sort $($(1)-ldflags))
 endef
 $(foreach curr,$(mod-so),$(eval $(call make-mod-so,$(curr))))
+endif
 
 define make-mod-ar
 $($(1)-out): $($(1)-objs) $(call find-deps,$(1)) $($(1)-bs)
@@ -337,16 +344,18 @@ $($(1)-out): $($(1)-objs) $(call find-deps,$(1)) $($(1)-bs)
 endef
 $(foreach curr,$(mod-ar),$(eval $(call make-mod-ar,$(curr))))
 
+ifeq (y,$(STATIC_LIBRARY))
 $(SOL_LIB_AR): $(all-objs)
 	$(Q)echo "      "AR"   "$(@)
 	$(Q)$(MKDIR) -p $(dir $(SOL_LIB_AR))
 	$(Q)$(TARGETAR) $(TARGET_ARFLAGS) $(@) $(all-objs)
-
-$(SOL_LIB_SO): $(SOL_LIB_AR) $(builtin-objs)
+else
+$(SOL_LIB_SO): $(builtin-objs)
 	$(Q)echo "      "LD"   "$(@)
 	$(Q)$(MKDIR) -p $(dir $(SOL_LIB_SO))
 	$(Q)$(TARGETCC) -shared $(builtin-objs) $(sort $(builtin-ldflags)) $(LIB_LDFLAGS) -o $(@).$(VERSION)
 	$(Q)$(LN) -fs $(notdir $(@).$(VERSION)) $(@)
+endif
 
 # generators
 define make-gen
@@ -376,7 +385,7 @@ $($(1)-src): $(1) $(SOL_FBP_GENERATOR_BIN)
 endef
 $(foreach gen,$(all-fbp-gens),$(eval $(call make-fbp-gen,$(gen))))
 
-$(FLOW_BUILTINS_DESC): $(SOL_LIB_SO) $(SOL_LIB_AR) $(all-mod-descs) $(JSON_FORMAT_SCRIPT)
+$(FLOW_BUILTINS_DESC): $(SOL_LIB_OUTPUT) $(all-mod-descs) $(JSON_FORMAT_SCRIPT)
 	$(Q)echo "     "GEN"   "$@
 	$(Q)$(MKDIR) -p $(dir $(@))
 	$(Q)$(PYTHON) $(FLOW_MERGE_BUILTINS_SCRIPT) --modules-dir=$(build_descdir) $(@) $(builtin-flows)

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -1,19 +1,19 @@
-check: $(SOL_LIB_SO) $(SOL_LIB_AR) $(tests-out)
+check: $(SOL_LIB_OUTPUT) $(tests-out)
 	$(Q)$(PYTHON) $(TEST_SUITE_RUN_SCRIPT) --tests="$(tests-out)"
 
 PHONY += check
 
-check-fbp: $(SOL_LIB_SO) $(SOL_LIB_AR) $(bins-out) $(modules-out)
+check-fbp: $(SOL_LIB_OUTPUT) $(bins-out) $(modules-out)
 	$(Q)$(PYTHON) $(TEST_FBP_SCRIPT) --runner="$(abspath $(SOL_FBP_RUNNER_BIN))"
 
 PHONY += check-fbp
 
 ifeq (y,$(HAVE_VALGRIND))
-check-valgrind: $(SOL_LIB_SO) $(SOL_LIB_AR) $(tests-out)
+check-valgrind: $(SOL_LIB_OUTPUT) $(tests-out)
 	$(Q)$(PYTHON) $(TEST_SUITE_RUN_SCRIPT) --tests="$(tests-out)" \
 		--valgrind=$(VALGRIND) --valgrind-supp=$(abspath $(TEST_VALGRIND_SUPP))
 
-check-fbp-valgrind: $(SOL_LIB_SO) $(SOL_LIB_AR) $(bins-out) $(modules-out)
+check-fbp-valgrind: $(SOL_LIB_OUTPUT) $(bins-out) $(modules-out)
 	$(Q)$(PYTHON) $(TEST_FBP_SCRIPT) --runner="$(abspath $(SOL_FBP_RUNNER_BIN))" --valgrind="$(VALGRIND)" --valgrind-supp="$(abspath $(TEST_VALGRIND_SUPP))"
 else
 check-valgrind:
@@ -50,7 +50,7 @@ PHONY += run-coverage coverage
 # sketch fine. Dummy module exercises all possible options and ports
 # data types.
 
-check-stub: $(SOL_LIB_SO) $(SOL_LIB_AR) $(NODE_TYPE_STUB_GEN_SCRIPT) $(NODE_TYPE_SCHEMA) $(NODE_TYPE_GEN_SCRIPT) $(NODE_TYPE_STUB_GEN_TEST)
+check-stub: $(SOL_LIB_OUTPUT) $(NODE_TYPE_STUB_GEN_SCRIPT) $(NODE_TYPE_SCHEMA) $(NODE_TYPE_GEN_SCRIPT) $(NODE_TYPE_STUB_GEN_TEST)
 	$(Q)$(MKDIR) -p $(NODE_TYPE_STUB_GEN_DIR)
 	$(Q)$(PYTHON) $(NODE_TYPE_GEN_SCRIPT) --prefix=sol-flow-node-type \
 		--genspec-schema=$(NODE_TYPE_SCHEMA) $(NODE_TYPE_STUB_GEN_TEST) \
@@ -77,11 +77,11 @@ check-stub: $(SOL_LIB_SO) $(SOL_LIB_AR) $(NODE_TYPE_STUB_GEN_SCRIPT) $(NODE_TYPE
 
 PHONY += check-stub
 
-samples: $(SOL_LIB_SO) $(SOL_LIB_AR) $(samples-out)
+samples: $(SOL_LIB_OUTPUT) $(samples-out)
 
 PHONY += samples
 
-PRE_INSTALL := $(PC_GEN) $(SOL_LIB_SO) $(SOL_LIB_AR) $(bins-out) $(modules-out) $(all-mod-descs)
+PRE_INSTALL := $(PC_GEN) $(SOL_LIB_OUTPUT) $(bins-out) $(modules-out) $(all-mod-descs)
 PRE_INSTALL += $(NODE_TYPE_SCHEMA_DEST) $(BOARD_DETECT_DEST) $(GDB_AUTOLOAD_PY_DEST)
 
 ifneq (,$(strip $(builtin-flows)))

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -41,6 +41,9 @@ all-mod-descs :=
 
 module-types := flow linux-micro pin-mux
 
+use-builtin-ldflags =
+use-builtin-cflags =
+
 # vars to distinguish the modules types
 flow-dir := $(top_srcdir)src/modules/flow/
 linux-micro-dir := $(top_srcdir)src/modules/linux-micro/
@@ -130,8 +133,12 @@ HEADERDIRS += $(build_includedir)
 LIB_OUTPUTDIR := $(build_libdir)
 
 SOL_LIB_AR := $(LIB_OUTPUTDIR)libsoletta.a
-ifeq (y,$(SHARED_LIBRARY))
 SOL_LIB_SO := $(LIB_OUTPUTDIR)libsoletta.so
+
+ifeq (y,$(SHARED_LIBRARY))
+SOL_LIB_OUTPUT := $(SOL_LIB_SO)
+else
+SOL_LIB_OUTPUT := $(SOL_LIB_AR)
 endif
 
 GDB_AUTOLOAD_PY_DEST := $(build_gdbautoload)libsoletta.so.$(VERSION)-gdb.py
@@ -196,7 +203,11 @@ DEP_RESOLVER_LDFLAGS := $(LDFLAGS)
 DEFINITIONS_H := $(top_srcdir)include/generated/sol_definitions.h
 MISSING_H := $(top_srcdir)src/lib/common/sol-missing.h
 
-COMMON_CFLAGS += -std=gnu99 -fPIC
+ifeq (y,$(SHARED_LIBRARY))
+COMMON_CFLAGS += -fPIC
+endif
+
+COMMON_CFLAGS += -std=gnu99
 COMMON_CFLAGS += -include $(abspath $(KCONFIG_AUTOHEADER))
 COMMON_CFLAGS += -include $(abspath $(DEFINITIONS_H))
 COMMON_CFLAGS += -include $(abspath $(MISSING_H))


### PR DESCRIPTION
This patch changes how shared and static libraries are built. Currently
we build both shared and static, with this patch we'll build only one of
them. The user can choose to build static or library using kconfig
interfaces, the default being shared.

If static is chosen the .so external modules are not built, everything
goes builtin - actually it's done before that way, but since we were
building the shared library together we should also generate the
external modules so it could be used by the shared library users.

Next step - as requested by Jesus - is to split the flags tested by
dependency-resolver, so we don't introduce compilation flags specific to
shared libraries and get the static build affected.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>