### PR TITLE
Add -I option to sol-fbp-generator

### DIFF
--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -59,8 +59,8 @@ static struct {
     const char *export_symbol;
 
     struct sol_ptr_vector json_files;
+    struct sol_ptr_vector include_paths;
     char *fbp_basename;
-    char *fbp_dirname;
 } args;
 
 static struct sol_arena *str_arena;
@@ -956,6 +956,43 @@ handle_json_path(const char *path)
     return true;
 }
 
+static bool
+handle_include_path(char *path)
+{
+    struct stat s;
+    char *dup_path;
+
+    if (stat(path, &s) != 0)
+        return false;
+
+    if (S_ISDIR(s.st_mode))
+        dup_path = sol_arena_strdup(str_arena, path);
+    else if (S_ISREG(s.st_mode))
+        dup_path = sol_arena_strdup(str_arena, dirname(path));
+
+    SOL_NULL_CHECK(dup_path, false);
+    sol_ptr_vector_append(&args.include_paths, dup_path);
+
+    return true;
+}
+
+static bool
+handle_include_dir(char *fullpath, const char *basename)
+{
+    struct stat s;
+    const char *p;
+    uint16_t i;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&args.include_paths, p, i) {
+        snprintf(fullpath, PATH_MAX, "%s/%s", p, basename);
+        if (stat(fullpath, &s) == 0)
+            if (S_ISREG(s.st_mode))
+                return true;
+    }
+
+    return false;
+}
+
 static void
 print_usage(const char *program)
 {
@@ -968,6 +1005,7 @@ print_usage(const char *program)
         "        Multiple -j can be passed.\n"
         "    -s  Define a function named SYMBOL that will return the type from FBP\n"
         "        and don't generate any main function or entry point.\n"
+        "    -I  Define search path for fbp files\n"
         "\n",
         program);
 }
@@ -975,7 +1013,7 @@ print_usage(const char *program)
 static bool
 parse_args(int argc, char *argv[])
 {
-    char *filename;
+    char *filename, *dup_path;
     bool has_json_file = false;
     int opt;
 
@@ -985,8 +1023,9 @@ parse_args(int argc, char *argv[])
     }
 
     sol_ptr_vector_init(&args.json_files);
+    sol_ptr_vector_init(&args.include_paths);
 
-    while ((opt = getopt(argc, argv, "s:c:j:")) != -1) {
+    while ((opt = getopt(argc, argv, "s:c:j:I:")) != -1) {
         switch (opt) {
         case 's':
             args.export_symbol = optarg;
@@ -1003,6 +1042,13 @@ parse_args(int argc, char *argv[])
             has_json_file = true;
             if (!handle_json_path(optarg)) {
                 SOL_ERR("Can't access JSON description path '%s': %s",
+                    optarg, sol_util_strerrora(errno));
+                return false;
+            }
+            break;
+        case 'I':
+            if (!handle_include_path(optarg)) {
+                SOL_ERR("Can't access include path '%s': %s",
                     optarg, sol_util_strerrora(errno));
                 return false;
             }
@@ -1034,12 +1080,12 @@ parse_args(int argc, char *argv[])
         return false;
     }
 
-    args.fbp_dirname = sol_arena_strdup(str_arena, dirname(strdupa(filename)));
-    if (!args.fbp_dirname) {
-        free(args.fbp_basename);
-        SOL_ERR("Couldn't get %s dirname args.", filename);
+    dup_path = sol_arena_strdup(str_arena, dirname(strdupa(filename)));
+    if (!dup_path) {
+        SOL_ERR("Couldn't get %s dirname.", filename);
         return false;
     }
+    sol_ptr_vector_append(&args.include_paths, dup_path);
 
     return true;
 }
@@ -1140,12 +1186,10 @@ create_fbp_data(struct sol_vector *fbp_data_vector, struct sol_ptr_vector *file_
     struct fbp_data *data;
     struct sol_fbp_error *fbp_error;
     struct sol_file_reader *fr;
-    char filename[2048];
-    int r;
+    char filename[PATH_MAX];
 
-    r = snprintf(filename, sizeof(filename), "%s/%s", args.fbp_dirname, fbp_basename);
-    if (r < 0 || r >= (int)sizeof(filename)) {
-        SOL_ERR("Couldn't find file '%s': %s\n", filename, sol_util_strerrora(errno));
+    if (!handle_include_dir(filename, fbp_basename)) {
+        SOL_ERR("Couldn't find file '%s': %s\n", fbp_basename, sol_util_strerrora(errno));
         return NULL;
     }
 


### PR DESCRIPTION
Now generator is able to search for fbp files according to paths
passed to it through -I option.

Signed-off-by: Luiz Ywata <luizg.ywata@intel.com>