### PR TITLE
build: turn optional the use of rpath - v2

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -85,6 +85,16 @@ config PREFIX
             further resources, such as loadable module support (see
             MODULES configuration help).
 
+config RPATH
+	bool "Uses rpath for local builds"
+	depends on HAVE_CHRPATH
+	help
+            This option defines if rpath ought be used to look up
+	    libraries. If disabled the user should adjust the environment
+	    accordingly.
+
+comment "rpath disabled, no chrpath found"
+	depends on !HAVE_CHRPATH
 endmenu
 
 menu "Core library"

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -358,8 +358,7 @@
     {
       "dependency": "chrpath",
       "type": "exec",
-      "exec": "chrpath",
-      "required": true
+      "exec": "chrpath"
     },
     {
       "dependency": "jsonschema",

--- a/data/scripts/dependency-resolver.py
+++ b/data/scripts/dependency-resolver.py
@@ -277,7 +277,7 @@ def handle_exec_check(args, conf, context):
         context.add_append_makefile_var("NOT_FOUND", req_label, True)
 
     context.add_cond_makefile_var(dep_sym, path)
-    context.add_cond_makefile_var("HAVE_%s" % dep_sym, "y" if path else "n")
+    context.add_kconfig("HAVE_%s" % dep_sym, "bool", "y" if path else "n")
 
     return success
 

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -88,6 +88,7 @@ ifneq (,$(strip $(builtin-flows)))
 PRE_GEN += $(FLOW_BUILTINS_DESC)
 endif
 
+ifeq (y,$(RPATH))
 rpath-bins := $(subst $(build_sysroot)/,$(DESTDIR),$(bins-out))
 
 rpath-bins-prepare = \
@@ -104,12 +105,15 @@ $($(1)-install)-rpath-cleanup: $(1) pre-install
 endef
 $(foreach bin,$(bins-out),$(eval $(call rpath-cleanup,$(bin))))
 
+post-install: $(all-rpath-bins)
+endif
+
 pre-install: $(PRE_INSTALL)
 	$(Q)echo "     "INSTALLING SYSROOT TO: $(DESTDIR)
 	$(Q)$(MKDIR) -p $(DESTDIR)/$(PREFIX)
 	$(Q)$(CP) -R $(build_sysroot)/$(PREFIX)/* $(DESTDIR)/$(PREFIX)
 
-post-install: pre-install $(all-rpath-bins)
+post-install: pre-install
 
 install: post-install
 

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -220,7 +220,13 @@ LIB_LDFLAGS := $(COMMON_LDFLAGS)
 
 LINKED_OBJS_LDFLAGS := $(addprefix -L,$(LIB_OUTPUTDIR))
 LINKED_OBJS_LDFLAGS += -lsoletta
+
+ifeq (y,$(RPATH))
 LINKED_OBJS_LDFLAGS += -Wl,-R$(abspath $(build_libdir))
+else
+# make sure we set lib path so internal scripts keep working
+export LD_LIBRARY_PATH := $(LD_LIBRARY_PATH):$(abspath $(build_libdir))
+endif
 
 OBJ_CFLAGS := $(COMMON_CFLAGS) $(COVERAGE_CFLAGS)
 OBJ_LDFLAGS += $(addprefix -L,$(LIB_OUTPUTDIR))


### PR DESCRIPTION
## Changes
  + v2 (since #616):
    - Changed exec tests to export HAVE_* vars to Kconfig.gen instead of Makefile.gen so we can use in the dependency chain;
    - call export to propagate the LD_LIBRARY_PATH to test suite script - ubuntu's make version requirement;

## Rationale
We don't need to force the users to have rpath installed to have the
build working - and all the tooling.

This patch makes the use of rpath optional.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>