### PR TITLE
Fix coverage report

### DIFF
--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -1,4 +1,4 @@
-check: $(SOL_LIB_OUTPUT) $(tests-out)
+check: $(SOL_LIB_OUTPUT) $(tests-out) $(modules-out)
 	$(Q)$(PYTHON) $(TEST_SUITE_RUN_SCRIPT) --tests="$(tests-out)"
 
 PHONY += check
@@ -30,7 +30,7 @@ ifneq (,$(LCOV))
 run-coverage: check check-fbp
 	$(Q)$(MKDIR) -p $(coveragedir)
 	$(Q)$(LCOV) --capture --directory $(top_srcdir) --output-file $(coveragedir)coverage.info
-	$(Q)$(LCOV) --remove $(coveragedir)coverage.info *thirdparty* --output-file $(coveragedir)coverage.info
+	$(Q)$(LCOV) --remove $(coveragedir)coverage.info *duk_* --output-file $(coveragedir)coverage.info
 	$(Q)$(MV) *.gcda $(build_bindir)
 	$(Q)$(GENHTML) coverage/coverage.info --output-directory coverage/
 


### PR DESCRIPTION
`make coverage` was failing after the change to make JS metatype a
module. First, test-javascript now may depend on modules, so `check`
should depend on them. Second, duktape is now compiled from the module
directory, so fix the removal from the coverage results to include them
specifically.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>