### PR TITLE
Add -I option to sol-fbp-runner

### DIFF
--- a/src/bin/sol-fbp-runner/runner.c
+++ b/src/bin/sol-fbp-runner/runner.c
@@ -32,6 +32,7 @@
 
 #include <errno.h>
 #include <libgen.h>
+#include <sys/stat.h>
 
 #include "sol-file-reader.h"
 #include "sol-flow-parser.h"
@@ -56,12 +57,31 @@ struct runner {
 
     const char *filename;
     char *basename;
-    char *dirname;
 
     struct sol_ptr_vector file_readers;
+    struct sol_ptr_vector *include_paths;
 
     struct sol_flow_parser_client parser_client;
 };
+
+static int
+handle_include_dir(struct runner *r, char **fullpath, const char *basename)
+{
+    struct stat s;
+    const char *p;
+    uint16_t i;
+    int err;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (r->include_paths, p, i) {
+        err = asprintf(fullpath, "%s/%s", p, basename);
+        SOL_INT_CHECK(err, < 0, err);
+
+        if (stat(*fullpath, &s) == 0 && S_ISREG(s.st_mode))
+            return 0;
+    }
+
+    return -EINVAL;
+}
 
 static int
 read_file(void *data, const char *name, const char **buf, size_t *size)
@@ -72,11 +92,9 @@ read_file(void *data, const char *name, const char **buf, size_t *size)
     char *path;
     int err;
 
-    err = asprintf(&path, "%s/%s", r->dirname, name);
-    if (err < 0) {
-        err = -ENOMEM;
+    err = handle_include_dir(r, &path, name);
+    if (err < 0)
         goto error;
-    }
 
     fr = sol_file_reader_open(path);
     if (!fr) {
@@ -96,7 +114,8 @@ read_file(void *data, const char *name, const char **buf, size_t *size)
     return 0;
 
 error:
-    free(path);
+    if (path)
+        free(path);
     if (fr)
         sol_file_reader_close(fr);
     return err;
@@ -332,10 +351,12 @@ end:
 struct runner *
 runner_new_from_file(
     const char *filename,
-    const char **options_strv)
+    const char **options_strv,
+    struct sol_ptr_vector *includes)
 {
     struct runner *r;
     const char *buf;
+    char *dir;
     size_t size;
     int err;
 
@@ -345,6 +366,7 @@ runner_new_from_file(
     SOL_NULL_CHECK(r, NULL);
 
     sol_ptr_vector_init(&r->file_readers);
+    r->include_paths = includes;
 
     r->parser_client.api_version = SOL_FLOW_PARSER_CLIENT_API_VERSION;
     r->parser_client.data = r;
@@ -355,7 +377,12 @@ runner_new_from_file(
         goto error;
 
     r->filename = filename;
-    r->dirname = strdup(dirname(strdupa(filename)));
+
+    dir = strdup(dirname(strdupa(filename)));
+    err = sol_ptr_vector_append(r->include_paths, dir);
+    if (err < 0)
+        goto error;
+
     r->basename = strdup(basename(strdupa(filename)));
 
     err = read_file(r, r->basename, &buf, &size);
@@ -455,7 +482,6 @@ runner_del(struct runner *r)
     }
     if (r->parser)
         sol_flow_parser_del(r->parser);
-    free(r->dirname);
     free(r->basename);
     free(r);
 }

--- a/src/bin/sol-fbp-runner/runner.h
+++ b/src/bin/sol-fbp-runner/runner.h
@@ -32,9 +32,11 @@
 
 #pragma once
 
+#include "sol-vector.h"
+
 struct runner;
 
-struct runner *runner_new_from_file(const char *filename, const char **options_strv);
+struct runner *runner_new_from_file(const char *filename, const char **options_strv, struct sol_ptr_vector *include);
 struct runner *runner_new_from_type(const char *typename, const char **options_strv);
 
 int runner_attach_simulation(struct runner *r);


### PR DESCRIPTION
Now runner is able to search for fbp files according to paths
passed to it through -I option.

Signed-off-by: Luiz Ywata <luizg.ywata@intel.com>