### PR TITLE
Add -I option to sol-fbp-runner

### DIFF
--- a/src/bin/sol-fbp-runner/runner.h
+++ b/src/bin/sol-fbp-runner/runner.h
@@ -32,9 +32,11 @@
 
 #pragma once
 
+#include "sol-vector.h"
+
 struct runner;
 
-struct runner *runner_new_from_file(const char *filename, const char **options_strv);
+struct runner *runner_new_from_file(const char *filename, const char **options_strv, struct sol_ptr_vector *fbps);
 struct runner *runner_new_from_type(const char *typename, const char **options_strv);
 
 int runner_attach_simulation(struct runner *r);


### PR DESCRIPTION
Now runner is able to search for fbp files according to paths
passed to it through -I option.

Signed-off-by: Luiz Ywata <luizg.ywata@intel.com>