### PR TITLE
Build modules name lookup and linux micro prefix - v2

### DIFF
--- a/src/modules/flow/calamari/Makefile
+++ b/src/modules/flow/calamari/Makefile
@@ -1,3 +1,3 @@
 obj-$(FLOW_NODE_TYPE_CALAMARI) += calamari.mod
 obj-calamari-$(FLOW_NODE_TYPE_CALAMARI) := calamari.json calamari.o
-obj-calamari-$(FLOW_NODE_TYPE_CALAMARI)-deps := flow-node-type-gpio.mod
+obj-calamari-$(FLOW_NODE_TYPE_CALAMARI)-deps := flow/gpio.mod

--- a/src/modules/linux-micro/bluetooth/Makefile
+++ b/src/modules/linux-micro/bluetooth/Makefile
@@ -1,2 +1,2 @@
-obj-$(LINUX_MICRO_BLUETOOTH) += linux-micro-bluetooth.mod
-obj-linux-micro-bluetooth-$(LINUX_MICRO_BLUETOOTH) += bluetooth.o
+obj-$(LINUX_MICRO_BLUETOOTH) += bluetooth.mod
+obj-bluetooth-$(LINUX_MICRO_BLUETOOTH) += bluetooth.o

--- a/src/modules/linux-micro/console/Makefile
+++ b/src/modules/linux-micro/console/Makefile
@@ -1,2 +1,2 @@
-obj-$(LINUX_MICRO_CONSOLE) += linux-micro-console.mod
-obj-linux-micro-console-$(LINUX_MICRO_CONSOLE) += console.o
+obj-$(LINUX_MICRO_CONSOLE) += console.mod
+obj-console-$(LINUX_MICRO_CONSOLE) += console.o

--- a/src/modules/linux-micro/dbus/Makefile
+++ b/src/modules/linux-micro/dbus/Makefile
@@ -1,2 +1,2 @@
-obj-$(LINUX_MICRO_DBUS) += linux-micro-dbus.mod
-obj-linux-micro-dbus-$(LINUX_MICRO_DBUS) += dbus.o
+obj-$(LINUX_MICRO_DBUS) += dbus.mod
+obj-dbus-$(LINUX_MICRO_DBUS) += dbus.o

--- a/src/modules/linux-micro/fstab/Makefile
+++ b/src/modules/linux-micro/fstab/Makefile
@@ -1,2 +1,2 @@
-obj-$(LINUX_MICRO_FSTAB) += linux-micro-fstab.mod
-obj-linux-micro-fstab-$(LINUX_MICRO_FSTAB) += fstab.o
+obj-$(LINUX_MICRO_FSTAB) += fstab.mod
+obj-fstab-$(LINUX_MICRO_FSTAB) += fstab.o

--- a/src/modules/linux-micro/hostname/Makefile
+++ b/src/modules/linux-micro/hostname/Makefile
@@ -1,2 +1,2 @@
-obj-$(LINUX_MICRO_HOSTNAME) += linux-micro-hostname.mod
-obj-linux-micro-hostname-$(LINUX_MICRO_HOSTNAME) += hostname.o
+obj-$(LINUX_MICRO_HOSTNAME) += hostname.mod
+obj-hostname-$(LINUX_MICRO_HOSTNAME) += hostname.o

--- a/src/modules/linux-micro/locale/Makefile
+++ b/src/modules/linux-micro/locale/Makefile
@@ -1,2 +1,2 @@
-obj-$(LINUX_MICRO_LOCALE) += linux-micro-locale.mod
-obj-linux-micro-locale-$(LINUX_MICRO_LOCALE) += locale.o
+obj-$(LINUX_MICRO_LOCALE) += locale.mod
+obj-locale-$(LINUX_MICRO_LOCALE) += locale.o

--- a/src/modules/linux-micro/network-up/Makefile
+++ b/src/modules/linux-micro/network-up/Makefile
@@ -1,2 +1,2 @@
-obj-$(LINUX_MICRO_NETWORK_UP) += linux-micro-network-up.mod
-obj-linux-micro-network-up-$(LINUX_MICRO_NETWORK_UP) += network-up.o
+obj-$(LINUX_MICRO_NETWORK_UP) += network-up.mod
+obj-network-up-$(LINUX_MICRO_NETWORK_UP) += network-up.o

--- a/src/modules/linux-micro/rc-d/Makefile
+++ b/src/modules/linux-micro/rc-d/Makefile
@@ -1,2 +1,2 @@
-obj-$(LINUX_MICRO_RC_D) += linux-micro-rc-d.mod
-obj-linux-micro-rc-d-$(LINUX_MICRO_RC_D) += rc-d.o
+obj-$(LINUX_MICRO_RC_D) += rc-d.mod
+obj-rc-d-$(LINUX_MICRO_RC_D) += rc-d.o

--- a/src/modules/linux-micro/sysctl/Makefile
+++ b/src/modules/linux-micro/sysctl/Makefile
@@ -1,2 +1,2 @@
-obj-$(LINUX_MICRO_SYSCTL) += linux-micro-sysctl.mod
-obj-linux-micro-sysctl-$(LINUX_MICRO_SYSCTL) += sysctl.o
+obj-$(LINUX_MICRO_SYSCTL) += sysctl.mod
+obj-sysctl-$(LINUX_MICRO_SYSCTL) += sysctl.o

--- a/src/modules/linux-micro/watchdog/Makefile
+++ b/src/modules/linux-micro/watchdog/Makefile
@@ -1,2 +1,2 @@
-obj-$(LINUX_MICRO_WATCHDOG) += linux-micro-watchdog.mod
-obj-linux-micro-watchdog-$(LINUX_MICRO_WATCHDOG) += watchdog.o
+obj-$(LINUX_MICRO_WATCHDOG) += watchdog.mod
+obj-watchdog-$(LINUX_MICRO_WATCHDOG) += watchdog.o

--- a/src/samples/flow/basics/Makefile
+++ b/src/samples/flow/basics/Makefile
@@ -1,20 +1,20 @@
 sample-$(FLOW_BASICS_CMDLINE_ARGS_SAMPLE) += cmdline-args
 sample-cmdline-args-$(FLOW_BASICS_CMDLINE_ARGS_SAMPLE) := cmdline-args.fbp
-sample-cmdline-args-$(FLOW_BASICS_CMDLINE_ARGS_SAMPLE)-deps := boolean.mod app.mod console.mod 
-sample-cmdline-args-$(FLOW_BASICS_CMDLINE_ARGS_SAMPLE)-deps += int.mod constant.mod
-sample-cmdline-args-$(FLOW_BASICS_CMDLINE_ARGS_SAMPLE)-deps += converter.mod
+sample-cmdline-args-$(FLOW_BASICS_CMDLINE_ARGS_SAMPLE)-deps := flow/boolean.mod flow/app.mod flow/console.mod
+sample-cmdline-args-$(FLOW_BASICS_CMDLINE_ARGS_SAMPLE)-deps += flow/int.mod flow/constant.mod
+sample-cmdline-args-$(FLOW_BASICS_CMDLINE_ARGS_SAMPLE)-deps += flow/converter.mod
 
 sample-$(FLOW_BASICS_FIBONACCI_SAMPLE) += fibonacci
 sample-fibonacci-$(FLOW_BASICS_FIBONACCI_SAMPLE) := fibonacci.fbp
-sample-fibonacci-$(FLOW_BASICS_FIBONACCI_SAMPLE)-deps := int.mod
+sample-fibonacci-$(FLOW_BASICS_FIBONACCI_SAMPLE)-deps := flow/int.mod
 
 sample-$(FLOW_BASICS_PLATORM_SERVICE_SAMPLE) += platform-service
 sample-platform-service-$(FLOW_BASICS_PLATORM_SERVICE_SAMPLE) := platform-service.fbp
 
 sample-$(FLOW_BASICS_SIMPLE_SAMPLE) += simple-fbp
 sample-simple-fbp-$(FLOW_BASICS_SIMPLE_SAMPLE) := simple.fbp
-sample-simple-fbp-$(FLOW_BASICS_SIMPLE_SAMPLE)-deps := timer.mod boolean.mod console.mod
+sample-simple-fbp-$(FLOW_BASICS_SIMPLE_SAMPLE)-deps := flow/timer.mod flow/boolean.mod flow/console.mod
 
 sample-$(FLOW_BASICS_SUBPROCESS_BC_SAMPLE) += subprocess-bc
 sample-subprocess-bc-$(FLOW_BASICS_SUBPROCESS_BC_SAMPLE) := subprocess_bc.fbp
-sample-subprocess-bc-$(FLOW_BASICS_SUBPROCESS_BC_SAMPLE)-deps := process.mod
+sample-subprocess-bc-$(FLOW_BASICS_SUBPROCESS_BC_SAMPLE)-deps := flow/process.mod

--- a/src/samples/flow/compass/Makefile
+++ b/src/samples/flow/compass/Makefile
@@ -1,3 +1,3 @@
 sample-$(FLOW_COMPASS_LSM303_SAMPLE) += compass-lsm303
 sample-compass-lsm303-$(FLOW_COMPASS_LSM303_SAMPLE) := lsm303.fbp
-sample-compass-lsm303-$(FLOW_COMPASS_LSM303_SAMPLE)-deps := accelerometer.mod magnetometer.mod
+sample-compass-lsm303-$(FLOW_COMPASS_LSM303_SAMPLE)-deps := flow/accelerometer.mod flow/magnetometer.mod

--- a/src/samples/flow/galileo-grove-kit/Makefile
+++ b/src/samples/flow/galileo-grove-kit/Makefile
@@ -5,7 +5,7 @@ sample-grove-button-$(FLOW_GALILEO_GROVE_BUTTON_SAMPLE)-conffile := galileo-grov
 sample-$(FLOW_GALILEO_GROVE_BUZZER_SAMPLE) += grove-buzzer
 sample-grove-buzzer-$(FLOW_GALILEO_GROVE_BUZZER_SAMPLE) := grove-buzzer.fbp
 sample-grove-buzzer-$(FLOW_GALILEO_GROVE_BUZZER_SAMPLE)-conffile := galileo-grove-kit.json
-sample-grove-buzzer-$(FLOW_GALILEO_GROVE_BUZZER_SAMPLE)-deps := piezo-speaker.mod
+sample-grove-buzzer-$(FLOW_GALILEO_GROVE_BUZZER_SAMPLE)-deps := flow/piezo-speaker.mod
 
 sample-$(FLOW_GALILEO_GROVE_LED_ACCUMULATOR_SAMPLE) += grove-led-accumulator
 sample-grove-led-accumulator-$(FLOW_GALILEO_GROVE_LED_ACCUMULATOR_SAMPLE) := grove-led-accumulator.fbp

--- a/src/samples/flow/galileo-grove-kit/lcd/Makefile
+++ b/src/samples/flow/galileo-grove-kit/lcd/Makefile
@@ -1,39 +1,39 @@
 sample-$(FLOW_GALILEO_GROVE_LCD_AUTOSCROLL_SAMPLE) += grove-lcd-autoscroll
 sample-grove-lcd-autoscroll-$(FLOW_GALILEO_GROVE_LCD_AUTOSCROLL_SAMPLE) := grove-lcd-autoscroll.fbp
 sample-grove-lcd-autoscroll-$(FLOW_GALILEO_GROVE_LCD_AUTOSCROLL_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-autoscroll-$(FLOW_GALILEO_GROVE_LCD_AUTOSCROLL_SAMPLE)-deps := grove.mod
+sample-grove-lcd-autoscroll-$(FLOW_GALILEO_GROVE_LCD_AUTOSCROLL_SAMPLE)-deps := flow/grove.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_BLINK_SAMPLE) += grove-lcd-blink
 sample-grove-lcd-blink-$(FLOW_GALILEO_GROVE_LCD_BLINK_SAMPLE) := grove-lcd-blink.fbp
 sample-grove-lcd-blink-$(FLOW_GALILEO_GROVE_LCD_BLINK_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-blink-$(FLOW_GALILEO_GROVE_LCD_BLINK_SAMPLE)-deps := grove.mod
+sample-grove-lcd-blink-$(FLOW_GALILEO_GROVE_LCD_BLINK_SAMPLE)-deps := flow/grove.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_CURSOR_SAMPLE) += grove-lcd-cursor
 sample-grove-lcd-cursor-$(FLOW_GALILEO_GROVE_LCD_CURSOR_SAMPLE) := grove-lcd-cursor.fbp
 sample-grove-lcd-cursor-$(FLOW_GALILEO_GROVE_LCD_CURSOR_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-cursor-$(FLOW_GALILEO_GROVE_LCD_CURSOR_SAMPLE)-deps := grove.mod
+sample-grove-lcd-cursor-$(FLOW_GALILEO_GROVE_LCD_CURSOR_SAMPLE)-deps := flow/grove.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_DISPLAY_SAMPLE) += grove-lcd-display
 sample-grove-lcd-display-$(FLOW_GALILEO_GROVE_LCD_DISPLAY_SAMPLE) := grove-lcd-display.fbp
 sample-grove-lcd-display-$(FLOW_GALILEO_GROVE_LCD_DISPLAY_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-display-$(FLOW_GALILEO_GROVE_LCD_DISPLAY_SAMPLE)-deps := grove.mod
+sample-grove-lcd-display-$(FLOW_GALILEO_GROVE_LCD_DISPLAY_SAMPLE)-deps := flow/grove.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_HELLO_WORLD_SAMPLE) += grove-lcd-hello-world
 sample-grove-lcd-hello-world-$(FLOW_GALILEO_GROVE_LCD_HELLO_WORLD_SAMPLE) := grove-lcd-hello-world.fbp
 sample-grove-lcd-hello-world-$(FLOW_GALILEO_GROVE_LCD_HELLO_WORLD_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-hello-world-$(FLOW_GALILEO_GROVE_LCD_HELLO_WORLD_SAMPLE)-deps := grove.mod
+sample-grove-lcd-hello-world-$(FLOW_GALILEO_GROVE_LCD_HELLO_WORLD_SAMPLE)-deps := flow/grove.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_SCROLL_SAMPLE) += grove-lcd-scroll
 sample-grove-lcd-scroll-$(FLOW_GALILEO_GROVE_LCD_SCROLL_SAMPLE) := grove-lcd-scroll.fbp
 sample-grove-lcd-scroll-$(FLOW_GALILEO_GROVE_LCD_SCROLL_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-scroll-$(FLOW_GALILEO_GROVE_LCD_SCROLL_SAMPLE)-deps := grove.mod
+sample-grove-lcd-scroll-$(FLOW_GALILEO_GROVE_LCD_SCROLL_SAMPLE)-deps := flow/grove.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_SET_CURSOR_SAMPLE) += grove-lcd-set-cursor
 sample-grove-lcd-set-cursor-$(FLOW_GALILEO_GROVE_LCD_SET_CURSOR_SAMPLE) := grove-lcd-set-cursor.fbp
 sample-grove-lcd-set-cursor-$(FLOW_GALILEO_GROVE_LCD_SET_CURSOR_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-set-cursor-$(FLOW_GALILEO_GROVE_LCD_SET_CURSOR_SAMPLE)-deps := grove.mod
+sample-grove-lcd-set-cursor-$(FLOW_GALILEO_GROVE_LCD_SET_CURSOR_SAMPLE)-deps := flow/grove.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_TEXT_DIRECTION_SAMPLE) += grove-lcd-text-direction
 sample-grove-lcd-text-direction-$(FLOW_GALILEO_GROVE_LCD_TEXT_DIRECTION_SAMPLE) := grove-lcd-text-direction.fbp
 sample-grove-lcd-text-direction-$(FLOW_GALILEO_GROVE_LCD_TEXT_DIRECTION_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-text-direction-$(FLOW_GALILEO_GROVE_LCD_TEXT_DIRECTION_SAMPLE)-deps := grove.mod
+sample-grove-lcd-text-direction-$(FLOW_GALILEO_GROVE_LCD_TEXT_DIRECTION_SAMPLE)-deps := flow/grove.mod

--- a/src/samples/flow/gtk-gallery/Makefile
+++ b/src/samples/flow/gtk-gallery/Makefile
@@ -1,3 +1,3 @@
 sample-$(FLOW_GTK_GALLERY_SAMPLE) += gtk-sample
 sample-gtk-sample-$(FLOW_GTK_GALLERY_SAMPLE) := gtk-gallery.fbp
-sample-gtk-sample-$(FLOW_GTK_GALLERY_SAMPLE)-deps := gtk.mod
+sample-gtk-sample-$(FLOW_GTK_GALLERY_SAMPLE)-deps := flow/gtk.mod

--- a/src/samples/flow/misc/Makefile
+++ b/src/samples/flow/misc/Makefile
@@ -1,14 +1,14 @@
 sample-$(FLOW_MISC_FILE_COPY_SAMPLE) += file-copy
 sample-file-copy-$(FLOW_MISC_FILE_COPY_SAMPLE) := file-copy.fbp
-sample-file-copy-$(FLOW_MISC_FILE_COPY_SAMPLE)-deps := file.mod
+sample-file-copy-$(FLOW_MISC_FILE_COPY_SAMPLE)-deps := flow/file.mod
 
 sample-$(FLOW_MISC_FS_PERSISTENCE_SAMPLE) += fs-persistence
 sample-fs-persistence-$(FLOW_MISC_FS_PERSISTENCE_SAMPLE) := fs-persitence.fbp
-sample-fs-persistence-$(FLOW_MISC_FS_PERSISTENCE_SAMPLE)-deps := fs.mod
+sample-fs-persistence-$(FLOW_MISC_FS_PERSISTENCE_SAMPLE)-deps := flow/fs.mod
 
 sample-$(FLOW_MISC_RANDOM_NUMBERS_SAMPLE) += random-numbers
 sample-random-numbers-$(FLOW_MISC_RANDOM_NUMBERS_SAMPLE) := random-numbers.fbp
 
 sample-$(FLOW_MISC_TICKETS_QUEUE_SAMPLE) += tickets-queue
 sample-tickets-queue-$(FLOW_MISC_TICKETS_QUEUE_SAMPLE) := tickets_queue.fbp
-sample-tickets-queue-$(FLOW_MISC_TICKETS_QUEUE_SAMPLE)-deps := keyboard.mod
+sample-tickets-queue-$(FLOW_MISC_TICKETS_QUEUE_SAMPLE)-deps := flow/keyboard.mod

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -12,13 +12,14 @@ test-test-fbp-scanner-$(TEST_FBP_SCANNER) := test.c test-fbp-scanner.c
 
 test-$(TEST_FLOW) += test-flow
 test-test-flow-$(TEST_FLOW) := test.c test-flow.c
-test-test-flow-$(TEST_FLOW)-deps := timer.mod pwm.mod console.mod
+test-test-flow-$(TEST_FLOW)-deps := flow/timer.mod flow/pwm.mod flow/console.mod
 
 test-$(TEST_FLOW_BUILDER) += test-flow-builder
 test-test-flow-builder-$(TEST_FLOW_BUILDER) := test.c test-flow-builder.c
 
 test-$(TEST_FLOW_PARSER) += test-flow-parser
 test-test-flow-parser-$(TEST_FLOW_PARSER) := test.c test-flow-parser.c
+test-test-flow-parser-$(TEST_FLOW_PARSER)-deps := flow/boolean.mod
 
 test-$(TEST_JAVASCRIPT) += test-javascript
 test-test-javascript-$(TEST_JAVASCRIPT) := test.c test-javascript.c

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -1,4 +1,4 @@
-find-deps = $(foreach dep,$($(1)-deps),$($(dep)-out))
+find-deps = $(foreach dep,$($(1)-deps),$($(filter %$(dep),$(modules))-out)$($(dep)-out))
 
 known-module-type = \
 	$(foreach curr,$(module-types), \
@@ -41,8 +41,8 @@ gen-artifact = \
 			$(eval all-mod-descs += $($(json)-desc)) \
 		) \
 		$(eval all-gens      += $(json)) \
-		$(eval $(1)-gens     += $(json)) \
-		$(eval $(1)-gen-cflags+= $(addprefix -I,$(dir $($(json)-src)))) \
+		$(eval $(4)-gens     += $(json)) \
+		$(eval $(4)-gen-cflags+= $(addprefix -I,$(dir $($(json)-src)))) \
 	) \
 
 extra-headers = \
@@ -90,26 +90,26 @@ parse-common-module = \
 	$(eval all-artifacts += $(artifacts)) \
 	$(eval mod-headers  := $(addprefix $(2),$(headers-$(1)-$(3)))) \
 	$(call extra-headers,$(mod-headers)) \
-	$(call gen-artifact,$(1),$(filter %.json,$(artifacts))) \
+	$(call gen-artifact,$(1),$(filter %.json,$(artifacts)),"",$(4)) \
 	$(eval mod-objs     := $(filter %.o,$(artifacts))) \
-	$(eval $(1)-cflags  := $(obj-$(1)-$(3)-extra-cflags)) \
-	$(eval $(1)-ldflags := $(obj-$(1)-$(3)-extra-ldflags)) \
-	$(eval $(1)-bs      := $(addprefix $(2),Makefile)) \
-	$(eval $(1)-bs      += $(if $(wildcard $(2)/Kconfig),$(addprefix $(2),Kconfig))) \
-	$(eval $(1)-hdrs    := $(filter %.h,$(artifacts))) \
+	$(eval $(4)-cflags  := $(obj-$(1)-$(3)-extra-cflags)) \
+	$(eval $(4)-ldflags := $(obj-$(1)-$(3)-extra-ldflags)) \
+	$(eval $(4)-bs      := $(addprefix $(2),Makefile)) \
+	$(eval $(4)-bs      += $(if $(wildcard $(2)/Kconfig),$(addprefix $(2),Kconfig))) \
+	$(eval $(4)-hdrs    := $(filter %.h,$(artifacts))) \
 	$(foreach obj,$(mod-objs), \
 		$(call object-path,$(obj),$(2),dest-obj) \
 		$(eval $(dest-obj)-src := $(subst .o,.c,$(obj))) \
-		$(eval $(1)-srcs       := $($(dest-obj)-src)) \
-	        $(eval $(1)-objs       += $(dest-obj)) \
+		$(eval $(4)-srcs       := $($(dest-obj)-src)) \
+	        $(eval $(4)-objs       += $(dest-obj)) \
 		$(eval all-objs        += $(dest-obj)) \
 	)\
 
 parse-builtin-module = \
-	$(call parse-common-module,$(1),$(2),y) \
-	$(eval builtin-cflags      += $($(1)-cflags)) \
-	$(eval builtin-ldflags     += $($(1)-ldflags)) \
-	$(eval builtin-objs        += $($(1)-objs)) \
+	$(call parse-common-module,$(1),$(2),y,$(3)) \
+	$(eval builtin-cflags      += $($(3)-cflags)) \
+	$(eval builtin-ldflags     += $($(3)-ldflags)) \
+	$(eval builtin-objs        += $($(3)-objs)) \
 	$(eval builtin-flows       += $(call flow-type,$(artifacts))) \
 	$(eval builtin-linux-micro += $(call linux-micro-type,$(artifacts))) \
 	$(eval builtin-pin-mux 	   += $(call pin-mux-type,$(artifacts))) \
@@ -117,18 +117,18 @@ parse-builtin-module = \
 
 parse-mod-output = \
 	$(if $(filter yes,$(obj-$(1)-static)), \
-		$(eval $(1)-out := $(addprefix $(subst $(top_srcdir)src/,$(build_stagedir),$(subdir)),$(1)).a) \
+		$(eval $(3)-out := $(addprefix $(subst $(top_srcdir)src/,$(build_stagedir),$(subdir)),$(1)).a) \
 		$(eval mod-ar     += $(1)), \
 		$(eval out-prefix := $(build_modulesdir)$(strip $(call module-type,$(2)))) \
-	        $(eval $(1)-out   := $(out-prefix)/$(1).so) \
-		$(eval mod-so     += $(1)) \
+	        $(eval $(3)-out   := $(out-prefix)/$(1).so) \
+		$(eval mod-so     += $(3)) \
 	) \
 
 parse-mod-module = \
-	$(call parse-common-module,$(1),$(2),m) \
-	$(eval $(1)-deps     := $(subst .mod,,$(obj-$(1)-m-deps))) \
-	$(call parse-mod-output,$(1),$(2)) \
-	$(eval modules-out += $($(1)-out)) \
+	$(call parse-common-module,$(1),$(2),m,$(3)) \
+	$(eval $(3)-deps     := $(subst .mod,,$(obj-$(1)-m-deps))) \
+	$(call parse-mod-output,$(1),$(2),$(3)) \
+	$(eval modules-out += $($(3)-out)) \
 
 parse-bin = \
 	$(eval bin-$(1)-srcs := $(addprefix $(2),$(bin-$(1)-y))) \
@@ -159,7 +159,7 @@ parse-sample = \
 	$(eval sample-$(1)-srcs := $(addprefix $(2),$(filter-out %.fbp,$(sample-$(1)-y)))) \
 	$(eval artifacts        := $(addprefix $(2),$(filter %.fbp,$(sample-$(1)-y)))) \
 	$(eval conffile         := $(addprefix $(2),$(filter %.json,$(sample-$(1)-y-conffile)))) \
-	$(call gen-artifact,$(1),$(addprefix $(2),$(filter %.json,$(sample-$(1)-y))),sample-$(1)-includedir) \
+	$(call gen-artifact,$(1),$(addprefix $(2),$(filter %.json,$(sample-$(1)-y))),sample-$(1)-includedir,$(1)) \
 	$(call gen-fbp-artifact,$(1),$(artifacts),sample-$(1)-srcs,$(conffile)) \
 	$(if $(filter %.o,$(sample-$(1)-srcs)), \
 		$(eval sample-$(1)-out  := $(subst $(top_srcdir)src/,$(build_stagedir),$(filter %.o,$(sample-$(1)-srcs)))) \
@@ -188,14 +188,16 @@ inc-subdirs = \
 		$(call extra-headers,$(addprefix $(subdir),$(headers-m))) \
 		$(call parse-warnings,$(subdir),$(warnings)) \
 		$(eval curr-builtins        := $(subst .mod,,$(filter %.mod,$(obj-y)))) \
-		$(eval builtins             += $(curr-builtins)) \
 		$(foreach buin,$(curr-builtins), \
-			$(call parse-builtin-module,$(buin),$(subdir)) \
+			$(eval mod-id := $(patsubst %/,%,$(subdir)$(buin))) \
+			$(call parse-builtin-module,$(buin),$(subdir),$(mod-id)) \
+			$(eval builtins += $(mod-id)) \
 		) \
 		$(eval curr-modules        := $(subst .mod,,$(filter %.mod,$(obj-m)))) \
-		$(eval modules             += $(curr-modules)) \
 		$(foreach mod,$(curr-modules), \
-			$(call parse-mod-module,$(mod),$(subdir)) \
+			$(eval mod-id := $(patsubst %/,%,$(subdir)$(buin))) \
+			$(call parse-mod-module,$(mod),$(subdir),$(mod-id)) \
+			$(eval modules += $(mod-id)) \
 		) \
 		$(eval curr-bins := $(bin-y)) \
 		$(eval bins += $(curr-bins)) \

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -117,7 +117,7 @@ parse-builtin-module = \
 
 parse-mod-output = \
 	$(if $(filter yes,$(obj-$(1)-static)), \
-		$(eval $(mod)-out := $(addprefix $(subst $(top_srcdir)src/,$(build_stagedir),$(subdir)),$(mod)).a) \
+		$(eval $(1)-out := $(addprefix $(subst $(top_srcdir)src/,$(build_stagedir),$(subdir)),$(1)).a) \
 		$(eval mod-ar     += $(1)), \
 		$(eval out-prefix := $(build_modulesdir)$(strip $(call module-type,$(2)))) \
 	        $(eval $(1)-out   := $(out-prefix)/$(1).so) \
@@ -126,9 +126,9 @@ parse-mod-output = \
 
 parse-mod-module = \
 	$(call parse-common-module,$(1),$(2),m) \
-	$(eval $(mod)-deps     := $(subst .mod,,$(obj-$(mod)-m-deps))) \
+	$(eval $(1)-deps     := $(subst .mod,,$(obj-$(1)-m-deps))) \
 	$(call parse-mod-output,$(1),$(2)) \
-	$(eval modules-out += $($(mod)-out)) \
+	$(eval modules-out += $($(1)-out)) \
 
 parse-bin = \
 	$(eval bin-$(1)-srcs := $(addprefix $(2),$(bin-$(1)-y))) \


### PR DESCRIPTION
## Changes
  + v2 (since #631):
    - Fixed issue with samples dep handling;

## Rationale
This pull request changes how modules are identified - so we can have multiple modules with same name in different categories. Also as a side effect changes how inter-modules dependencies are handled. With these 2 first changes in hand we can finally remove linux-micro prefix from linux-micro modules names.