### PR TITLE
build: make sure we reset obj-*-[y,m] variables

### DIFF
--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -87,6 +87,7 @@ object-path = $(if $(filter y,$(1)-intree), \
 parse-common-module = \
 	$(eval artifacts :=) \
 	$(call artifact-path,$(obj-$(1)-$(3)),$(2),artifacts) \
+	$(eval obj-$(1)-$(3) :=) \
 	$(eval all-artifacts += $(artifacts)) \
 	$(eval mod-headers  := $(addprefix $(2),$(headers-$(1)-$(3)))) \
 	$(call extra-headers,$(mod-headers)) \


### PR DESCRIPTION
After parsing a module's makefile we should make sure we reset
obj-*-[y,m] variables so we don't end up appending named clashing
objects variables.

An exposed problem was console.mod, we have flow/console.mod and
linux-micro/console.mod, after parsing flow/console.mod we left
obj-console-m set with console.o and then when parsing
linux-micro/console.mod (because it does obj-console-m += console.o) we
ended up with obj-console-m set as "console.o console.o", with that
Makefile.rules created 2 rules for linux-micro/console.o.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>