### PR TITLE
Fix depending on packet buf [v2]

### DIFF
--- a/data/oic/oicgen.py
+++ b/data/oic/oicgen.py
@@ -909,6 +909,7 @@ def master_c_as_string(generated):
 
 #include "oic-gen.h"
 
+#include "sol-buffer.h"
 #include "sol-coap.h"
 #include "sol-json.h"
 #include "sol-mainloop.h"
@@ -1296,7 +1297,7 @@ server_resource_schedule_update(struct server_resource *resource)
 
 static sol_coap_responsecode_t
 server_handle_put(const struct sol_network_link_addr *cliaddr, const void *data,
-    uint8_t *payload, uint16_t *payload_len)
+    const struct sol_buffer *req_payload, struct sol_buffer *resp_payload)
 {
     const struct server_resource *resource = data;
     int r;
@@ -1304,10 +1305,10 @@ server_handle_put(const struct sol_network_link_addr *cliaddr, const void *data,
     if (!resource->funcs->deserialize)
         return SOL_COAP_RSPCODE_NOT_IMPLEMENTED;
 
-    r = resource->funcs->deserialize((struct server_resource *)resource, payload, *payload_len);
+    r = resource->funcs->deserialize((struct server_resource *)resource,
+        req_payload->data, req_payload->used);
     if (!r) {
         server_resource_schedule_update((struct server_resource *)resource);
-        *payload_len = 0;
         return SOL_COAP_RSPCODE_CHANGED;
     }
     return SOL_COAP_RSPCODE_PRECONDITION_FAILED;
@@ -1315,11 +1316,13 @@ server_handle_put(const struct sol_network_link_addr *cliaddr, const void *data,
 
 static sol_coap_responsecode_t
 server_handle_get(const struct sol_network_link_addr *cliaddr, const void *data,
-    uint8_t *payload, uint16_t *payload_len)
+    const struct sol_buffer *req_payload, struct sol_buffer *resp_payload)
 {
     const struct server_resource *resource = data;
     uint16_t serialized_len;
     uint8_t *serialized;
+    struct sol_str_slice buf;
+    sol_coap_responsecode_t code;
 
     if (!resource->funcs->serialize)
         return SOL_COAP_RSPCODE_NOT_IMPLEMENTED;
@@ -1328,15 +1331,16 @@ server_handle_get(const struct sol_network_link_addr *cliaddr, const void *data,
     if (!serialized)
         return SOL_COAP_RSPCODE_INTERNAL_ERROR;
 
-    if (serialized_len > *payload_len) {
-        free(serialized);
-        return SOL_COAP_RSPCODE_INTERNAL_ERROR;
-    }
+    buf.data = (char *) serialized;
+    buf.len = serialized_len;
 
-    memcpy(payload, serialized, serialized_len);
-    *payload_len = serialized_len;
+    code = SOL_COAP_RSPCODE_CONTENT;
+    if (sol_buffer_set_slice(resp_payload, buf) < 0)
+        code = SOL_COAP_RSPCODE_INTERNAL_ERROR;
+
     free(serialized);
-    return SOL_COAP_RSPCODE_CONTENT;
+
+    return code;
 }
 
 // log_init() implementation happens within oic-gen.c

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -207,11 +207,6 @@ struct sol_coap_packet *sol_coap_packet_notification_new(struct sol_coap_server 
 struct sol_coap_packet *sol_coap_packet_ref(struct sol_coap_packet *pkt);
 void sol_coap_packet_unref(struct sol_coap_packet *pkt);
 
-/* FIXME - remove this function.
- * Some refactory will be needed before removing it, so it's exposed this
- * way by now - DO NOT add other users for this function. */
-int sol_coap_packet_get_buf(struct sol_coap_packet *pkt, uint8_t **buf, uint16_t *len);
-
 int sol_coap_packet_get_payload(struct sol_coap_packet *pkt, uint8_t **buf, uint16_t *len);
 int sol_coap_packet_set_payload_used(struct sol_coap_packet *pkt, uint16_t len);
 bool sol_coap_packet_has_payload(struct sol_coap_packet *pkt);

--- a/src/lib/comms/include/sol-oic-server.h
+++ b/src/lib/comms/include/sol-oic-server.h
@@ -99,7 +99,7 @@ struct sol_oic_resource_type {
 
     struct {
         sol_coap_responsecode_t (*handle)(const struct sol_network_link_addr *cliaddr,
-            const void *data, uint8_t *payload, uint16_t *payload_len);
+            const void *data, const struct sol_buffer *req_payload, struct sol_buffer *resp_payload);
     } get, put, post, delete;
 };
 

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -1457,19 +1457,6 @@ error:
 }
 
 SOL_API int
-sol_coap_packet_get_buf(struct sol_coap_packet *pkt, uint8_t **buf, uint16_t *len)
-{
-    SOL_NULL_CHECK(pkt, -EINVAL);
-    SOL_NULL_CHECK(buf, -EINVAL);
-    SOL_NULL_CHECK(len, -EINVAL);
-
-    *buf = pkt->buf;
-    *len = sizeof(pkt->buf);
-
-    return 0;
-}
-
-SOL_API int
 sol_coap_packet_get_payload(struct sol_coap_packet *pkt, uint8_t **buf, uint16_t *len)
 {
     SOL_NULL_CHECK(pkt, -EINVAL);

--- a/src/samples/flow/oic/light-client.json
+++ b/src/samples/flow/oic/light-client.json
@@ -6,7 +6,7 @@
    "options": {
     "hwaddr": "08:00:27:ab:45:32"
    },
-   "type": "oic/client-core-brightlight"
+   "type": "oic/client-brightlight"
   }
  ]
 }


### PR DESCRIPTION
Updated version of https://github.com/solettaproject/soletta/pull/248

The objective is to remove `sol_coap_packet_get_buf()` because it exposes the raw buffer of the packet.

On one discussion we had offline, the idea was to provide the function handles access to both the incoming packet (request) payload and the outgoing packet payload, so use cases where the response depends on the content of the packet payload can be addressed.

@lpereira Can you take a look and help test this?