### PR TITLE
build: fix requires-private

### DIFF
--- a/pc/soletta.pc.in
+++ b/pc/soletta.pc.in
@@ -11,4 +11,4 @@ Description: SOLETTA io library
 Version: {{@VERSION@}}
 Libs: -L${libdir} -lsoletta
 Cflags: -I${includedir}/soletta
-Requires.private: {{@requires-private-y@}}
+Requires.private: {{@requires-private@}}

--- a/src/modules/flow/string/Makefile
+++ b/src/modules/flow/string/Makefile
@@ -35,4 +35,4 @@ obj-string-$(FLOW_NODE_TYPE_STRING)-extra-ldflags += $(LOCALE_LDFLAGS) $(ICU_LDF
 
 requires-private-$(FLOW_NODE_TYPE_STRING) := \
     $(ICU_REQUIRES_PRIVATE) \
-    $(LIBPCRE_LDFLAGS)
+    $(LIBPCRE_REQUIRES_PRIVATE)

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -179,7 +179,8 @@ parse-warnings = \
 
 clean-control = $(eval headers-y:=) $(eval obj-y:=) $(eval obj-m:=) $(eval bin-y:=) \
 		$(eval test-y:=) $(eval test-internal-y:=) $(eval sample-y:=) $(eval headers-m:=) \
-		$(eval warning-msg:=) $(eval warning-msg-y:=) $(eval warning-msg-m:=)
+		$(eval warning-msg:=) $(eval warning-msg-y:=) $(eval warning-msg-m:=) \
+		$(eval requires-private-y:=)
 
 inc-subdirs = \
 	$(foreach subdir,$(SUBDIRS), $(clean-control) \
@@ -217,9 +218,11 @@ inc-subdirs = \
 		$(foreach sample,$(sample-y), \
 			$(call parse-sample,$(sample),$(subdir)) \
 		) \
+		$(eval requires-private += $(requires-private-y)) \
 		$(clean-control) \
 	) \
-	export requires-private-y
+	$(eval requires-private := $(sort $(requires-private))) \
+	export requires-private
 
 extra-bins = \
 	$(foreach bin,$(EXTRA_BINS), \

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -39,6 +39,7 @@ all-dest-hdr :=
 all-hdr :=
 all-dest-bin :=
 all-mod-descs :=
+requires-private :=
 
 module-types := flow linux-micro pin-mux flow-metatype
 


### PR DESCRIPTION
We're not supporting the common "local context" idiom for
requires-private-y where each sub makefile may want to reset the
requires-private-y variable like it's done to all other variables i.e:

requires-private-y := $(DEP_REQUIRES_PRIVATE)

With that whenever we get a similar case the requires-private-y variable
will be reset.

This patch changes the code append a global requires-private variable
given a local requires-private-y.

The patch also fixes a makefile setting requires-private-y with LDFLAGS
instead of REQUIRES_PRIVATE.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>