### PR TITLE
pin-mux: Fix missing 'hole' in Edison AIO vector

### DIFF
--- a/src/modules/pin-mux/intel-edison-rev-c/intel-edison-rev-c.c
+++ b/src/modules/pin-mux/intel-edison-rev-c/intel-edison-rev-c.c
@@ -292,6 +292,7 @@ static struct sol_pin_mux_description *aio_0[] = {
 };
 
 static struct sol_pin_mux_controller edison_rev_c_mux_aio[] = {
+    { 0, NULL },
     { ARRAY_SIZE(aio_0), aio_0 },
 };
 


### PR DESCRIPTION
The correct ADC device should be always 1.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>