### PR TITLE
AIO setup was never called because of incorrect ifdef check

### DIFF
--- a/src/lib/io/sol-aio-common.c
+++ b/src/lib/io/sol-aio-common.c
@@ -47,7 +47,7 @@ sol_aio_open(const int device, const int pin, const unsigned int precision)
     SOL_LOG_INTERNAL_INIT_ONCE;
 
     aio = sol_aio_open_raw(device, pin, precision);
-#ifdef HAVE_PIN_MUX
+#ifdef USE_PIN_MUX
     if (aio && sol_pin_mux_setup_aio(device, pin)) {
         SOL_WRN("Pin Multiplexer Recipe for aio device=%d pin=%d found, "
             "but couldn't be applied.", device, pin);


### PR DESCRIPTION
ifdef was checking for an incorrect definition, so aio setup code was
never called. Using USE_PIN_MUX instead of HAVE_PIN_MUX

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>