### PR TITLE
modules/flow: fix buffers on int and boolean regarding operations

### DIFF
--- a/src/modules/flow/boolean/boolean.json
+++ b/src/modules/flow/boolean/boolean.json
@@ -255,7 +255,7 @@
           {
             "data_type": "string",
             "default": "all_true",
-            "description": "Operation to be applied in the buffer elements to compute the output.",
+            "description": "Operation to be applied in the buffer elements to compute the output. Supported operations are: all_true, all_false, any_true, any_false.",
             "name": "operation"
           }
         ],

--- a/src/modules/flow/int/int.json
+++ b/src/modules/flow/int/int.json
@@ -524,8 +524,8 @@
           },
           {
             "data_type": "string",
-            "default": "all_true",
-            "description": "Operation to be applied in the buffer elements to compute the output.",
+            "default": "mean",
+            "description": "Operation to be applied in the buffer elements to compute the output. Supported operations: mean and median.",
             "name": "operation"
           }
         ],

--- a/src/test-fbp/irange-buffer.fbp
+++ b/src/test-fbp/irange-buffer.fbp
@@ -37,7 +37,7 @@ gen1(test/int-generator:sequence="0 4 8 12") OUT -> IN median_buffer
 median_buffer OUT -> IN[0] median_equal
 median_result OUT -> IN[1] median_equal
 
-median_equal OUT -> RESULT test_median(test/result)
+median_equal OUT -> RESULT test_median_even(test/result)
 
 # --------------------------
 
@@ -49,4 +49,17 @@ timeout(constant/int:value=1) OUT -> TIMEOUT median_buffer2
 
 median_buffer2 OUT -> IN[0] median_equal2
 median_result2 OUT -> IN[1] median_equal2
-median_equal2 OUT -> RESULT test_median2(test/result)
+median_equal2 OUT -> RESULT test_median_odd(test/result)
+
+# --------------------------
+
+mean_result(constant/int:value=6)
+mean_buffer(int/buffer)
+mean_equal(int/equal)
+
+gen3(test/int-generator:sequence="0 4 5 15") OUT -> IN mean_buffer
+
+mean_buffer OUT -> IN[0] mean_equal
+mean_result OUT -> IN[1] mean_equal
+
+mean_equal OUT -> RESULT test_mean(test/result)


### PR DESCRIPTION
Option 'operation' is a string and shouldn't fallback silently
to one of the supported operations in case of mismatch.
So it was added a warning. Also, int/buffer operation default
was invalid.

Supported operations were added to node type description.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>