### PR TITLE
fbp-runner: display error message if fbp isn't found

### DIFF
--- a/src/bin/sol-fbp-runner/runner.c
+++ b/src/bin/sol-fbp-runner/runner.c
@@ -102,6 +102,7 @@ search_fbp_file(struct runner *r, const char *basename)
             return fullpath;
     }
 
+    SOL_ERR("Couldn't find file '%s'", basename);
     errno = EINVAL;
     return NULL;
 }


### PR DESCRIPTION
Instead of just quit with an error code (that nobody
checks when running it manually in a terminal).

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>