### PR TITLE
shared: Introduce sol-rng, a Random Number Generator API

### DIFF
--- a/src/modules/flow/random/random.c
+++ b/src/modules/flow/random/random.c
@@ -35,166 +35,14 @@
 
 #include <errno.h>
 #include <float.h>
+#include <sol-rng.h>
 #include <sol-util.h>
 #include <stdlib.h>
 #include <time.h>
 
-#ifdef SOL_PLATFORM_LINUX
-#include <fcntl.h>
-#include <sys/stat.h>
-#include <sys/syscall.h>
-#include <sys/types.h>
-#include <unistd.h>
-#endif
-
-#ifdef SOL_PLATFORM_LINUX
-static int
-getrandom_shim(void *buf, size_t buflen, unsigned int flags)
-{
-    int fd;
-    ssize_t ret;
-
-#ifdef SYS_getrandom
-    /* No wrappers are commonly available for this system call yet, so
-     * use syscall(2) directly. */
-    long gr_ret = syscall(SYS_getrandom, buf, buflen, flags);
-    if (gr_ret >= 0)
-        return gr_ret;
-#endif
-
-    fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
-    if (fd < 0) {
-        errno = EIO;
-        return -1;
-    }
-
-    ret = read(fd, buf, buflen);
-    close(fd);
-
-    return ret;
-}
-#endif /* SOL_PLATFORM_LINUX */
-
-static int
-get_platform_seed(int seed)
-{
-    int ret;
-
-    /* If a seed is provided, use it. */
-    if (seed)
-        return seed;
-
-#ifdef SOL_PLATFORM_LINUX
-    /* Use Linux-specific getrandom(2) if available to initialize the
-     * seed.  If syscall isn't available, read from /dev/urandom instead. */
-    ret = getrandom_shim(&seed, sizeof(seed), 0);
-    if (ret == sizeof(seed))
-        return seed;
-#endif /* SOL_PLATFORM_LINUX */
-
-    /* Fall back to using a bad source of entropy if platform-specific,
-     * higher quality random sources, are unavailable. */
-    return (int)time(NULL);
-}
-
-#ifdef HAVE_RANDOM_R
-
 struct random_node_data {
-    char buffer[32];
-    struct random_data state;
+    struct sol_rng_engine *engine;
 };
-
-static unsigned int
-get_random_uint(struct random_node_data *mdata)
-{
-    int32_t result;
-
-    /* Return code ignored: no error case is possible at this point. */
-    (void)random_r(&mdata->state, &result);
-
-    return result;
-}
-
-static int
-get_random_int(struct random_node_data *mdata)
-{
-    return get_random_uint(mdata);
-}
-
-static bool
-initialize_seed(struct random_node_data *mdata, int seed)
-{
-    memset(&mdata->state, 0, sizeof(mdata->state));
-
-    /* Return code ignored: no error case is possible at this point. */
-    (void)initstate_r(get_platform_seed(seed), mdata->buffer, sizeof(mdata->buffer), &mdata->state);
-
-    return true;
-}
-
-#else /* HAVE_RANDOM_R */
-
-/* This implementation is a direct pseudocode-to-C conversion from the Wikipedia
- * article about Mersenne Twister (MT19937). */
-
-struct random_node_data {
-    unsigned int state[624];
-    int index;
-};
-
-static unsigned int
-get_random_uint(struct random_node_data *mdata)
-{
-    const size_t state_array_size = ARRAY_SIZE(mdata->state);
-    unsigned int y;
-
-    if (mdata->index == 0) {
-        size_t i;
-
-        for (i = 0; i < state_array_size; i++) {
-            y = (mdata->state[i] & 0x80000000UL);
-            y += (mdata->state[(i + 1UL) % state_array_size] & 0x7fffffffUL);
-
-            mdata->state[i] = mdata->state[(i + 397UL) % state_array_size] ^ (y >> 1UL);
-            if (y % 2 != 0)
-                mdata->state[i] ^= 0x9908b0dfUL;
-        }
-    }
-
-    y = mdata->state[mdata->index];
-    y ^= y >> 11UL;
-    y ^= (y << 7UL) & 0x9d2c5680UL;
-    y ^= (y << 15UL) & 0xefc60000UL;
-    y ^= (y >> 18UL);
-
-    mdata->index = (mdata->index + 1) % state_array_size;
-
-    return y;
-}
-
-static int
-get_random_int(struct random_node_data *mdata)
-{
-    unsigned int value = get_random_uint(mdata);
-
-    return (int)(value >> 1UL); /* kill sign bit */
-}
-
-static bool
-initialize_seed(struct random_node_data *mdata, int seed)
-{
-    const size_t state_array_size = ARRAY_SIZE(mdata->state);
-    size_t i;
-
-    mdata->index = 0;
-    mdata->state[0] = get_platform_seed(seed);
-    for (i = 1; i < state_array_size; i++)
-        mdata->state[i] = i + 0x6c078965UL * (mdata->state[i - 1] ^ (mdata->state[i - 1] >> 30UL));
-
-    return true;
-}
-
-#endif /* HAVE_RANDOM_R */
 
 static int
 random_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
@@ -206,12 +54,20 @@ random_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_o
        multiple node types */
     opts = (const struct sol_flow_node_type_random_int_options *)options;
 
-    if (!initialize_seed(mdata, opts->seed.val)) {
-        SOL_ERR("Could not initialize random seed: %s", sol_util_strerrora(errno));
-        return -EINVAL;
-    }
+    mdata->engine = sol_rng_engine_new(SOL_RNG_ENGINE_IMPL_DEFAULT);
+    SOL_NULL_CHECK(mdata->engine, -EINVAL);
+
+    sol_rng_engine_seed(mdata->engine, opts->seed.val);
 
     return 0;
+}
+
+static void
+random_close(struct sol_flow_node *node, void *data)
+{
+    struct random_node_data *mdata = data;
+
+    sol_rng_engine_destroy(mdata->engine);
 }
 
 /*
@@ -223,7 +79,7 @@ random_int_generate(struct sol_flow_node *node, void *data, uint16_t port, uint1
     struct sol_irange value = { 0, 0, INT32_MAX, 1 };
     struct random_node_data *mdata = data;
 
-    value.val = get_random_int(mdata);
+    sol_rng_engine_generate_bytes(mdata->engine, &value.val, sizeof(value.val));
 
     return sol_flow_send_irange_packet(node,
         SOL_FLOW_NODE_TYPE_RANDOM_INT__OUT__OUT,
@@ -240,8 +96,8 @@ random_float_generate(struct sol_flow_node *node, void *data, uint16_t port, uin
     struct sol_drange out_value = { 0, 0, INT32_MAX, 1 };
     int value, fraction;
 
-    value = get_random_int(mdata);
-    fraction = get_random_int(mdata);
+    sol_rng_engine_generate_bytes(mdata->engine, &value, sizeof(value));
+    sol_rng_engine_generate_bytes(mdata->engine, &fraction, sizeof(fraction));
 
     out_value.val = value * ((double)(INT32_MAX - 1) / INT32_MAX) +
         (double)fraction / INT32_MAX;
@@ -260,7 +116,8 @@ random_byte_generate(struct sol_flow_node *node, void *data, uint16_t port, uint
     struct random_node_data *mdata = data;
     unsigned int value;
 
-    value = get_random_uint(mdata) & 0xff;
+    sol_rng_engine_generate_bytes(mdata->engine, &value, sizeof(value));
+    value &= 0xff;
 
     return sol_flow_send_byte_packet(node,
         SOL_FLOW_NODE_TYPE_RANDOM_BYTE__OUT__OUT,
@@ -276,7 +133,7 @@ random_boolean_generate(struct sol_flow_node *node, void *data, uint16_t port, u
     struct random_node_data *mdata = data;
     unsigned int value;
 
-    value = get_random_uint(mdata);
+    sol_rng_engine_generate_bytes(mdata->engine, &value, sizeof(value));
 
     return sol_flow_send_boolean_packet(node,
         SOL_FLOW_NODE_TYPE_RANDOM_BOOLEAN__OUT__OUT,
@@ -292,7 +149,7 @@ random_seed_set(struct sol_flow_node *node, void *data, uint16_t port, uint16_t 
 
     r = sol_flow_packet_get_irange_value(packet, &in_value);
     SOL_INT_CHECK(r, < 0, r);
-    initialize_seed(mdata, in_value);
+    sol_rng_engine_seed(mdata->engine, in_value);
     return 0;
 }
 

--- a/src/modules/flow/random/random.json
+++ b/src/modules/flow/random/random.json
@@ -29,7 +29,8 @@
         }
       ],
       "methods": {
-        "open": "random_open"
+        "open": "random_open",
+        "close": "random_close"
       },
       "name": "random/boolean",
       "options": {
@@ -75,7 +76,8 @@
         }
       ],
       "methods": {
-        "open": "random_open"
+        "open": "random_open",
+        "close": "random_close"
       },
       "name": "random/byte",
       "options": {
@@ -121,7 +123,8 @@
         }
       ],
       "methods": {
-        "open": "random_open"
+        "open": "random_open",
+        "close": "random_close"
       },
       "name": "random/float",
       "options": {
@@ -167,7 +170,8 @@
         }
       ],
       "methods": {
-        "open": "random_open"
+        "open": "random_open",
+        "close": "random_close"
       },
       "name": "random/int",
       "options": {

--- a/src/shared/Makefile
+++ b/src/shared/Makefile
@@ -2,7 +2,8 @@ obj-y += libshared.mod
 
 obj-libshared-y := \
     sol-monitors.o \
-    sol-util.o
+    sol-util.o \
+    sol-rng.o
 
 obj-libshared-$(FLOW_SUPPORT) += \
     sol-fbp-graph.o \

--- a/src/shared/sol-rng.c
+++ b/src/shared/sol-rng.c
@@ -1,0 +1,375 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <sol-log.h>
+#include <sol-util.h>
+#include <time.h>
+
+#ifdef SOL_PLATFORM_LINUX
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#endif
+
+#include "sol-rng.h"
+
+struct sol_rng_engine {
+    const struct sol_rng_engine_impl *impl;
+};
+
+struct sol_rng_engine_impl {
+    bool (*init)(struct sol_rng_engine *engine);
+    void (*shutdown)(struct sol_rng_engine *engine);
+    void (*seed)(struct sol_rng_engine *engine, uint64_t value);
+    size_t (*generate_bytes)(struct sol_rng_engine *engine, unsigned char *buffer, size_t len);
+    size_t struct_size;
+};
+
+#ifdef SOL_PLATFORM_LINUX
+static int
+getrandom_shim(void *buf, size_t buflen, unsigned int flags)
+{
+    int fd;
+    ssize_t ret;
+
+#ifdef SYS_getrandom
+    /* No wrappers are commonly available for this system call yet, so
+     * use syscall(2) directly. */
+    long gr_ret = syscall(SYS_getrandom, buf, buflen, flags);
+    if (gr_ret >= 0)
+        return gr_ret;
+#endif
+
+    fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+    if (fd < 0) {
+        errno = EIO;
+        return -1;
+    }
+
+    ret = read(fd, buf, buflen);
+    close(fd);
+
+    return ret;
+}
+#endif /* SOL_PLATFORM_LINUX */
+
+static uint64_t
+get_platform_seed(uint64_t seed)
+{
+    int ret;
+
+    /* If a seed is provided, use it. */
+    if (seed)
+        return seed;
+
+#ifdef SOL_PLATFORM_LINUX
+    /* Use Linux-specific getrandom(2) if available to initialize the
+     * seed.  If syscall isn't available, read from /dev/urandom instead. */
+    ret = getrandom_shim(&seed, sizeof(seed), 0);
+    if (ret == sizeof(seed))
+        return seed;
+#endif /* SOL_PLATFORM_LINUX */
+
+    /* Fall back to using a bad source of entropy if platform-specific,
+     * higher quality random sources, are unavailable. */
+    return (uint64_t)time(NULL);
+}
+
+static inline size_t
+min(size_t a, size_t b)
+{
+    return a < b ? a : b;
+}
+
+struct sol_rng_engine_mt19937 {
+    struct sol_rng_engine base;
+    unsigned int state[624];
+    int index;
+};
+
+static bool
+engine_mt19937_init(struct sol_rng_engine *generic)
+{
+    return true;
+}
+
+static void
+engine_mt19937_seed(struct sol_rng_engine *generic, uint64_t seed)
+{
+    struct sol_rng_engine_mt19937 *engine = (struct sol_rng_engine_mt19937 *)generic;
+    const size_t state_array_size = ARRAY_SIZE(engine->state);
+    size_t i;
+
+    engine->index = 0;
+    engine->state[0] = seed;
+    for (i = 1; i < state_array_size; i++)
+        engine->state[i] = i + 0x6c078965UL * (engine->state[i - 1] ^ (engine->state[i - 1] >> 30UL));
+}
+
+static unsigned int
+engine_mt19937_generate_uint(struct sol_rng_engine_mt19937 *engine)
+{
+    const size_t state_array_size = ARRAY_SIZE(engine->state);
+    unsigned int y;
+
+    if (engine->index == 0) {
+        size_t i;
+
+        for (i = 0; i < state_array_size; i++) {
+            y = (engine->state[i] & 0x80000000UL);
+            y += (engine->state[(i + 1UL) % state_array_size] & 0x7fffffffUL);
+
+            engine->state[i] = engine->state[(i + 397UL) % state_array_size] ^ (y >> 1UL);
+            if (y % 2 != 0)
+                engine->state[i] ^= 0x9908b0dfUL;
+        }
+    }
+
+    y = engine->state[engine->index];
+    y ^= y >> 11UL;
+    y ^= (y << 7UL) & 0x9d2c5680UL;
+    y ^= (y << 15UL) & 0xefc60000UL;
+    y ^= (y >> 18UL);
+
+    engine->index = (engine->index + 1) % state_array_size;
+
+    return y;
+}
+
+static size_t
+engine_mt19937_generate(struct sol_rng_engine *generic, unsigned char *buffer,
+	size_t length)
+{
+    struct sol_rng_engine_mt19937 *engine = (struct sol_rng_engine_mt19937 *)generic;
+    ssize_t total = (ssize_t)length;
+
+    while (total > 0) {
+        unsigned int value = engine_mt19937_generate_uint(engine);
+        size_t to_copy = min(sizeof(value), (size_t)total);
+
+        memcpy(buffer, &value, to_copy);
+        total -= to_copy;
+        buffer += to_copy;
+    }
+
+    return length;
+}
+
+const struct sol_rng_engine_impl *SOL_RNG_ENGINE_IMPL_MT19937 =
+    &(struct sol_rng_engine_impl) {
+        .init = engine_mt19937_init,
+        .shutdown = NULL,
+        .seed = engine_mt19937_seed,
+        .generate_bytes = engine_mt19937_generate,
+        .struct_size = sizeof(struct sol_rng_engine_mt19937)
+    };
+
+#ifdef HAVE_RANDOMR
+struct sol_rng_engine_randomr {
+    struct sol_rng_engine base;
+    unsigned char buffer[32];
+    struct random_data state;
+};
+
+static bool
+engine_randomr_init(struct sol_rng_engine *generic)
+{
+    struct sol_rng_engine_randomr *engine = (struct sol_rng_engine_randomr *)generic;
+
+    memset(engine->state, 0, sizeof(engine->state));
+
+    return true;
+}
+
+static void
+engine_randomr_seed(struct sol_rng_engine *generic, uint64_t seed)
+{
+    struct sol_rng_engine_randomr *engine = (struct sol_rng_engine_randomr *)generic;
+
+    /* Return code ignored: no error case is possible at this point. */
+    (void)initstate_r(seed, engine->buffer, sizeof(engine->buffer), &engine->state);
+}
+
+static size_t
+engine_randomr_generate(struct sol_rng_engine *generic,
+    unsigned char *buffer, size_t length)
+{
+    struct sol_rng_engine_randomr *engine = (struct sol_rng_engine_randomr *)generic;
+    ssize_t total = (ssize_t)length;
+
+    while (total > 0) {
+        int32_t value;
+        size_t to_copy = min(sizeof(value), (size_t)total);
+
+        /* Return code ignored: no error case is possible at this point. */
+        (void)random_r(&engine->state, &value);
+
+        memcpy(buffer, &value, to_copy);
+        total -= to_copy;
+        buffer += to_copy;
+    }
+
+    return length;
+}
+
+struct sol_rng_engine_impl *SOL_RNG_ENGINE_IMPL_URANDOM =
+    &(struct sol_rng_engine_impl) {
+        .init = engine_randomr_init,
+        .shutdown = NULL,
+        .seed = engine_randomr_seed,
+        .generate_bytes = engine_randomr_generate,
+        .struct_size = sizeof(struct sol_rng_engine_randomr)
+    };
+#else
+const struct sol_rng_engine_impl *SOL_RNG_ENGINE_IMPL_RANDOMR = NULL;
+#endif
+
+#ifdef SOL_PLATFORM_LINUX
+struct sol_rng_engine_urandom {
+    struct sol_rng_engine base;
+    int fd;
+};
+
+static bool
+engine_urandom_init(struct sol_rng_engine *generic)
+{
+    struct sol_rng_engine_urandom *engine = (struct sol_rng_engine_urandom *)generic;
+
+    engine->fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+    if (engine->fd < 0) {
+        SOL_WRN("Could not open /dev/urandom");
+        return false;
+    }
+
+    return true;
+}
+
+static void
+engine_urandom_shutdown(struct sol_rng_engine *generic)
+{
+    struct sol_rng_engine_urandom *engine = (struct sol_rng_engine_urandom *)generic;
+
+    close(engine->fd);
+}
+
+static void
+engine_urandom_seed(struct sol_rng_engine *generic, uint64_t seed)
+{
+}
+
+static size_t
+engine_urandom_generate(struct sol_rng_engine *generic,
+    unsigned char *buffer, size_t length)
+{
+    struct sol_rng_engine_urandom *engine = (struct sol_rng_engine_urandom *)generic;
+
+    return read(engine->fd, buffer, length);
+}
+
+const struct sol_rng_engine_impl *SOL_RNG_ENGINE_IMPL_URANDOM =
+    &(struct sol_rng_engine_impl) {
+        .init = engine_urandom_init,
+        .shutdown = engine_urandom_shutdown,
+        .seed = engine_urandom_seed,
+        .generate_bytes = engine_urandom_generate,
+        .struct_size = sizeof(struct sol_rng_engine_urandom)
+    };
+#else
+const struct sol_rng_engine_impl *SOL_RNG_ENGINE_IMPL_URANDOM = NULL;
+#endif
+
+const struct sol_rng_engine_impl *SOL_RNG_ENGINE_IMPL_DEFAULT = NULL;
+
+struct sol_rng_engine *
+sol_rng_engine_new(const struct sol_rng_engine_impl *impl)
+{
+    struct sol_rng_engine *engine = malloc(impl->struct_size);
+
+    SOL_NULL_CHECK(engine, NULL);
+
+    if (!impl)
+        impl = SOL_RNG_ENGINE_IMPL_MT19937;
+
+    engine->impl = impl;
+    if (!impl->init(engine)) {
+        free(engine);
+        return NULL;
+    }
+
+    return engine;
+}
+
+struct sol_rng_engine *
+sol_rng_engine_seeded_new(const struct sol_rng_engine_impl *impl)
+{
+    struct sol_rng_engine *engine;
+
+    engine = sol_rng_engine_new(impl);
+    if (!engine)
+        return NULL;
+
+    sol_rng_engine_seed(engine, 0);
+    return engine;
+}
+
+void
+sol_rng_engine_destroy(struct sol_rng_engine *engine)
+{
+    SOL_NULL_CHECK(engine);
+
+    if (engine->impl->shutdown)
+        engine->impl->shutdown(engine);
+    free(engine);
+}
+
+void
+sol_rng_engine_seed(struct sol_rng_engine *engine, uint64_t value)
+{
+    SOL_NULL_CHECK(engine);
+    SOL_NULL_CHECK(engine->impl);
+    SOL_NULL_CHECK(engine->impl->seed);
+
+    engine->impl->seed(engine, get_platform_seed(value));
+}
+
+size_t
+sol_rng_engine_generate_bytes(struct sol_rng_engine *engine, void *buffer,
+    size_t len)
+{
+    SOL_NULL_CHECK(engine, 0);
+    SOL_NULL_CHECK(engine->impl, 0);
+    SOL_NULL_CHECK(engine->impl->generate_bytes, 0);
+
+    return engine->impl->generate_bytes(engine, buffer, len);
+}

--- a/src/shared/sol-rng.h
+++ b/src/shared/sol-rng.h
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+struct sol_rng_engine;
+struct sol_rng_engine_impl;
+
+extern const struct sol_rng_engine_impl *SOL_RNG_ENGINE_IMPL_MT19937;
+extern const struct sol_rng_engine_impl *SOL_RNG_ENGINE_IMPL_URANDOM;
+extern const struct sol_rng_engine_impl *SOL_RNG_ENGINE_IMPL_RANDOMR;
+extern const struct sol_rng_engine_impl *SOL_RNG_ENGINE_IMPL_DEFAULT;
+
+struct sol_rng_engine *sol_rng_engine_new(const struct sol_rng_engine_impl *impl);
+struct sol_rng_engine *sol_rng_engine_seeded_new(const struct sol_rng_engine_impl *impl);
+void sol_rng_engine_destroy(struct sol_rng_engine *engine);
+
+void sol_rng_engine_seed(struct sol_rng_engine *engine, uint64_t value);
+
+size_t sol_rng_engine_generate_bytes(struct sol_rng_engine *engine,
+    void *buffer, size_t len);


### PR DESCRIPTION
This is a simple abstraction to generate random numbers. It is
loosely-based on the C++11 API supported by <random> include, sans the
distribution stuff.

Current implementation contains three engine implementations: a MT19937
(default), a random_r() generator (if available; currently only glibc
supports it), and a /dev/urandom reader.

Only raw bytes can be generated by the API at the moment.  The idea is
to implement custom type generation (with proper distribution) as the
need arises.

Currently, the implementation is completely opaque, but can be opened
up if the need to let Soletta API users implement their own engines
arise.

Usage is pretty simple at the moment:

	struct sol_rng_engine *engine;
	uint64_t value;

	/* Passing the default engine or an engine not supported by
	 * the platform will fallback to the MT19937 engine. */
	engine = sol_rng_engine_new(SOL_RNG_ENGINE_IMPL_DEFAULT);

	/* Passing 0 to the seed will try to use a good source of
	 * entropy available in the system.  This is /dev/urandom on
	 * Linux (using getrandom() if available). */
	sol_rng_engine_seed(engine, 0);

	assert(sizeof(value) == sol_rng_engine_generate_bytes(engine, &value, sizeof(value)));

	sol_rng_engine_destroy(engine);

As a bonus, move random node types to use this new API.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>