### PR TITLE
build: reintroduce the initial-services

### DIFF
--- a/data/linux-micro/initial-services.in
+++ b/data/linux-micro/initial-services.in
@@ -1,0 +1,9 @@
+{{
+import os
+
+for curr in os.environ.get("builtin-linux-micro").split():
+  st.println(curr)
+
+for curr in os.environ.get("modules-linux-micro").split():
+  st.println("%s?" % curr)
+}}

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -117,6 +117,8 @@ parse-mod-module = \
 	$(eval $(3)-deps     := $(subst .mod,,$(obj-$(1)-m-deps))) \
 	$(call parse-mod-output,$(1),$(2),$(3)) \
 	$(eval modules-out += $($(3)-out)) \
+	$(if $(filter $(linux-micro-dir)%,$(2)), \
+		$(eval modules-linux-micro += $(1))) \
 
 parse-bin = \
 	$(eval bin-$(1)-srcs := $(addprefix $(2),$(bin-$(1)-y))) \
@@ -226,6 +228,7 @@ $(eval $(call extra-bins))
 
 export builtin-flows
 export builtin-linux-micro
+export modules-linux-micro
 export builtin-pin-mux
 export builtin-flow-metatype
 

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -13,6 +13,8 @@ builtin-linux-micro :=
 builtin-pin-mux :=
 builtin-objs :=
 
+modules-linux-micro :=
+
 # module objects, deps and configs lookup variables
 modules :=
 modules-out :=
@@ -296,11 +298,19 @@ FLOW_MERGE_BUILTINS_SCRIPT := $(SCRIPTDIR)flow-merge-builtins.py
 JSON_FORMAT_SCRIPT := $(SCRIPTDIR)json-format.py
 
 HEADER_GEN :=
+PRE_GEN :=
 
 ifeq (y,$(PLATFORM_LINUX_MICRO))
 HEADER_GEN += $(LINUX_MICRO_BUILTINS_H)
 
 $(call add-template,$(LINUX_MICRO_BUILTINS_H_IN),$(LINUX_MICRO_BUILTINS_H))
+
+INITIAL_SERVICES := $(build_modulesdir)linux-micro/initial-service
+INITIAL_SERVICES_IN := $(top_srcdir)data/linux-micro/initial-services.in
+
+$(call add-template,$(INITIAL_SERVICES_IN),$(INITIAL_SERVICES))
+PRE_GEN += $(INITIAL_SERVICES)
+
 endif
 
 ifeq (y,$(USE_PIN_MUX))
@@ -364,7 +374,7 @@ PC_GEN_IN := $(top_srcdir)pc/soletta.pc.in
 
 $(call add-template,$(PC_GEN_IN),$(PC_GEN))
 
-PRE_GEN := $(HEADER_GEN) $(KCONFIG_AUTOHEADER) $(KCONFIG_CONFIG) $(BSDEPS)
+PRE_GEN += $(HEADER_GEN) $(KCONFIG_AUTOHEADER) $(KCONFIG_CONFIG) $(BSDEPS)
 PRE_GEN += $(NODE_TYPE_GEN_SCRIPT) $(PC_GEN)
 
 CLEANUP_GEN := $(FLOW_OIC_GEN) $(HEADER_GEN)


### PR DESCRIPTION
After kconfig migration we lost initial-service generation and
instalattion, this patch brings it back.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>