### PR TITLE
Build header installation and fixes v3

### DIFF
--- a/data/linux-micro/initial-services.in
+++ b/data/linux-micro/initial-services.in
@@ -1,7 +1,7 @@
 {{
 import os
 
-for curr in os.environ.get("builtin-linux-micro").split():
+for curr in os.environ.get("builtins-linux-micro").split():
   st.println(curr)
 
 for curr in os.environ.get("modules-linux-micro").split():

--- a/data/linux-micro/initial-services.in
+++ b/data/linux-micro/initial-services.in
@@ -1,9 +1,9 @@
 {{
 import os
 
-for curr in os.environ.get("builtins-linux-micro").split():
+for curr in os.environ.get("builtins-linux-micro", "").split():
   st.println(curr)
 
-for curr in os.environ.get("modules-linux-micro").split():
+for curr in os.environ.get("modules-linux-micro", "").split():
   st.println("%s?" % curr)
 }}

--- a/data/oic/oicgen.py
+++ b/data/oic/oicgen.py
@@ -907,7 +907,7 @@ def master_c_as_string(generated):
 #include <stdlib.h>
 #include <sys/socket.h>
 
-#include "oic-gen.h"
+#include "sol-flow/oic.h"
 
 #include "sol-coap.h"
 #include "sol-json.h"

--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -560,7 +560,7 @@ def generate_code_head(outfile, data):
  * types are defined.
  */
 #ifndef %(NAME_C)s_DEFINED
-#include "%(header)s"
+#include "%(namespace)s%(header)s"
 #endif
 #include <sol-flow-packet.h>
 #include <sol-macros.h>
@@ -594,6 +594,7 @@ log_init(void)
 """ % {
     "input": data["input"],
     "header": os.path.basename(data["header"]),
+    "namespace": data["namespace"],
     "NAME_C": data["NAME_C"],
     "float_h": uses_float(data),
     "domain": "flow-" + c_clean(data["name"].lower())
@@ -1204,6 +1205,13 @@ using the sol-flow-node-type-stub-gen.py tool.
                               "'struct sol_flow_node_options' and "
                               "C pre-processor (CPP) defines for all ports."),
                         type=argparse.FileType('w', encoding='UTF-8'))
+    parser.add_argument("--namespace",
+                        help=("The module's namespace i.e sol-flow, for Soletta's "
+                              "in tree modules it makes sense to have the namespace "
+                              "but for cases where an application is generating a "
+                              "custom node type - like it's done in samples we'll "
+                              "not want to have the namespace prefix."),
+                        type=str, default=None)
     parser.add_argument("output_code",
                         help=("Boilerplate output code (.c) file. This file "
                               "will contain only the declaration of "
@@ -1263,6 +1271,12 @@ using the sol-flow-node-type-stub-gen.py tool.
 
         data["input"] = args.genspec.name
         data["header"] = args.output_header.name
+
+        if args.namespace:
+            data["namespace"] = "%s/" % args.namespace
+        else:
+            data["namespace"] = ""
+        
         data["source"] = args.output_code.name
 
         ntypes = len(data["types"])
@@ -1277,6 +1291,7 @@ using the sol-flow-node-type-stub-gen.py tool.
             t.setdefault("author", meta.get("author"))
             t.setdefault("version", meta.get("version"))
             t["header"] = data["header"]
+            t["namespace"] = data["namespace"]
             t["source"] = data["source"]
             t["input"] = data["input"]
             t["name_c"] = data["prefix_c"] + "_" + c_clean(t["name"].lower())

--- a/data/templates/builtins-common.tpl
+++ b/data/templates/builtins-common.tpl
@@ -6,7 +6,7 @@
 import os
 
 def gen_builtins(decl, item, array, count, builtins):
-    builtins = os.environ.get(builtins)
+    builtins = os.environ.get(builtins, "")
     builtins = builtins.strip()
     if builtins:
         builtins = builtins.replace("-","_").split(" ")

--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -785,7 +785,7 @@ generate(struct sol_vector *fbp_data_vector)
 
     /* Header name is currently inferred from the module name. */
     SOL_VECTOR_FOREACH_IDX (&ctx->modules, module, i) {
-        out("#include \"%.*s-gen.h\"\n", SOL_STR_SLICE_PRINT(*module));
+        out("#include \"sol-flow/%.*s.h\"\n", SOL_STR_SLICE_PRINT(*module));
     }
 
     /* Reverse since the dependencies appear later in the vector. */

--- a/src/lib/common/sol-pin-mux-builtins-gen.h.in
+++ b/src/lib/common/sol-pin-mux-builtins-gen.h.in
@@ -5,5 +5,5 @@ array = "static const struct sol_pin_mux *SOL_PIN_MUX_BUILTINS_ALL[]"
 count = "SOL_PIN_MUX_BUILTIN_COUNT"
 decl = "const struct sol_pin_mux SOL_PIN_MUX_@NAME@"
 item = "&SOL_PIN_MUX_@NAME@"
-gen_builtins(decl, item, array, count, "builtin-pin-mux")
+gen_builtins(decl, item, array, count, "builtins-pin-mux")
 }}

--- a/src/lib/common/sol-platform-linux-micro-builtins-gen.h.in
+++ b/src/lib/common/sol-platform-linux-micro-builtins-gen.h.in
@@ -5,5 +5,5 @@ array = "static const struct sol_platform_linux_micro_module *SOL_PLATFORM_LINUX
 count = "SOL_PLATFORM_LINUX_MICRO_MODULE_COUNT"
 decl = "struct sol_platform_linux_micro_module SOL_PLATFORM_LINUX_MICRO_MODULE_@NAME@"
 item = "&SOL_PLATFORM_LINUX_MICRO_MODULE_@NAME@"
-gen_builtins(decl, item, array, count, "builtin-linux-micro")
+gen_builtins(decl, item, array, count, "builtins-linux-micro")
 }}

--- a/src/lib/flow/sol-flow-builtins-gen.h.in
+++ b/src/lib/flow/sol-flow-builtins-gen.h.in
@@ -4,5 +4,5 @@ decl = "const struct sol_flow_node_type *sol_flow_foreach_builtin_node_type_@nam
 item = "sol_flow_foreach_builtin_node_type_@name@"
 array = "static const void *SOL_FLOW_BUILTIN_NODE_TYPE_ALL[]"
 count = "SOL_FLOW_BUILTIN_NODE_TYPE_COUNT"
-gen_builtins(decl, item, array, count, "builtin-flows")
+gen_builtins(decl, item, array, count, "builtins-flow")
 }}

--- a/src/lib/flow/sol-flow-metatype-builtins-gen.h.in
+++ b/src/lib/flow/sol-flow-metatype-builtins-gen.h.in
@@ -5,5 +5,5 @@ array = "static const struct sol_flow_metatype *SOL_FLOW_METATYPE_BUILTINS_ALL[]
 count = "SOL_FLOW_METATYPE_BUILTINS_COUNT"
 decl = "const struct sol_flow_metatype SOL_FLOW_METATYPE_@NAME@"
 item = "&SOL_FLOW_METATYPE_@NAME@"
-gen_builtins(decl, item, array, count, "builtin-flow-metatype")
+gen_builtins(decl, item, array, count, "builtins-flow-metatype")
 }}

--- a/src/modules/flow-metatype/js/Makefile
+++ b/src/modules/flow-metatype/js/Makefile
@@ -4,6 +4,7 @@ obj-js-$(FLOW_METATYPE_JAVASCRIPT) += \
 	js.o \
 	$(DUKTAPE_SRC_PATH)/duktape.o
 
+obj-js-$(FLOW_METATYPE_JAVASCRIPT)-type := flow-metatype
 
 # TODO: Allow CFLAGS_object.o as a way to set CFLAGS only for
 # compiling a certain object, so that we can apply the extra CFLAGS

--- a/src/modules/flow/accelerometer/Makefile
+++ b/src/modules/flow/accelerometer/Makefile
@@ -1,3 +1,4 @@
 obj-$(FLOW_NODE_TYPE_ACCELEROMETER) += accelerometer.mod
 obj-accelerometer-$(FLOW_NODE_TYPE_ACCELEROMETER) := accelerometer.json \
 	accelerometer.o
+obj-accelerometer-$(FLOW_NODE_TYPE_ACCELEROMETER)-type := flow

--- a/src/modules/flow/accelerometer/adxl45.c
+++ b/src/modules/flow/accelerometer/adxl45.c
@@ -33,7 +33,7 @@
 #include <errno.h>
 #include <math.h>
 
-#include "accelerometer-gen.h"
+#include "sol-flow/accelerometer.h"
 
 #include "sol-i2c.h"
 #include "sol-mainloop.h"

--- a/src/modules/flow/accelerometer/lsm303.c
+++ b/src/modules/flow/accelerometer/lsm303.c
@@ -34,7 +34,7 @@
 #include <errno.h>
 #include <math.h>
 
-#include "accelerometer-gen.h"
+#include "sol-flow/accelerometer.h"
 
 #include "sol-i2c.h"
 #include "sol-mainloop.h"

--- a/src/modules/flow/aio/Makefile
+++ b/src/modules/flow/aio/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_AIO) += aio.mod
 obj-aio-$(FLOW_NODE_TYPE_AIO) := aio.json aio.o
+obj-aio-$(FLOW_NODE_TYPE_AIO)-type := flow

--- a/src/modules/flow/aio/aio.c
+++ b/src/modules/flow/aio/aio.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "aio-gen.h"
+#include "sol-flow/aio.h"
 
 #include "sol-aio.h"
 #include "sol-flow-internal.h"

--- a/src/modules/flow/am2315/Makefile
+++ b/src/modules/flow/am2315/Makefile
@@ -2,3 +2,4 @@ obj-$(FLOW_NODE_TYPE_AM2315) += am2315.mod
 obj-am2315-$(FLOW_NODE_TYPE_AM2315) := am2315.json \
 	am2315.o \
 	nodes.o
+obj-am2315-$(FLOW_NODE_TYPE_AM2315)-type := flow

--- a/src/modules/flow/am2315/nodes.c
+++ b/src/modules/flow/am2315/nodes.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "am2315-gen.h"
+#include "sol-flow/am2315.h"
 #include "sol-flow-internal.h"
 
 #include <sol-util.h>

--- a/src/modules/flow/app/Makefile
+++ b/src/modules/flow/app/Makefile
@@ -1,2 +1,4 @@
 obj-$(FLOW_NODE_TYPE_APP) += app.mod
 obj-app-$(FLOW_NODE_TYPE_APP) := app.json app.o
+obj-app-$(FLOW_NODE_TYPE_APP)-type := flow
+

--- a/src/modules/flow/app/app.c
+++ b/src/modules/flow/app/app.c
@@ -32,7 +32,7 @@
 
 #include <errno.h>
 
-#include "app-gen.h"
+#include "sol-flow/app.h"
 #include "sol-flow-internal.h"
 #include "sol-mainloop.h"
 #include "sol-util.h"

--- a/src/modules/flow/boolean/Makefile
+++ b/src/modules/flow/boolean/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_BOOLEAN) += boolean.mod
 obj-boolean-$(FLOW_NODE_TYPE_BOOLEAN) := boolean.json boolean.o
+obj-boolean-$(FLOW_NODE_TYPE_BOOLEAN)-type := flow

--- a/src/modules/flow/boolean/boolean.c
+++ b/src/modules/flow/boolean/boolean.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "boolean-gen.h"
+#include "sol-flow/boolean.h"
 #include "sol-flow-internal.h"
 #include "sol-mainloop.h"
 #include "sol-vector.h"

--- a/src/modules/flow/byte/Makefile
+++ b/src/modules/flow/byte/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_BYTE) += byte.mod
 obj-byte-$(FLOW_NODE_TYPE_BYTE) := byte.json byte.o
+obj-byte-$(FLOW_NODE_TYPE_BYTE)-type := flow

--- a/src/modules/flow/byte/byte.c
+++ b/src/modules/flow/byte/byte.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "byte-gen.h"
+#include "sol-flow/byte.h"
 
 #include "sol-flow-internal.h"
 

--- a/src/modules/flow/calamari/Makefile
+++ b/src/modules/flow/calamari/Makefile
@@ -1,3 +1,4 @@
 obj-$(FLOW_NODE_TYPE_CALAMARI) += calamari.mod
 obj-calamari-$(FLOW_NODE_TYPE_CALAMARI) := calamari.json calamari.o
 obj-calamari-$(FLOW_NODE_TYPE_CALAMARI)-deps := flow/gpio.mod
+obj-calamari-$(FLOW_NODE_TYPE_CALAMARI)-type := flow

--- a/src/modules/flow/calamari/calamari.c
+++ b/src/modules/flow/calamari/calamari.c
@@ -35,8 +35,8 @@
 #include <string.h>
 #include <errno.h>
 
-#include "calamari-gen.h"
-#include "gpio-gen.h"
+#include "sol-flow/calamari.h"
+#include "sol-flow/gpio.h"
 
 #include "sol-flow.h"
 #include "sol-flow-static.h"

--- a/src/modules/flow/color/Makefile
+++ b/src/modules/flow/color/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_COLOR) += color.mod
 obj-color-$(FLOW_NODE_TYPE_COLOR) := color.json color.o
+obj-color-$(FLOW_NODE_TYPE_COLOR)-type := flow

--- a/src/modules/flow/color/color.c
+++ b/src/modules/flow/color/color.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "color-gen.h"
+#include "sol-flow/color.h"
 
 #include "sol-flow-internal.h"
 

--- a/src/modules/flow/compass/Makefile
+++ b/src/modules/flow/compass/Makefile
@@ -2,3 +2,4 @@ obj-$(FLOW_NODE_TYPE_COMPASS) += compass.mod
 obj-compass-$(FLOW_NODE_TYPE_COMPASS) := \
 	compass.json \
 	compass.o
+obj-compass-$(FLOW_NODE_TYPE_COMPASS)-type := flow

--- a/src/modules/flow/compass/compass.c
+++ b/src/modules/flow/compass/compass.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "compass-gen.h"
+#include "sol-flow/compass.h"
 #include "sol-flow-internal.h"
 
 #include <sol-util.h>

--- a/src/modules/flow/console/Makefile
+++ b/src/modules/flow/console/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_CONSOLE) += console.mod
 obj-console-$(FLOW_NODE_TYPE_CONSOLE) := console.json console.o
+obj-console-$(FLOW_NODE_TYPE_CONSOLE)-type := flow

--- a/src/modules/flow/console/console.c
+++ b/src/modules/flow/console/console.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "console-gen.h"
+#include "sol-flow/console.h"
 #include "sol-flow-internal.h"
 #include "sol-types.h"
 

--- a/src/modules/flow/constant/Makefile
+++ b/src/modules/flow/constant/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_CONSTANT) += constant.mod
 obj-constant-$(FLOW_NODE_TYPE_CONSTANT) := constant.json constant.o
+obj-constant-$(FLOW_NODE_TYPE_CONSTANT)-type := flow

--- a/src/modules/flow/constant/constant.c
+++ b/src/modules/flow/constant/constant.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "constant-gen.h"
+#include "sol-flow/constant.h"
 #include "sol-flow-internal.h"
 
 #include <sol-util.h>

--- a/src/modules/flow/converter/Makefile
+++ b/src/modules/flow/converter/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_CONVERTER) += converter.mod
 obj-converter-$(FLOW_NODE_TYPE_CONVERTER) := converter.json converter.o string-format.o
+obj-converter-$(FLOW_NODE_TYPE_CONVERTER)-type := flow

--- a/src/modules/flow/converter/string-format.h
+++ b/src/modules/flow/converter/string-format.h
@@ -36,7 +36,7 @@
 #include "sol-log-internal.h"
 extern struct sol_log_domain _converter_log_domain;
 
-#include "converter-gen.h"
+#include "sol-flow/converter.h"
 #include "sol-mainloop.h"
 #include "sol-flow-internal.h"
 

--- a/src/modules/flow/evdev/Makefile
+++ b/src/modules/flow/evdev/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_EVDEV) += evdev.mod
 obj-evdev-$(FLOW_NODE_TYPE_EVDEV) := evdev.json evdev.o
+obj-evdev-$(FLOW_NODE_TYPE_EVDEV)-type := flow

--- a/src/modules/flow/evdev/evdev.c
+++ b/src/modules/flow/evdev/evdev.c
@@ -40,7 +40,7 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 
-#include "evdev-gen.h"
+#include "sol-flow/evdev.h"
 #include "sol-buffer.h"
 #include "sol-flow.h"
 #include "sol-mainloop.h"

--- a/src/modules/flow/file/Makefile
+++ b/src/modules/flow/file/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_FILE) += file.mod
 obj-file-$(FLOW_NODE_TYPE_FILE) := file.json file.o
+obj-file-$(FLOW_NODE_TYPE_FILE)-type := flow

--- a/src/modules/flow/file/file.c
+++ b/src/modules/flow/file/file.c
@@ -37,7 +37,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 
-#include "file-gen.h"
+#include "sol-flow/file.h"
 
 #include "sol-file-reader.h"
 #include "sol-flow-internal.h"

--- a/src/modules/flow/filter-repeated/Makefile
+++ b/src/modules/flow/filter-repeated/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_FILTER_REPEATED) += filter-repeated.mod
 obj-filter-repeated-$(FLOW_NODE_TYPE_AIO) := filter-repeated.json filter-repeated.o
+obj-filter-repeated-$(FLOW_NODE_TYPE_AIO)-type := flow

--- a/src/modules/flow/filter-repeated/filter-repeated.c
+++ b/src/modules/flow/filter-repeated/filter-repeated.c
@@ -32,7 +32,7 @@
 
 #include <errno.h>
 
-#include "filter-repeated-gen.h"
+#include "sol-flow/filter-repeated.h"
 #include "sol-flow-internal.h"
 #include "sol-util.h"
 

--- a/src/modules/flow/float/Makefile
+++ b/src/modules/flow/float/Makefile
@@ -1,2 +1,4 @@
 obj-$(FLOW_NODE_TYPE_FLOAT) += float.mod
 obj-float-$(FLOW_NODE_TYPE_FLOAT) := float.json float.o
+obj-float-$(FLOW_NODE_TYPE_FLOAT)-type := flow
+

--- a/src/modules/flow/float/float.c
+++ b/src/modules/flow/float/float.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "float-gen.h"
+#include "sol-flow/float.h"
 #include "sol-flow-internal.h"
 #include "sol-mainloop.h"
 

--- a/src/modules/flow/flower-power/Makefile
+++ b/src/modules/flow/flower-power/Makefile
@@ -5,5 +5,7 @@ obj-flower-power-$(FLOW_NODE_TYPE_FLOWER_POWER) := \
 	flower-power.json \
 	flower-power.o
 
+obj-flower-power-$(FLOW_NODE_TYPE_FLOWER_POWER)-type := flow
+
 headers-$(FLOW_NODE_TYPE_FLOWER_POWER) := \
     include/sol-flower-power.h

--- a/src/modules/flow/flower-power/flower-power.c
+++ b/src/modules/flow/flower-power/flower-power.c
@@ -31,7 +31,7 @@
  */
 
 #include "sol-flower-power.h"
-#include "flower-power-gen.h"
+#include "sol-flow/flower-power.h"
 #include "sol-flow-internal.h"
 
 #include <sol-http-client.h>

--- a/src/modules/flow/freegeoip/Makefile
+++ b/src/modules/flow/freegeoip/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_FREEGEOIP) += freegeoip.mod
 obj-freegeoip-$(FLOW_NODE_TYPE_FREEGEOIP) := freegeoip.json freegeoip.o
+obj-freegeoip-$(FLOW_NODE_TYPE_FREEGEOIP)-type := flow

--- a/src/modules/flow/freegeoip/freegeoip.c
+++ b/src/modules/flow/freegeoip/freegeoip.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "freegeoip-gen.h"
+#include "sol-flow/freegeoip.h"
 #include "sol-flow-internal.h"
 
 #include <errno.h>

--- a/src/modules/flow/gpio/Makefile
+++ b/src/modules/flow/gpio/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_GPIO) += gpio.mod
 obj-gpio-$(FLOW_NODE_TYPE_GPIO) := gpio.json gpio.o
+obj-gpio-$(FLOW_NODE_TYPE_GPIO)-type := flow

--- a/src/modules/flow/gpio/gpio.c
+++ b/src/modules/flow/gpio/gpio.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "gpio-gen.h"
+#include "sol-flow/gpio.h"
 #include "sol-flow-internal.h"
 
 #include "sol-flow.h"

--- a/src/modules/flow/grove/Makefile
+++ b/src/modules/flow/grove/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_GROVE) += grove.mod
 obj-grove-$(FLOW_NODE_TYPE_GROVE) := grove.json grove.o
+obj-grove-$(FLOW_NODE_TYPE_GROVE)-type := flow

--- a/src/modules/flow/grove/grove.c
+++ b/src/modules/flow/grove/grove.c
@@ -34,8 +34,8 @@
 #include <errno.h>
 #include <math.h>
 
-#include "grove-gen.h"
-#include "aio-gen.h"
+#include "sol-flow/grove.h"
+#include "sol-flow/aio.h"
 
 #include "sol-flow-static.h"
 #include "sol-flow-internal.h"

--- a/src/modules/flow/gtk/Makefile
+++ b/src/modules/flow/gtk/Makefile
@@ -5,6 +5,7 @@ obj-gtk-$(FLOW_NODE_TYPE_GTK) += pwm-viewer.o rgb-editor.o slider.o
 obj-gtk-$(FLOW_NODE_TYPE_GTK) += spinbutton.o toggle.o window.o
 obj-gtk-$(FLOW_NODE_TYPE_GTK)-extra-cflags += $(GTK_CFLAGS) $(GLIB_CFLAGS)
 obj-gtk-$(FLOW_NODE_TYPE_GTK)-extra-ldflags += $(GTK_LDFLAGS) $(GLIB_LDFLAGS)
+obj-gtk-$(FLOW_NODE_TYPE_GTK)-type := flow
 
 requires-private-$(FLOW_NODE_TYPE_GTK) := \
     $(GTK_REQUIRES_PRIVATE)

--- a/src/modules/flow/gtk/byte-editor.c
+++ b/src/modules/flow/gtk/byte-editor.c
@@ -31,7 +31,7 @@
  */
 
 #include "byte-editor.h"
-#include "gtk-gen.h"
+#include "sol-flow/gtk.h"
 
 #define INT_VALUE_MAX (0xF)
 static const char *BIT_POSITION_KEY = "bit_position";

--- a/src/modules/flow/gtk/gtk.c
+++ b/src/modules/flow/gtk/gtk.c
@@ -35,7 +35,7 @@
 #include <string.h>
 
 #include "common.h"
-#include "gtk-gen.h"
+#include "sol-flow/gtk.h"
 
 SOL_LOG_INTERNAL_DECLARE(_gtk_log_domain, "flow-gtk");
 

--- a/src/modules/flow/gtk/label.c
+++ b/src/modules/flow/gtk/label.c
@@ -31,7 +31,7 @@
  */
 
 #include "label.h"
-#include "gtk-gen.h"
+#include "sol-flow/gtk.h"
 
 static void
 set_min_size(GtkWidget *widget)

--- a/src/modules/flow/gtk/led.c
+++ b/src/modules/flow/gtk/led.c
@@ -33,7 +33,7 @@
 #include <math.h>
 
 #include "led.h"
-#include "gtk-gen.h"
+#include "sol-flow/gtk.h"
 #include "sol-types.h"
 
 #define LED_VIEW_DIMENSION (50)

--- a/src/modules/flow/gtk/pushbutton.c
+++ b/src/modules/flow/gtk/pushbutton.c
@@ -31,7 +31,7 @@
  */
 
 #include "pushbutton.h"
-#include "gtk-gen.h"
+#include "sol-flow/gtk.h"
 
 static void
 on_pushbutton_pressed(GtkButton *button, gpointer data)

--- a/src/modules/flow/gtk/pwm-editor.c
+++ b/src/modules/flow/gtk/pwm-editor.c
@@ -31,7 +31,7 @@
  */
 
 #include "pwm-editor.h"
-#include "gtk-gen.h"
+#include "sol-flow/gtk.h"
 
 static void
 on_pwm_editor_toggle_changed(GtkToggleButton *toggle, gpointer data)

--- a/src/modules/flow/gtk/pwm-viewer.c
+++ b/src/modules/flow/gtk/pwm-viewer.c
@@ -31,7 +31,7 @@
  */
 
 #include "pwm-viewer.h"
-#include "gtk-gen.h"
+#include "sol-flow/gtk.h"
 
 #define CHART_HEIGHT 42
 #define CHART_WIDTH 340

--- a/src/modules/flow/gtk/rgb-editor.c
+++ b/src/modules/flow/gtk/rgb-editor.c
@@ -31,7 +31,7 @@
  */
 
 #include "rgb-editor.h"
-#include "gtk-gen.h"
+#include "sol-flow/gtk.h"
 #include "sol-types.h"
 
 #define COLOR_VALUE_MIN (0)

--- a/src/modules/flow/gtk/slider.c
+++ b/src/modules/flow/gtk/slider.c
@@ -31,7 +31,7 @@
  */
 
 #include "slider.h"
-#include "gtk-gen.h"
+#include "sol-flow/gtk.h"
 
 static void
 on_slider_changed(GtkRange *range, gpointer data)

--- a/src/modules/flow/gtk/spinbutton.c
+++ b/src/modules/flow/gtk/spinbutton.c
@@ -31,7 +31,7 @@
  */
 
 #include "spinbutton.h"
-#include "gtk-gen.h"
+#include "sol-flow/gtk.h"
 
 static void
 on_spinbutton_changed(GtkSpinButton *spin, gpointer data)

--- a/src/modules/flow/gtk/toggle.c
+++ b/src/modules/flow/gtk/toggle.c
@@ -31,7 +31,7 @@
  */
 
 #include "toggle.h"
-#include "gtk-gen.h"
+#include "sol-flow/gtk.h"
 
 static void
 on_toggle_changed(GtkRange *range, gpointer data)

--- a/src/modules/flow/gyroscope/Makefile
+++ b/src/modules/flow/gyroscope/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_GYROSCOPE) += gyroscope.mod
 obj-gyroscope-$(FLOW_NODE_TYPE_GYROSCOPE) := gyroscope.json gyroscope.o
+obj-gyroscope-$(FLOW_NODE_TYPE_GYROSCOPE)-type := flow

--- a/src/modules/flow/gyroscope/gyroscope.c
+++ b/src/modules/flow/gyroscope/gyroscope.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "gyroscope-gen.h"
+#include "sol-flow/gyroscope.h"
 
 #include <errno.h>
 

--- a/src/modules/flow/iio/Makefile
+++ b/src/modules/flow/iio/Makefile
@@ -1,3 +1,4 @@
 obj-$(FLOW_NODE_TYPE_IIO) += iio.mod
 obj-iio-$(FLOW_NODE_TYPE_IIO) := iio.json \
 	nodes.o
+obj-iio-$(FLOW_NODE_TYPE_IIO)-type := flow

--- a/src/modules/flow/iio/nodes.c
+++ b/src/modules/flow/iio/nodes.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "iio-gen.h"
+#include "sol-flow/iio.h"
 #include "sol-flow-internal.h"
 
 #include <sol-util.h>

--- a/src/modules/flow/int/Makefile
+++ b/src/modules/flow/int/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_INT) += int.mod
 obj-int-$(FLOW_NODE_TYPE_INT) := int.json int.o
+obj-int-$(FLOW_NODE_TYPE_INT)-type := flow

--- a/src/modules/flow/int/int.c
+++ b/src/modules/flow/int/int.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "int-gen.h"
+#include "sol-flow/int.h"
 
 #include "sol-flow-internal.h"
 #include "sol-types.h"

--- a/src/modules/flow/keyboard/Makefile
+++ b/src/modules/flow/keyboard/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_KEYBOARD) += keyboard.mod
 obj-keyboard-$(FLOW_NODE_TYPE_KEYBOARD) := keyboard.json keyboard.o
+obj-keyboard-$(FLOW_NODE_TYPE_KEYBOARD)-type := flow

--- a/src/modules/flow/keyboard/keyboard.c
+++ b/src/modules/flow/keyboard/keyboard.c
@@ -41,7 +41,7 @@
 #include <inttypes.h>
 #include <fcntl.h>
 
-#include "keyboard-gen.h"
+#include "sol-flow/keyboard.h"
 
 #include "sol-flow.h"
 #include "sol-buffer.h"

--- a/src/modules/flow/led-strip/Makefile
+++ b/src/modules/flow/led-strip/Makefile
@@ -2,3 +2,4 @@ obj-$(FLOW_NODE_TYPE_LED_STRIP) += led-strip.mod
 obj-led-strip-$(FLOW_NODE_TYPE_LED_STRIP) := \
 	led-strip.json \
 	lpd8806.o
+obj-led-strip-$(FLOW_NODE_TYPE_LED_STRIP)-type := flow

--- a/src/modules/flow/led-strip/lpd8806.c
+++ b/src/modules/flow/led-strip/lpd8806.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "led-strip-gen.h"
+#include "sol-flow/led-strip.h"
 #include "sol-flow-internal.h"
 
 #include <sol-spi.h>

--- a/src/modules/flow/magnetometer/Makefile
+++ b/src/modules/flow/magnetometer/Makefile
@@ -2,3 +2,4 @@ obj-$(FLOW_NODE_TYPE_MAGNETOMETER) += magnetometer.mod
 obj-magnetometer-$(FLOW_NODE_TYPE_MAGNETOMETER) := \
 	magnetometer.json \
 	lsm303.o
+obj-magnetometer-$(FLOW_NODE_TYPE_MAGNETOMETER)-type := flow

--- a/src/modules/flow/magnetometer/lsm303.c
+++ b/src/modules/flow/magnetometer/lsm303.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "magnetometer-gen.h"
+#include "sol-flow/magnetometer.h"
 #include "sol-flow-internal.h"
 
 #include <sol-i2c.h>

--- a/src/modules/flow/max31855/Makefile
+++ b/src/modules/flow/max31855/Makefile
@@ -1,3 +1,5 @@
 obj-$(FLOW_NODE_TYPE_MAX31855) += max31855.mod
 obj-max31855-$(FLOW_NODE_TYPE_MAX31855) := max31855.json \
 		max31855.o
+obj-max31855-$(FLOW_NODE_TYPE_MAX31855)-type := flow
+

--- a/src/modules/flow/max31855/max31855.c
+++ b/src/modules/flow/max31855/max31855.c
@@ -30,12 +30,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "max31855-gen.h"
+#include "sol-flow/max31855.h"
 
 #include "sol-flow-internal.h"
+#include "sol-flow/max31855.h"
 #include "sol-spi.h"
 #include "sol-types.h"
-#include "max31855-gen.h"
 
 #include <sol-util.h>
 #include <errno.h>

--- a/src/modules/flow/network/Makefile
+++ b/src/modules/flow/network/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_NETWORK) += network.mod
 obj-network-$(FLOW_NODE_TYPE_NETWORK) := network.json network.o
+obj-network-$(FLOW_NODE_TYPE_NETWORK)-type := flow

--- a/src/modules/flow/network/network.c
+++ b/src/modules/flow/network/network.c
@@ -38,7 +38,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "network-gen.h"
+#include "sol-flow/network.h"
 #include "sol-flow.h"
 #include "sol-mainloop.h"
 #include "sol-network.h"

--- a/src/modules/flow/oic/Makefile
+++ b/src/modules/flow/oic/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_OIC) += oic.mod
 obj-oic-$(FLOW_NODE_TYPE_OIC) := oic.json oic.o
+obj-oic-$(FLOW_NODE_TYPE_OIC)-type := flow

--- a/src/modules/flow/persistence/Makefile
+++ b/src/modules/flow/persistence/Makefile
@@ -3,3 +3,4 @@ obj-persistence-$(FLOW_NODE_TYPE_PERSISTENCE) := persistence.json \
 	persistence.o \
 	fs-storage.o \
 	efivarfs-storage.o
+obj-persistence-$(FLOW_NODE_TYPE_PERSISTENCE)-type := flow

--- a/src/modules/flow/persistence/persistence.c
+++ b/src/modules/flow/persistence/persistence.c
@@ -32,7 +32,7 @@
 
 #include <errno.h>
 
-#include "persistence-gen.h"
+#include "sol-flow/persistence.h"
 
 #include "sol-buffer.h"
 #include "sol-flow.h"

--- a/src/modules/flow/piezo-speaker/Makefile
+++ b/src/modules/flow/piezo-speaker/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_PIEZO_SPEAKER) += piezo-speaker.mod
 obj-piezo-speaker-$(FLOW_NODE_TYPE_PIEZO_SPEAKER) := piezo-speaker.json piezo-speaker.o
+obj-piezo-speaker-$(FLOW_NODE_TYPE_PIEZO_SPEAKER)-type := flow

--- a/src/modules/flow/piezo-speaker/piezo-speaker.c
+++ b/src/modules/flow/piezo-speaker/piezo-speaker.c
@@ -37,7 +37,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "piezo-speaker-gen.h"
+#include "sol-flow/piezo-speaker.h"
 
 #include "sol-flow.h"
 #include "sol-mainloop.h"

--- a/src/modules/flow/platform/Makefile
+++ b/src/modules/flow/platform/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_PLATFORM) += platform.mod
 obj-platform-$(FLOW_NODE_TYPE_PLATFORM) := platform.json platform.o
+obj-platform-$(FLOW_NODE_TYPE_PLATFORM)-type := flow

--- a/src/modules/flow/platform/platform.c
+++ b/src/modules/flow/platform/platform.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "platform-gen.h"
+#include "sol-flow/platform.h"
 #include "sol-platform.h"
 #include "sol-flow-internal.h"
 

--- a/src/modules/flow/process/Makefile
+++ b/src/modules/flow/process/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_PROCESS) += process.mod
 obj-process-$(FLOW_NODE_TYPE_PROCESS) := process.json common.h output.o process.o stdin.o subprocess.o
+obj-process-$(FLOW_NODE_TYPE_PROCESS)-type := flow

--- a/src/modules/flow/process/common.h
+++ b/src/modules/flow/process/common.h
@@ -36,7 +36,7 @@
 #include "sol-log-internal.h"
 extern struct sol_log_domain _process_log_domain;
 
-#include "process-gen.h"
+#include "sol-flow/process.h"
 #include "sol-mainloop.h"
 #include "sol-flow-internal.h"
 

--- a/src/modules/flow/pwm/Makefile
+++ b/src/modules/flow/pwm/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_PWM) += pwm.mod
 obj-pwm-$(FLOW_NODE_TYPE_PWM) := pwm.json pwm.o
+obj-pwm-$(FLOW_NODE_TYPE_PWM)-type := flow

--- a/src/modules/flow/pwm/pwm.c
+++ b/src/modules/flow/pwm/pwm.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "pwm-gen.h"
+#include "sol-flow/pwm.h"
 #include "sol-flow-internal.h"
 
 #include "sol-flow.h"

--- a/src/modules/flow/random/Makefile
+++ b/src/modules/flow/random/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_RANDOM) += random.mod
 obj-random-$(FLOW_NODE_TYPE_RANDOM) := random.json random.o
+obj-random-$(FLOW_NODE_TYPE_RANDOM)-type := flow

--- a/src/modules/flow/random/random.c
+++ b/src/modules/flow/random/random.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "random-gen.h"
+#include "sol-flow/random.h"
 #include "sol-flow-internal.h"
 
 #include <errno.h>

--- a/src/modules/flow/servo-motor/Makefile
+++ b/src/modules/flow/servo-motor/Makefile
@@ -1,2 +1,4 @@
 obj-$(FLOW_NODE_TYPE_SERVO_MOTOR) += servo-motor.mod
 obj-servo-motor-$(FLOW_NODE_TYPE_SERVO_MOTOR) := servo-motor.json servo-motor.o
+obj-servo-motor-$(FLOW_NODE_TYPE_SERVO_MOTOR)-type := flow
+

--- a/src/modules/flow/servo-motor/servo-motor.c
+++ b/src/modules/flow/servo-motor/servo-motor.c
@@ -37,7 +37,7 @@
 #include <math.h>
 #include <stdlib.h>
 
-#include "servo-motor-gen.h"
+#include "sol-flow/servo-motor.h"
 
 struct servo_motor_data {
     struct sol_irange duty_cycle_range;

--- a/src/modules/flow/string/Makefile
+++ b/src/modules/flow/string/Makefile
@@ -32,6 +32,7 @@ endif
 
 obj-string-$(FLOW_NODE_TYPE_STRING)-extra-cflags += $(LOCALE_CFLAGS) $(ICU_CFLAGS) $(LIBPCRE_CFLAGS)
 obj-string-$(FLOW_NODE_TYPE_STRING)-extra-ldflags += $(LOCALE_LDFLAGS) $(ICU_LDFLAGS) $(LIBPCRE_LDFLAGS)
+obj-string-$(FLOW_NODE_TYPE_STRING)-type := flow
 
 requires-private-$(FLOW_NODE_TYPE_STRING) := \
     $(ICU_REQUIRES_PRIVATE) \

--- a/src/modules/flow/string/string-ascii.c
+++ b/src/modules/flow/string/string-ascii.c
@@ -39,7 +39,7 @@
 
 #include "sol-flow-internal.h"
 
-#include "string-gen.h"
+#include "sol-flow/string.h"
 #include "string-ascii.h"
 #include "string-regexp.h"
 #include "string-uuid.h"

--- a/src/modules/flow/string/string-icu.c
+++ b/src/modules/flow/string/string-icu.c
@@ -35,7 +35,7 @@
 
 #include "sol-flow-internal.h"
 
-#include "string-gen.h"
+#include "sol-flow/string.h"
 #include "string-icu.h"
 #include "string-regexp.h"
 #include "string-uuid.h"

--- a/src/modules/flow/string/string-regexp.c
+++ b/src/modules/flow/string/string-regexp.c
@@ -39,7 +39,7 @@
 
 #include "sol-flow-internal.h"
 
-#include "string-gen.h"
+#include "sol-flow/string.h"
 #include "string-regexp.h"
 
 #ifdef USE_LIBPCRE

--- a/src/modules/flow/string/string-uuid.c
+++ b/src/modules/flow/string/string-uuid.c
@@ -38,7 +38,7 @@
 #include "sol-flow-internal.h"
 #include "sol-platform.h"
 
-#include "string-gen.h"
+#include "sol-flow/string.h"
 #include "string-uuid.h"
 
 int

--- a/src/modules/flow/switcher/Makefile
+++ b/src/modules/flow/switcher/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_SWITCHER) += switcher.mod
 obj-switcher-$(FLOW_NODE_TYPE_SWITCHER) := switcher.json switcher.o
+obj-switcher-$(FLOW_NODE_TYPE_SWITCHER)-type := flow

--- a/src/modules/flow/switcher/switcher.c
+++ b/src/modules/flow/switcher/switcher.c
@@ -32,7 +32,7 @@
 
 #include <errno.h>
 
-#include "switcher-gen.h"
+#include "sol-flow/switcher.h"
 #include "sol-flow-internal.h"
 #include "sol-util.h"
 

--- a/src/modules/flow/temperature/Makefile
+++ b/src/modules/flow/temperature/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_TEMPERATURE) += temperature.mod
 obj-temperature-$(FLOW_NODE_TYPE_TEMPERATURE) := temperature.json temperature.o
+obj-temperature-$(FLOW_NODE_TYPE_TEMPERATURE)-type := flow

--- a/src/modules/flow/temperature/temperature.c
+++ b/src/modules/flow/temperature/temperature.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "temperature-gen.h"
+#include "sol-flow/temperature.h"
 #include "sol-flow-internal.h"
 
 #include <sol-util.h>

--- a/src/modules/flow/test/Makefile
+++ b/src/modules/flow/test/Makefile
@@ -3,3 +3,4 @@ obj-test-$(FLOW_NODE_TYPE_TEST) += boolean-generator.o boolean-validator.o
 obj-test-$(FLOW_NODE_TYPE_TEST) += int-generator.o int-validator.o
 obj-test-$(FLOW_NODE_TYPE_TEST) += result.o test.o test.json float-validator.o
 obj-test-$(FLOW_NODE_TYPE_TEST) += float-generator.o blob-validator.o
+obj-test-$(FLOW_NODE_TYPE_TEST)-type := flow

--- a/src/modules/flow/test/blob-validator.c
+++ b/src/modules/flow/test/blob-validator.c
@@ -39,7 +39,7 @@
 #include "sol-util.h"
 
 #include "blob-validator.h"
-#include "test-gen.h"
+#include "sol-flow/test.h"
 
 int
 blob_validator_open(

--- a/src/modules/flow/test/boolean-generator.c
+++ b/src/modules/flow/test/boolean-generator.c
@@ -40,7 +40,7 @@
 
 #include "test-module.h"
 #include "boolean-generator.h"
-#include "test-gen.h"
+#include "sol-flow/test.h"
 
 static bool
 timer_tick(void *data)

--- a/src/modules/flow/test/boolean-validator.c
+++ b/src/modules/flow/test/boolean-validator.c
@@ -39,7 +39,7 @@
 #include "sol-util.h"
 
 #include "boolean-validator.h"
-#include "test-gen.h"
+#include "sol-flow/test.h"
 
 int
 boolean_validator_open(

--- a/src/modules/flow/test/float-generator.c
+++ b/src/modules/flow/test/float-generator.c
@@ -40,7 +40,7 @@
 
 #include "test-module.h"
 #include "float-generator.h"
-#include "test-gen.h"
+#include "sol-flow/test.h"
 
 static bool
 timer_tick(void *data)

--- a/src/modules/flow/test/float-validator.c
+++ b/src/modules/flow/test/float-validator.c
@@ -40,7 +40,7 @@
 
 #include "test-module.h"
 #include "float-validator.h"
-#include "test-gen.h"
+#include "sol-flow/test.h"
 
 int
 float_validator_open(

--- a/src/modules/flow/test/int-generator.c
+++ b/src/modules/flow/test/int-generator.c
@@ -41,7 +41,7 @@
 
 #include "test-module.h"
 #include "int-generator.h"
-#include "test-gen.h"
+#include "sol-flow/test.h"
 
 static bool
 timer_tick(void *data)

--- a/src/modules/flow/test/int-validator.c
+++ b/src/modules/flow/test/int-validator.c
@@ -40,7 +40,7 @@
 #include "sol-util.h"
 
 #include "int-validator.h"
-#include "test-gen.h"
+#include "sol-flow/test.h"
 
 static int
 _populate_values(void *data)

--- a/src/modules/flow/test/result.c
+++ b/src/modules/flow/test/result.c
@@ -38,7 +38,7 @@
 
 #include "test-module.h"
 #include "result.h"
-#include "test-gen.h"
+#include "sol-flow/test.h"
 
 static int node_count;
 

--- a/src/modules/flow/test/test.c
+++ b/src/modules/flow/test/test.c
@@ -38,7 +38,7 @@
 
 #include "test-module.h"
 
-#include "test-gen.h"
+#include "sol-flow/test.h"
 
 SOL_LOG_INTERNAL_DECLARE(_test_log_domain, "flow-test");
 

--- a/src/modules/flow/thingspeak/Makefile
+++ b/src/modules/flow/thingspeak/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_THINGSPEAK) += thingspeak.mod
 obj-thingspeak-$(FLOW_NODE_TYPE_THINGSPEAK) := thingspeak.json thingspeak.o
+obj-thingspeak-$(FLOW_NODE_TYPE_THINGSPEAK)-type := flow

--- a/src/modules/flow/thingspeak/thingspeak.c
+++ b/src/modules/flow/thingspeak/thingspeak.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "thingspeak-gen.h"
+#include "sol-flow/thingspeak.h"
 #include "sol-flow-internal.h"
 
 #include <errno.h>

--- a/src/modules/flow/timer/Makefile
+++ b/src/modules/flow/timer/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_TIMER) += timer.mod
 obj-timer-$(FLOW_NODE_TYPE_TIMER) := timer.json timer.o
+obj-timer-$(FLOW_NODE_TYPE_TIMER)-type := flow

--- a/src/modules/flow/timer/timer.c
+++ b/src/modules/flow/timer/timer.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "timer-gen.h"
+#include "sol-flow/timer.h"
 #include "sol-flow-internal.h"
 #include "sol-mainloop.h"
 

--- a/src/modules/flow/timestamp/Makefile
+++ b/src/modules/flow/timestamp/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_TIMESTAMP) += timestamp.mod
 obj-timestamp-$(FLOW_NODE_TYPE_TIMESTAMP) := timestamp.json timestamp.o
+obj-timestamp-$(FLOW_NODE_TYPE_TIMESTAMP)-type := flow

--- a/src/modules/flow/timestamp/timestamp.c
+++ b/src/modules/flow/timestamp/timestamp.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "timestamp-gen.h"
+#include "sol-flow/timestamp.h"
 #include "sol-flow-internal.h"
 
 #include <sol-util.h>

--- a/src/modules/flow/trigonometry/Makefile
+++ b/src/modules/flow/trigonometry/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_TRIGONOMETRY) += trigonometry.mod
 obj-trigonometry-$(FLOW_NODE_TYPE_TRIGONOMETRY) := trigonometry.json trigonometry.o
+obj-trigonometry-$(FLOW_NODE_TYPE_TRIGONOMETRY)-type := flow

--- a/src/modules/flow/trigonometry/trigonometry.c
+++ b/src/modules/flow/trigonometry/trigonometry.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "trigonometry-gen.h"
+#include "sol-flow/trigonometry.h"
 
 #include "sol-flow-internal.h"
 

--- a/src/modules/flow/udev/Makefile
+++ b/src/modules/flow/udev/Makefile
@@ -2,6 +2,7 @@ obj-$(FLOW_NODE_TYPE_UDEV) += udev.mod
 obj-udev-$(FLOW_NODE_TYPE_UDEV) := udev.json udev.o
 obj-udev-$(FLOW_NODE_TYPE_UDEV)-extra-cflags += $(UDEV_CFLAGS)
 obj-udev-$(FLOW_NODE_TYPE_UDEV)-extra-ldflags += $(UDEV_LDFLAGS)
+obj-udev-$(FLOW_NODE_TYPE_UDEV)-type := flow
 
 requires-private-$(FLOW_NODE_TYPE_UDEV) := \
     $(UDEV_REQUIRES_PRIVATE)

--- a/src/modules/flow/udev/udev.c
+++ b/src/modules/flow/udev/udev.c
@@ -38,7 +38,7 @@
 
 #include <libudev.h>
 
-#include "udev-gen.h"
+#include "sol-flow/udev.h"
 #include "sol-flow.h"
 #include "sol-mainloop.h"
 #include "sol-util.h"

--- a/src/modules/flow/unix-socket/Makefile
+++ b/src/modules/flow/unix-socket/Makefile
@@ -1,3 +1,4 @@
 obj-$(FLOW_NODE_TYPE_UNIX_SOCKET) += unix-socket.mod
 obj-unix-socket-$(FLOW_NODE_TYPE_UNIX_SOCKET) := unix-socket.json unix-socket.o
 obj-unix-socket-$(FLOW_NODE_TYPE_UNIX_SOCKET) += unix-socket-impl.o
+obj-unix-socket-$(FLOW_NODE_TYPE_UNIX_SOCKET)-type := flow

--- a/src/modules/flow/unix-socket/unix-socket.c
+++ b/src/modules/flow/unix-socket/unix-socket.c
@@ -37,7 +37,7 @@
 #include <unistd.h>
 
 #include "unix-socket.h"
-#include "unix-socket-gen.h"
+#include "sol-flow/unix-socket.h"
 #include "sol-buffer.h"
 #include "sol-flow.h"
 #include "sol-mainloop.h"

--- a/src/modules/flow/wallclock/Makefile
+++ b/src/modules/flow/wallclock/Makefile
@@ -1,2 +1,3 @@
 obj-$(FLOW_NODE_TYPE_WALLCLOCK) += wallclock.mod
 obj-wallclock-$(FLOW_NODE_TYPE_WALLCLOCK) := wallclock.json wallclock.o
+obj-wallclock-$(FLOW_NODE_TYPE_WALLCLOCK)-type := flow

--- a/src/modules/flow/wallclock/wallclock.c
+++ b/src/modules/flow/wallclock/wallclock.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "wallclock-gen.h"
+#include "sol-flow/wallclock.h"
 #include "sol-flow-internal.h"
 #include "sol-mainloop.h"
 #include "sol-vector.h"

--- a/src/modules/linux-micro/bluetooth/Makefile
+++ b/src/modules/linux-micro/bluetooth/Makefile
@@ -1,2 +1,3 @@
 obj-$(LINUX_MICRO_BLUETOOTH) += bluetooth.mod
 obj-bluetooth-$(LINUX_MICRO_BLUETOOTH) += bluetooth.o
+obj-bluetooth-$(LINUX_MICRO_BLUETOOTH)-type := linux-micro

--- a/src/modules/linux-micro/console/Makefile
+++ b/src/modules/linux-micro/console/Makefile
@@ -1,2 +1,3 @@
 obj-$(LINUX_MICRO_CONSOLE) += console.mod
 obj-console-$(LINUX_MICRO_CONSOLE) += console.o
+obj-console-$(LINUX_MICRO_CONSOLE)-type := linux-micro

--- a/src/modules/linux-micro/dbus/Makefile
+++ b/src/modules/linux-micro/dbus/Makefile
@@ -1,2 +1,3 @@
 obj-$(LINUX_MICRO_DBUS) += dbus.mod
 obj-dbus-$(LINUX_MICRO_DBUS) += dbus.o
+obj-dbus-$(LINUX_MICRO_DBUS)-type := linux-micro

--- a/src/modules/linux-micro/fstab/Makefile
+++ b/src/modules/linux-micro/fstab/Makefile
@@ -1,2 +1,3 @@
 obj-$(LINUX_MICRO_FSTAB) += fstab.mod
 obj-fstab-$(LINUX_MICRO_FSTAB) += fstab.o
+obj-fstab-$(LINUX_MICRO_FSTAB)-type := linux-micro

--- a/src/modules/linux-micro/hostname/Makefile
+++ b/src/modules/linux-micro/hostname/Makefile
@@ -1,2 +1,3 @@
 obj-$(LINUX_MICRO_HOSTNAME) += hostname.mod
 obj-hostname-$(LINUX_MICRO_HOSTNAME) += hostname.o
+obj-hostname-$(LINUX_MICRO_HOSTNAME)-type := linux-micro

--- a/src/modules/linux-micro/locale/Makefile
+++ b/src/modules/linux-micro/locale/Makefile
@@ -1,2 +1,3 @@
 obj-$(LINUX_MICRO_LOCALE) += locale.mod
 obj-locale-$(LINUX_MICRO_LOCALE) += locale.o
+obj-locale-$(LINUX_MICRO_LOCALE)-type := linux-micro

--- a/src/modules/linux-micro/network-up/Makefile
+++ b/src/modules/linux-micro/network-up/Makefile
@@ -1,2 +1,3 @@
 obj-$(LINUX_MICRO_NETWORK_UP) += network-up.mod
 obj-network-up-$(LINUX_MICRO_NETWORK_UP) += network-up.o
+obj-network-up-$(LINUX_MICRO_NETWORK_UP)-type := linux-micro

--- a/src/modules/linux-micro/rc-d/Makefile
+++ b/src/modules/linux-micro/rc-d/Makefile
@@ -1,2 +1,3 @@
 obj-$(LINUX_MICRO_RC_D) += rc-d.mod
 obj-rc-d-$(LINUX_MICRO_RC_D) += rc-d.o
+obj-rc-d-$(LINUX_MICRO_RC_D)-type := linux-micro

--- a/src/modules/linux-micro/sysctl/Makefile
+++ b/src/modules/linux-micro/sysctl/Makefile
@@ -1,2 +1,3 @@
 obj-$(LINUX_MICRO_SYSCTL) += sysctl.mod
 obj-sysctl-$(LINUX_MICRO_SYSCTL) += sysctl.o
+obj-sysctl-$(LINUX_MICRO_SYSCTL)-type := linux-micro

--- a/src/modules/linux-micro/watchdog/Makefile
+++ b/src/modules/linux-micro/watchdog/Makefile
@@ -1,2 +1,3 @@
 obj-$(LINUX_MICRO_WATCHDOG) += watchdog.mod
 obj-watchdog-$(LINUX_MICRO_WATCHDOG) += watchdog.o
+obj-watchdog-$(LINUX_MICRO_WATCHDOG)-type := linux-micro

--- a/src/modules/pin-mux/intel-edison-rev-c/Makefile
+++ b/src/modules/pin-mux/intel-edison-rev-c/Makefile
@@ -1,2 +1,3 @@
 obj-$(PIN_MUX_INTEL_EDISON_REV_C) += intel-edison-rev-c.mod
 obj-intel-edison-rev-c-$(PIN_MUX_INTEL_EDISON_REV_C) := intel-edison-rev-c.o
+obj-intel-edison-rev-c-$(PIN_MUX_INTEL_EDISON_REV_C)-type := pin-mux

--- a/src/modules/pin-mux/intel-galileo-rev-d/Makefile
+++ b/src/modules/pin-mux/intel-galileo-rev-d/Makefile
@@ -1,2 +1,3 @@
 obj-$(PIN_MUX_INTEL_GALILEO_REV_D) += intel-galileo-rev-d.mod
 obj-intel-galileo-rev-d-$(PIN_MUX_INTEL_GALILEO_REV_D) := intel-galileo-rev-d.o
+obj-intel-galileo-rev-d-$(PIN_MUX_INTEL_GALILEO_REV_D)-type := pin-mux

--- a/src/modules/pin-mux/intel-galileo-rev-g/Makefile
+++ b/src/modules/pin-mux/intel-galileo-rev-g/Makefile
@@ -1,2 +1,3 @@
 obj-$(PIN_MUX_INTEL_GALILEO_REV_G) += intel-galileo-rev-g.mod
 obj-intel-galileo-rev-g-$(PIN_MUX_INTEL_GALILEO_REV_G) := intel-galileo-rev-g.o
+obj-intel-galileo-rev-g-$(PIN_MUX_INTEL_GALILEO_REV_G)-type := pin-mux

--- a/src/samples/flow/c-api/lowlevel.c
+++ b/src/samples/flow/c-api/lowlevel.c
@@ -45,7 +45,7 @@
  * Since we're at the low-level API we can't use the foreach
  * functions, as they rely on node type descriptions.
  */
-#include "console-gen.h"
+#include "sol-flow/console.h"
 #include "sol-mainloop.h"
 
 /**

--- a/src/test/test-flow.c
+++ b/src/test/test-flow.c
@@ -36,11 +36,11 @@
 #include "sol-util.h"
 #include "sol-vector.h"
 
-#include "console-gen.h"
+#include "sol-flow/console.h"
 #ifdef USE_PWM
-#include "pwm-gen.h"
+#include "sol-flow/pwm.h"
 #endif
-#include "timer-gen.h"
+#include "sol-flow/timer.h"
 
 #include "test.h"
 

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -1,14 +1,5 @@
 find-deps = $(foreach dep,$($(1)-deps),$($(filter %$(dep),$(modules))-out)$($(dep)-out))
 
-known-module-type = \
-	$(foreach curr,$(module-types), \
-		$(if $(filter $(curr)/%,$(subst ./src/modules/,,$(1))),$(strip $(curr))) \
-	) \
-
-module-type = \
-	$(eval curr-mod-type:=$(call known-module-type,$(1))) \
-	$(if $(curr-mod-type),$(curr-mod-type),external) \
-
 all-gen-hdrs = $(foreach gen,$(all-gens),$($(gen)-hdr))
 
 gen-artifact = \
@@ -81,6 +72,8 @@ parse-common-module = \
 	$(eval $(4)-bs      := $(addprefix $(2),Makefile)) \
 	$(eval $(4)-bs      += $(if $(wildcard $(2)/Kconfig),$(addprefix $(2),Kconfig))) \
 	$(eval $(4)-hdrs    := $(filter %.h,$(artifacts))) \
+	$(eval $(5)         := $(if $(obj-$(1)-$(3)-type),$(obj-$(1)-$(3)-type),$(mod-type))) \
+	$(eval $(4)-type    := $($(5))) \
 	$(foreach obj,$(mod-objs), \
 		$(call object-path,$(obj),$(2),dest-obj) \
 		$(eval $(dest-obj)-src := $(subst .o,.c,$(obj))) \
@@ -90,31 +83,23 @@ parse-common-module = \
 	)\
 
 parse-builtin-module = \
-	$(call parse-common-module,$(1),$(2),y,$(3)) \
+	$(call parse-common-module,$(1),$(2),y,$(3),curr-mod-type) \
 	$(eval builtin-cflags      += $($(3)-cflags)) \
 	$(eval builtin-ldflags     += $($(3)-ldflags)) \
 	$(eval builtin-objs        += $($(3)-objs)) \
-	$(if $(filter $(flow-dir)%,$(2)), \
-		$(eval builtin-flows += $(1))) \
-	$(if $(filter $(linux-micro-dir)%,$(2)), \
-		$(eval builtin-linux-micro += $(1))) \
-	$(if $(filter $(pin-mux-dir)%,$(2)), \
-		$(eval builtin-pin-mux += $(1))) \
-	$(if $(filter $(flow-metatype-dir)%,$(2)), \
-		$(eval builtin-flow-metatype += $(1))) \
+	$(eval export builtins-$(curr-mod-type) += $(1)) \
 
 parse-mod-output = \
-	$(eval out-prefix := $(build_modulesdir)$(strip $(call module-type,$(2)))) \
+	$(eval out-prefix := $(build_modulesdir)$($(3)-type)) \
         $(eval $(3)-out   := $(out-prefix)/$(1).so) \
 	$(eval mod-so     += $(3)) \
 
 parse-mod-module = \
-	$(call parse-common-module,$(1),$(2),m,$(3)) \
+	$(call parse-common-module,$(1),$(2),m,$(3),curr-mod-type) \
 	$(eval $(3)-deps     := $(subst .mod,,$(obj-$(1)-m-deps))) \
 	$(call parse-mod-output,$(1),$(2),$(3)) \
 	$(eval modules-out += $($(3)-out)) \
-	$(if $(filter $(linux-micro-dir)%,$(2)), \
-		$(eval modules-linux-micro += $(1))) \
+	$(eval export modules-$(curr-mod-type) += $(1)) \
 
 parse-bin = \
 	$(eval bin-$(1)-srcs := $(addprefix $(2),$(bin-$(1)-y))) \
@@ -165,7 +150,7 @@ parse-warnings = \
 clean-control = $(eval headers-y:=) $(eval obj-y:=) $(eval obj-m:=) $(eval bin-y:=) \
 		$(eval test-y:=) $(eval test-internal-y:=) $(eval sample-y:=) $(eval headers-m:=) \
 		$(eval warning-msg:=) $(eval warning-msg-y:=) $(eval warning-msg-m:=) \
-		$(eval requires-private-y:=)
+		$(eval requires-private-y:=) $(eval mod-type:=)
 
 inc-subdirs = \
 	$(foreach subdir,$(SUBDIRS), $(clean-control) \
@@ -221,12 +206,6 @@ endif # $(M)
 
 $(eval $(call inc-subdirs))
 $(eval $(call extra-bins))
-
-export builtin-flows
-export builtin-linux-micro
-export modules-linux-micro
-export builtin-pin-mux
-export builtin-flow-metatype
 
 PRE_GEN += $(all-gen-hdrs) $(all-dest-hdr) $(all-dest-bin)
 
@@ -379,7 +358,7 @@ $(foreach gen,$(all-fbp-gens),$(eval $(call make-fbp-gen,$(gen))))
 $(FLOW_BUILTINS_DESC): $(SOL_LIB_OUTPUT) $(all-mod-descs) $(JSON_FORMAT_SCRIPT)
 	$(Q)echo "     "GEN"   "$@
 	$(Q)$(MKDIR) -p $(dir $(@))
-	$(Q)$(PYTHON) $(FLOW_MERGE_BUILTINS_SCRIPT) --modules-dir=$(build_descdir) $(@) $(builtin-flows)
+	$(Q)$(PYTHON) $(FLOW_MERGE_BUILTINS_SCRIPT) --modules-dir=$(build_descdir) $(@) $(builtins-flow)
 
 define install-resource
 $(2): $(1)

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -10,7 +10,8 @@ gen-artifact = \
 			$(eval $(json)-desc  := $(subst $(top_srcdir)src/,$(build_stagedir),$(json))) \
 			$(eval $(3)          := $(addprefix -I,$(dir $($(json)-src)))) \
 		, \
-			$(eval $(json)-hdr   := $(build_includedir)$(notdir $(subst .json,-gen.h,$(json)))) \
+			$(eval $(json)-hdr   := $(build_includedir)sol-$($(4)-type)/$(notdir $(subst .json,.h,$(json)))) \
+			$(eval $(json)-namespace := sol-$($(4)-type)) \
 			$(eval $(json)-desc  := $(build_descdir)$(1).json) \
 			$(eval all-mod-descs += $($(json)-desc)) \
 		) \
@@ -65,7 +66,6 @@ parse-common-module = \
 	$(eval all-artifacts += $(artifacts)) \
 	$(eval mod-headers  := $(addprefix $(2),$(headers-$(1)-$(3)))) \
 	$(call extra-headers,$(mod-headers)) \
-	$(call gen-artifact,$(1),$(filter %.json,$(artifacts)),"",$(4)) \
 	$(eval mod-objs     := $(filter %.o,$(artifacts))) \
 	$(eval $(4)-cflags  := $(obj-$(1)-$(3)-extra-cflags)) \
 	$(eval $(4)-ldflags := $(obj-$(1)-$(3)-extra-ldflags)) \
@@ -74,6 +74,7 @@ parse-common-module = \
 	$(eval $(4)-hdrs    := $(filter %.h,$(artifacts))) \
 	$(eval $(5)         := $(if $(obj-$(1)-$(3)-type),$(obj-$(1)-$(3)-type),$(mod-type))) \
 	$(eval $(4)-type    := $($(5))) \
+	$(call gen-artifact,$(1),$(filter %.json,$(artifacts)),"",$(4)) \
 	$(foreach obj,$(mod-objs), \
 		$(call object-path,$(obj),$(2),dest-obj) \
 		$(eval $(dest-obj)-src := $(subst .o,.c,$(obj))) \
@@ -333,7 +334,7 @@ $($(1)-hdr) $($(1)-src) $($(1)-desc): $(1) $(NODE_TYPE_GEN_SCRIPT)
 	$(Q)$(MKDIR) -p $(dir $($(1)-hdr))
 	$(Q)$(MKDIR) -p $(dir $($(1)-src))
 	$(Q)$(MKDIR) -p $(dir $($(1)-desc))
-	$(Q)$(PYTHON) $(NODE_TYPE_GEN_SCRIPT) --prefix=sol-flow-node-type \
+	$(Q)$(PYTHON) $(NODE_TYPE_GEN_SCRIPT) --prefix=sol-flow-node-type --namespace=$($(1)-namespace) \
 		--genspec-schema=$(NODE_TYPE_SCHEMA) $(1) $($(1)-hdr) $($(1)-src) $($(1)-desc)
 endef
 $(foreach gen,$(sort $(all-gens)),$(eval $(call make-gen,$(gen))))

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -85,7 +85,7 @@ PHONY += samples
 PRE_INSTALL := $(PC_GEN) $(SOL_LIB_OUTPUT) $(bins-out) $(modules-out) $(all-mod-descs)
 PRE_INSTALL += $(NODE_TYPE_SCHEMA_DEST) $(BOARD_DETECT_DEST) $(GDB_AUTOLOAD_PY_DEST)
 
-ifneq (,$(strip $(builtin-flows)))
+ifneq (,$(strip $(builtins-flow)))
 PRE_GEN += $(FLOW_BUILTINS_DESC)
 endif
 

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -7,13 +7,7 @@ sample-y :=
 # builtin objects, deps and configs lookup variables
 builtins :=
 builtin-cflags :=
-builtin-flows :=
-builtin-flow-metatype :=
-builtin-linux-micro :=
-builtin-pin-mux :=
 builtin-objs :=
-
-modules-linux-micro :=
 
 # module objects, deps and configs lookup variables
 modules :=
@@ -49,9 +43,6 @@ use-builtin-cflags =
 
 # vars to distinguish the modules types
 flow-dir := $(top_srcdir)src/modules/flow/
-linux-micro-dir := $(top_srcdir)src/modules/linux-micro/
-pin-mux-dir := $(top_srcdir)src/modules/pin-mux/
-flow-metatype-dir := $(top_srcdir)src/modules/flow-metatype/
 
 # build/debugging
 ifeq ($(V),1)

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -295,7 +295,7 @@ HEADER_GEN += $(LINUX_MICRO_BUILTINS_H)
 
 $(call add-template,$(LINUX_MICRO_BUILTINS_H_IN),$(LINUX_MICRO_BUILTINS_H))
 
-INITIAL_SERVICES := $(build_modulesdir)linux-micro/initial-service
+INITIAL_SERVICES := $(build_modulesdir)linux-micro/initial-services
 INITIAL_SERVICES_IN := $(top_srcdir)data/linux-micro/initial-services.in
 
 $(call add-template,$(INITIAL_SERVICES_IN),$(INITIAL_SERVICES))


### PR DESCRIPTION
## Changes
  + v2 (since #687):
    - fixes issue with modules only - linux-micro configuration;
  + v3 (since #688):
    - fixed string-uuid - got with semaphore's git rebase (thanks semaphore for doing your great job);

## Rationale
this series changes the generated source headers names and directory of installation, also fixes an misspelled initial-service file name.