### PR TITLE
build: add -lasan ldflags

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -407,14 +407,14 @@
         "value": "-fsanitize=undefined"
       },
       "ldflags": {
-        "value": "-fsanitize=undefined"
+        "value": "-fsanitize=undefined -lasan"
       }
     },
     {
       "dependency": "no_sanitize",
       "type": "ccode",
       "cflags": {
-        "value": "-fno-sanitize=all"
+        "value": "-fno-sanitize=all -lasan"
       }
     },
     {
@@ -424,7 +424,7 @@
         "value": "-fsanitize=address"
       },
       "ldflags": {
-        "value": "-fsanitize=address"
+        "value": "-fsanitize=address -lasan"
       }
     },
     {


### PR DESCRIPTION
Since gcc < 5.0 will not adjust the ldflags for us - given an -fsanitize
we should do so ourselves to be backward compatible with older gcc.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>