### PR TITLE
Build make check fbp bin v2

### DIFF
--- a/src/test-fbp/console-direction-vector.fbp
+++ b/src/test-fbp/console-direction-vector.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Generator failing to properly generate code
+
 _(constant/direction-vector:value=255|0|125) OUT -> IN c(console)
 _(constant/int:value=1) OUT -> INTERVAL _(timer) OUT -> QUIT _(app/quit)
 

--- a/src/test-fbp/converter-float-boolean.fbp
+++ b/src/test-fbp/converter-float-boolean.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Generator failing to properly generate code
+
 below_min(constant/float:value=9.9)
 above_max(constant/float:value=20.001)
 within_range(constant/float:value=15.38)

--- a/src/test-fbp/converter-float-direction-vector.fbp
+++ b/src/test-fbp/converter-float-direction-vector.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Generator failing to properly generate code
+
 XFloat(constant/float:value=20|0|100|1)
 YFloat(constant/float:value=40|0|100|1)
 ZFloat(constant/float:value=70|0|100|1)

--- a/src/test-fbp/converter-float-empty.fbp
+++ b/src/test-fbp/converter-float-empty.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Generator failing to properly generate code
+
 float_to_empty(converter/float-to-empty:range=min:0|max:20)
 match_ten(constant/float:value=10)
 

--- a/src/test-fbp/converter-float-rgb.fbp
+++ b/src/test-fbp/converter-float-rgb.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Generator failing to properly generate code
+
 RedFloat(constant/float:value=20|0|100|1)
 GreenFloat(constant/float:value=40|0|100|1)
 BlueFloat(constant/float:value=70|0|100|1)

--- a/src/test-fbp/converter-int-direction-vector.fbp
+++ b/src/test-fbp/converter-int-direction-vector.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Generator failing to properly generate code
+
 XInt(constant/int:value=20|0|100|1)
 YInt(constant/int:value=40|0|100|1)
 ZInt(constant/int:value=70|0|100|1)

--- a/src/test-fbp/converter-rgb-direction-vector.fbp
+++ b/src/test-fbp/converter-rgb-direction-vector.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Generator failing to properly generate code
+
 color(constant/rgb:value=255|255|255)
 rgb_to_direction_vector(converter/rgb-to-direction-vector)
 

--- a/src/test-fbp/converter-string-float.fbp
+++ b/src/test-fbp/converter-string-float.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Generator failing to properly generate code
+
 const_float(constant/float:value=3.1415)
 const_float_str(constant/string:value="3.141500")
 

--- a/src/test-fbp/converter-string-int.fbp
+++ b/src/test-fbp/converter-string-int.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Generator failing to properly generate code
+
 const_int(constant/int:value=666)
 const_int_str(constant/string:value="666")
 

--- a/src/test-fbp/declare.fbp
+++ b/src/test-fbp/declare.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Seems generator doesn't known about add_value option, so skipping by now
+
 DECLARE=MyAdder:fbp:_adder22.fbp
 
 _(constant/int:value=20) OUT -> IN adder(MyAdder)

--- a/src/test-fbp/drange-classify.fbp
+++ b/src/test-fbp/drange-classify.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Generator failing to properly generate code
+
 dbl_min(constant/float:value=2.2250738585072014e-308)
 two(constant/float:value=2)
 zero(constant/float:value=0)

--- a/src/test-fbp/drange-math.fbp
+++ b/src/test-fbp/drange-math.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Generator failing to properly generate code
+
 negative_val(constant/float:value=-365.017)
 positive_val(constant/float:value=183784.872)
 absolute_val(constant/float:value=365.017)

--- a/src/test-fbp/file-reader.fbp
+++ b/src/test-fbp/file-reader.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Due to path resolution to test-blob-data.txt we're disabling this test until we get it right
+
 reader(file/reader)
 blob_validator(test/blob-validator:expected="test validator data")
 file(constant/string:value="test-blob-data.txt") OUT -> PATH reader

--- a/src/test-fbp/file-writer.fbp
+++ b/src/test-fbp/file-writer.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Due to path resolution to file-writer-test.txt we're disabling this test until we get it right
+
 file_writer(file/writer)
 
 path(constant/string:value="file-writer-test.txt") OUT -> PATH file_writer

--- a/src/test-fbp/filter-repeated.fbp
+++ b/src/test-fbp/filter-repeated.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Generator failing to properly generate code
+
 filter_boolean(filter-repeated/boolean)
 filter_byte(filter-repeated/byte)
 filter_float(filter-repeated/float)

--- a/src/test-fbp/javascript.fbp
+++ b/src/test-fbp/javascript.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE It seems generator doesn't know about metatype 'js'
+
 DECLARE=MyScript:js:javascript.js
 
 _(constant/boolean:value=true) OUT -> IN_BOOLEAN s(MyScript)

--- a/src/test-fbp/parser-errors/anonymous-node-with-empty-parens.fbp
+++ b/src/test-fbp/parser-errors/anonymous-node-with-empty-parens.fbp
@@ -34,3 +34,5 @@ _()
 
 ## TEST-OUTPUT
 # anonymous-node-with-empty-parens.fbp:31:1 Anonymous node type must be defined. e.g. '_(nodetype)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/anonymous-node-without-component.fbp
+++ b/src/test-fbp/parser-errors/anonymous-node-without-component.fbp
@@ -34,3 +34,5 @@ _
 
 ## TEST-OUTPUT
 # anonymous-node-without-component.fbp:31:1 Anonymous node type must be defined. e.g. '_(nodetype)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/brackets-instead-of-parens.fbp
+++ b/src/test-fbp/parser-errors/brackets-instead-of-parens.fbp
@@ -34,3 +34,5 @@
 
 ## TEST-OUTPUT
 # brackets-instead-of-parens.fbp:31:1 Couldn't parse statement.
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/component-without-node.fbp
+++ b/src/test-fbp/parser-errors/component-without-node.fbp
@@ -34,3 +34,5 @@
 
 ## TEST-OUTPUT
 # component-without-node.fbp:31:1 Couldn't parse statement.
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-anon-without-component-2.fbp
+++ b/src/test-fbp/parser-errors/conn-anon-without-component-2.fbp
@@ -34,3 +34,5 @@ _() -> _()
 
 ## TEST-OUTPUT
 # conn-anon-without-component-2.fbp:31:1 Anonymous node type must be defined. e.g. '_(nodetype)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-anon-without-component-3.fbp
+++ b/src/test-fbp/parser-errors/conn-anon-without-component-3.fbp
@@ -34,3 +34,5 @@ foo(Foo) OUT -> IN _
 
 ## TEST-OUTPUT
 # conn-anon-without-component-3.fbp:31:20 Anonymous node type must be defined. e.g. '_(nodetype)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-anon-without-component-4.fbp
+++ b/src/test-fbp/parser-errors/conn-anon-without-component-4.fbp
@@ -34,3 +34,5 @@ foo(Foo) OUT -> IN _()
 
 ## TEST-OUTPUT
 # conn-anon-without-component-4.fbp:31:20 Anonymous node type must be defined. e.g. '_(nodetype)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-anon-without-component.fbp
+++ b/src/test-fbp/parser-errors/conn-anon-without-component.fbp
@@ -34,3 +34,5 @@ _ -> _
 
 ## TEST-OUTPUT
 # conn-anon-without-component.fbp:31:1 Anonymous node type must be defined. e.g. '_(nodetype)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-without-arrow-and-ports.fbp
+++ b/src/test-fbp/parser-errors/conn-without-arrow-and-ports.fbp
@@ -34,3 +34,5 @@ foo(Foo) bar(Bar)
 
 ## TEST-OUTPUT
 # conn-without-arrow-and-ports.fbp:31:13 Expected node and port while defining a connection. e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-without-arrow.fbp
+++ b/src/test-fbp/parser-errors/conn-without-arrow.fbp
@@ -34,3 +34,5 @@ foo(Foo) OUT IN bar(Bar)
 
 ## TEST-OUTPUT
 # conn-without-arrow.fbp:31:14 Expected '->' between connection statement. e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-without-both-ports.fbp
+++ b/src/test-fbp/parser-errors/conn-without-both-ports.fbp
@@ -34,3 +34,5 @@ foo(Foo) -> bar(Bar)
 
 ## TEST-OUTPUT
 # conn-without-both-ports.fbp:31:8 Expected node and port while defining a connection. e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-without-destination-port.fbp
+++ b/src/test-fbp/parser-errors/conn-without-destination-port.fbp
@@ -34,3 +34,5 @@ foo(Foo) -> IN bar(Bar)
 
 ## TEST-OUTPUT
 # conn-without-destination-port.fbp:31:8 Expected node and port while defining a connection. e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-without-destination.fbp
+++ b/src/test-fbp/parser-errors/conn-without-destination.fbp
@@ -34,3 +34,5 @@
 
 ## TEST-OUTPUT
 # conn-without-destination.fbp:31:1 Arrow symbol must appear between two port names
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-without-nodes.fbp
+++ b/src/test-fbp/parser-errors/conn-without-nodes.fbp
@@ -34,3 +34,5 @@ OUT -> IN
 
 ## TEST-OUTPUT
 # conn-without-nodes.fbp:31:1 Expected node and port while defining a connection. e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-without-port-index-closing-bracket.fbp
+++ b/src/test-fbp/parser-errors/conn-without-port-index-closing-bracket.fbp
@@ -34,3 +34,5 @@ foo PORT[123
 
 ## TEST-OUTPUT
 # conn-without-port-index-closing-bracket.fbp:31:13 Expected ']' after port index
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-without-port-index.fbp
+++ b/src/test-fbp/parser-errors/conn-without-port-index.fbp
@@ -34,3 +34,5 @@ foo PORT[
 
 ## TEST-OUTPUT
 # conn-without-port-index.fbp:31:10 Expected integer number for port index
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-without-target-port-anon-2.fbp
+++ b/src/test-fbp/parser-errors/conn-without-target-port-anon-2.fbp
@@ -34,3 +34,5 @@ foo(Foo) OUT -> _
 
 ## TEST-OUTPUT
 # conn-without-target-port-anon-2.fbp:31:17 Expected node and port while defining a connection. e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-without-target-port-anon-3.fbp
+++ b/src/test-fbp/parser-errors/conn-without-target-port-anon-3.fbp
@@ -34,3 +34,5 @@ foo(Foo) OUT -> _()
 
 ## TEST-OUTPUT
 # conn-without-target-port-anon-3.fbp:31:17 Expected node and port while defining a connection. e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-without-target-port-anon.fbp
+++ b/src/test-fbp/parser-errors/conn-without-target-port-anon.fbp
@@ -34,3 +34,5 @@ foo(Foo) OUT -> _(Bar)
 
 ## TEST-OUTPUT
 # conn-without-target-port-anon.fbp:31:17 Expected node and port while defining a connection. e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-without-target-port.fbp
+++ b/src/test-fbp/parser-errors/conn-without-target-port.fbp
@@ -34,3 +34,5 @@ foo(Foo) OUT -> bar(Bar)
 
 ## TEST-OUTPUT
 # conn-without-target-port.fbp:31:17 Expected node and port while defining a connection. e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-without-target.fbp
+++ b/src/test-fbp/parser-errors/conn-without-target.fbp
@@ -34,3 +34,5 @@ foo(Foo) OUT ->
 
 ## TEST-OUTPUT
 # conn-without-target.fbp:31:14 Expected node and port while defining a connection. e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-wrong-arrow-2.fbp
+++ b/src/test-fbp/parser-errors/conn-wrong-arrow-2.fbp
@@ -34,3 +34,5 @@ foo(Foo) OUT > IN bar(Bar)
 
 ## TEST-OUTPUT
 # conn-wrong-arrow-2.fbp:31:14 Expected '->' between connection statement. e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/conn-wrong-arrow.fbp
+++ b/src/test-fbp/parser-errors/conn-wrong-arrow.fbp
@@ -34,3 +34,5 @@ foo(Foo) OUT - IN bar(Bar)
 
 ## TEST-OUTPUT
 # conn-wrong-arrow.fbp:31:14 Expected '->' between connection statement. e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/declare-duplicate-type.fbp
+++ b/src/test-fbp/parser-errors/declare-duplicate-type.fbp
@@ -35,3 +35,5 @@ DECLARE=MyType:fbp:Other.fbp
 
 ## TEST-OUTPUT
 # declare-duplicate-type.fbp:32:9 Type 'MyType' already declared
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/duplicated-exported-port-2.fbp
+++ b/src/test-fbp/parser-errors/duplicated-exported-port-2.fbp
@@ -37,3 +37,5 @@ node(boolean/and)
 
 ## TEST-OUTPUT
 # duplicated-exported-port-2.fbp:32:17 Node 'node' and input port 'IN0' already exported as 'PORT_A' declared in 31:17
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/duplicated-exported-port-3.fbp
+++ b/src/test-fbp/parser-errors/duplicated-exported-port-3.fbp
@@ -37,3 +37,5 @@ node(boolean/filter)
 
 ## TEST-OUTPUT
 # duplicated-exported-port-3.fbp:32:20 Exported output port with name 'OUT' already declared in 31:19
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/duplicated-exported-port-4.fbp
+++ b/src/test-fbp/parser-errors/duplicated-exported-port-4.fbp
@@ -37,3 +37,5 @@ node(boolean/and)
 
 ## TEST-OUTPUT
 # duplicated-exported-port-4.fbp:32:18 Node 'node' and output port 'OUT' already exported as 'PORT_A' declared in 31:18
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/duplicated-exported-port.fbp
+++ b/src/test-fbp/parser-errors/duplicated-exported-port.fbp
@@ -37,3 +37,5 @@ node(boolean/and)
 
 ## TEST-OUTPUT
 # duplicated-exported-port.fbp:32:17 Exported input port with name 'IN' already declared in 31:17
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/exported-port-missing-closing-bracket.fbp
+++ b/src/test-fbp/parser-errors/exported-port-missing-closing-bracket.fbp
@@ -36,3 +36,5 @@ node(boolean/and)
 
 ## TEST-OUTPUT
 # exported-port-missing-closing-bracket.fbp:31:17 Expected ']' after port index
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/exported-port-no-index.fbp
+++ b/src/test-fbp/parser-errors/exported-port-no-index.fbp
@@ -36,3 +36,5 @@ node(boolean/and)
 
 ## TEST-OUTPUT
 # exported-port-no-index.fbp:31:16 Expected integer number for port index
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/foo-equals-foo.fbp
+++ b/src/test-fbp/parser-errors/foo-equals-foo.fbp
@@ -34,3 +34,5 @@ foo=Foo
 
 ## TEST-OUTPUT
 # foo-equals-foo.fbp:31:1 Expected node and port while defining a connection. e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/multi-conn-without-arrow.fbp
+++ b/src/test-fbp/parser-errors/multi-conn-without-arrow.fbp
@@ -34,3 +34,5 @@ foo(Foo) OUT -> IN bar(Bar) OUTPUT INPUT xpto(Xpto)
 
 ## TEST-OUTPUT
 # multi-conn-without-arrow.fbp:31:36 Expected '->' between connection statement. e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/multi-conn-without-destination-port.fbp
+++ b/src/test-fbp/parser-errors/multi-conn-without-destination-port.fbp
@@ -34,3 +34,5 @@ foo(Foo) OUT -> IN bar(Bar) -> INPUT xpto(Xpto)
 
 ## TEST-OUTPUT
 # multi-conn-without-destination-port.fbp:31:29 Arrow symbol must appear between two port names
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/multi-conn-without-ports.fbp
+++ b/src/test-fbp/parser-errors/multi-conn-without-ports.fbp
@@ -34,3 +34,5 @@ foo(Foo) OUT -> IN bar(Bar) -> xpto(Xpto)
 
 ## TEST-OUTPUT
 # multi-conn-without-ports.fbp:31:29 Arrow symbol must appear between two port names
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/multi-conn-without-target-port.fbp
+++ b/src/test-fbp/parser-errors/multi-conn-without-target-port.fbp
@@ -34,3 +34,5 @@ foo(Foo) OUT -> IN bar(Bar) OUTPUT -> xpto(Xpto)
 
 ## TEST-OUTPUT
 # multi-conn-without-target-port.fbp:31:39 Expected node and port while defining a connection. e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/multi-conn-wrong-arrow-2.fbp
+++ b/src/test-fbp/parser-errors/multi-conn-wrong-arrow-2.fbp
@@ -34,3 +34,5 @@ foo(Foo) OUT -> IN bar(Bar) OUTPUT > INPUT xpto(Xpto)
 
 ## TEST-OUTPUT
 # multi-conn-wrong-arrow-2.fbp:31:36 Expected '->' between connection statement. e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/multi-conn-wrong-arrow.fbp
+++ b/src/test-fbp/parser-errors/multi-conn-wrong-arrow.fbp
@@ -34,3 +34,5 @@ foo(Foo) OUT -> IN bar(Bar) OUTPUT - INPUT xpto(Xpto)
 
 ## TEST-OUTPUT
 # multi-conn-wrong-arrow.fbp:31:36 Expected '->' between connection statement. e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/node-colon-foo.fbp
+++ b/src/test-fbp/parser-errors/node-colon-foo.fbp
@@ -34,3 +34,5 @@ Node:Foo
 
 ## TEST-OUTPUT
 # node-colon-foo.fbp:31:1 Expected node and port while defining a connection. e.g. 'node(nodetype) OUTPUT_PORT_NAME -> INPUT_PORT_NAME node2(nodetype2)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/node-defined-twice.fbp
+++ b/src/test-fbp/parser-errors/node-defined-twice.fbp
@@ -35,3 +35,5 @@ foo(boolean/not)
 
 ## TEST-OUTPUT
 # node-defined-twice.fbp:32:1 Node 'foo' already declared with type 'boolean/and' at 31:1
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/node-starting-with-underscore-without-component.fbp
+++ b/src/test-fbp/parser-errors/node-starting-with-underscore-without-component.fbp
@@ -34,3 +34,5 @@ _foo
 
 ## TEST-OUTPUT
 # node-starting-with-underscore-without-component.fbp:31:1 Node '_foo' doesn't have a type, Node type must be defined. e.g. 'node(nodetype)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/node-with-empty-parens.fbp
+++ b/src/test-fbp/parser-errors/node-with-empty-parens.fbp
@@ -34,3 +34,5 @@ foo()
 
 ## TEST-OUTPUT
 # node-with-empty-parens.fbp:31:1 Node 'foo' doesn't have a type, Node type must be defined. e.g. 'node(nodetype)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/node-without-component.fbp
+++ b/src/test-fbp/parser-errors/node-without-component.fbp
@@ -34,3 +34,5 @@ foo
 
 ## TEST-OUTPUT
 # node-without-component.fbp:31:1 Node 'foo' doesn't have a type, Node type must be defined. e.g. 'node(nodetype)'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/parser-errors/options-wrong-types.fbp
+++ b/src/test-fbp/parser-errors/options-wrong-types.fbp
@@ -36,3 +36,5 @@ foo(console:prefix="prefix",suffix=10,output_on_stdout="really!",random_option=t
 # options-wrong-types.fbp:31:39 Option 'output_on_stdout' (boolean) of node 'foo' must not be quoted since it's not a string
 # options-wrong-types.fbp:31:66 Unknown option name 'random_option' of node 'foo'
 # options-wrong-types.fbp:31:85 Couldn't parse value 'now' for option 'flush' (boolean) of node 'foo'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose
+

--- a/src/test-fbp/rgb.fbp
+++ b/src/test-fbp/rgb.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Generator failing to properly generate code
+
 Color(color/luminance-rgb:color=255|100|0|255|255|255)
 Luminance(constant/int:value=50|0|100|1) OUT -> IN Color
 

--- a/src/test-fbp/switcher-simple-forward.fbp
+++ b/src/test-fbp/switcher-simple-forward.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Generator failing to properly generate code
+
 const_boolean(constant/boolean:value=1)
 const_byte(constant/byte:value=10)
 const_float(constant/float:value=100.5)

--- a/src/test-fbp/test-json-confguration.fbp
+++ b/src/test-fbp/test-json-confguration.fbp
@@ -34,3 +34,4 @@ _(constant/int:value=1) OUT -> INTERVAL _(timer) OUT -> QUIT _(app/quit)
 ## TEST-OUTPUT
 # -=-=- soletta -=-=-4 (integer range)
 
+## TEST-SKIP-COMPILE Generator will not know how to resolve TestConsole

--- a/src/test-fbp/types-to-empty.fbp
+++ b/src/test-fbp/types-to-empty.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Generator failing to properly generate code
+
 const_true(constant/boolean:value=true)
 const_byte(constant/byte:value=127)
 const_int(constant/int:value=10)

--- a/src/test-fbp/wave-generator.fbp
+++ b/src/test-fbp/wave-generator.fbp
@@ -28,6 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## TEST-SKIP-COMPILE Generator failing to properly generate code
+
 # 15 samples for each
 tick_gen(test/boolean-generator:sequence="TTTTTTTTTTTTTTT",interval=0)
 

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -118,13 +118,16 @@ parse-test = \
 	$(eval $(1)-deps      := $(subst .mod,,$($(3)-$(1)-y-deps))) \
 	$(eval tests-out      += $(test-$(1)-out)) \
 
+gen-fbp-common = \
+	$(eval $(1)-src     := $(subst $(top_srcdir)src/,$(build_stagedir),$(subst .fbp,-gen.c,$(1)))) \
+	$(eval all-fbp-gens += $(1)) \
+
 gen-fbp-artifact = \
 	$(foreach fbp,$(filter %.fbp,$(2)), \
-		$(eval $(fbp)-src       := $(subst $(top_srcdir)src/,$(build_stagedir),$(subst .fbp,-gen.c,$(fbp)))) \
+		$(call gen-fbp-common,$(fbp)) \
 		$(eval $(fbp)-conffile  := $(4)) \
 		$(eval $(3)             += $($(fbp)-src)) \
 		$(eval sample-$(1)-gens += $(fbp)) \
-		$(eval all-fbp-gens     += $(fbp)) \
 	) \
 
 parse-sample = \
@@ -201,12 +204,22 @@ extra-bins = \
 		$(eval all-dest-bin += $($(bin)-dest)) \
 	) \
 
+parse-tests-fbp-bin = \
+	$(foreach fbp,$(tests-fbp-bin), \
+		$(eval curr := $(subst $(abspath $(top_srcdir))/,$(top_srcdir),$(fbp))) \
+		$(call gen-fbp-common,$(curr)) \
+		$(eval $(curr)-out := $(subst -gen.c,,$($(curr)-src))) \
+		$(eval all-tests-fbp-bin += $(curr)) \
+		$(eval all-tests-fbp-bin-out += $($(curr)-out)) \
+	) \
+
 ifneq ($(M),)
 SUBDIRS += $(M)/
 endif # $(M)
 
 $(eval $(call inc-subdirs))
 $(eval $(call extra-bins))
+$(eval $(call parse-tests-fbp-bin))
 
 PRE_GEN += $(all-gen-hdrs) $(all-dest-hdr) $(all-dest-bin)
 
@@ -263,6 +276,14 @@ $(sample-$(1)-out): $(SOL_LIB_OUTPUT) $(sample-$(1)-srcs) $(call find-deps,$(1))
 	$(sample-$(1)-ldflags) $(sort $(builtin-ldflags))
 endef
 $(foreach sample,$(samples),$(eval $(call make-sample,$(sample))))
+
+define make-test-fbp-bin
+$($(1)-out): $(SOL_LIB_OUTPUT) $($(1)-src) $(modules-out)
+	$(Q)echo "     " CC"   "$$@
+	$(Q)$(MKDIR) -p $(dir $($(1)-out))
+	$(Q)$(TARGETCC) $(SAMPLE_CFLAGS) $(modules-out) $($(1)-src) -o $($(1)-out) $(SAMPLE_LDFLAGS)
+endef
+$(foreach test-fbp-bin,$(all-tests-fbp-bin),$(eval $(call make-test-fbp-bin,$(test-fbp-bin))))
 
 ifeq (y,$(STATIC_LIBRARY))
 use-builtin-ldflags = $(sort $(builtin-ldflags))

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -8,6 +8,12 @@ check-fbp: $(SOL_LIB_OUTPUT) $(bins-out) $(modules-out)
 
 PHONY += check-fbp
 
+check-fbp-bin: $(SOL_LIB_OUTPUT) $(bins-out) $(modules-out) $(all-tests-fbp-bin-out)
+	$(Q)$(PYTHON) $(TEST_FBP_SCRIPT) --compiled --compiled-dir $(abspath $(build_stagedir)test-fbp/) \
+		--skip SKIP_SIMPLE SKIP_COMPILE SKIP_VALGRIND
+
+PHONY += check-fbp-bin
+
 ifeq (y,$(HAVE_VALGRIND))
 check-valgrind: $(SOL_LIB_OUTPUT) $(tests-out)
 	$(Q)$(PYTHON) $(TEST_SUITE_RUN_SCRIPT) --tests="$(tests-out)" \

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -4,6 +4,8 @@ bin-y :=
 test-y :=
 sample-y :=
 
+tests-fbp-bin :=
+
 # builtin objects, deps and configs lookup variables
 builtins :=
 builtin-cflags :=
@@ -381,3 +383,7 @@ kconfig-targets := config nconfig menuconfig xconfig gconfig oldconfig localmodc
 		randconfig listnewconfig olddefconfig kvmconfig tinyconfig help
 
 dep-avoid-targets := $(kconfig-targets) $(warning-targets) clean distclean
+
+ifneq (,$(filter check-fbp-bin,$(MAKECMDGOALS)))
+tests-fbp-bin := $(shell $(TEST_FBP_SCRIPT) --query-only --skip SKIP_SIMPLE SKIP_VALGRIND SKIP_COMPILE)
+endif

--- a/tools/run-fbp-tests
+++ b/tools/run-fbp-tests
@@ -39,10 +39,105 @@ from io import open
 
 import argparse
 import difflib
+import logging
 import os
 import re
 import subprocess
 import sys
+
+DEFAULT_VALGRIND_OPTS = (
+    "--show-reachable=no",
+    "--quiet",
+    "--error-exitcode=1",
+    "--leak-check=full",
+)
+
+class FbpTest:
+    SKIP_NONE = 0
+    SKIP_SIMPLE = 1
+    SKIP_VALGRIND = 2
+    SKIP_COMPILE = 3
+
+    SUPPORTED_SKIP = {
+        "TEST-SKIP": SKIP_SIMPLE,
+        "TEST-SKIP-VALGRIND": SKIP_VALGRIND,
+        "TEST-SKIP-COMPILE": SKIP_COMPILE,
+    }
+
+    def __init__(self, test_file):
+        self.test_file = test_file
+        self.skip_msg = None
+        self.skip = self.SKIP_NONE
+        self.output = False
+        self.output_regex = False
+        self.output_spec = ""
+        self.exit_code = 0
+
+        self._parse_test()
+
+    def _parse_skip(self, cmd, splitted):
+        self.skip = self.SUPPORTED_SKIP.get(cmd, self.SKIP_NONE)
+        if not self.skip:
+            return
+
+        if len(splitted) > 2:
+            self.skip_msg = splitted[2]
+
+    def _parse_command(self, line):
+        splitted = line.split(None, 2)
+        cmd = splitted[1]
+
+        if cmd == "TEST-OUTPUT-REGEX":
+            self.output_regex = True
+        elif cmd == "TEST-OUTPUT":
+            self.output = True
+        elif cmd == "TEST-EXPECTS-ERROR":
+            self.exit_code = 1
+        elif cmd.startswith("TEST-SKIP"):
+            self._parse_skip(cmd, splitted)
+        else:
+            logging.info("Ignoring unknown test command '%s' in test %s" %
+                         (cmd, self.test_file))
+
+    def _parse_test(self):
+        for line in open(self.test_file, encoding="UTF-8"):
+            if line.startswith("## "):
+                self._parse_command(line)
+            elif (self.output or self.output_regex) and line.startswith("#"):
+                self.output_spec += line[2:] or "\n"
+
+    def should_skip(self, skips):
+        if self.skip == self.SKIP_NONE:
+            return False
+        elif self.skip in skips:
+            return True
+        return False
+
+    def show_result_status(self, out, code):
+        if self.output and self.output_spec != out:
+            orig = out.splitlines(True)
+            dest = self.output_spec.splitlines(True)
+            logging.warning("FAILED running %s: wrong output" % os.path.basename(self.test_file))
+            for line in difflib.unified_diff(orig, dest):
+                sys.stdout.write(line)
+            return "failed"
+        elif self.output_regex and not re.match(self.output_spec, out):
+            logging.warning("FAILED running %s: wrong output" % os.path.basename(self.test_file))
+            logging.warning("Expected expression:")
+            logging.warning(self.output_spec)
+            logging.warning("Output:")
+            logging.warning(out)
+            return "failed"
+        elif self.exit_code != code:
+            logging.warning("FAILED running %s: wrong exit code, got %d but expected %d" %
+                            (os.path.basename(self.test_file), code, self.exit_code))
+            logging.warning("Output:")
+            logging.warning(out)
+            return "failed"
+        elif self.output is None and len(out) > 0:
+            logging.warning("IGNORING unexpected output from", os.path.basename(self.test_file))
+            logging.warning(out)
+        return "passed"
 
 def sh(cmd, cwd=None):
     try:
@@ -67,146 +162,162 @@ def collect_tests(tests):
     for t in args.tests:
         t = os.path.abspath(t)
         if not os.path.exists(t):
-            print("Ignoring non-existent test file or directory", t)
+            logging.warning("Ignoring non-existent test file or directory", t)
             continue
 
         if os.path.isdir(t):
             collect_tests_dir(t, result)
         elif is_valid_fbp(t):
             result.append(t)
-    return result
+    return sorted(set(result))
 
-def get_expected(t, args):
-    code = 0
-    out = None
-    skip = None
-    is_regex = False
-
-    f = open(t, encoding="UTF-8")
-    for line in f:
-        if not line.startswith("## "):
-            continue
-        splitted = line.split(None, 2)
-        cmd = splitted[1]
-
-        if cmd == "TEST-OUTPUT-REGEX":
-            is_regex = True
-
-        if cmd == "TEST-EXPECTS-ERROR":
-            code = 1
-        elif cmd == "TEST-SKIP-VALGRIND":
-            if args.valgrind:
-                if len(splitted) > 2:
-                    skip = splitted[2]
-                else:
-                    skip = ""
-        elif cmd == "TEST-SKIP":
-            if len(splitted) > 2:
-                skip = splitted[2]
-            else:
-                skip = ""
-        elif cmd in ["TEST-OUTPUT", "TEST-OUTPUT-REGEX"]:
-            out = ""
-            break
-        else:
-            print("Ignoring unknown test command '%s' in test %s" % (cmd, t))
-            continue
-
-    if out is not None:
-        for line in f:
-            if not line.startswith("#"):
-                break
-            out += line[2:] or '\n'
-    f.close()
-
-    return out, code, skip, is_regex
-
-if __name__ == "__main__":
+def valgrind_prepare(args):
     cmd_prefix = []
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--runner", help="Path to the sol-fbp-runner program", default="build/soletta_sysroot/usr/bin/sol-fbp-runner", type=str)
-    parser.add_argument("--valgrind", help="Enable valgrind, if path not passed, assume default location in the system", nargs='?', const="/usr/bin/valgrind", type=str)
-    parser.add_argument("--valgrind-supp", help="Path to valgrind's suppression file", type=str)
-    parser.add_argument("--verbose", help="Be verbose", dest="verbose", action="store_true")
-    parser.add_argument("tests", metavar="TEST", help="Path to FBP file or directory containing FBP file to be tested.", nargs='*', default=["src/test-fbp/"])
+    if not args.valgrind:
+        return cmd_prefix
 
-    args = parser.parse_args()
-    if args.valgrind:
-        valgrind = os.path.abspath(args.valgrind)
-        if not os.path.isfile(valgrind):
-            sys.exit("Couldn't find valgrind program at", valgrind)
-        cmd_prefix.extend([
-            valgrind,
-            "--show-reachable=no",
-            "--quiet",
-            "--error-exitcode=1",
-            "--leak-check=full",
-        ])
+    valgrind = os.path.abspath(args.valgrind)
+    if not os.path.isfile(valgrind) and os.access(valgrind, os.X_OK):
+        sys.exit("Couldn't find valid executable valgrind program at: %s, check if file "
+                 "exists and is executable" % valgrind)
+    valgrind_opts = list(DEFAULT_VALGRIND_OPTS)
+    valgrind_opts.insert(0, valgrind)
+    cmd_prefix.extend(valgrind_opts)
 
-        if args.valgrind_supp:
-            supp = os.path.abspath(args.valgrind_supp)
-            if not os.path.abspath(supp):
-                sys.exit("Couldn't find valgrind suppression file at", supp)
-            cmd_prefix.append("--suppressions=%s" % supp)
+    if args.valgrind_supp:
+        supp = os.path.abspath(args.valgrind_supp)
+        if not os.path.abspath(supp):
+            sys.exit("Couldn't find valgrind suppression file at", supp)
+        cmd_prefix.append("--suppressions=%s" % supp)
 
-    runner = os.path.abspath(args.runner)
-    if not os.path.isfile(runner):
-        sys.exit("Couldn't find runner program at %s" % runner)
+    return cmd_prefix
+
+def run_tests(args):
+    failures = False
+    runner = None
+
+    if not args.compiled:
+        runner = os.path.abspath(args.runner)
+        if not os.path.isfile(runner):
+            sys.exit("Couldn't find runner program at %s" % runner)
 
     tests = collect_tests(args.tests)
     if not tests:
         sys.exit("No test files found.")
 
-    passed = 0
-    failed = 0
-    skipped = 0
+    cmd_prefix = valgrind_prepare(args)
+    status = {
+        "passed": 0,
+        "failed": 0,
+        "skipped": 0
+    }
 
-    for t in sorted(set(tests)):
-        dir = os.path.dirname(t)
-        file = os.path.basename(t)
-        if args.verbose:
-            print("Testing file: %s/%s" % (dir, file))
-        expected_out, expected_code, skip, is_regex = get_expected(t, args)
-        if skip is not None:
-            print("SKIPPED running %s: %s" % (t, skip))
-            skipped += 1
+    skips = get_skip_list(args)
+    if args.valgrind:
+        skips.append(FbpTest.SKIP_VALGRIND)
+
+    for t in tests:
+        path = {
+            "dir": os.path.dirname(t),
+            "file": os.path.basename(t),
+        }
+
+        logging.debug("Testing file: %s" % t)
+
+        curr = FbpTest(t)
+        if curr.should_skip(skips):
+            logging.debug("SKIPPED running %s: %s" % (t, curr.skip_msg))
+            status["skipped"] += 1
             continue
 
-        out, code = sh(cmd_prefix + [runner, file], cwd=dir)
-        if expected_out is not None:
-            if is_regex:
-                if not re.match(expected_out, out):
-                    failed += 1
-                    print("FAILED running %s: wrong output" % t)
-                    print("Expected expression:")
-                    print(expected_out)
-                    print("Output:")
-                    print(out)
-                    print()
-                    continue
-            elif out != expected_out:
-                failed += 1
-                print("FAILED running %s: wrong output" % t)
-                for line in difflib.unified_diff(out.splitlines(True), expected_out.splitlines(True)):
-                    sys.stdout.write(line)
-                print()
-                continue
-        if expected_code != code:
-            failed += 1
-            print("FAILED running %s: wrong exit code, got %d but expected %d" % (t, code, expected_code))
-            print("Output:")
-            print(out)
-            print()
-            continue
-        if expected_out is None and len(out) > 0:
-            print("IGNORING unexpected output from", t)
-            print(out)
-        passed += 1
+        if not args.compiled:
+            cmd = cmd_prefix + [runner, path["file"]]
+            test_cwd = path["dir"]
+        else:
+            exe = os.path.join(args.compiled_dir, path["file"].replace(".fbp", ""))
+            cmd = cmd_prefix + [exe]
+            test_cwd = "./"
 
-    print("%d tests passed." % passed)
-    if skipped > 0:
-        print("%d tests skipped." % skipped)
-    if failed > 0:
-        print("%d tests failed." % failed)
+        out, code = sh(cmd, cwd=test_cwd)
+        result = curr.show_result_status(out, code)
+        status[result] += 1
+        if result == "failed":
+            failures = True
+
+    for k,v in status.items():
+        if v > 0:
+            logging.warning("%d tests %s." % (v, k))
+
+    if failures:
         sys.exit(1)
+
+def get_skip_list(args):
+    result = []
+    for curr in args.skip:
+        if not curr.upper().startswith('SKIP_'):
+            logging.info("Invalid skip spec: %s" % curr)
+            continue
+
+        skip = getattr(FbpTest, curr.upper(), None)
+        if not skip:
+            logging.info("Unknown skip spec: %s" % curr)
+
+        result.append(skip)
+    return set(result)
+
+def query_tests(args):
+    result = []
+    skips = get_skip_list(args)
+    tests = collect_tests(args.tests)
+    for t in tests:
+        curr = FbpTest(t)
+        if curr.should_skip(skips):
+            continue
+        result.append(t)
+    print(" ".join(result))
+
+def set_log_level(args):
+    if not args.log:
+        logging.debug("No log level specified, using default one: INFO")
+        level = logging.INFO
+    else:
+        level = getattr(logging, args.log.upper(), None)
+        if not level:
+            raise ValueError('Invalid log level: %s' % args.log)
+
+    root = logging.getLogger()
+    hdlr = root.handlers[0]
+    fmt = logging.Formatter('%(message)s')
+    hdlr.setFormatter(fmt)
+    hdlr.setLevel(level)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--runner", help="Path to the sol-fbp-runner program",
+                        default="build/soletta_sysroot/usr/bin/sol-fbp-runner", type=str)
+    parser.add_argument("--valgrind", help="Enable valgrind, if path not provided, assume "
+                        "default location in the system", nargs='?', const="/usr/bin/valgrind",
+                        type=str)
+    parser.add_argument("--valgrind-supp", help="Path to valgrind's suppression file",
+                        type=str)
+    parser.add_argument("--log", help="The log level, valid are: DEBUG, INFO, WARNING, ERROR, CRITICAL",
+                        type=str)
+    parser.add_argument("--query-only", help="Only query for tests expected to be run",
+                        action="store_true")
+    parser.add_argument("--skip", help="Skips to consider, valid values are: SKIP_SIMPLE, "
+                        "SKIP_VALGRIND, SKIP_COMPILE. SKIP_SIMPLE and SKIP_VALGRIND are considered "
+                        "by default", nargs="*", default=["SKIP_SIMPLE"])
+    parser.add_argument("tests", metavar="TEST", help="Path to FBP file or directory containing "
+                        "FBP file to be tested.", nargs='*', default=["src/test-fbp/"])
+    parser.add_argument("--compiled", help="Run compiled tests - not the FBPs themselves.",
+                        action="store_true")
+    parser.add_argument("--compiled-dir", help="Where to find the compiled tests.", type=str,
+                        default="build/stage/test-fbp")
+
+    args = parser.parse_args()
+    set_log_level(args)
+    if args.query_only:
+        query_tests(args)
+    else:
+        run_tests(args)


### PR DESCRIPTION
## Changes
  + v2 (since #694):
    + run-fbp-tests:
      - fixed issues pointed by @lpereira in the previous review;
      - changed the output handling to use logging instead of simply printing out;
        - with that also introduced the ```--log``` argument, so the user may specify the logging level;
    + Makefile.target:
      - dropped the ```*.txt``` copy from ```check-fbp-bin``` rule - we're skipping the reader/writer tests, as result we're not using these files at all;

## Rationale
Add's ```check-fbp-bin``` rules, for that changes and adaptations were required on ```run-fbp-tests``` scripts so we can query the "wanted" tests to be compiled with that the build system can handle the compilation itself. Also in the process of changing the ```run-fbp-tests``` scripts we incorporated a bunch of improvements and design changes.