### PR TITLE
build: link to static libasan

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -407,14 +407,14 @@
         "value": "-fsanitize=undefined"
       },
       "ldflags": {
-        "value": "-fsanitize=undefined -lasan"
+        "value": "-fsanitize=undefined -static-libasan"
       }
     },
     {
       "dependency": "no_sanitize",
       "type": "ccode",
       "cflags": {
-        "value": "-fno-sanitize=all -lasan"
+        "value": "-fno-sanitize=all -static-libasan"
       }
     },
     {
@@ -424,7 +424,7 @@
         "value": "-fsanitize=address"
       },
       "ldflags": {
-        "value": "-fsanitize=address -lasan"
+        "value": "-fsanitize=address -static-libasan"
       }
     },
     {


### PR DESCRIPTION
In the commit 202bff12f21b114d39b818b887ff94771a034c4d we changed the
sanitze dependencies to also force linking against libasan - in the
commit message we state that this would be harmless to newer gcc
versions. I turns out not to be true, if we're linking against the
shared libasan we should make sure to preload the lib or make sure it is
the first DSO name[1].

To avoid this kind of runtime issues we're forcing libasan to be
statically linked.

[1] -
https://github.com/gcc-mirror/gcc/blob/master/libsanitizer/asan/asan_linux.cc#L112

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>