### PR TITLE
Fixes

### DIFF
--- a/src/modules/flow/flower-power/Kconfig
+++ b/src/modules/flow/flower-power/Kconfig
@@ -1,7 +1,7 @@
 config FLOW_NODE_TYPE_FLOWER_POWER
 	tristate "Node type: flower-power"
 	depends on HTTP_CLIENT
-	default y
+	default m
 	help
 		Parrot Flower Power is a wireless plant monitor that measures
 		and analyses the four elements crucial to plant's health:

--- a/src/modules/flow/freegeoip/Kconfig
+++ b/src/modules/flow/freegeoip/Kconfig
@@ -1,7 +1,7 @@
 config FLOW_NODE_TYPE_FREEGEOIP
 	tristate "Node type: freegeoip"
 	depends on HTTP_CLIENT
-	default y
+	default m
 	help
 		Uses the free FreeGeoip service to obtain the location of
 		either a given IP address or the originating address.  The

--- a/src/modules/flow/freegeoip/freegeoip.c
+++ b/src/modules/flow/freegeoip/freegeoip.c
@@ -90,7 +90,7 @@ freegeoip_query_finished(void *data,
 #define JSON_FIELD_TO_FLOW_PORT(json_field_, flow_field_) \
     if (sol_json_token_str_eq(&key, json_field_, strlen(json_field_))) { \
         sol_flow_send_string_slice_packet(mdata->node, \
-            SOL_FLOW_NODE_TYPE_LOCATION_FREEGEOIP__OUT__ ## flow_field_, \
+            SOL_FLOW_NODE_TYPE_FREEGEOIP_LOCATION__OUT__ ## flow_field_, \
             SOL_STR_SLICE_STR(value.start + 1, value.end - value.start - 2)); \
         continue; \
     }
@@ -121,7 +121,7 @@ freegeoip_query_finished(void *data,
     /* `reason` is ignored here; only the following matters now: */
     if (!isnan(location.lat) && !isnan(location.lon)) {
         sol_flow_send_location_packet(mdata->node,
-            SOL_FLOW_NODE_TYPE_LOCATION_FREEGEOIP__OUT__LOCATION, &location);
+            SOL_FLOW_NODE_TYPE_FREEGEOIP_LOCATION__OUT__LOCATION, &location);
     }
 
     return;
@@ -205,11 +205,11 @@ static int
 freegeoip_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
 {
     struct freegeoip_data *mdata = data;
-    const struct sol_flow_node_type_location_freegeoip_options *opts;
+    const struct sol_flow_node_type_freegeoip_location_options *opts;
 
-    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_LOCATION_FREEGEOIP_OPTIONS_API_VERSION,
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_FREEGEOIP_LOCATION_OPTIONS_API_VERSION,
         -EINVAL);
-    opts = (const struct sol_flow_node_type_location_freegeoip_options *)options;
+    opts = (const struct sol_flow_node_type_freegeoip_location_options *)options;
 
     mdata->node = node;
     mdata->endpoint = strdup(opts->endpoint);

--- a/src/modules/flow/freegeoip/freegeoip.json
+++ b/src/modules/flow/freegeoip/freegeoip.json
@@ -14,7 +14,7 @@
         "open": "freegeoip_open",
         "close": "freegeoip_close"
       },
-      "name": "location/freegeoip",
+      "name": "freegeoip/location",
       "options": {
         "members": [
           {

--- a/src/modules/flow/string/string-icu.c
+++ b/src/modules/flow/string/string-icu.c
@@ -1063,7 +1063,7 @@ prefix_suffix_match_do(struct string_prefix_suffix_data *mdata,
     int32_t end;
     UErrorCode err;
     bool ret = false;
-    int32_t in_str_len, sub_str_len, off;
+    int32_t in_str_len = 0, sub_str_len, off;
 
     if (!new_in_str)
         goto starts_with;

--- a/src/modules/flow/thingspeak/Kconfig
+++ b/src/modules/flow/thingspeak/Kconfig
@@ -1,7 +1,7 @@
 config FLOW_NODE_TYPE_THINGSPEAK
 	tristate "Node type: thingspeak"
 	depends on HTTP_CLIENT
-	default y
+	default m
 	help
 		ThingSpeak is a service that allows publishing data via HTTP
 		to be consumed by IoT devices.

--- a/src/samples/flow/misc/freegeoip.fbp
+++ b/src/samples/flow/misc/freegeoip.fbp
@@ -42,7 +42,7 @@
 # Location: latitude=37.354, longitude=-121.956 altitude=0 (location)
 #
 
-_(constant/empty) OUT -> IN F(location/freegeoip)
+_(constant/empty) OUT -> IN F(freegeoip/location)
 
 F IP -> IN _(console:prefix="IP address: ")
 F COUNTRY_CODE -> IN _(console:prefix="Country code: ")


### PR DESCRIPTION
- netlink requests (using recvmsg instead of read) are not longer returning EINVAL
- freegeoip (allow build as module)
- Make the http nodes build as module (instead of builtin)