### PR TITLE
modules/byte: add comparison node types

### DIFF
--- a/src/modules/flow/byte/byte.json
+++ b/src/modules/flow/byte/byte.json
@@ -210,6 +210,204 @@
 
       "private_data_type": "byte_filter_data",
       "url": "http://solettaproject.org/doc/latest/node_types/byte/filter.html"
+    },
+    {
+      "category": "comparison/byte",
+      "description": "Check if an byte is equal to other.",
+      "in_ports": [
+        {
+          "data_type": "byte",
+          "description": "Two ports for equal comparison operation. Indexed from 0 to 1.",
+          "methods": {
+            "process": "comparison_process"
+          },
+          "name": "IN[2]"
+        }
+      ],
+      "name": "byte/equal",
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct byte_comparison_node_type",
+        "extra_methods": {
+          "func": "byte_val_equal"
+        }
+      },
+      "out_ports": [
+        {
+          "data_type": "boolean",
+          "description": "True if value received on port IN[0] is equal to value received on port IN[1].",
+          "name": "OUT"
+        }
+      ],
+      "private_data_type": "byte_comparison_data",
+      "url": "http://solettaproject.org/doc/latest/node_types/comparison/byte/equal.html"
+    },
+    {
+      "category": "comparison/byte",
+      "description": "Check if an byte is greater than other.",
+      "in_ports": [
+        {
+          "data_type": "byte",
+          "description": "Two ports for greater comparison operation. Indexed from 0 to 1, and IN[0] being the left operand.",
+          "methods": {
+            "process": "comparison_process"
+          },
+          "name": "IN[2]"
+        }
+      ],
+      "name": "byte/greater",
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct byte_comparison_node_type",
+        "extra_methods": {
+          "func": "byte_val_greater"
+        }
+      },
+      "out_ports": [
+        {
+          "data_type": "boolean",
+          "description": "True if value received on port IN[0] is greater than value received on port IN[1].",
+          "name": "OUT"
+        }
+      ],
+      "private_data_type": "byte_comparison_data",
+      "url": "http://solettaproject.org/doc/latest/node_types/comparison/byte/greater.html"
+    },
+    {
+      "category": "comparison/byte",
+      "description": "Check if an byte is greater than or equal to other.",
+      "in_ports": [
+        {
+          "data_type": "byte",
+          "description": "Two ports for greater-or-equal comparison operation. Indexed from 0 to 1, and IN[0] being the left operand.",
+          "methods": {
+            "process": "comparison_process"
+          },
+          "name": "IN[2]"
+        }
+      ],
+      "name": "byte/greater-or-equal",
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct byte_comparison_node_type",
+        "extra_methods": {
+          "func": "byte_val_greater_or_equal"
+        }
+      },
+      "out_ports": [
+        {
+          "data_type": "boolean",
+          "description": "True if value received on port IN[0] is greater than or equal to value received on port IN[1].",
+          "name": "OUT"
+        }
+      ],
+      "private_data_type": "byte_comparison_data",
+      "url": "http://solettaproject.org/doc/latest/node_types/comparison/byte/greater-or-equal.html"
+    },
+    {
+      "category": "comparison/byte",
+      "description": "Check if an byte is less than other.",
+      "in_ports": [
+        {
+          "data_type": "byte",
+          "description": "Two ports for less comparison operation. Indexed from 0 to 1, and IN[0] being the left operand.",
+          "methods": {
+            "process": "comparison_process"
+          },
+          "name": "IN[2]"
+        }
+      ],
+      "name": "byte/less",
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct byte_comparison_node_type",
+        "extra_methods": {
+          "func": "byte_val_less"
+        }
+      },
+      "out_ports": [
+        {
+          "data_type": "boolean",
+          "description": "True if value received on port IN[0] is less than value received on port IN[1].",
+          "name": "OUT"
+        }
+      ],
+      "private_data_type": "byte_comparison_data",
+      "url": "http://solettaproject.org/doc/latest/node_types/comparison/byte/less.html"
+    },
+    {
+      "category": "comparison/byte",
+      "description": "Check if an byte is less than or equal to other.",
+      "in_ports": [
+        {
+          "data_type": "byte",
+          "description": "Two ports for less-or-equal comparison operation. Indexed from 0 to 1, and IN[0] being the left operand.",
+          "methods": {
+            "process": "comparison_process"
+          },
+          "name": "IN[2]"
+        }
+      ],
+      "name": "byte/less-or-equal",
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct byte_comparison_node_type",
+        "extra_methods": {
+          "func": "byte_val_less_or_equal"
+        }
+      },
+      "out_ports": [
+        {
+          "data_type": "boolean",
+          "description": "True if value received on port IN[0] is less than or equal to value received on port IN[1].",
+          "name": "OUT"
+        }
+      ],
+      "private_data_type": "byte_comparison_data",
+      "url": "http://solettaproject.org/doc/latest/node_types/comparison/byte/less-or-equal.html"
+    },
+    {
+      "category": "comparison/byte",
+      "description": "Check if an byte is different from other.",
+      "in_ports": [
+        {
+          "data_type": "byte",
+          "description": "Two ports for not-equal comparison operation. Indexed from 0 to 1",
+          "methods": {
+            "process": "comparison_process"
+          },
+          "name": "IN[2]"
+        }
+      ],
+      "name": "byte/not-equal",
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct byte_comparison_node_type",
+        "extra_methods": {
+          "func": "byte_val_not_equal"
+        }
+      },
+      "out_ports": [
+        {
+          "data_type": "boolean",
+          "description": "True if value received on port IN[0] is different from value received on port IN[1].",
+          "name": "OUT"
+        }
+      ],
+      "private_data_type": "byte_comparison_data",
+      "url": "http://solettaproject.org/doc/latest/node_types/comparison/byte/not-equal.html"
     }
   ]
 }

--- a/src/test-fbp/byte-comparison.fbp
+++ b/src/test-fbp/byte-comparison.fbp
@@ -14,7 +14,7 @@
 #     distribution.
 #   * Neither the name of Intel Corporation nor the names of its
 #     contributors may be used to endorse or promote products derived
-#     from this software without specific prior written permission.
+#     from this software without specific prior writmed permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -28,13 +28,38 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-const_byte(constant/byte:value=14)
-const_byte_str(constant/string:value=0x0e)
+med(constant/byte:value=0x80)
+low(constant/byte:value=0x0c)
+high(constant/byte:value=0xde)
 
-const_byte OUT -> IN byte_to_str(converter/byte-to-string) OUT -> IN[0] str_cmp(string/compare)
-const_byte_str OUT -> IN[1] str_cmp EQUAL -> RESULT byte_converts_to_string(test/result)
+low OUT -> IN[0] equal(byte/equal)
+low OUT -> IN[1] equal
+equal OUT -> RESULT r_equal(test/result)
 
-byte_to_str OUT -> IN str_to_byte(converter/string-to-byte)
-str_to_byte OUT -> IN[0] is_byte_equal(byte/equal)
-const_byte OUT -> IN[1] is_byte_equal
-is_byte_equal OUT -> RESULT string_converts_to_byte(test/result)
+med OUT -> IN[0] not_equal(byte/not-equal)
+high OUT -> IN[1] not_equal
+not_equal OUT -> RESULT r_not_equal(test/result)
+
+med OUT -> IN[0] greater(byte/greater)
+low OUT -> IN[1] greater
+greater OUT -> RESULT r_greater(test/result)
+
+med OUT -> IN[0] greater_or_equal_greater(byte/greater-or-equal)
+low OUT -> IN[1] greater_or_equal_greater
+greater_or_equal_greater OUT -> RESULT r_greater_or_equal_greater(test/result)
+
+low OUT -> IN[0] greater_or_equal_equal(byte/greater-or-equal)
+low OUT -> IN[1] greater_or_equal_equal
+greater_or_equal_equal OUT -> RESULT r_greater_or_equal_equal(test/result)
+
+low OUT -> IN[0] less(byte/less)
+high OUT -> IN[1] less
+less OUT -> RESULT r_less(test/result)
+
+low OUT -> IN[0] less_or_equal_less(byte/less-or-equal)
+med OUT -> IN[1] less_or_equal_less
+less_or_equal_less OUT -> RESULT r_less_or_equal_less(test/result)
+
+high OUT -> IN[0] less_or_equal_equal(byte/less-or-equal)
+high OUT -> IN[1] less_or_equal_equal
+less_or_equal_equal OUT -> RESULT r_less_or_equal_equal(test/result)

--- a/src/test-fbp/converter-boolean-byte.fbp
+++ b/src/test-fbp/converter-boolean-byte.fbp
@@ -49,13 +49,13 @@ byte_to_boolean_within OUT -> RESULT result_within_range(test/result)
 
 true(constant/boolean:value=true)
 false(constant/boolean:value=false)
-true_value(constant/int:value=117)
-false_value(constant/int:value=254)
+true_value(constant/byte:value=117)
+false_value(constant/byte:value=254)
 boolean_to_byte_true(converter/boolean-to-byte:true_value=117,false_value=254)
 boolean_to_byte_false(converter/boolean-to-byte:true_value=117,false_value=254)
 
-true OUT -> IN boolean_to_byte_true OUT -> IN _(converter/byte-to-int) OUT -> IN[0] cmp_true(int/equal)
+true OUT -> IN boolean_to_byte_true OUT -> IN[0] cmp_true(byte/equal)
 true_value OUT -> IN[1] cmp_true OUT -> RESULT result_true(test/result)
 
-false OUT -> IN boolean_to_byte_false OUT -> IN _(converter/byte-to-int) OUT -> IN[0] cmp_false(int/equal)
+false OUT -> IN boolean_to_byte_false OUT -> IN[0] cmp_false(byte/equal)
 false_value OUT -> IN[1] cmp_false OUT -> RESULT result_false(test/result)

--- a/src/test-fbp/converter-direction-vector-byte.fbp
+++ b/src/test-fbp/converter-direction-vector-byte.fbp
@@ -37,17 +37,17 @@ XByte OUT -> X byte_to_direction_vector
 YByte OUT -> Y byte_to_direction_vector
 ZByte OUT -> Z byte_to_direction_vector
 
-match_twenty(constant/int:value=20)
-match_eighty(constant/int:value=80)
-match_seventy(constant/int:value=70)
+match_twenty(constant/byte:value=20)
+match_eighty(constant/byte:value=80)
+match_seventy(constant/byte:value=70)
 
 byte_to_direction_vector OUT -> IN direction_vector_to_byte(converter/direction-vector-to-byte)
 
-direction_vector_to_byte X -> IN _(converter/byte-to-int) OUT -> IN[0] eq_twenty(int/equal)
+direction_vector_to_byte X -> IN[0] eq_twenty(byte/equal)
 match_twenty OUT -> IN[1] eq_twenty OUT -> RESULT x(test/result)
 
-direction_vector_to_byte Y -> IN _(converter/byte-to-int) OUT -> IN[0] eq_eighty(int/equal)
+direction_vector_to_byte Y -> IN[0] eq_eighty(byte/equal)
 match_eighty OUT -> IN[1] eq_eighty OUT -> IN _(boolean/not) OUT -> RESULT y(test/result)
 
-direction_vector_to_byte Z -> IN _(converter/byte-to-int) OUT -> IN[0] eq_seventy(int/equal)
+direction_vector_to_byte Z -> IN[0] eq_seventy(byte/equal)
 match_seventy OUT -> IN[1] eq_seventy OUT -> RESULT z(test/result)

--- a/src/test-fbp/converter-rgb-byte.fbp
+++ b/src/test-fbp/converter-rgb-byte.fbp
@@ -37,17 +37,17 @@ RedByte OUT -> RED byte_to_rgb
 GreenByte OUT -> GREEN byte_to_rgb
 BlueByte OUT -> BLUE byte_to_rgb
 
-match_twenty(constant/int:value=20)
-match_eighty(constant/int:value=80)
-match_seventy(constant/int:value=70)
+match_twenty(constant/byte:value=20)
+match_eighty(constant/byte:value=80)
+match_seventy(constant/byte:value=70)
 
 byte_to_rgb OUT -> IN rgb_to_byte(converter/rgb-to-byte)
 
-rgb_to_byte RED -> IN _(converter/byte-to-int) OUT -> IN[0] eq_twenty(int/equal)
+rgb_to_byte RED -> IN[0] eq_twenty(byte/equal)
 match_twenty OUT -> IN[1] eq_twenty OUT -> RESULT red(test/result)
 
-rgb_to_byte GREEN -> IN _(converter/byte-to-int) OUT -> IN[0] eq_eighty(int/equal)
+rgb_to_byte GREEN -> IN[0] eq_eighty(byte/equal)
 match_eighty OUT -> IN[1] eq_eighty OUT -> IN _(boolean/not) OUT -> RESULT green(test/result)
 
-rgb_to_byte BLUE -> IN _(converter/byte-to-int) OUT -> IN[0] eq_seventy(int/equal)
+rgb_to_byte BLUE -> IN[0] eq_seventy(byte/equal)
 match_seventy OUT -> IN[1] eq_seventy OUT -> RESULT blue(test/result)

--- a/src/test-fbp/led-7seg-char-to-byte.fbp
+++ b/src/test-fbp/led-7seg-char-to-byte.fbp
@@ -29,50 +29,50 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 null_str(constant/string:value="")
-null_byte(constant/int:value=0)
+null_byte(constant/byte:value=0)
 null_conv(led-7seg/char-to-byte)
-null_equal(int/equal)
+null_equal(byte/equal)
 space_str(constant/string:value=" ")
-space_byte(constant/int:value=0)
+space_byte(constant/byte:value=0)
 space_conv(led-7seg/char-to-byte)
-space_equal(int/equal)
+space_equal(byte/equal)
 five_str(constant/string:value="5")
-five_byte(constant/int:value=0xb6)
+five_byte(constant/byte:value=0xb6)
 five_conv(led-7seg/char-to-byte)
-five_equal(int/equal)
+five_equal(byte/equal)
 J_str(constant/string:value="J")
-J_byte(constant/int:value=0x78)
+J_byte(constant/byte:value=0x78)
 J_conv(led-7seg/char-to-byte)
-J_equal(int/equal)
+J_equal(byte/equal)
 l_str(constant/string:value="l")
-l_byte(constant/int:value=0x60)
+l_byte(constant/byte:value=0x60)
 l_conv(led-7seg/char-to-byte)
-l_equal(int/equal)
+l_equal(byte/equal)
 w_str(constant/string:value="w")
 w_conv(led-7seg/char-to-byte)
 
 null_str OUT -> IN null_conv
-null_conv OUT -> IN _(converter/byte-to-int) OUT -> IN[0] null_equal
+null_conv OUT -> IN[0] null_equal
 null_byte OUT -> IN[1] null_equal
 null_equal OUT -> RESULT led_char_byte_null(test/result)
 
 space_str OUT -> IN space_conv
-space_conv OUT -> IN _(converter/byte-to-int) OUT -> IN[0] space_equal
+space_conv OUT -> IN[0] space_equal
 space_byte OUT -> IN[1] space_equal
 space_equal OUT -> RESULT led_char_byte_space(test/result)
 
 five_str OUT -> IN five_conv
-five_conv OUT -> IN _(converter/byte-to-int) OUT -> IN[0] five_equal
+five_conv OUT -> IN[0] five_equal
 five_byte OUT -> IN[1] five_equal
 five_equal OUT -> RESULT led_char_byte_five(test/result)
 
 J_str OUT -> IN J_conv
-J_conv OUT -> IN _(converter/byte-to-int) OUT -> IN[0] J_equal
+J_conv OUT -> IN[0] J_equal
 J_byte OUT -> IN[1] J_equal
 J_equal OUT -> RESULT led_char_byte_J(test/result)
 
 l_str OUT -> IN l_conv
-l_conv OUT -> IN _(converter/byte-to-int) OUT -> IN[0] l_equal
+l_conv OUT -> IN[0] l_equal
 l_byte OUT -> IN[1] l_equal
 l_equal OUT -> RESULT led_char_byte_l(test/result)
 

--- a/src/test-fbp/switcher-simple-forward.fbp
+++ b/src/test-fbp/switcher-simple-forward.fbp
@@ -65,8 +65,8 @@ const_boolean OUT -> IN[0] hub_empty
 hub_empty OUT[0] -> IN empty_to_boolean OUT -> RESULT result_switcher_empty(test/result)
 
 const_byte OUT -> IN[0] hub_byte
-const_int OUT -> IN[0] byte_equal(int/equal)
-hub_byte OUT[0] -> IN _(converter/byte-to-int) OUT -> IN[1] byte_equal
+const_byte OUT -> IN[0] byte_equal(byte/equal)
+hub_byte OUT[0] -> IN[1] byte_equal
 byte_equal OUT -> RESULT result_switcher_byte(test/result)
 
 const_float OUT -> IN[0] hub_float


### PR DESCRIPTION
It has been a bit frequent to convert bytes to int to make
comparisons, so let's make this operation easier adding
node types to do it directly.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>