### PR TITLE
Basic implementantion of machine_id and serial number for RIOT

### DIFF
--- a/src/lib/common/sol-platform.c
+++ b/src/lib/common/sol-platform.c
@@ -367,7 +367,9 @@ sol_platform_get_machine_id(char id[static 33])
 SOL_API int
 sol_platform_get_serial_number(char **number)
 {
+#ifdef SOL_PLATFORM_LINUX
     char *env_id;
+#endif
 
     SOL_NULL_CHECK(number, -EINVAL);
 

--- a/src/modules/linux-micro/machine-id/machine-id.c
+++ b/src/modules/linux-micro/machine-id/machine-id.c
@@ -94,7 +94,7 @@ run_do(void)
         SOL_INT_CHECK(r, == 0, 0);
     }
 
-    r = sol_util_uuid_gen(false, true, id);
+    r = sol_util_uuid_gen(false, false, id);
     SOL_INT_CHECK_GOTO(r, < 0, err);
 
     if (write_machine_id(etc_path, id) >= 0)

--- a/src/shared/sol-random.c
+++ b/src/shared/sol-random.c
@@ -86,7 +86,9 @@ getrandom_shim(void *buf, size_t buflen, unsigned int flags)
 static uint64_t
 get_platform_seed(uint64_t seed)
 {
+#ifdef SOL_PLATFORM_LINUX
     int ret;
+#endif /* SOL_PLATFORM_LINUX */
 
     /* If a seed is provided, use it. */
     if (seed)

--- a/src/shared/sol-util-contiki.c
+++ b/src/shared/sol-util-contiki.c
@@ -54,14 +54,3 @@ sol_util_timespec_get_realtime(struct timespec *t)
     errno = ENOSYS;
     return -1;
 }
-
-int
-sol_util_uuid_gen(bool upcase,
-    bool with_hyphens,
-    char id[static 37])
-{
-    //FIXME: use whatever source there is of pseudo-random numbers on
-    //Contiki
-    SOL_WRN("Not implemented");
-    return -ENOSYS;
-}

--- a/src/shared/sol-util-linux.c
+++ b/src/shared/sol-util-linux.c
@@ -30,9 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "sol-buffer.h"
 #include "sol-log.h"
-#include "sol-random.h"
 #include "sol-util.h"
 
 #include <ctype.h>
@@ -54,75 +52,4 @@ int
 sol_util_timespec_get_realtime(struct timespec *t)
 {
     return clock_gettime(CLOCK_REALTIME, t);
-}
-
-static struct sol_uuid
-assert_uuid_v4(struct sol_uuid id)
-{
-    id.bytes[6] = (id.bytes[6] & 0x0F) | 0x40;
-    id.bytes[8] = (id.bytes[8] & 0x3F) | 0x80;
-
-    return id;
-}
-
-static int
-uuid_gen(struct sol_uuid *ret)
-{
-    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(ret, sizeof(*ret),
-        SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
-    struct sol_random *engine;
-    ssize_t size;
-
-    SOL_NULL_CHECK(ret, -EINVAL);
-    engine = sol_random_new(SOL_RANDOM_DEFAULT, 0);
-    SOL_NULL_CHECK(engine, -errno);
-
-    size = sol_random_fill_buffer(engine, &buf, sizeof(*ret));
-    sol_random_del(engine);
-    sol_buffer_fini(&buf);
-
-    if (size != (ssize_t)sizeof(*ret))
-        return -EIO;
-
-    *ret = assert_uuid_v4(*ret);
-    return 0;
-}
-
-// 37 = 2 * 16 (chars) + 4 (hyphens) + 1 (\0)
-int
-sol_util_uuid_gen(bool upcase,
-    bool with_hyphens,
-    char id[static 37])
-{
-    static struct sol_str_slice hyphen = SOL_STR_SLICE_LITERAL("-");
-    /* hyphens on positions 8, 13, 18, 23 (from 0) */
-    static const int hyphens_pos[] = { 8, 13, 18, 23 };
-    struct sol_uuid uuid = { 0 };
-    unsigned i;
-    int r;
-
-    struct sol_buffer buf = { 0 };
-
-    sol_buffer_init_flags(&buf, id, 37,
-        SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
-
-    r = uuid_gen(&uuid);
-    SOL_INT_CHECK(r, < 0, r);
-
-    for (i = 0; i < ARRAY_SIZE(uuid.bytes); i++) {
-        r = sol_buffer_append_printf(&buf, upcase ? "%02hhX" : "%02hhx",
-            uuid.bytes[i]);
-        SOL_INT_CHECK_GOTO(r, < 0, err);
-    }
-
-    if (with_hyphens) {
-        for (i = 0; i < ARRAY_SIZE(hyphens_pos); i++) {
-            r = sol_buffer_insert_slice(&buf, hyphens_pos[i], hyphen);
-            SOL_INT_CHECK_GOTO(r, < 0, err);
-        }
-    }
-
-err:
-    sol_buffer_fini(&buf);
-    return r;
 }

--- a/src/shared/sol-util-riot.c
+++ b/src/shared/sol-util-riot.c
@@ -68,14 +68,3 @@ sol_util_timespec_get_realtime(struct timespec *t)
     return -1;
 #endif
 }
-
-int
-sol_util_uuid_gen(bool upcase,
-    bool with_hyphens,
-    char id[static 37])
-{
-    //FIXME: use whatever source there is of pseudo-random numbers on
-    //Riot
-    SOL_WRN("Not implemented");
-    return -ENOSYS;
-}

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -39,8 +39,10 @@
 #include <locale.h>
 #endif
 
+#include "sol-buffer.h"
 #include "sol-util.h"
 #include "sol-log.h"
+#include "sol-random.h"
 #include "sol-str-slice.h"
 
 #if defined(HAVE_NEWLOCALE) && defined(HAVE_STRTOD_L)
@@ -248,4 +250,75 @@ sol_util_str_split(const struct sol_str_slice slice,
 err:
     sol_vector_clear(&v);
     return v;
+}
+
+static struct sol_uuid
+assert_uuid_v4(struct sol_uuid id)
+{
+    id.bytes[6] = (id.bytes[6] & 0x0F) | 0x40;
+    id.bytes[8] = (id.bytes[8] & 0x3F) | 0x80;
+
+    return id;
+}
+
+static int
+uuid_gen(struct sol_uuid *ret)
+{
+    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(ret, sizeof(*ret),
+        SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+    struct sol_random *engine;
+    ssize_t size;
+
+    SOL_NULL_CHECK(ret, -EINVAL);
+    engine = sol_random_new(SOL_RANDOM_DEFAULT, 0);
+    SOL_NULL_CHECK(engine, -errno);
+
+    size = sol_random_fill_buffer(engine, &buf, sizeof(*ret));
+    sol_random_del(engine);
+    sol_buffer_fini(&buf);
+
+    if (size != (ssize_t)sizeof(*ret))
+        return -EIO;
+
+    *ret = assert_uuid_v4(*ret);
+    return 0;
+}
+
+// 37 = 2 * 16 (chars) + 4 (hyphens) + 1 (\0)
+int
+sol_util_uuid_gen(bool upcase,
+    bool with_hyphens,
+    char id[static 37])
+{
+    static struct sol_str_slice hyphen = SOL_STR_SLICE_LITERAL("-");
+    /* hyphens on positions 8, 13, 18, 23 (from 0) */
+    static const int hyphens_pos[] = { 8, 13, 18, 23 };
+    struct sol_uuid uuid = { 0 };
+    unsigned i;
+    int r;
+
+    struct sol_buffer buf = { 0 };
+
+    sol_buffer_init_flags(&buf, id, 37,
+        SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
+
+    r = uuid_gen(&uuid);
+    SOL_INT_CHECK(r, < 0, r);
+
+    for (i = 0; i < ARRAY_SIZE(uuid.bytes); i++) {
+        r = sol_buffer_append_printf(&buf, upcase ? "%02hhX" : "%02hhx",
+            uuid.bytes[i]);
+        SOL_INT_CHECK_GOTO(r, < 0, err);
+    }
+
+    if (with_hyphens) {
+        for (i = 0; i < ARRAY_SIZE(hyphens_pos); i++) {
+            r = sol_buffer_insert_slice(&buf, hyphens_pos[i], hyphen);
+            SOL_INT_CHECK_GOTO(r, < 0, err);
+        }
+    }
+
+err:
+    sol_buffer_fini(&buf);
+    return r;
 }


### PR DESCRIPTION
Makes use of the cpuid_get() function from RIOT if it's available.
For boards that don't implement it or don't provide a valid UUID there,
we need more infrastructure to create a valid and persistend UUID using
other characteristics of the board, like the MAC address if it has one.