### PR TITLE
pc: update description + add nodedescriptionpath

### DIFF
--- a/pc/soletta.pc.in
+++ b/pc/soletta.pc.in
@@ -5,9 +5,10 @@ includedir={{@INCLUDEDIR@}}
 modulesdir={{@MODULESDIR@}}
 pkgdatadir={{@DATADIR@}}soletta
 nodeschemapath=${pkgdatadir}/flow/schemas/node-type-genspec.schema
+nodedescriptionpath={{@DESCDIR@}}
 
 Name: {{@PKGNAME@}}
-Description: SOLETTA io library
+Description: Soletta Project is a framework for making IoT devices.
 Version: {{@VERSION@}}
 Libs: -L${libdir} -lsoletta
 Cflags: -I${includedir}/soletta


### PR DESCRIPTION
This patch updates the soletta's .pc description to some more acurate
text and introduces the nodedescriptionpath variable so the lib's users
may find out where the json descriptions are installed.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>