### PR TITLE
Use device/machine ID instead of MAC address in OIC nodes

### DIFF
--- a/data/oic/oicgen.py
+++ b/data/oic/oicgen.py
@@ -1542,10 +1542,8 @@ escape_json_string(const char *s, char *buf)
     return out;
 }
 
-#define ESCAPE_STRING(s) ({ \\
-        char buffer ## __COUNT__[calculate_escaped_len(s)]; \\
-        escape_json_string(s, buffer ## __COUNT__); \\
-    })
+#define ESCAPE_STRING(s) \
+    escape_json_string(s, alloca(calculate_escaped_len(s)))
 
 SOL_ATTR_USED static bool
 json_token_to_string(struct sol_json_token *token, char **out)

--- a/data/oic/oicgen.py
+++ b/data/oic/oicgen.py
@@ -121,6 +121,12 @@ JSON_TO_SOL_JSON = {
     "number": "double"
 }
 
+def props_are_equivalent(p1, p2):
+    # This disconsiders comments
+    p1 = {k: get_type_from_property(v) for k, v in p1.items()}
+    p2 = {k: get_type_from_property(v) for k, v in p2.items()}
+    return p1 == p2
+
 def object_fields_common_c(state_struct_name, name, props):
     fields = []
     for prop_name, descr in props.items():
@@ -205,12 +211,6 @@ def get_type_from_property(prop):
     raise ValueError('Unknown type for property')
 
 def object_serialize_fn_common_c(state_struct_name, name, props, client, equivalent={}):
-    def props_are_equivalent(p1, p2):
-        # This disconsiders comments
-        p1 = {k: get_type_from_property(v) for k, v in p1.items()}
-        p2 = {k: get_type_from_property(v) for k, v in p2.items()}
-        return p1 == p2
-
     for item_name, item_props in equivalent.items():
         if item_props[0] == client and props_are_equivalent(props, item_props[1]):
             return '''static uint8_t *
@@ -387,10 +387,6 @@ out:
     }
 
 def object_deserialize_fn_common_c(name, props, equivalent={}):
-    def props_are_equivalent(p1, p2):
-        p1 = {k: get_type_from_property(v) for k, v in p1.items()}
-        p2 = {k: get_type_from_property(v) for k, v in p2.items()}
-        return p1 == p2
 
     for item_name, item_props in equivalent.items():
         if props_are_equivalent(props, item_props):

--- a/data/oic/oicgen.py
+++ b/data/oic/oicgen.py
@@ -993,6 +993,7 @@ initialize_multicast_addresses_once(void)
         return false;
     }
 
+    multicast_addresses_initialized = true;
     return true;
 }
 

--- a/data/oic/oicgen.py
+++ b/data/oic/oicgen.py
@@ -1414,6 +1414,7 @@ client_resource_init(struct sol_flow_node *node, struct client_resource *resourc
     if (!hwaddr)
         return -EINVAL;
 
+    resource->client.api_version = SOL_OIC_CLIENT_API_VERSION;
     resource->client.server = sol_coap_server_new(0);
     SOL_NULL_CHECK(resource->client.server, -ENOMEM);
 

--- a/src/lib/comms/include/sol-oic-client.h
+++ b/src/lib/comms/include/sol-oic-client.h
@@ -95,6 +95,13 @@ bool sol_oic_client_find_resource(struct sol_oic_client *client,
     void *data),
     void *data);
 
+struct sol_oic_server_information;
+bool sol_oic_client_get_server_info(struct sol_oic_client *client,
+    struct sol_oic_resource *resource,
+    void (*info_received_cb)(struct sol_oic_client *cli,
+    const struct sol_oic_server_information *info, void *data),
+    void *data);
+
 bool sol_oic_client_resource_request(struct sol_oic_client *client, struct sol_oic_resource *res,
     sol_coap_method_t method, uint8_t *payload, size_t payload_len,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,

--- a/src/lib/comms/include/sol-oic-server.h
+++ b/src/lib/comms/include/sol-oic-server.h
@@ -56,9 +56,6 @@ extern "C" {
 #ifndef OIC_DEVICE_RESOURCE_TYPE
 #define OIC_DEVICE_RESOURCE_TYPE "oc.core"
 #endif
-#ifndef OIC_DEVICE_ID
-#define OIC_DEVICE_ID "soletta0"
-#endif
 #ifndef OIC_MANUFACTURER_NAME
 #define OIC_MANUFACTURER_NAME "Custom"
 #endif

--- a/src/lib/comms/include/sol-oic-server.h
+++ b/src/lib/comms/include/sol-oic-server.h
@@ -86,10 +86,35 @@ extern "C" {
 
 struct sol_oic_device_definition;
 
+struct sol_oic_server_information {
+#define SOL_OIC_SERVER_INFORMATION_API_VERSION (1)
+    uint16_t api_version;
+    int : 0; /* save possible hole for a future field */
+
+    /* All fields are required by the spec. */
+    struct {
+        struct sol_str_slice name;
+        struct sol_str_slice resource_type;
+        struct sol_str_slice id;
+    } device;
+    struct {
+        struct sol_str_slice name;
+        struct sol_str_slice model;
+        struct sol_str_slice date;
+    } manufacturer;
+    struct {
+        struct sol_str_slice version;
+    } interface, platform, firmware;
+    struct sol_str_slice support_link;
+    struct sol_str_slice location;
+    struct sol_str_slice epi;
+};
+
 struct sol_oic_resource_type {
 #define SOL_OIC_RESOURCE_TYPE_API_VERSION (1)
     uint16_t api_version;
     int : 0; /* save possible hole for a future field */
+
     struct sol_str_slice endpoint;
     struct sol_str_slice resource_type;
     struct sol_str_slice iface;

--- a/src/lib/comms/sol-oic-client.c
+++ b/src/lib/comms/sol-oic-client.c
@@ -277,6 +277,8 @@ _find_resource_reply_cb(struct sol_coap_packet *req, const struct sol_network_li
 
     res->refcnt = 1;
 
+    res->api_version = SOL_OIC_RESOURCE_API_VERSION;
+
     if (_parse_resource_reply_payload(res, payload, payload_len)) {
         res->observable = res->observable || _has_observable_option(req);
         res->addr = *cliaddr;

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -37,14 +37,14 @@
 #include <stdio.h>
 
 #define SOL_LOG_DOMAIN &_sol_oic_server_log_domain
+#include "sol-coap.h"
+#include "sol-json.h"
 #include "sol-log-internal.h"
-#include "sol-vector.h"
+#include "sol-oic-server.h"
+#include "sol-platform.h"
 #include "sol-str-slice.h"
 #include "sol-util.h"
-#include "sol-oic-server.h"
-#include "sol-json.h"
-
-#include "sol-coap.h"
+#include "sol-vector.h"
 
 SOL_LOG_INTERNAL_DECLARE(_sol_oic_server_log_domain, "oic-server");
 
@@ -349,11 +349,12 @@ static const struct sol_coap_resource rts_coap_resorce = {
 static struct sol_oic_server_information *
 init_static_info(void)
 {
+    static char machine_id[33];
     struct sol_oic_server_information information = {
         .device = {
             .name = OIC_DEVICE_NAME,
             .resource_type = OIC_DEVICE_RESOURCE_TYPE,
-            .id = OIC_DEVICE_ID
+            .id = machine_id
         },
         .manufacturer = {
             .name = OIC_MANUFACTURER_NAME,
@@ -373,9 +374,16 @@ init_static_info(void)
         .location = OIC_LOCATION,
         .epi = OIC_EPI
     };
+    struct sol_oic_server_information *info;
+    int r;
 
-    struct sol_oic_server_information *info = sol_util_memdup(&information, sizeof(*info));
+    r = sol_platform_get_machine_id(machine_id);
+    if (r < 0) {
+        SOL_WRN("Could not get machine ID to initialize OIC server");
+        return NULL;
+    }
 
+    info = sol_util_memdup(&information, sizeof(*info));
     SOL_NULL_CHECK(info, NULL);
 
     return info;

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -90,12 +90,12 @@ struct resource_type_data {
 
 static struct sol_oic_server oic_server;
 
-#define OIC_SERVER_CHECK(ret)                               \
-    do {                                                    \
-        if (oic_server.refcnt == 0) {                       \
-            SOL_WRN("OIC API used before initialization");   \
-            return ret;                                     \
-        }                                                   \
+#define OIC_SERVER_CHECK(ret) \
+    do { \
+        if (oic_server.refcnt == 0) { \
+            SOL_WRN("OIC API used before initialization"); \
+            return ret; \
+        } \
     } while (0)
 
 static uint16_t
@@ -159,14 +159,14 @@ _sol_oic_server_d(const struct sol_coap_resource *resource,
     *payload++ = '{';
     payload_len++;
 
-#define APPEND_KEY_VALUE(k, v)                          \
-    do {                                    \
-        uint16_t r;                             \
-        r = _append_json_key_value(payload, payload_size, payload_len, k,   \
-            sol_str_slice_from_str(oic_server.information->v));     \
-        if (!r) goto no_memory;                     \
-        payload += (r - payload_len);                   \
-        payload_len = r;                            \
+#define APPEND_KEY_VALUE(k, v) \
+    do { \
+        uint16_t r; \
+        r = _append_json_key_value(payload, payload_size, payload_len, k, \
+            sol_str_slice_from_str(oic_server.information->v)); \
+        if (!r) goto no_memory; \
+        payload += (r - payload_len); \
+        payload_len = r; \
     } while (0)
 
     APPEND_KEY_VALUE("dt", device.name);
@@ -195,7 +195,6 @@ no_memory:
     sol_coap_packet_unref(response);
     return -ENOMEM;
 }
-
 
 static int
 _sol_oic_server_res(const struct sol_coap_resource *resource,

--- a/src/lib/parsers/include/sol-json.h
+++ b/src/lib/parsers/include/sol-json.h
@@ -40,6 +40,7 @@
 #include <errno.h>
 #include <stdint.h>
 #include <sol-macros.h>
+#include <sol-str-slice.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -316,6 +317,21 @@ sol_json_token_get_int32(const struct sol_json_token *token, int32_t *value)
  * @see sol_json_token_get_int32()
  */
 int sol_json_token_get_double(const struct sol_json_token *token, double *value) SOL_ATTR_WARN_UNUSED_RESULT SOL_ATTR_NONNULL(1, 2);
+
+/**
+ * Converts a JSON token to a string slice.
+ *
+ * @param token the token to convert to string slice.
+ *
+ * @return A string slice struct.
+ *
+ * @see sol_str_slice
+ */
+static inline struct sol_str_slice
+sol_json_token_to_slice(const struct sol_json_token *token)
+{
+    return SOL_STR_SLICE_STR(token->start, token->end - token->start);
+}
 
 
 bool sol_json_scanner_next(struct sol_json_scanner *scanner,

--- a/src/samples/flow/oic/light-client.json
+++ b/src/samples/flow/oic/light-client.json
@@ -4,9 +4,9 @@
   {
    "name": "Light",
    "options": {
-    "hwaddr": "08:00:27:ab:45:32"
+    "device_id": "580a3d6a9d194a23b90a24573558d2f4"
    },
-   "type": "oic/client-core-brightlight"
+   "type": "oic/client-brightlight"
   }
  ]
 }


### PR DESCRIPTION
This enables the use of device/machine ID instead of MAC address in OIC nodes.

This is performed by making another query to each device that replies to a find_resource query, to obtain the device information, and comparing with the number provided in the node configuration. This will eventually be complemented by a device ID port, so that persistence nodes can be used as well.

As a bonus, a few odds and ends in related code were fixed.