### PR TITLE
generator: Use the right type name for float options

### DIFF
--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -221,7 +221,7 @@ handle_option(const struct sol_fbp_meta *meta, struct sol_vector *options, const
             meta = &unquoted_meta;
         }
 
-        if (streq(o->data_type, "int") || streq(o->data_type, "double")) {
+        if (streq(o->data_type, "int") || streq(o->data_type, "float")) {
             if (memchr(meta->value.data, ':', meta->value.len))
                 handle_suboptions(meta, handle_suboption_with_explicit_fields, fbp_file);
             else

--- a/src/lib/io/sol-aio-common.c
+++ b/src/lib/io/sol-aio-common.c
@@ -39,7 +39,7 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "aio");
 #include "sol-aio.h"
 #include "sol-pin-mux.h"
 
-struct sol_aio *
+SOL_API struct sol_aio *
 sol_aio_open(const int device, const int pin, const unsigned int precision)
 {
     struct sol_aio *aio;

--- a/src/lib/io/sol-aio-linux.c
+++ b/src/lib/io/sol-aio-linux.c
@@ -82,7 +82,7 @@ _aio_open_fp(struct sol_aio *aio)
     return true;
 }
 
-struct sol_aio *
+SOL_API struct sol_aio *
 sol_aio_open_raw(const int device, const int pin, const unsigned int precision)
 {
     char path[PATH_MAX];
@@ -120,7 +120,7 @@ sol_aio_open_raw(const int device, const int pin, const unsigned int precision)
     return aio;
 }
 
-void
+SOL_API void
 sol_aio_close(struct sol_aio *aio)
 {
     SOL_NULL_CHECK(aio);
@@ -131,7 +131,7 @@ sol_aio_close(struct sol_aio *aio)
     free(aio);
 }
 
-int32_t
+SOL_API int32_t
 sol_aio_get_value(const struct sol_aio *aio)
 {
     unsigned int val;

--- a/src/modules/flow/string/string-ascii.c
+++ b/src/modules/flow/string/string-ascii.c
@@ -37,9 +37,9 @@
 #include <locale.h>
 #endif
 
+#include "sol-flow/string.h"
 #include "sol-flow-internal.h"
 
-#include "sol-flow/string.h"
 #include "string-ascii.h"
 #include "string-regexp.h"
 #include "string-uuid.h"

--- a/src/modules/flow/string/string-icu.c
+++ b/src/modules/flow/string/string-icu.c
@@ -33,9 +33,9 @@
 #include <ctype.h>
 #include <errno.h>
 
+#include "sol-flow/string.h"
 #include "sol-flow-internal.h"
 
-#include "sol-flow/string.h"
 #include "string-icu.h"
 #include "string-regexp.h"
 #include "string-uuid.h"

--- a/src/modules/flow/string/string-regexp.c
+++ b/src/modules/flow/string/string-regexp.c
@@ -37,9 +37,9 @@
 #include <pcre.h>
 #endif
 
+#include "sol-flow/string.h"
 #include "sol-flow-internal.h"
 
-#include "sol-flow/string.h"
 #include "string-regexp.h"
 
 #ifdef USE_LIBPCRE

--- a/src/modules/flow/string/string-uuid.c
+++ b/src/modules/flow/string/string-uuid.c
@@ -35,10 +35,10 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include "sol-flow/string.h"
 #include "sol-flow-internal.h"
 #include "sol-platform.h"
 
-#include "sol-flow/string.h"
 #include "string-uuid.h"
 
 int


### PR DESCRIPTION
Since the option type is float, not double, the generator was not
properly producing the options initialization for each field, resulting
in a considerable amount of warnings when running make check-fbp-bin