### PR TITLE
comms:http:server: Set minimal microhttpd's version

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -450,6 +450,7 @@
       "dependency": "libmicrohttpd",
       "type": "pkg-config",
       "pkgname": "libmicrohttpd"
+      "atleast-version": "0.9.40"
     }
   ]
 }


### PR DESCRIPTION
The code is using symbols that are available only in versions greater than 0.9.40