### PR TITLE
build: check-fbp-bin rule should place the mods in the end

### DIFF
--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -281,7 +281,7 @@ define make-test-fbp-bin
 $($(1)-out): $(SOL_LIB_OUTPUT) $($(1)-src) $(modules-out)
 	$(Q)echo "     " CC"   "$$@
 	$(Q)$(MKDIR) -p $(dir $($(1)-out))
-	$(Q)$(TARGETCC) $(SAMPLE_CFLAGS) $(modules-out) $($(1)-src) -o $($(1)-out) $(SAMPLE_LDFLAGS)
+	$(Q)$(TARGETCC) $(SAMPLE_CFLAGS) $($(1)-src) -o $($(1)-out) $(SAMPLE_LDFLAGS) $(modules-out)
 endef
 $(foreach test-fbp-bin,$(all-tests-fbp-bin),$(eval $(call make-test-fbp-bin,$(test-fbp-bin))))
 


### PR DESCRIPTION
Some compilers will not like to have the list of external modules close
to the cflags but will expect it to be with the ldflags (namely ubuntu's
gcc). This patch changes that and make everybody happier.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>