### PR TITLE
Ensure make check{,-fbp,-fbp-bin} work on non default configurations

### DIFF
--- a/src/lib/flow/sol-flow-resolver-conffile.c
+++ b/src/lib/flow/sol-flow-resolver-conffile.c
@@ -261,9 +261,17 @@ resolver_conffile_resolve_by_id(const char *id,
 
     /* TODO: replace strv in sol_conffile interface with something
     * that holds line/column number information for each entry. */
-    if (sol_conffile_resolve(id, &type_name, &opts_strv) < 0) {
-        SOL_DBG("could not resolve a type name for id='%s'", id);
-        return -EINVAL;
+    r = sol_conffile_resolve(id, &type_name, &opts_strv);
+    if (r < 0) {
+        /* the resolver may fail because there's no entry with the given
+         * name, but that may be because it's the name of a single type
+         * module, like console or timer, so treat that case especially */
+        if (r != -ENOENT) {
+            SOL_DBG("could not resolve a type name for id='%s'", id);
+            return -EINVAL;
+        }
+        type_name = id;
+        r = 0;
     }
 
     /* TODO: is this needed given we already handle builtins from the outside? */

--- a/src/modules/flow/float/float.c
+++ b/src/modules/flow/float/float.c
@@ -670,7 +670,7 @@ wave_generator_trapezoidal_process(struct sol_flow_node *node,
     trapezoidal_iterate(mdata);
 
     return sol_flow_send_drange_packet
-               (node, SOL_FLOW_NODE_TYPE_WAVE_GENERATOR_TRAPEZOIDAL__OUT__OUT,
+               (node, SOL_FLOW_NODE_TYPE_FLOAT_WAVE_GENERATOR_TRAPEZOIDAL__OUT__OUT,
                &mdata->t_state.val);
 }
 
@@ -680,12 +680,12 @@ wave_generator_trapezoidal_open(struct sol_flow_node *node,
     const struct sol_flow_node_options *options)
 {
     struct drange_wave_generator_trapezoidal_data *mdata = data;
-    const struct sol_flow_node_type_wave_generator_trapezoidal_options *opts = (const struct sol_flow_node_type_wave_generator_trapezoidal_options *)options;
+    const struct sol_flow_node_type_float_wave_generator_trapezoidal_options *opts = (const struct sol_flow_node_type_float_wave_generator_trapezoidal_options *)options;
     uint32_t tick_start;
     struct t_state *t_state;
     struct sol_drange *val;
 
-    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(opts, SOL_FLOW_NODE_TYPE_WAVE_GENERATOR_TRAPEZOIDAL_OPTIONS_API_VERSION, -EINVAL);
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(opts, SOL_FLOW_NODE_TYPE_FLOAT_WAVE_GENERATOR_TRAPEZOIDAL_OPTIONS_API_VERSION, -EINVAL);
 
     if (isgreaterequal(opts->min.val, opts->max.val)) {
         SOL_ERR("Trapezoidal wave generator's min must be less than its max");
@@ -808,7 +808,7 @@ wave_generator_sinusoidal_process(struct sol_flow_node *node,
     sinusoidal_iterate(mdata);
 
     return sol_flow_send_drange_packet
-               (node, SOL_FLOW_NODE_TYPE_WAVE_GENERATOR_SINUSOIDAL__OUT__OUT,
+               (node, SOL_FLOW_NODE_TYPE_FLOAT_WAVE_GENERATOR_SINUSOIDAL__OUT__OUT,
                &mdata->s_state.val);
 }
 
@@ -818,13 +818,13 @@ wave_generator_sinusoidal_open(struct sol_flow_node *node,
     const struct sol_flow_node_options *options)
 {
     struct drange_wave_generator_sinusoidal_data *mdata = data;
-    const struct sol_flow_node_type_wave_generator_sinusoidal_options *opts = (const struct sol_flow_node_type_wave_generator_sinusoidal_options *)options;
+    const struct sol_flow_node_type_float_wave_generator_sinusoidal_options *opts = (const struct sol_flow_node_type_float_wave_generator_sinusoidal_options *)options;
     uint32_t tick_start;
     struct s_state *s_state;
     struct sol_drange *val;
     unsigned i;
 
-    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(opts, SOL_FLOW_NODE_TYPE_WAVE_GENERATOR_SINUSOIDAL_OPTIONS_API_VERSION, -EINVAL);
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(opts, SOL_FLOW_NODE_TYPE_FLOAT_WAVE_GENERATOR_SINUSOIDAL_OPTIONS_API_VERSION, -EINVAL);
 
     if (islessequal(opts->amplitude.val, 0)) {
         SOL_ERR("Sinusoidal wave generator's multiplier must be greater "

--- a/src/modules/flow/float/float.json
+++ b/src/modules/flow/float/float.json
@@ -734,7 +734,7 @@
       "methods": {
         "open": "wave_generator_trapezoidal_open"
       },
-      "name": "wave-generator/trapezoidal",
+      "name": "float/wave-generator-trapezoidal",
       "options": {
         "members": [
           {
@@ -798,7 +798,7 @@
         }
       ],
       "private_data_type": "drange_wave_generator_trapezoidal_data",
-      "url": "http://solettaproject.org/doc/latest/node_types/wave-generator/trapezoidal.html"
+      "url": "http://solettaproject.org/doc/latest/node_types/float/wave-generator-trapezoidal.html"
     },
     {
       "category": "wave-generator",
@@ -816,7 +816,7 @@
       "methods": {
         "open": "wave_generator_sinusoidal_open"
       },
-      "name": "wave-generator/sinusoidal",
+      "name": "float/wave-generator-sinusoidal",
       "options": {
         "members": [
           {
@@ -851,7 +851,7 @@
         }
       ],
       "private_data_type": "drange_wave_generator_sinusoidal_data",
-      "url": "http://solettaproject.org/doc/latest/node_types/wave-generator/sinusoidal.html"
+      "url": "http://solettaproject.org/doc/latest/node_types/float/wave-generator-sinusoidal.html"
     },
     {
       "category": "float/classify",

--- a/src/samples/flow/galileo-grove-kit/grove-led-wave-generator.fbp
+++ b/src/samples/flow/galileo-grove-kit/grove-led-wave-generator.fbp
@@ -46,7 +46,7 @@ constant_duty_cycle_step(constant/float:value=7971)
 timer(timer:interval=5)
 
 # min_ticks: 100 * 5 ms = 500 ms. max_ticks: 20 * 5 ms = 100 ms
-wave(wave-generator/trapezoidal:min=0,max=255,ticks_inc=255,ticks_dec=255,ticks_at_min=100,ticks_at_max=20,tick_start=100)
+wave(float/wave-generator-trapezoidal:min=0,max=255,ticks_inc=255,ticks_dec=255,ticks_at_min=100,ticks_at_max=20,tick_start=100)
 
 timer OUT -> TICK wave
 

--- a/src/samples/flow/galileo-grove-kit/lcd/grove-lcd-fade.fbp
+++ b/src/samples/flow/galileo-grove-kit/lcd/grove-lcd-fade.fbp
@@ -58,13 +58,13 @@ initial_color(constant/rgb:value=0|0|0|255|255|255) OUT -> COLOR lcd
 
 # 1520 = 2 * (2 * 100 + 2 * 255) + 100
 
-red_wave(wave-generator/trapezoidal:tick_start=1520,min=0,max=255,ticks_inc=255,ticks_dec=255,ticks_at_min=1520,ticks_at_max=100)
+red_wave(float/wave-generator-trapezoidal:tick_start=1520,min=0,max=255,ticks_inc=255,ticks_dec=255,ticks_at_min=1520,ticks_at_max=100)
 
 # 1520 - (2 * 100 + 2 * 255) = 810
-green_wave(wave-generator/trapezoidal:tick_start=810,min=0,max=255,ticks_inc=255,ticks_dec=255,ticks_at_min=1520,ticks_at_max=100)
+green_wave(float/wave-generator-trapezoidal:tick_start=810,min=0,max=255,ticks_inc=255,ticks_dec=255,ticks_at_min=1520,ticks_at_max=100)
 
 # 1520 - 2 * (2 * 100 + 2 * 255) = 100
-blue_wave(wave-generator/trapezoidal:tick_start=100,min=0,max=255,ticks_inc=255,ticks_dec=255,ticks_at_min=1520,ticks_at_max=100)
+blue_wave(float/wave-generator-trapezoidal:tick_start=100,min=0,max=255,ticks_inc=255,ticks_dec=255,ticks_at_min=1520,ticks_at_max=100)
 
 timer OUT -> TICK red_wave OUT -> RED converter
 timer OUT -> TICK green_wave OUT -> GREEN converter

--- a/src/shared/sol-conffile.c
+++ b/src/shared/sol-conffile.c
@@ -485,7 +485,7 @@ _resolve_config(const char *id, const char **type, const char ***opts)
     void **vector_pointer;
 
     if (sol_ptr_vector_get_len(&_conffile_entry_vector) <= 0) {
-        return -EINVAL;
+        return -ENOENT;
     }
 
     key.id = (char *)id;
@@ -496,7 +496,7 @@ _resolve_config(const char *id, const char **type, const char ***opts)
         _bsearch_entry_cb);
     if (!vector_pointer) {
         SOL_DBG("could not find entry [%s]", id);
-        return -EINVAL;
+        return -ENOENT;
     }
 
     entry = *vector_pointer;

--- a/src/test-fbp/wave-generator.fbp
+++ b/src/test-fbp/wave-generator.fbp
@@ -34,17 +34,17 @@
 tick_gen(test/boolean-generator:sequence="TTTTTTTTTTTTTTT",interval=0)
 
 square_validate(test/float-validator:sequence="-5.0 -5.0 0.0 -5.0 -5.0 0.0 -5.0 -5.0 0.0 -5.0 -5.0 0.0 -5.0 -5.0 0.0")
-square_wave(wave-generator/trapezoidal:min=-5,max=0,ticks_inc=1,ticks_dec=1,ticks_at_min=1,ticks_at_max=0)
+square_wave(float/wave-generator-trapezoidal:min=-5,max=0,ticks_inc=1,ticks_dec=1,ticks_at_min=1,ticks_at_max=0)
 
 triangle_validate(test/float-validator:sequence="3.0 4.0 3.0 2.0 1.0 0.0 -1.0 0.0 1.0 2.0 3.0 4.0 3.0 2.0 1.0")
-triangle_wave(wave-generator/trapezoidal:tick_start=4,min=-1,max=4,ticks_inc=5,ticks_dec=5,ticks_at_min=0,ticks_at_max=0)
+triangle_wave(float/wave-generator-trapezoidal:tick_start=4,min=-1,max=4,ticks_inc=5,ticks_dec=5,ticks_at_min=0,ticks_at_max=0)
 
 trapezoid_validate(test/float-validator:sequence="1.0 4.0 4.0 4.0 1.0 -2.0 -2.0 1.0 4.0 4.0 4.0 1.0 -2.0 -2.0 1.0")
-trapezoid_wave(wave-generator/trapezoidal:tick_start=2,min=-2,max=4,ticks_inc=2,ticks_dec=2,ticks_at_min=1,ticks_at_max=2)
+trapezoid_wave(float/wave-generator-trapezoidal:tick_start=2,min=-2,max=4,ticks_inc=2,ticks_dec=2,ticks_at_min=1,ticks_at_max=2)
 
 # writing sine values up to double precision
 sine_validate(test/float-validator:sequence="0.0 0.06279051952931337 0.12533323356430426 0.18738131458572463 0.24868988716485479 0.30901699437494740 0.36812455268467792 0.42577929156507260 0.48175367410171521 0.53582679497899655 0.58778525229247303 0.63742398974868963 0.68454710592868850 0.72896862742141133 0.77051324277578903")
-sine_wave(wave-generator/sinusoidal:ticks_per_period=100,amplitude=1)
+sine_wave(float/wave-generator-sinusoidal:ticks_per_period=100,amplitude=1)
 
 tick_gen OUT -> TICK square_wave OUT -> IN square_validate OUT -> RESULT _(test/result)
 tick_gen OUT -> TICK triangle_wave OUT -> IN triangle_validate OUT -> RESULT _(test/result)

--- a/src/test/test-flow-builder.c
+++ b/src/test/test-flow-builder.c
@@ -460,7 +460,8 @@ custom_resolve(void *data, const char *id, struct sol_flow_node_type const **typ
         *named_opts = (struct sol_flow_node_named_options){};
         return 0;
     }
-    return -ENOENT;
+
+    return sol_flow_resolve(NULL, id, type, named_opts);
 }
 
 static const struct sol_flow_resolver custom_resolver = {

--- a/src/test/test-flow-parser.c
+++ b/src/test/test-flow-parser.c
@@ -296,7 +296,6 @@ parse_with_string(void)
 {
     struct sol_flow_node *flow;
     struct sol_flow_parser *parser;
-    const struct sol_flow_resolver *builtins_resolver;
     unsigned int i;
 
     static const char *tests[] = {
@@ -305,10 +304,7 @@ parse_with_string(void)
         "a(boolean/not) OUT -> IN b(boolean/not) OUT -> IN c(boolean/not)",
     };
 
-    builtins_resolver = sol_flow_get_builtins_resolver();
-    ASSERT(builtins_resolver);
-
-    parser = sol_flow_parser_new(NULL, builtins_resolver);
+    parser = sol_flow_parser_new(NULL, NULL);
     ASSERT(parser);
 
     for (i = 0; i < ARRAY_SIZE(tests); i++) {
@@ -339,7 +335,6 @@ static void
 parse_and_fail_with_invalid_string(void)
 {
     struct sol_flow_parser *parser;
-    const struct sol_flow_resolver *builtins_resolver;
     unsigned int i;
 
     static const char *tests[] = {
@@ -351,10 +346,7 @@ parse_and_fail_with_invalid_string(void)
         "a(boolean/not) PORT_THAT_DOESNT-exist -> IN b(boolean/not)",
     };
 
-    builtins_resolver = sol_flow_get_builtins_resolver();
-    ASSERT(builtins_resolver);
-
-    parser = sol_flow_parser_new(NULL, builtins_resolver);
+    parser = sol_flow_parser_new(NULL, NULL);
     ASSERT(parser);
 
     for (i = 0; i < ARRAY_SIZE(tests); i++) {


### PR DESCRIPTION
Fix the checks for allmodconfig, basically. Tested also with
allyesconfig and alldefconfig, all work. User configurations still have
the potential to break due to assumptions from the tests that certain
node-types will be available always.