### PR TITLE
build: [samples] add all used dependencies

### DIFF
--- a/src/samples/flow/basics/Makefile
+++ b/src/samples/flow/basics/Makefile
@@ -6,10 +6,21 @@ sample-cmdline-args-$(FLOW_BASICS_CMDLINE_ARGS_SAMPLE)-deps += flow/converter.mo
 
 sample-$(FLOW_BASICS_FIBONACCI_SAMPLE) += fibonacci
 sample-fibonacci-$(FLOW_BASICS_FIBONACCI_SAMPLE) := fibonacci.fbp
-sample-fibonacci-$(FLOW_BASICS_FIBONACCI_SAMPLE)-deps := flow/int.mod
+sample-fibonacci-$(FLOW_BASICS_FIBONACCI_SAMPLE)-deps := \
+	flow/app.mod \
+	flow/boolean.mod \
+	flow/console.mod \
+	flow/constant.mod \
+	flow/converter.mod \
+	flow/int.mod \
+	flow/switcher.mod
 
 sample-$(FLOW_BASICS_PLATORM_SERVICE_SAMPLE) += platform-service
 sample-platform-service-$(FLOW_BASICS_PLATORM_SERVICE_SAMPLE) := platform-service.fbp
+sample-platform-service-$(FLOW_BASICS_PLATORM_SERVICE_SAMPLE)-deps := \
+	flow/console.mod \
+	flow/platform.mod \
+	flow/timer.mod
 
 sample-$(FLOW_BASICS_SIMPLE_SAMPLE) += simple-fbp
 sample-simple-fbp-$(FLOW_BASICS_SIMPLE_SAMPLE) := simple.fbp
@@ -17,4 +28,7 @@ sample-simple-fbp-$(FLOW_BASICS_SIMPLE_SAMPLE)-deps := flow/timer.mod flow/boole
 
 sample-$(FLOW_BASICS_SUBPROCESS_BC_SAMPLE) += subprocess-bc
 sample-subprocess-bc-$(FLOW_BASICS_SUBPROCESS_BC_SAMPLE) := subprocess_bc.fbp
-sample-subprocess-bc-$(FLOW_BASICS_SUBPROCESS_BC_SAMPLE)-deps := flow/process.mod
+sample-subprocess-bc-$(FLOW_BASICS_SUBPROCESS_BC_SAMPLE)-deps := \
+	flow/console.mod \
+	flow/constant.mod \
+	flow/process.mod

--- a/src/samples/flow/c-api/Makefile
+++ b/src/samples/flow/c-api/Makefile
@@ -10,7 +10,9 @@ sample-highlevel-$(FLOW_C_API_HIGHLEVEL_SAMPLE)-deps := sample-custom-node-types
 sample-$(FLOW_C_API_LOWLEVEL_SAMPLE) += lowlevel
 sample-lowlevel-$(FLOW_C_API_LOWLEVEL_SAMPLE) := lowlevel.c
 sample-lowlevel-$(FLOW_C_API_LOWLEVEL_SAMPLE) += custom-node-types.json
-sample-lowlevel-$(FLOW_C_API_LOWLEVEL_SAMPLE)-deps := sample-custom-node-types
+sample-lowlevel-$(FLOW_C_API_LOWLEVEL_SAMPLE)-deps := \
+	flow/console.mod \
+	sample-custom-node-types
 
 sample-$(FLOW_C_API_SIMPLECTYPE_SAMPLE) += simplectype
 sample-simplectype-$(FLOW_C_API_SIMPLECTYPE_SAMPLE) := simplectype.c

--- a/src/samples/flow/compass/Makefile
+++ b/src/samples/flow/compass/Makefile
@@ -3,4 +3,5 @@ sample-compass-lsm303-$(FLOW_COMPASS_LSM303_SAMPLE) := lsm303.fbp
 sample-compass-lsm303-$(FLOW_COMPASS_LSM303_SAMPLE)-deps := \
 	flow/accelerometer.mod \
 	flow/compass.mod \
+	flow/console.mod \
 	flow/magnetometer.mod

--- a/src/samples/flow/foosball/Makefile
+++ b/src/samples/flow/foosball/Makefile
@@ -2,5 +2,10 @@ sample-$(FLOW_FOOSBALL_SAMPLE) += foosball
 sample-foosball-$(FLOW_FOOSBALL_SAMPLE) := \
 	foosball.fbp
 sample-foosball-$(FLOW_FOOSBALL_SAMPLE)-deps := \
+	flow/boolean.mod \
+	flow/constant.mod \
+	flow/converter.mod \
+	flow/int.mod \
+	flow/timer.mod \
 	gtk.mod \
 	tracker.fbp

--- a/src/samples/flow/galileo-grove-kit/Makefile
+++ b/src/samples/flow/galileo-grove-kit/Makefile
@@ -1,6 +1,8 @@
 sample-$(FLOW_GALILEO_GROVE_BUTTON_SAMPLE) += grove-button
 sample-grove-button-$(FLOW_GALILEO_GROVE_BUTTON_SAMPLE) := grove-button.fbp
 sample-grove-button-$(FLOW_GALILEO_GROVE_BUTTON_SAMPLE)-conffile := galileo-grove-kit.json
+sample-grove-button-$(FLOW_GALILEO_GROVE_BUTTON_SAMPLE)-deps := \
+	flow/gpio.mod
 
 sample-$(FLOW_GALILEO_GROVE_BUZZER_SAMPLE) += grove-buzzer
 sample-grove-buzzer-$(FLOW_GALILEO_GROVE_BUZZER_SAMPLE) := grove-buzzer.fbp
@@ -10,11 +12,25 @@ sample-grove-buzzer-$(FLOW_GALILEO_GROVE_BUZZER_SAMPLE)-deps := flow/piezo-speak
 sample-$(FLOW_GALILEO_GROVE_LED_ACCUMULATOR_SAMPLE) += grove-led-accumulator
 sample-grove-led-accumulator-$(FLOW_GALILEO_GROVE_LED_ACCUMULATOR_SAMPLE) := grove-led-accumulator.fbp
 sample-grove-led-accumulator-$(FLOW_GALILEO_GROVE_LED_ACCUMULATOR_SAMPLE)-conffile := galileo-grove-kit.json
+sample-grove-led-accumulator-$(FLOW_GALILEO_GROVE_LED_ACCUMULATOR_SAMPLE)-deps := \
+	flow/boolean.mod \
+	flow/constant.mod \
+	flow/converter.mod \
+	flow/int.mod \
+	flow/pwm.mod \
+	flow/timer.mod
 
 sample-$(FLOW_GALILEO_GROVE_RELAY_SAMPLE) += grove-relay
 sample-grove-relay-$(FLOW_GALILEO_GROVE_RELAY_SAMPLE) := grove-relay.fbp
 sample-grove-relay-$(FLOW_GALILEO_GROVE_RELAY_SAMPLE)-conffile := galileo-grove-kit.json
+sample-grove-relay-$(FLOW_GALILEO_GROVE_RELAY_SAMPLE)-deps := \
+	flow/gpio.mod
 
 sample-$(FLOW_GALILEO_GROVE_SOUND_SENSOR_SAMPLE) += grove-sound-sensor
 sample-grove-sound-sensor-$(FLOW_GALILEO_GROVE_SOUND_SENSOR_SAMPLE) := grove-sound-sensor.fbp
 sample-grove-sound-sensor-$(FLOW_GALILEO_GROVE_SOUND_SENSOR_SAMPLE)-conffile := galileo-grove-kit.json
+sample-grove-sound-sensor-$(FLOW_GALILEO_GROVE_SOUND_SENSOR_SAMPLE)-deps := \
+	flow/aio.mod \
+	flow/constant.mod \
+	flow/gpio.mod \
+	flow/int.mod

--- a/src/samples/flow/galileo-grove-kit/lcd/Makefile
+++ b/src/samples/flow/galileo-grove-kit/lcd/Makefile
@@ -1,39 +1,88 @@
 sample-$(FLOW_GALILEO_GROVE_LCD_AUTOSCROLL_SAMPLE) += grove-lcd-autoscroll
 sample-grove-lcd-autoscroll-$(FLOW_GALILEO_GROVE_LCD_AUTOSCROLL_SAMPLE) := grove-lcd-autoscroll.fbp
 sample-grove-lcd-autoscroll-$(FLOW_GALILEO_GROVE_LCD_AUTOSCROLL_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-autoscroll-$(FLOW_GALILEO_GROVE_LCD_AUTOSCROLL_SAMPLE)-deps := flow/grove.mod
+sample-grove-lcd-autoscroll-$(FLOW_GALILEO_GROVE_LCD_AUTOSCROLL_SAMPLE)-deps := \
+	flow/aio.mod \
+	flow/boolean.mod \
+	flow/constant.mod \
+	flow/converter.mod \
+	flow/grove.mod \
+	flow/int.mod \
+	flow/timer.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_BLINK_SAMPLE) += grove-lcd-blink
 sample-grove-lcd-blink-$(FLOW_GALILEO_GROVE_LCD_BLINK_SAMPLE) := grove-lcd-blink.fbp
 sample-grove-lcd-blink-$(FLOW_GALILEO_GROVE_LCD_BLINK_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-blink-$(FLOW_GALILEO_GROVE_LCD_BLINK_SAMPLE)-deps := flow/grove.mod
+sample-grove-lcd-blink-$(FLOW_GALILEO_GROVE_LCD_BLINK_SAMPLE)-deps := \
+	flow/aio.mod \
+	flow/boolean.mod \
+	flow/constant.mod \
+	flow/converter.mod \
+	flow/grove.mod \
+	flow/timer.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_CURSOR_SAMPLE) += grove-lcd-cursor
 sample-grove-lcd-cursor-$(FLOW_GALILEO_GROVE_LCD_CURSOR_SAMPLE) := grove-lcd-cursor.fbp
 sample-grove-lcd-cursor-$(FLOW_GALILEO_GROVE_LCD_CURSOR_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-cursor-$(FLOW_GALILEO_GROVE_LCD_CURSOR_SAMPLE)-deps := flow/grove.mod
+sample-grove-lcd-cursor-$(FLOW_GALILEO_GROVE_LCD_CURSOR_SAMPLE)-deps := \
+	flow/aio.mod \
+	flow/boolean.mod \
+	flow/constant.mod \
+	flow/grove.mod \
+	flow/timer.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_DISPLAY_SAMPLE) += grove-lcd-display
 sample-grove-lcd-display-$(FLOW_GALILEO_GROVE_LCD_DISPLAY_SAMPLE) := grove-lcd-display.fbp
 sample-grove-lcd-display-$(FLOW_GALILEO_GROVE_LCD_DISPLAY_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-display-$(FLOW_GALILEO_GROVE_LCD_DISPLAY_SAMPLE)-deps := flow/grove.mod
+sample-grove-lcd-display-$(FLOW_GALILEO_GROVE_LCD_DISPLAY_SAMPLE)-deps := \
+	flow/aio.mod \
+	flow/boolean.mod \
+	flow/constant.mod \
+	flow/grove.mod \
+	flow/timer.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_HELLO_WORLD_SAMPLE) += grove-lcd-hello-world
 sample-grove-lcd-hello-world-$(FLOW_GALILEO_GROVE_LCD_HELLO_WORLD_SAMPLE) := grove-lcd-hello-world.fbp
 sample-grove-lcd-hello-world-$(FLOW_GALILEO_GROVE_LCD_HELLO_WORLD_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-hello-world-$(FLOW_GALILEO_GROVE_LCD_HELLO_WORLD_SAMPLE)-deps := flow/grove.mod
+sample-grove-lcd-hello-world-$(FLOW_GALILEO_GROVE_LCD_HELLO_WORLD_SAMPLE)-deps := \
+	flow/aio.mod \
+	flow/constant.mod \
+	flow/converter.mod \
+	flow/grove.mod \
+	flow/int.mod \
+	flow/timer.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_SCROLL_SAMPLE) += grove-lcd-scroll
 sample-grove-lcd-scroll-$(FLOW_GALILEO_GROVE_LCD_SCROLL_SAMPLE) := grove-lcd-scroll.fbp
 sample-grove-lcd-scroll-$(FLOW_GALILEO_GROVE_LCD_SCROLL_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-scroll-$(FLOW_GALILEO_GROVE_LCD_SCROLL_SAMPLE)-deps := flow/grove.mod
+sample-grove-lcd-scroll-$(FLOW_GALILEO_GROVE_LCD_SCROLL_SAMPLE)-deps := \
+	flow/aio.mod \
+	flow/boolean.mod \
+	flow/constant.mod \
+	flow/converter.mod \
+	flow/grove.mod \
+	flow/int.mod \
+	flow/timer.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_SET_CURSOR_SAMPLE) += grove-lcd-set-cursor
 sample-grove-lcd-set-cursor-$(FLOW_GALILEO_GROVE_LCD_SET_CURSOR_SAMPLE) := grove-lcd-set-cursor.fbp
 sample-grove-lcd-set-cursor-$(FLOW_GALILEO_GROVE_LCD_SET_CURSOR_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-set-cursor-$(FLOW_GALILEO_GROVE_LCD_SET_CURSOR_SAMPLE)-deps := flow/grove.mod
+sample-grove-lcd-set-cursor-$(FLOW_GALILEO_GROVE_LCD_SET_CURSOR_SAMPLE)-deps := \
+	flow/aio.mod \
+	flow/constant.mod \
+	flow/converter.mod \
+	flow/grove.mod \
+	flow/int.mod \
+	flow/timer.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_TEXT_DIRECTION_SAMPLE) += grove-lcd-text-direction
 sample-grove-lcd-text-direction-$(FLOW_GALILEO_GROVE_LCD_TEXT_DIRECTION_SAMPLE) := grove-lcd-text-direction.fbp
 sample-grove-lcd-text-direction-$(FLOW_GALILEO_GROVE_LCD_TEXT_DIRECTION_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-text-direction-$(FLOW_GALILEO_GROVE_LCD_TEXT_DIRECTION_SAMPLE)-deps := flow/grove.mod
+sample-grove-lcd-text-direction-$(FLOW_GALILEO_GROVE_LCD_TEXT_DIRECTION_SAMPLE)-deps := \
+	flow/aio.mod \
+	flow/boolean.mod \
+	flow/constant.mod \
+	flow/converter.mod \
+	flow/grove.mod \
+	flow/int.mod \
+	flow/timer.mod

--- a/src/samples/flow/io/Makefile
+++ b/src/samples/flow/io/Makefile
@@ -5,13 +5,21 @@ sample-$(FLOW_IO_SAMPLE) += \
 sample-io-pwm-$(FLOW_IO_SAMPLE) := \
 	pwm.fbp
 sample-io-pwm-$(FLOW_IO_SAMPLE)-deps := \
-	flow/pwm.mod
+	flow/boolean.mod \
+	flow/console.mod \
+	flow/int.mod \
+	flow/pwm.mod \
+	flow/timer.mod
 sample-io-pwm-$(FLOW_IO_SAMPLE)-conffile := \
 	pwm.json
 
 sample-io-servo-motor-$(FLOW_IO_SAMPLE) := \
 	servo-motor.fbp
 sample-io-servo-motor-$(FLOW_IO_SAMPLE)-deps := \
-	flow/servo-motor.mod
+	flow/console.mod \
+	flow/converter.mod \
+	flow/int.mod \
+	flow/servo-motor.mod \
+	flow/timer.mod
 sample-io-servo-motor-$(FLOW_IO_SAMPLE)-conffile := \
 	servo-motor.json

--- a/src/samples/flow/led-strip/Makefile
+++ b/src/samples/flow/led-strip/Makefile
@@ -1,4 +1,9 @@
 sample-$(FLOW_LD_STRIP_LPD8806_SAMPLE) += lpd8806
 sample-lpd8806-$(FLOW_LD_STRIP_LPD8806_SAMPLE) := lpd8806.fbp
 sample-lpd8806-$(FLOW_LD_STRIP_LPD8806_SAMPLE)-deps := \
+	flow/boolean.mod \
+	flow/converter.mod \
+	flow/int.mod \
 	flow/led-strip.mod \
+	flow/random.mod \
+	flow/timer.mod

--- a/src/samples/flow/misc/Makefile
+++ b/src/samples/flow/misc/Makefile
@@ -1,6 +1,13 @@
 sample-$(FLOW_MISC_FILE_COPY_SAMPLE) += file-copy
 sample-file-copy-$(FLOW_MISC_FILE_COPY_SAMPLE) := file-copy.fbp
-sample-file-copy-$(FLOW_MISC_FILE_COPY_SAMPLE)-deps := flow/file.mod
+sample-file-copy-$(FLOW_MISC_FILE_COPY_SAMPLE)-deps := \
+	flow/app.mod \
+	flow/console.mod \
+	flow/constant.mod \
+	flow/converter.mod \
+	flow/file.mod \
+	flow/int.mod \
+	flow/timer.mod
 
 sample-$(FLOW_MISC_FS_PERSISTENCE_SAMPLE) += fs-persistence
 sample-fs-persistence-$(FLOW_MISC_FS_PERSISTENCE_SAMPLE) := fs-persitence.fbp
@@ -8,7 +15,16 @@ sample-fs-persistence-$(FLOW_MISC_FS_PERSISTENCE_SAMPLE)-deps := flow/fs.mod
 
 sample-$(FLOW_MISC_RANDOM_NUMBERS_SAMPLE) += random-numbers
 sample-random-numbers-$(FLOW_MISC_RANDOM_NUMBERS_SAMPLE) := random-numbers.fbp
+sample-random-numbers-$(FLOW_MISC_RANDOM_NUMBERS_SAMPLE)-deps := \
+	flow/console.mod \
+	flow/random.mod \
+	flow/timer.mod
 
 sample-$(FLOW_MISC_TICKETS_QUEUE_SAMPLE) += tickets-queue
 sample-tickets-queue-$(FLOW_MISC_TICKETS_QUEUE_SAMPLE) := tickets_queue.fbp
-sample-tickets-queue-$(FLOW_MISC_TICKETS_QUEUE_SAMPLE)-deps := flow/keyboard.mod
+sample-tickets-queue-$(FLOW_MISC_TICKETS_QUEUE_SAMPLE)-deps := \
+	flow/boolean.mod \
+	flow/console.mod \
+	flow/converter.mod \
+	flow/int.mod \
+	flow/keyboard.mod

--- a/src/samples/flow/oic/Makefile
+++ b/src/samples/flow/oic/Makefile
@@ -5,6 +5,8 @@ sample-$(FLOW_OIC_SAMPLE) += \
 sample-light-client-$(FLOW_OIC_SAMPLE) := \
 	light-client.fbp
 sample-light-client-$(FLOW_OIC_SAMPLE)-deps := \
+	flow/boolean.mod \
+	flow/timer.mod \
 	oic.mod
 sample-light-client-$(FLOW_OIC_SAMPLE)-conffile := \
 	light-client.json
@@ -12,6 +14,7 @@ sample-light-client-$(FLOW_OIC_SAMPLE)-conffile := \
 sample-light-server-$(FLOW_OIC_SAMPLE) := \
 	light-server.fbp
 sample-light-server-$(FLOW_OIC_SAMPLE)-deps := \
-	oic.mod
+	oic.mod \
+	flow/console.mod
 sample-light-server-$(FLOW_OIC_SAMPLE)-conffile := \
 	light-server.json

--- a/src/samples/flow/trash-disposer/Makefile
+++ b/src/samples/flow/trash-disposer/Makefile
@@ -1,4 +1,11 @@
 sample-$(FLOW_TRASH_DISPOSER) += trash-disposer
 sample-trash-disposer-$(FLOW_TRASH_DISPOSER) := trash-disposer.fbp
 sample-trash-disposer-$(FLOW_TRASH_DISPOSER)-conffile := contiki-config.json
-sample-trash-disposer-$(FLOW_TRASH_DISPOSER)-deps := flow/servo-motor.mod flow/gpio.mod
+sample-trash-disposer-$(FLOW_TRASH_DISPOSER)-deps := \
+	flow/boolean.mod \
+	flow/console.mod \
+	flow/constant.mod \
+	flow/converter.mod \
+	flow/gpio.mod \
+	flow/servo-motor.mod \
+	flow/timer.mod

--- a/src/samples/flow/unix-socket/Makefile
+++ b/src/samples/flow/unix-socket/Makefile
@@ -17,6 +17,7 @@ sample-$(FLOW_UNIX_SOCKET_SAMPLE) += \
 sample-boolean-reader-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	boolean-reader.fbp
 sample-boolean-reader-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
+	flow/console.mod \
 	flow/unix-socket.mod
 
 sample-boolean-writer-$(FLOW_UNIX_SOCKET_SAMPLE) := \
@@ -28,66 +29,91 @@ sample-boolean-writer-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
 sample-byte-reader-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	byte-reader.fbp
 sample-byte-reader-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
+	flow/console.mod \
 	flow/unix-socket.mod
 
 sample-byte-writer-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	byte-writer.fbp
 sample-byte-writer-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
+	flow/converter.mod \
+	flow/int.mod \
 	flow/keyboard.mod \
+	flow/timer.mod \
 	flow/unix-socket.mod
 
 sample-direction-vector-reader-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	direction-vector-reader.fbp
 sample-direction-vector-reader-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
+	flow/console.mod \
 	flow/unix-socket.mod
 
 sample-direction-vector-writer-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	direction-vector-writer.fbp
 sample-direction-vector-writer-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
+	flow/constant.mod \
+	flow/converter.mod \
+	flow/int.mod \
 	flow/keyboard.mod \
+	flow/timer.mod \
 	flow/unix-socket.mod
 
 sample-float-reader-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	float-reader.fbp
 sample-float-reader-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
+	flow/console.mod \
 	flow/unix-socket.mod
 
 sample-float-writer-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	float-writer.fbp
 sample-float-writer-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
+	flow/converter.mod \
+	flow/int.mod \
 	flow/keyboard.mod \
+	flow/timer.mod \
 	flow/unix-socket.mod
 
 sample-int-reader-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	int-reader.fbp
 sample-int-reader-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
+	flow/console.mod \
 	flow/keyboard.mod \
 	flow/unix-socket.mod
 
 sample-int-writer-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	int-writer.fbp
 sample-int-writer-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
+	flow/int.mod \
 	flow/keyboard.mod \
+	flow/timer.mod \
 	flow/unix-socket.mod
 
 sample-rgb-reader-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	rgb-reader.fbp
 sample-rgb-reader-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
+	flow/console.mod \
 	flow/unix-socket.mod
 
 sample-rgb-writer-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	rgb-writer.fbp
 sample-rgb-writer-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
+	flow/constant.mod \
+	flow/converter.mod \
+	flow/int.mod \
 	flow/keyboard.mod \
+	flow/timer.mod \
 	flow/unix-socket.mod
 
 sample-string-reader-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	string-reader.fbp
 sample-string-reader-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
+	flow/console.mod \
 	flow/unix-socket.mod
 
 sample-string-writer-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	string-writer.fbp
 sample-string-writer-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
+	flow/converter.mod \
+	flow/int.mod \
 	flow/keyboard.mod \
+	flow/timer.mod \
 	flow/unix-socket.mod


### PR DESCRIPTION
Since now we can successfully run check + check-fbp + check-fbp-bin with
allmodconfig it's reasonable to also run make samples with that
configuration, for that we should name all the required dependencies.

We plan to make it "automatic" in a near future but for now it's ok to
to namely declare the deps;

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>