### PR TITLE
flow: support receiving scaped suboptions keys

### DIFF
--- a/src/lib/flow/sol-flow-node-options.c
+++ b/src/lib/flow/sol-flow-node-options.c
@@ -115,7 +115,7 @@ get_member_memory(const struct sol_flow_node_options_member_description *member,
             } \
             i = key_name + strlen(#_key); \
             for (; i < _key; i++) \
-                if (!isspace(*i)) { \
+                if (!(isspace(*i) || *i == '"')) { \
                     remaining = _key; \
                     break; \
                 } \


### PR DESCRIPTION
Since conffiles parts are passed to these options parser functions,
they need to be able to handle double quotes after keynames.

Example of possible value passed to rgb_parse:
  "rgb": {
      "red": 255
  }

It would fail because there is a char different from space
between keyname (rgb) and ':'.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>