### PR TITLE
build: Stop creating builtins.json

### DIFF
--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -378,11 +378,6 @@ $($(1)-src): $(1) $(SOL_FBP_GENERATOR_BIN)
 endef
 $(foreach gen,$(all-fbp-gens),$(eval $(call make-fbp-gen,$(gen))))
 
-$(FLOW_BUILTINS_DESC): $(SOL_LIB_OUTPUT) $(all-mod-descs) $(JSON_FORMAT_SCRIPT)
-	$(Q)echo "     "GEN"   "$@
-	$(Q)$(MKDIR) -p $(dir $(@))
-	$(Q)$(PYTHON) $(FLOW_MERGE_BUILTINS_SCRIPT) --modules-dir=$(build_descdir) $(@) $(builtins-flow)
-
 define install-resource
 $(2): $(1)
 	$(Q)echo "    "INST"   "$(1)

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -96,10 +96,6 @@ PHONY += samples
 PRE_INSTALL := $(PC_GEN) $(SOL_LIB_OUTPUT) $(bins-out) $(modules-out) $(all-mod-descs)
 PRE_INSTALL += $(NODE_TYPE_SCHEMA_DEST) $(BOARD_DETECT_DEST) $(GDB_AUTOLOAD_PY_DEST)
 
-ifneq (,$(strip $(builtins-flow)))
-PRE_GEN += $(FLOW_BUILTINS_DESC)
-endif
-
 ifeq (y,$(RPATH))
 rpath-bins := $(subst $(build_sysroot)/,$(DESTDIR),$(bins-out))
 

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -288,8 +288,6 @@ FLOW_NODE_TYPE_FIND_IN := $(SCRIPTDIR)sol-flow-node-type-find.py.in
 
 $(call add-template,$(FLOW_NODE_TYPE_FIND_IN),$(FLOW_NODE_TYPE_FIND))
 
-FLOW_BUILTINS_DESC := $(build_descdir)builtins.json
-
 FLOW_MERGE_BUILTINS_SCRIPT := $(SCRIPTDIR)flow-merge-builtins.py
 
 JSON_FORMAT_SCRIPT := $(SCRIPTDIR)json-format.py


### PR DESCRIPTION
Individual jsons are being generated for all modules,
even the builtin ones.

Signed-off-by: Anselmo L. S. Melo <anselmo.melo@intel.com>