### PR TITLE
check-license fixes, use spdx format for BSD-3-Clause

### DIFF
--- a/data/oic/oicgen.py
+++ b/data/oic/oicgen.py
@@ -886,7 +886,7 @@ def master_json_as_string(generated):
         'name': 'oic',
         'meta': {
             'author': 'Intel Corporation',
-            'license': 'BSD 3-Clause',
+            'license': 'BSD-3-Clause',
             'version': '1'
         },
         'types': [t['json_server'] for t in generated] + [t['json_client'] for t in generated]

--- a/src/bin/sol-fbp-runner/sol-flow.json
+++ b/src/bin/sol-fbp-runner/sol-flow.json
@@ -1,4 +1,5 @@
 {
+ "$schema": "http://solettaproject.github.io/soletta/schemas/config.schema",
  "nodetypes": [
   {
    "name": "Label",

--- a/src/modules/flow/accelerometer/accelerometer.json
+++ b/src/modules/flow/accelerometer/accelerometer.json
@@ -3,7 +3,7 @@
   "name": "accelerometer",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/aio/aio.json
+++ b/src/modules/flow/aio/aio.json
@@ -3,7 +3,7 @@
   "name": "aio",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/am2315/am2315.json
+++ b/src/modules/flow/am2315/am2315.json
@@ -3,7 +3,7 @@
   "name": "am2315",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/app/app.json
+++ b/src/modules/flow/app/app.json
@@ -3,7 +3,7 @@
   "name": "app",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/boolean/boolean.json
+++ b/src/modules/flow/boolean/boolean.json
@@ -3,7 +3,7 @@
   "name": "boolean",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/byte/byte.json
+++ b/src/modules/flow/byte/byte.json
@@ -3,7 +3,7 @@
   "name": "byte",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/calamari/calamari.json
+++ b/src/modules/flow/calamari/calamari.json
@@ -3,7 +3,7 @@
   "name": "calamari",
   "meta": {
       "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
       "version": "1"
   },
   "types": [

--- a/src/modules/flow/color/color.json
+++ b/src/modules/flow/color/color.json
@@ -3,7 +3,7 @@
   "name": "color",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/compass/compass.json
+++ b/src/modules/flow/compass/compass.json
@@ -3,7 +3,7 @@
   "name": "compass",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/console/console.json
+++ b/src/modules/flow/console/console.json
@@ -2,7 +2,7 @@
   "$schema": "http://solettaproject.github.io/soletta/schemas/node-type-genspec.schema",
   "category": "output/sw",
   "author": "Intel Corporation",
-  "license": "BSD 3-Clause",
+  "license": "BSD-3-Clause",
   "description": "Console Output",
   "in_ports": [
   {

--- a/src/modules/flow/constant/constant.json
+++ b/src/modules/flow/constant/constant.json
@@ -3,7 +3,7 @@
   "name": "constant",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/converter/converter.json
+++ b/src/modules/flow/converter/converter.json
@@ -3,7 +3,7 @@
   "name": "converter",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/evdev/evdev.json
+++ b/src/modules/flow/evdev/evdev.json
@@ -3,7 +3,7 @@
   "name": "evdev",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/file/file.json
+++ b/src/modules/flow/file/file.json
@@ -3,7 +3,7 @@
   "name": "file",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/filter-repeated/filter-repeated.json
+++ b/src/modules/flow/filter-repeated/filter-repeated.json
@@ -3,7 +3,7 @@
   "name": "filter-repeated",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/float/float.json
+++ b/src/modules/flow/float/float.json
@@ -3,7 +3,7 @@
   "name": "float",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/flower-power/flower-power.json
+++ b/src/modules/flow/flower-power/flower-power.json
@@ -3,7 +3,7 @@
   "name": "flower-power",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/gpio/gpio.json
+++ b/src/modules/flow/gpio/gpio.json
@@ -3,7 +3,7 @@
   "name": "gpio",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/grove/grove.json
+++ b/src/modules/flow/grove/grove.json
@@ -3,7 +3,7 @@
   "name": "grove",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/gtk/gtk.json
+++ b/src/modules/flow/gtk/gtk.json
@@ -3,7 +3,7 @@
   "name": "gtk",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/gyroscope/gyroscope.json
+++ b/src/modules/flow/gyroscope/gyroscope.json
@@ -3,7 +3,7 @@
   "name": "gyroscope",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/http-server/http-server.json
+++ b/src/modules/flow/http-server/http-server.json
@@ -3,7 +3,7 @@
   "name": "http-server",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/iio/iio.json
+++ b/src/modules/flow/iio/iio.json
@@ -3,7 +3,7 @@
   "name": "iio",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/int/int.json
+++ b/src/modules/flow/int/int.json
@@ -3,7 +3,7 @@
   "name": "int",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/keyboard/keyboard.json
+++ b/src/modules/flow/keyboard/keyboard.json
@@ -3,7 +3,7 @@
   "name": "keyboard",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/led-7seg/led-7seg.json
+++ b/src/modules/flow/led-7seg/led-7seg.json
@@ -3,7 +3,7 @@
   "name": "led-7seg",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/led-strip/led-strip.json
+++ b/src/modules/flow/led-strip/led-strip.json
@@ -3,7 +3,7 @@
   "name": "led-strip",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/location/location.json
+++ b/src/modules/flow/location/location.json
@@ -3,7 +3,7 @@
   "name": "location",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/magnetometer/magnetometer.json
+++ b/src/modules/flow/magnetometer/magnetometer.json
@@ -3,7 +3,7 @@
   "name": "magnetometer",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/max31855/max31855.json
+++ b/src/modules/flow/max31855/max31855.json
@@ -3,7 +3,7 @@
   "name": "max31855",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/network/network.json
+++ b/src/modules/flow/network/network.json
@@ -3,7 +3,7 @@
   "name": "network",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/persistence/persistence.json
+++ b/src/modules/flow/persistence/persistence.json
@@ -3,7 +3,7 @@
   "name": "persistence",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/piezo-speaker/piezo-speaker.json
+++ b/src/modules/flow/piezo-speaker/piezo-speaker.json
@@ -3,7 +3,7 @@
   "name": "piezo-speaker",
   "meta": {
       "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
       "version": "1"
   },
   "types": [

--- a/src/modules/flow/platform/platform.json
+++ b/src/modules/flow/platform/platform.json
@@ -3,7 +3,7 @@
   "name": "platform",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/process/process.json
+++ b/src/modules/flow/process/process.json
@@ -3,7 +3,7 @@
   "name": "process",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/pwm/pwm.json
+++ b/src/modules/flow/pwm/pwm.json
@@ -2,7 +2,7 @@
   "$schema": "http://solettaproject.github.io/soletta/schemas/node-type-genspec.schema",
   "category": "io/hw",
   "author": "Intel Corporation",
-  "license": "BSD 3-Clause",
+  "license": "BSD-3-Clause",
   "description": "PWM",
   "in_ports": [
   {

--- a/src/modules/flow/random/random.json
+++ b/src/modules/flow/random/random.json
@@ -3,7 +3,7 @@
   "name": "random",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/servo-motor/servo-motor.json
+++ b/src/modules/flow/servo-motor/servo-motor.json
@@ -3,7 +3,7 @@
   "name": "servo-motor",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/string/string.json
+++ b/src/modules/flow/string/string.json
@@ -3,7 +3,7 @@
   "name": "string",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/switcher/switcher.json
+++ b/src/modules/flow/switcher/switcher.json
@@ -3,7 +3,7 @@
   "name": "switcher",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/temperature/temperature.json
+++ b/src/modules/flow/temperature/temperature.json
@@ -3,7 +3,7 @@
   "name": "temperature",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/test/test.json
+++ b/src/modules/flow/test/test.json
@@ -3,7 +3,7 @@
   "name": "test",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/thingspeak/thingspeak.json
+++ b/src/modules/flow/thingspeak/thingspeak.json
@@ -3,7 +3,7 @@
   "name": "thingspeak",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/timer/timer.json
+++ b/src/modules/flow/timer/timer.json
@@ -2,7 +2,7 @@
   "$schema": "http://solettaproject.github.io/soletta/schemas/node-type-genspec.schema",
   "category": "timer",
   "author": "Intel Corporation",
-  "license": "BSD 3-Clause",
+  "license": "BSD-3-Clause",
   "description": "Provides an empty packet on a timely manner",
   "in_ports": [
   {

--- a/src/modules/flow/timestamp/timestamp.json
+++ b/src/modules/flow/timestamp/timestamp.json
@@ -3,7 +3,7 @@
   "name": "timestamp",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/trigonometry/trigonometry.json
+++ b/src/modules/flow/trigonometry/trigonometry.json
@@ -3,7 +3,7 @@
   "name": "trigonometry",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/udev/udev.json
+++ b/src/modules/flow/udev/udev.json
@@ -3,7 +3,7 @@
   "name": "udev",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/unix-socket/unix-socket.json
+++ b/src/modules/flow/unix-socket/unix-socket.json
@@ -3,7 +3,7 @@
   "name": "unix-socket",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/modules/flow/wallclock/wallclock.json
+++ b/src/modules/flow/wallclock/wallclock.json
@@ -3,7 +3,7 @@
   "name": "wallclock",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/samples/flow/c-api/custom-node-types.json
+++ b/src/samples/flow/c-api/custom-node-types.json
@@ -3,7 +3,7 @@
   "name": "custom-node-types",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/src/test-fbp/sol-flow.json
+++ b/src/test-fbp/sol-flow.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "http://solettaproject.github.io/soletta/schemas/config.schema",
     "nodetypes": [
 	{ 
             "name": "TestConsole",

--- a/src/test-stub-gen/dummy.json
+++ b/src/test-stub-gen/dummy.json
@@ -3,7 +3,7 @@
   "name": "dummy",
   "meta": {
     "author": "Intel Corporation",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1"
   },
   "types": [

--- a/tools/check-license.sh
+++ b/tools/check-license.sh
@@ -83,7 +83,7 @@ for f in $(cat $DIFF_LIST); do
         if [ $(grep -c -m 1 "config.schema" $f) -ne 0 ]; then
             continue;
         fi
-        r=$(grep -c -m 1 "\"license\": \"BSD 3\-Clause\"" $f);
+        r=$(grep -c -m 1 "\"license\": \"BSD-3-Clause\"" $f);
     else
         r=$(grep -c -m 1 "This file is part of the Soletta Project" $f)
     fi


### PR DESCRIPTION
spdx identifiers: http://spdx.org/licenses/

Hopefully the check-license script will be replaced by a new one (python?) in the future, for the sake of the sanity.