### PR TITLE
Use uname(2) on get_os_version.

### DIFF
--- a/src/lib/common/sol-platform-impl-contiki.c
+++ b/src/lib/common/sol-platform-impl-contiki.c
@@ -109,10 +109,3 @@ sol_platform_impl_get_serial_number(char **number)
     SOL_WRN("Not implemented");
     return -ENOTSUP;
 }
-
-char *
-sol_platform_impl_get_os_version(void)
-{
-    SOL_WRN("Not implemented");
-    return NULL;
-}

--- a/src/lib/common/sol-platform-impl-dummy.c
+++ b/src/lib/common/sol-platform-impl-dummy.c
@@ -109,10 +109,3 @@ sol_platform_impl_get_serial_number(char **number)
     SOL_WRN("Not implemented");
     return -ENOTSUP;
 }
-
-char *
-sol_platform_impl_get_os_version(void)
-{
-    SOL_WRN("Not implemented");
-    return NULL;
-}

--- a/src/lib/common/sol-platform-impl-linux-micro.c
+++ b/src/lib/common/sol-platform-impl-linux-micro.c
@@ -846,18 +846,6 @@ sol_platform_impl_get_serial_number(char **number)
     return r;
 }
 
-char *
-sol_platform_impl_get_os_version(void)
-{
-    char *ret = NULL;
-    int r;
-
-    r = sol_util_get_os_version(&ret);
-    SOL_INT_CHECK(r, < 0, NULL);
-
-    return ret;
-}
-
 SOL_API void
 sol_platform_linux_micro_inform_service_state(const char *service, enum sol_platform_service_state state)
 {

--- a/src/lib/common/sol-platform-impl-riot.c
+++ b/src/lib/common/sol-platform-impl-riot.c
@@ -180,9 +180,3 @@ sol_platform_impl_get_serial_number(char **number)
     return -ENOSYS;
 #endif
 }
-
-char *
-sol_platform_impl_get_os_version(void)
-{
-    return strdup(RIOT_VERSION);
-}

--- a/src/lib/common/sol-platform-impl-systemd.c
+++ b/src/lib/common/sol-platform-impl-systemd.c
@@ -446,6 +446,7 @@ int
 sol_platform_impl_get_machine_id(char id[static 33])
 {
     int r;
+
     r = sol_util_read_file("/etc/machine-id", "%32s", id);
     /* that id should have already been validated by systemd */
 
@@ -467,18 +468,6 @@ sol_platform_impl_get_serial_number(char **number)
         return -errno;
 
     return r;
-}
-
-char *
-sol_platform_impl_get_os_version(void)
-{
-    char *ret = NULL;
-    int r;
-
-    r = sol_util_get_os_version(&ret);
-    SOL_INT_CHECK(r, < 0, NULL);
-
-    return ret;
 }
 
 int

--- a/src/lib/common/sol-platform-impl.h
+++ b/src/lib/common/sol-platform-impl.h
@@ -54,7 +54,6 @@ int sol_platform_impl_set_target(const char *target) SOL_ATTR_NONNULL(1);
 
 int sol_platform_impl_get_machine_id(char id[static 33]);
 int sol_platform_impl_get_serial_number(char **number);
-char *sol_platform_impl_get_os_version(void);
 
 /* callbacks into generic platform abstraction */
 void sol_platform_inform_state_monitors(enum sol_platform_state state);

--- a/src/lib/common/sol-platform.c
+++ b/src/lib/common/sol-platform.c
@@ -394,7 +394,13 @@ sol_platform_get_sw_version(void)
 SOL_API char *
 sol_platform_get_os_version(void)
 {
-    return sol_platform_impl_get_os_version();
+    char *out = NULL;
+
+    int r = sol_util_get_os_version(&out);
+
+    SOL_INT_CHECK(r, < 0, NULL);
+
+    return out;
 }
 
 void

--- a/src/shared/sol-util-contiki.c
+++ b/src/shared/sol-util-contiki.c
@@ -54,3 +54,10 @@ sol_util_timespec_get_realtime(struct timespec *t)
     errno = ENOSYS;
     return -1;
 }
+
+int
+sol_util_get_os_version(char **out)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}

--- a/src/shared/sol-util-file.c
+++ b/src/shared/sol-util-file.c
@@ -372,46 +372,6 @@ sol_util_get_rootdir(char *out, size_t size)
 }
 
 int
-sol_util_get_os_version(char **out)
-{
-    char *ptr, *end, *str;
-    static const char version[] = "VERSION_ID";
-
-    SOL_NULL_CHECK(out, -EINVAL);
-
-    str = sol_util_load_file_string("/etc/os-release", NULL);
-    if (!str) {
-        str = sol_util_load_file_string("/usr/lib/os-release", NULL);
-        if (!str)
-            goto err;
-    }
-
-    ptr = strstr(str, version);
-    if (!ptr)
-        goto err;
-
-    ptr += sizeof(version);
-
-    if (!*ptr)
-        goto err;
-
-    end = strstr(ptr, "\n");
-    if (!end || end == ptr)
-        goto err;
-
-    *out = strndup(ptr, end - ptr);
-    if (!*out)
-        goto err;
-
-    free(str);
-    return 0;
-
-err:
-    free(str);
-    return -ENOTSUP;
-}
-
-int
 sol_util_fd_set_flag(int fd, int flag)
 {
     int flags;

--- a/src/shared/sol-util-file.h
+++ b/src/shared/sol-util-file.h
@@ -51,7 +51,6 @@ struct sol_buffer *sol_util_load_file_raw(const int fd) SOL_ATTR_WARN_UNUSED_RES
 char *sol_util_load_file_string(const char *filename, size_t *size) SOL_ATTR_WARN_UNUSED_RESULT;
 char *sol_util_load_file_fd_string(const int fd, size_t *size) SOL_ATTR_WARN_UNUSED_RESULT;
 int sol_util_get_rootdir(char *out, size_t size) SOL_ATTR_WARN_UNUSED_RESULT;
-int sol_util_get_os_version(char **out) SOL_ATTR_WARN_UNUSED_RESULT;
 int sol_util_fd_set_flag(int fd, int flag) SOL_ATTR_WARN_UNUSED_RESULT;
 
 /**

--- a/src/shared/sol-util-linux.c
+++ b/src/shared/sol-util-linux.c
@@ -38,6 +38,7 @@
 #include <stdio.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/utsname.h>
 #include <unistd.h>
 
 struct timespec
@@ -52,4 +53,20 @@ int
 sol_util_timespec_get_realtime(struct timespec *t)
 {
     return clock_gettime(CLOCK_REALTIME, t);
+}
+
+int
+sol_util_get_os_version(char **out)
+{
+    struct utsname hostinfo;
+    int r;
+
+    r = uname(&hostinfo);
+    SOL_INT_CHECK(r, == -1, -errno);
+
+    r = asprintf(out, "%s %s", hostinfo.sysname, hostinfo.release);
+    if (r == -1)
+        return -ENOMEM;
+
+    return 0;
 }

--- a/src/shared/sol-util-riot.c
+++ b/src/shared/sol-util-riot.c
@@ -68,3 +68,9 @@ sol_util_timespec_get_realtime(struct timespec *t)
     return -1;
 #endif
 }
+
+int
+sol_util_get_os_version(char **out)
+{
+    return strdup(RIOT_VERSION);
+}

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -134,6 +134,7 @@ sol_util_int_compare(const int a, const int b)
 
 struct timespec sol_util_timespec_get_current(void);
 int sol_util_timespec_get_realtime(struct timespec *t);
+int sol_util_get_os_version(char **out) SOL_ATTR_WARN_UNUSED_RESULT;
 
 static inline void
 sol_util_timespec_sum(struct timespec *t1, struct timespec *t2, struct timespec *result)


### PR DESCRIPTION
Also moving it to a sol_util function, that is now more suitable.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>