### PR TITLE
Memmap v3

### DIFF
--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -57,6 +57,7 @@ static struct {
     const char *conf_file;
     const char *output_file;
     const char *export_symbol;
+    const char *memory_map_file;
 
     struct sol_ptr_vector json_files;
     struct sol_ptr_vector fbp_search_paths;
@@ -757,6 +758,135 @@ collect_context_info(struct generate_context *ctx, struct fbp_data *data)
     return true;
 }
 
+static bool
+generate_memory_map_struct(const char *json_file, int *elements)
+{
+    struct sol_file_reader *fr = NULL;
+    struct sol_json_scanner scanner, entries;
+    struct sol_str_slice contents;
+    struct sol_json_token token, key, value;
+    enum sol_json_loop_reason reason;
+    uint32_t version = 0;
+
+    *elements = 0;
+
+    fr = sol_file_reader_open(json_file);
+    if (!fr) {
+        SOL_ERR("Couldn't open json file '%s': %s\n", json_file, sol_util_strerrora(errno));
+        return false;
+    }
+
+    contents = sol_file_reader_get_all(fr);
+    sol_json_scanner_init(&scanner, contents.data, contents.len);
+
+    SOL_JSON_SCANNER_OBJECT_LOOP (&scanner, &token, &key, &value, reason) {
+        if (!SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "maps"))
+            continue;
+
+        sol_json_scanner_init_from_token(&scanner, &value);
+        SOL_JSON_SCANNER_ARRAY_LOOP (&scanner, &token, SOL_JSON_TYPE_OBJECT_START, reason) {
+            struct sol_str_slice path = { };
+
+            out("static const struct sol_memmap_map _memmap%d = {\n", (*elements)++);
+
+            SOL_JSON_SCANNER_OBJECT_LOOP_NEST (&scanner, &token, &key, &value, reason) {
+
+                if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "path")) {
+                    sol_json_token_remove_quotes(&value);
+                    path = sol_json_token_to_slice(&value);
+                } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "version")) {
+                    if (sol_json_token_get_uint32(&value, &version) < 0) {
+                        SOL_WRN("Couldn't get memory map version");
+                        goto error;
+                    }
+                } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "entries")) {
+                    sol_json_scanner_init_from_token(&entries, &value);
+
+                    out("    .entries = {\n");
+
+                    SOL_JSON_SCANNER_ARRAY_LOOP (&entries, &token, SOL_JSON_TYPE_OBJECT_START, reason) {
+                        uint32_t size = 0, offset = 0, bit_offset = 0, bit_size = 0;
+                        struct sol_str_slice name = { };
+
+                        SOL_JSON_SCANNER_OBJECT_LOOP_NEST (&entries, &token, &key, &value, reason) {
+                            if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "name")) {
+                                sol_json_token_remove_quotes(&value);
+                                name = sol_json_token_to_slice(&value);
+                                if (!name.len) {
+                                    SOL_WRN("Couldn't get entry name");
+                                    goto error;
+                                }
+                            } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "offset")) {
+                                if (sol_json_token_get_uint32(&value, &offset) < 0) {
+                                    SOL_WRN("Couldn't get entry offset");
+                                    goto error;
+                                }
+                            } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "size")) {
+                                if (sol_json_token_get_uint32(&value, &size) < 0) {
+                                    SOL_WRN("Couldn't get entry size");
+                                    goto error;
+                                }
+                            } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "bit_offset")) {
+                                if (sol_json_token_get_uint32(&value, &bit_offset) < 0) {
+                                    SOL_WRN("Couldn't get entry size");
+                                    goto error;
+                                }
+                                if (bit_offset > 7) {
+                                    SOL_WRN("Entry bit offset cannot be greater than 7");
+                                    goto error;
+                                }
+                            } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "bit_size")) {
+                                if (sol_json_token_get_uint32(&value, &bit_size) < 0) {
+                                    SOL_WRN("Couldn't get entry bit size");
+                                    goto error;
+                                }
+                            }
+                        }
+
+                        if (bit_size > (size * 8)) {
+                            SOL_WRN("Invalid bit size for entry. Must not be greater"
+                                "than size * 8 [%d]", size * 8);
+                            goto error;
+                        }
+                        if (!size) {
+                            SOL_WRN("Invalid size for entry");
+                            goto error;
+                        }
+
+                        out("       SOL_MEMMAP_ENTRY_BIT_SIZE(\"%.*s\", %u, %u, %u, %u),\n",
+                            SOL_STR_SLICE_PRINT(name), offset, size, bit_offset, bit_size);
+                    }
+                    if (reason != SOL_JSON_LOOP_REASON_OK)
+                        goto error;
+                }
+            }
+            if (reason != SOL_JSON_LOOP_REASON_OK)
+                goto error;
+
+
+            if (!version) {
+                SOL_WRN("Invalid map file version, it must be greater than 0");
+                goto error;
+            }
+
+            out("       { }\n"
+                "   },\n"
+                "   .version = %u,\n"
+                "   .path = \"%.*s\"\n"
+                "};\n", version, SOL_STR_SLICE_PRINT(path));
+        }
+        if (reason != SOL_JSON_LOOP_REASON_OK)
+            goto error;
+    }
+    sol_file_reader_close(fr);
+
+    return true;
+
+error:
+    sol_file_reader_close(fr);
+    return false;
+}
+
 static int
 generate(struct sol_vector *fbp_data_vector)
 {
@@ -768,7 +898,7 @@ generate(struct sol_vector *fbp_data_vector)
     struct fbp_data *data;
     struct sol_str_slice *module, *symbol;
     uint16_t i;
-    int r;
+    int r, memmap_elems;
 
     out(
         "#include \"sol-flow.h\"\n"
@@ -790,6 +920,14 @@ generate(struct sol_vector *fbp_data_vector)
         out("#include \"sol-flow/%.*s.h\"\n", SOL_STR_SLICE_PRINT(*module));
     }
 
+    if (args.memory_map_file) {
+        out("#include \"sol-memmap-storage.h\"\n\n");
+        if (!generate_memory_map_struct(args.memory_map_file, &memmap_elems)) {
+            r = EXIT_FAILURE;
+            goto end;
+        }
+    }
+
     /* Reverse since the dependencies appear later in the vector. */
     SOL_VECTOR_FOREACH_REVERSE_IDX (fbp_data_vector, data, i) {
         if (!generate_create_type_function(data)) {
@@ -809,6 +947,11 @@ generate(struct sol_vector *fbp_data_vector)
             "        %.*s->init_type();\n",
             SOL_STR_SLICE_PRINT(*symbol),
             SOL_STR_SLICE_PRINT(*symbol));
+    }
+    if (args.memory_map_file) {
+        out("\n");
+        for (i = 0; i < memmap_elems; i++)
+            out("   sol_memmap_add_map(&_memmap%d);\n", i);
     }
     out(
         "}\n\n");
@@ -1002,13 +1145,15 @@ search_fbp_file(char *fullpath, const char *basename)
 static void
 print_usage(const char *program)
 {
-    fprintf(stderr, "usage: %s [-c CONF] [-j DESC -j DESC...] [-s SYMBOL] INPUT OUTPUT\n"
+    fprintf(stderr, "usage: %s [-c CONF] [-j DESC -j DESC...] [-m MAP] [-s SYMBOL] INPUT OUTPUT\n"
         "Generates C code from INPUT into the OUTPUT file.\n\n"
         "Options:\n"
         "    -c  Uses the CONF .json file for resolving unknown types.\n"
         "    -j  When resolving types, use the passed DESC files. If DESC is\n"
         "        a directory then all the .json files in the directory will be used.\n"
         "        Multiple -j can be passed.\n"
+        "    -m  Uses memory map MAP .json file to map 'persistence' fields on.\n"
+        "        persistent storage, like NVRAM or EEPROM\n"
         "    -s  Define a function named SYMBOL that will return the type from FBP\n"
         "        and don't generate any main function or entry point.\n"
         "    -I  Define search path for FBP files\n"
@@ -1031,7 +1176,7 @@ parse_args(int argc, char *argv[])
     sol_ptr_vector_init(&args.json_files);
     sol_ptr_vector_init(&args.fbp_search_paths);
 
-    while ((opt = getopt(argc, argv, "s:c:j:I:")) != -1) {
+    while ((opt = getopt(argc, argv, "s:c:j:I:m:")) != -1) {
         switch (opt) {
         case 's':
             args.export_symbol = optarg;
@@ -1058,6 +1203,14 @@ parse_args(int argc, char *argv[])
                     optarg, sol_util_strerrora(errno));
                 return false;
             }
+            break;
+        case 'm':
+            if (access(optarg, R_OK) == -1) {
+                SOL_ERR("Can't access memory map file '%s': %s",
+                    optarg, sol_util_strerrora(errno));
+                return false;
+            }
+            args.memory_map_file = optarg;
             break;
         case '?':
             print_usage(argv[0]);

--- a/src/bin/sol-fbp-runner/main.c
+++ b/src/bin/sol-fbp-runner/main.c
@@ -35,10 +35,18 @@
 #include <unistd.h>
 #include <stdlib.h>
 
+#include "sol-arena.h"
+#include "sol-file-reader.h"
 #include "sol-flow-buildopts.h"
+#include "sol-json.h"
 #include "sol-log.h"
 #include "sol-mainloop.h"
+#include "sol-util.h"
 #include "sol-vector.h"
+
+#ifdef USE_MEMMAP
+#include "sol-memmap-storage.h"
+#endif
 
 #include "runner.h"
 
@@ -46,6 +54,8 @@
 
 static struct {
     const char *name;
+
+    const char *memory_map_file;
 
     const char *options[MAX_OPTS + 1];
     int options_count;
@@ -57,6 +67,11 @@ static struct {
 } args;
 
 static struct runner *the_runner;
+static struct sol_arena *str_arena;
+
+#ifdef USE_MEMMAP
+static struct sol_ptr_vector memory_maps = SOL_PTR_VECTOR_INIT;
+#endif
 
 #ifdef SOL_FLOW_INSPECTOR_ENABLED
 /* defined in inspector.c */
@@ -73,6 +88,10 @@ usage(const char *program)
         "Options:\n"
         "    -c            Check syntax only. The program will exit as soon as the flow\n"
         "                  is built and the syntax is verified.\n"
+#ifdef USE_MEMMAP
+        "    -m            Uses memory map MAP .json file to map 'persistence' fields on\n"
+        "                  persistent storage, like NVRAM and EEPROM\n"
+#endif
         "    -s            Provide simulation nodes for flows with exported ports.\n"
         "    -t            Instead of reading a file, execute a node type with the name\n"
         "                  passed as first argument. Implies -s.\n"
@@ -92,6 +111,9 @@ parse_args(int argc, char *argv[])
     const char known_opts[] = "cho:stI:"
 #ifdef SOL_FLOW_INSPECTOR_ENABLED
         "D"
+#endif
+#ifdef USE_MEMMAP
+        "m:"
 #endif
     ;
 
@@ -131,6 +153,16 @@ parse_args(int argc, char *argv[])
                 exit(1);
             }
             break;
+#ifdef USE_MEMMAP
+        case 'm':
+            if (access(optarg, R_OK) == -1) {
+                fprintf(stderr, "Can't access memory map file '%s': %s\n",
+                    optarg, sol_util_strerrora(errno));
+                return false;
+            }
+            args.memory_map_file = optarg;
+            break;
+#endif
         default:
             return false;
         }
@@ -149,11 +181,207 @@ parse_args(int argc, char *argv[])
     return true;
 }
 
+#ifdef USE_MEMMAP
+static void
+clear_memory_maps(void)
+{
+    const struct sol_str_table_ptr *iter;
+    struct sol_memmap_map *map;
+    int i;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&memory_maps, map, i) {
+        for (iter = map->entries; iter->key; iter++) {
+            free((void *)iter->val);
+        }
+
+        free(map);
+    }
+
+    sol_ptr_vector_clear(&memory_maps);
+}
+
+static bool
+load_memory_map_file(const char *json_file)
+{
+    struct sol_file_reader *fr = NULL;
+    struct sol_json_scanner scanner, entries;
+    struct sol_str_slice contents;
+    struct sol_json_token token, key, value;
+    enum sol_json_loop_reason reason;
+    struct sol_vector entries_vector = SOL_VECTOR_INIT(struct sol_str_table_ptr);
+    struct sol_memmap_map *map = NULL;
+    struct sol_memmap_entry *memmap_entry;
+    struct sol_str_table_ptr *ptr_table_entry;
+    uint32_t version;
+    size_t entries_vector_size;
+    void *data;
+    int i;
+    char *path;
+
+    fr = sol_file_reader_open(json_file);
+    if (!fr) {
+        SOL_ERR("Couldn't open json file '%s': %s\n", json_file, sol_util_strerrora(errno));
+        return false;
+    }
+
+    contents = sol_file_reader_get_all(fr);
+    sol_json_scanner_init(&scanner, contents.data, contents.len);
+
+    SOL_JSON_SCANNER_OBJECT_LOOP (&scanner, &token, &key, &value, reason) {
+        if (!SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "maps"))
+            continue;
+
+        sol_json_scanner_init_from_token(&scanner, &value);
+        SOL_JSON_SCANNER_ARRAY_LOOP (&scanner, &token, SOL_JSON_TYPE_OBJECT_START, reason) {
+            SOL_JSON_SCANNER_OBJECT_LOOP_NEST (&scanner, &token, &key, &value, reason) {
+                if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "path")) {
+                    sol_json_token_remove_quotes(&value);
+                    path = strndupa(value.start,
+                        sol_json_token_get_size(&value));
+                    if (!path) {
+                        SOL_WRN("Couldn't get map path");
+                        goto error;
+                    }
+                } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "version")) {
+                    if (sol_json_token_get_uint32(&value, &version) < 0) {
+                        SOL_WRN("Couldn't get memory map version");
+                        goto error;
+                    }
+                } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "entries")) {
+                    sol_json_scanner_init_from_token(&entries, &value);
+
+                    SOL_JSON_SCANNER_ARRAY_LOOP (&entries, &token, SOL_JSON_TYPE_OBJECT_START, reason) {
+                        uint32_t size = 0, offset = 0, bit_offset = 0, bit_size = 0;
+                        struct sol_str_slice name = { };
+
+                        SOL_JSON_SCANNER_OBJECT_LOOP_NEST (&entries, &token, &key, &value, reason) {
+                            if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "name")) {
+                                sol_json_token_remove_quotes(&value);
+                                name = sol_json_token_to_slice(&value);
+                                if (!name.len) {
+                                    SOL_WRN("Couldn't get entry name");
+                                    goto error;
+                                }
+                            } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "offset")) {
+                                if (sol_json_token_get_uint32(&value, &offset) < 0) {
+                                    SOL_WRN("Couldn't get entry offset");
+                                    goto error;
+                                }
+                            } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "size")) {
+                                if (sol_json_token_get_uint32(&value, &size) < 0) {
+                                    SOL_WRN("Couldn't get entry size");
+                                    goto error;
+                                }
+                            } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "bit_offset")) {
+                                if (sol_json_token_get_uint32(&value, &bit_offset) < 0) {
+                                    SOL_WRN("Couldn't get entry size");
+                                    goto error;
+                                }
+                                if (bit_offset > 7) {
+                                    SOL_WRN("Entry bit offset cannot be greater than 7");
+                                    goto error;
+                                }
+                            } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "bit_size")) {
+                                if (sol_json_token_get_uint32(&value, &bit_size) < 0) {
+                                    SOL_WRN("Couldn't get entry bit size");
+                                    goto error;
+                                }
+                            }
+                        }
+                        if (reason != SOL_JSON_LOOP_REASON_OK)
+                            goto error;
+
+                        if (bit_size > (size * 8)) {
+                            SOL_WRN("Invalid bit size for entry. Must not be greater"
+                                "than size * 8 [%d]", size * 8);
+                            goto error;
+                        }
+                        if (!size) {
+                            SOL_WRN("Invalid size for entry");
+                            goto error;
+                        }
+
+                        ptr_table_entry = sol_vector_append(&entries_vector);
+                        SOL_NULL_CHECK_GOTO(ptr_table_entry, error);
+
+                        memmap_entry = calloc(sizeof(struct sol_memmap_entry), 1);
+                        SOL_NULL_CHECK_GOTO(memmap_entry, error);
+
+                        memmap_entry->offset = offset;
+                        memmap_entry->size = size;
+                        memmap_entry->bit_offset = bit_offset;
+                        memmap_entry->bit_size = bit_size;
+
+                        if (!name.len) {
+                            SOL_WRN("Memmap entries must have a name");
+                            goto error;
+                        }
+                        ptr_table_entry->key = sol_arena_strdup_slice(str_arena, name);
+                        if (!ptr_table_entry->key) {
+                            SOL_WRN("Could not copy entry name");
+                            goto error;
+                        }
+                        ptr_table_entry->len = name.len;
+                        ptr_table_entry->val = memmap_entry;
+                    }
+                    if (reason != SOL_JSON_LOOP_REASON_OK)
+                        goto error;
+                }
+            }
+
+            /* Add ptr_table guard element */
+            ptr_table_entry = sol_vector_append(&entries_vector);
+            SOL_NULL_CHECK_GOTO(ptr_table_entry, error);
+
+            entries_vector_size = sizeof(struct sol_str_table_ptr) * entries_vector.len;
+            map = calloc(1, sizeof(struct sol_memmap_map) + entries_vector_size);
+            SOL_NULL_CHECK_GOTO(map, error);
+
+            map->version = version;
+            map->path = sol_arena_strdup(str_arena, path);
+            SOL_NULL_CHECK_GOTO(map->path, error);
+            data = sol_vector_take_data(&entries_vector);
+            memmove(map->entries, data, entries_vector_size);
+            free(data);
+
+            if (sol_memmap_add_map(map) < 0)
+                goto error;
+            if (sol_ptr_vector_append(&memory_maps, map) < 0)
+                goto error;
+        }
+        if (reason != SOL_JSON_LOOP_REASON_OK)
+            goto error;
+    }
+
+    sol_file_reader_close(fr);
+
+    return true;
+
+error:
+    free(map);
+    SOL_VECTOR_FOREACH_IDX (&entries_vector, ptr_table_entry, i) {
+        free((void *)ptr_table_entry->val);
+    }
+    sol_vector_clear(&entries_vector);
+
+    sol_file_reader_close(fr);
+
+    return false;
+}
+
+#endif
+
 static bool
 startup(void *data)
 {
     bool finished = true;
     int result = EXIT_FAILURE;
+
+    str_arena = sol_arena_new();
+    if (!str_arena) {
+        fprintf(stderr, "Cannot create str arena\n");
+        goto end;
+    }
 
     if (args.execute_type) {
         the_runner = runner_new_from_type(args.name, args.options);
@@ -180,6 +408,17 @@ startup(void *data)
         }
     }
 
+    if (args.memory_map_file) {
+#ifdef USE_MEMMAP
+        if (!load_memory_map_file(args.memory_map_file)) {
+            fprintf(stderr, "Could not load memory map file\n");
+            goto end;
+        }
+#else
+        fprintf(stderr, "Memory map file defined, but Soletta has been built without Memory map support.\n");
+#endif
+    }
+
     if (runner_run(the_runner) < 0) {
         fprintf(stderr, "Failed to run\n");
         goto end;
@@ -199,6 +438,12 @@ shutdown(void)
 {
     if (the_runner)
         runner_del(the_runner);
+
+    if (str_arena)
+        sol_arena_del(str_arena);
+#ifdef USE_MEMMAP
+    clear_memory_maps();
+#endif
 
     sol_ptr_vector_clear(&args.fbp_search_paths);
 }

--- a/src/lib/io/Kconfig
+++ b/src/lib/io/Kconfig
@@ -52,3 +52,18 @@ menuconfig USE_PIN_MUX
 source "src/modules/pin-mux/intel-galileo-rev-d/Kconfig"
 source "src/modules/pin-mux/intel-galileo-rev-g/Kconfig"
 source "src/modules/pin-mux/intel-edison-rev-c/Kconfig"
+
+menuconfig USE_STORAGE
+    bool "Persistence Storage Support"
+    depends on LINUX
+    default y
+
+config USE_FILESYSTEM
+    bool "File system persistence storage"
+    depends on USE_STORAGE
+    default y
+
+config USE_EFIVARS
+    bool "EFI vars persistence storage"
+    depends on USE_STORAGE
+    default y

--- a/src/lib/io/Kconfig
+++ b/src/lib/io/Kconfig
@@ -67,3 +67,13 @@ config USE_EFIVARS
     bool "EFI vars persistence storage"
     depends on USE_STORAGE
     default y
+
+config USE_MEMMAP
+    bool "Memory map persistence storage"
+    depends on USE_STORAGE
+    default y
+    help
+        Provide persistence storage based on memory maps.
+        Users must provide a mapping - for instance, using a JSON
+        file - that will be used to define where on memory
+        entries will be saved. Examples of memory are NVRAM or EEPROM.

--- a/src/lib/io/Makefile
+++ b/src/lib/io/Makefile
@@ -16,6 +16,9 @@ obj-$(USE_I2C) += \
 obj-$(USE_SPI) += \
     io-spi.mod
 
+obj-$(USE_STORAGE) += \
+    io-storage.mod
+
 obj-io-aio-$(USE_AIO) := \
     sol-aio-common.o
 obj-io-aio-$(PLATFORM_RIOTOS) += \
@@ -56,6 +59,11 @@ obj-io-uart-$(PLATFORM_RIOTOS) := \
 obj-io-uart-$(PLATFORM_LINUX) := \
     sol-uart-linux.o
 
+obj-io-storage-$(USE_FILESYSTEM) += \
+    sol-fs-storage.o
+obj-io-storage-$(USE_EFIVARS) += \
+    sol-efivarfs-storage.o
+
 headers-$(USE_AIO) += \
     include/sol-aio.h
 headers-$(USE_GPIO) += \
@@ -68,3 +76,7 @@ headers-$(USE_SPI) += \
     include/sol-spi.h
 headers-$(USE_UART) += \
     include/sol-uart.h
+headers-$(USE_FILESYSTEM) += \
+    include/sol-fs-storage.h
+headers-$(USE_EFIVARS) += \
+    include/sol-efivarfs-storage.h

--- a/src/lib/io/Makefile
+++ b/src/lib/io/Makefile
@@ -63,6 +63,8 @@ obj-io-storage-$(USE_FILESYSTEM) += \
     sol-fs-storage.o
 obj-io-storage-$(USE_EFIVARS) += \
     sol-efivarfs-storage.o
+obj-io-storage-$(USE_MEMMAP) += \
+    sol-memmap-storage.o
 
 headers-$(USE_AIO) += \
     include/sol-aio.h
@@ -80,3 +82,5 @@ headers-$(USE_FILESYSTEM) += \
     include/sol-fs-storage.h
 headers-$(USE_EFIVARS) += \
     include/sol-efivarfs-storage.h
+headers-$(USE_MEMMAP) += \
+    include/sol-memmap-storage.h

--- a/src/lib/io/include/sol-efivarfs-storage.h
+++ b/src/lib/io/include/sol-efivarfs-storage.h
@@ -30,124 +30,129 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#pragma once
+
 #include <stddef.h>
 #include <stdint.h>
 
 #include "sol-buffer.h"
 #include "sol-types.h"
 
-int efivars_write_raw(const char *name, struct sol_buffer *buffer);
-int efivars_read_raw(const char *name, struct sol_buffer *buffer);
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int sol_efivars_write_raw(const char *name, struct sol_buffer *buffer);
+int sol_efivars_read_raw(const char *name, struct sol_buffer *buffer);
 
 #define CREATE_BUFFER(_val, _empty) \
-    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val,\
-        sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED); \
-    buf.capacity = sizeof(*(_val)); \
+    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val, \
+    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED); \
     buf.used = (_empty) ? 0 : sizeof(*(_val));
 
 static inline int
-efivars_read_uint8_t(const char *name, uint8_t *value)
+sol_efivars_read_uint8(const char *name, uint8_t *value)
 {
     CREATE_BUFFER(value, true);
 
-    return efivars_read_raw(name, &buf);
+    return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-efivars_write_uint8_t(const char *name, uint8_t value)
+sol_efivars_write_uint8(const char *name, uint8_t value)
 {
     CREATE_BUFFER(&value, false);
 
-    return efivars_write_raw(name, &buf);
+    return sol_efivars_write_raw(name, &buf);
 }
 
 static inline int
-efivars_read_bool(const char *name, bool *value)
+sol_efivars_read_bool(const char *name, bool *value)
 {
     CREATE_BUFFER(value, true);
 
-    return efivars_read_raw(name, &buf);
+    return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-efivars_write_bool(const char *name, bool value)
+sol_efivars_write_bool(const char *name, bool value)
 {
     CREATE_BUFFER(&value, false);
 
-    return efivars_write_raw(name, &buf);
+    return sol_efivars_write_raw(name, &buf);
 }
 
 static inline int
-efivars_read_int32_t(const char *name, int32_t *value)
+sol_efivars_read_int32(const char *name, int32_t *value)
 {
     CREATE_BUFFER(value, true);
 
-    return efivars_read_raw(name, &buf);
+    return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-efivars_write_int32_t(const char *name, int32_t value)
+sol_efivars_write_int32(const char *name, int32_t value)
 {
     CREATE_BUFFER(&value, false);
 
-    return efivars_write_raw(name, &buf);
+    return sol_efivars_write_raw(name, &buf);
 }
 
 static inline int
-efivars_read_irange(const char *name, struct sol_irange *value)
+sol_efivars_read_irange(const char *name, struct sol_irange *value)
 {
     CREATE_BUFFER(value, true);
 
-    return efivars_read_raw(name, &buf);
+    return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-efivars_write_irange(const char *name, struct sol_irange *value)
+sol_efivars_write_irange(const char *name, struct sol_irange *value)
 {
     CREATE_BUFFER(value, false);
 
-    return efivars_write_raw(name, &buf);
+    return sol_efivars_write_raw(name, &buf);
 }
 
 static inline int
-efivars_read_drange(const char *name, struct sol_drange *value)
+sol_efivars_read_drange(const char *name, struct sol_drange *value)
 {
     CREATE_BUFFER(value, true);
 
-    return efivars_read_raw(name, &buf);
+    return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-efivars_write_drange(const char *name, struct sol_drange *value)
+sol_efivars_write_drange(const char *name, struct sol_drange *value)
 {
     CREATE_BUFFER(value, false);
 
-    return efivars_write_raw(name, &buf);
+    return sol_efivars_write_raw(name, &buf);
 }
 
 static inline int
-efivars_read_double(const char *name, double *value)
+sol_efivars_read_double(const char *name, double *value)
 {
     CREATE_BUFFER(value, true);
 
-    return efivars_read_raw(name, &buf);
+    return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-efivars_write_double(const char *name, double value)
+sol_efivars_write_double(const char *name, double value)
 {
     CREATE_BUFFER(&value, false);
 
-    return efivars_write_raw(name, &buf);
+    return sol_efivars_write_raw(name, &buf);
 }
 
 static inline int
-efivars_read_string(const char *name, char **value)
+sol_efivars_read_string(const char *name, char **value)
 {
     struct sol_buffer buf = SOL_BUFFER_INIT_EMPTY;
     int r;
 
-    r = efivars_read_raw(name, &buf);
+    r = sol_efivars_read_raw(name, &buf);
     if (r < 0) {
         sol_buffer_fini(&buf);
         return r;
@@ -159,14 +164,18 @@ efivars_read_string(const char *name, char **value)
 }
 
 static inline int
-efivars_write_string(const char *name, const char *value)
+sol_efivars_write_string(const char *name, const char *value)
 {
     struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS((void *)value, strlen(value),
         SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
 
     buf.used = buf.capacity;
 
-    return efivars_write_raw(name, &buf);
+    return sol_efivars_write_raw(name, &buf);
 }
 
 #undef CREATE_BUFFER
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/lib/io/include/sol-fs-storage.h
+++ b/src/lib/io/include/sol-fs-storage.h
@@ -30,124 +30,129 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#pragma once
+
 #include <stddef.h>
 #include <stdint.h>
 
 #include "sol-buffer.h"
 #include "sol-types.h"
 
-int fs_write_raw(const char *name,  struct sol_buffer *buffer);
-int fs_read_raw(const char *name, struct sol_buffer *buffer);
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int sol_fs_write_raw(const char *name,  struct sol_buffer *buffer);
+int sol_fs_read_raw(const char *name, struct sol_buffer *buffer);
 
 #define CREATE_BUFFER(_val, _empty) \
-    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val,\
-        sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED); \
-    buf.capacity = sizeof(*(_val)); \
+    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val, \
+    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED); \
     buf.used = (_empty) ? 0 : sizeof(*(_val));
 
 static inline int
-fs_read_uint8_t(const char *name, uint8_t *value)
+sol_fs_read_uint8(const char *name, uint8_t *value)
 {
     CREATE_BUFFER(value, true);
 
-    return fs_read_raw(name, &buf);
+    return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-fs_write_uint8_t(const char *name, uint8_t value)
+sol_fs_write_uint8(const char *name, uint8_t value)
 {
     CREATE_BUFFER(&value, false);
 
-    return fs_write_raw(name, &buf);
+    return sol_fs_write_raw(name, &buf);
 }
 
 static inline int
-fs_read_bool(const char *name, bool *value)
+sol_fs_read_bool(const char *name, bool *value)
 {
     CREATE_BUFFER(value, true);
 
-    return fs_read_raw(name, &buf);
+    return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-fs_write_bool(const char *name, bool value)
+sol_fs_write_bool(const char *name, bool value)
 {
     CREATE_BUFFER(&value, false);
 
-    return fs_write_raw(name, &buf);
+    return sol_fs_write_raw(name, &buf);
 }
 
 static inline int
-fs_read_int32_t(const char *name, int32_t *value)
+sol_fs_read_int32(const char *name, int32_t *value)
 {
     CREATE_BUFFER(value, true);
 
-    return fs_read_raw(name, &buf);
+    return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-fs_write_int32_t(const char *name, int32_t value)
+sol_fs_write_int32(const char *name, int32_t value)
 {
     CREATE_BUFFER(&value, false);
 
-    return fs_write_raw(name, &buf);
+    return sol_fs_write_raw(name, &buf);
 }
 
 static inline int
-fs_read_irange(const char *name, struct sol_irange *value)
+sol_fs_read_irange(const char *name, struct sol_irange *value)
 {
     CREATE_BUFFER(value, true);
 
-    return fs_read_raw(name, &buf);
+    return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-fs_write_irange(const char *name, struct sol_irange *value)
+sol_fs_write_irange(const char *name, struct sol_irange *value)
 {
     CREATE_BUFFER(value, false);
 
-    return fs_write_raw(name, &buf);
+    return sol_fs_write_raw(name, &buf);
 }
 
 static inline int
-fs_read_drange(const char *name, struct sol_drange *value)
+sol_fs_read_drange(const char *name, struct sol_drange *value)
 {
     CREATE_BUFFER(value, true);
 
-    return fs_read_raw(name, &buf);
+    return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-fs_write_drange(const char *name, struct sol_drange *value)
+sol_fs_write_drange(const char *name, struct sol_drange *value)
 {
     CREATE_BUFFER(value, false);
 
-    return fs_write_raw(name, &buf);
+    return sol_fs_write_raw(name, &buf);
 }
 
 static inline int
-fs_read_double(const char *name, double *value)
+sol_fs_read_double(const char *name, double *value)
 {
     CREATE_BUFFER(value, true);
 
-    return fs_read_raw(name, &buf);
+    return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-fs_write_double(const char *name, double value)
+sol_fs_write_double(const char *name, double value)
 {
     CREATE_BUFFER(&value, false);
 
-    return fs_write_raw(name, &buf);
+    return sol_fs_write_raw(name, &buf);
 }
 
 static inline int
-fs_read_string(const char *name, char **value)
+sol_fs_read_string(const char *name, char **value)
 {
     struct sol_buffer buf = SOL_BUFFER_INIT_EMPTY;
     int r;
 
-    r = fs_read_raw(name, &buf);
+    r = sol_fs_read_raw(name, &buf);
     if (r < 0) {
         sol_buffer_fini(&buf);
         return r;
@@ -159,14 +164,18 @@ fs_read_string(const char *name, char **value)
 }
 
 static inline int
-fs_write_string(const char *name, const char *value)
+sol_fs_write_string(const char *name, const char *value)
 {
     struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS((void *)value, strlen(value),
         SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
 
     buf.used = buf.capacity;
 
-    return fs_write_raw(name, &buf);
+    return sol_fs_write_raw(name, &buf);
 }
 
 #undef CREATE_BUFFER
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/lib/io/include/sol-memmap-storage.h
+++ b/src/lib/io/include/sol-memmap-storage.h
@@ -1,0 +1,273 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sol-buffer.h"
+#include "sol-str-table.h"
+#include "sol-types.h"
+#include "sol-log.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file
+ * @brief Routines to save values to memory mapped persistent storage
+ */
+
+/**
+ * @defgroup Memmap Memmap
+ * @ingroup IO
+ *
+ * Memory mapped persistence storage (like NVRAM or EEPROM) API on Soletta.
+ *
+ * A map must be provided, either directly via @c sol_memmap_add_map or by
+ * informing a JSON file to Soletta runner or generator.
+ * This map needs to contain a property @c _version (@c MEMMAP_VERSION_ENTRY),
+ * which will store version of map stored. This API will refuse to work if
+ * stored map is different from map version. Note that @c _version field
+ * is a @c uint8_t and that versions should start on 1, so Soletta will know
+ * if dealing with a totally new storage.
+ *
+ * @{
+ */
+
+#define MEMMAP_VERSION_ENTRY "_version" /**< Name of property which contains stored map version */
+
+#define SOL_MEMMAP_ENTRY(_name, _offset, _size) \
+    SOL_STR_TABLE_PTR_ITEM(_name, &((struct sol_memmap_entry){.offset = (_offset), .size = (_size) }))
+
+#define SOL_MEMMAP_BOOL_ENTRY(_name, _offset, _bit_offset) \
+    SOL_STR_TABLE_PTR_ITEM(_name, &((struct sol_memmap_entry){.offset = (_offset), .size = 1, .bit_offset = (_bit_offset), .bit_size = 1 }))
+
+#define SOL_MEMMAP_ENTRY_BIT_SIZE(_name, _offset, _size, _bit_offset, _bit_size) \
+    SOL_STR_TABLE_PTR_ITEM(_name, &((struct sol_memmap_entry){.offset = (_offset), .size = (_size), .bit_offset = (_bit_offset), .bit_size = (_bit_size) }))
+
+struct sol_memmap_map {
+    uint8_t version; /**< Version of map. Functions will refuse to read/write on storage if this version and the one storad differs */
+    char *path; /**< Where to find the storage. Under Linux, it is the file mapping the storage, like @c /dev/nvram */
+    struct sol_str_table_ptr entries[]; /**< Entries on map, containing name, offset and size */
+};
+
+struct sol_memmap_entry {
+    size_t offset; /**< Offset of this entry on storage, in bytes. If zero, it will be calculated from previous entry on @c entries array */
+    size_t size; /**< Total size of this entry on storage, in bytes. */
+    uint32_t bit_size; /**< Total size of this entry on storage, in bits. Must be up to <tt>size * 8</tt>. If zero, it will be assumed as <tt>size * 8</tt>. Note that this will be ignored if @c size is greater than 8. */
+    uint8_t bit_offset; /**< Bit offset on first byte. Note that this will be ignored if @c size is greater than 8. */
+};
+
+/**
+ * Writes buffer contents to storage.
+ *
+ * @param name name of property. must be present in one of maps previoulsy
+ * added via @c sol_memmap_add_map (if present in more than one,
+ * behaviour is undefined)
+ * @param buffer buffer that will be written, according to its entry on map.
+ *
+ * return 0 on success, a negative number on failure
+ */
+int sol_memmap_write_raw(const char *name, struct sol_buffer *buffer);
+
+/**
+ * Read storage contents to buffer.
+ *
+ * @param name name of property. must be present in one of maps previoulsy
+ * added via @c sol_memmap_add_map (if present in more than one,
+ * behaviour is undefined)
+ * @param buffer buffer where result will be read into, according to its entry
+ * on map.
+ *
+ * return 0 on success, a negative number on failure
+ */
+int sol_memmap_read_raw(const char *name, struct sol_buffer *buffer);
+
+/**
+ * Add a map to internal list of available maps.
+ *
+ * @param map map to be add.
+ *
+ * @return 0 on success, a negative number on failure.
+ */
+int sol_memmap_add_map(const struct sol_memmap_map *map);
+
+/**
+ * Removes a previously added map from internal list of available maps.
+ *
+ * @param map map to be removed.
+ *
+ * @return 0 on success, a negative number on failure.
+ */
+int sol_memmap_remove_map(const struct sol_memmap_map *map);
+
+#define CREATE_BUFFER(_val, _empty) \
+    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val, \
+    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED); \
+    buf.used = (_empty) ? 0 : sizeof(*(_val));
+
+static inline int
+sol_memmap_read_uint8(const char *name, uint8_t *value)
+{
+    CREATE_BUFFER(value, true);
+
+    return sol_memmap_read_raw(name, &buf);
+}
+
+static inline int
+sol_memmap_write_uint8(const char *name, uint8_t value)
+{
+    CREATE_BUFFER(&value, false);
+
+    return sol_memmap_write_raw(name, &buf);
+}
+
+static inline int
+sol_memmap_read_bool(const char *name, bool *value)
+{
+    CREATE_BUFFER(value, true);
+
+    return sol_memmap_read_raw(name, &buf);
+}
+
+static inline int
+sol_memmap_write_bool(const char *name, bool value)
+{
+    CREATE_BUFFER(&value, false);
+
+    return sol_memmap_write_raw(name, &buf);
+}
+
+static inline int
+sol_memmap_read_int32(const char *name, int32_t *value)
+{
+    CREATE_BUFFER(value, true);
+
+    return sol_memmap_read_raw(name, &buf);
+}
+
+static inline int
+sol_memmap_write_int32(const char *name, int32_t value)
+{
+    CREATE_BUFFER(&value, false);
+
+    return sol_memmap_write_raw(name, &buf);
+}
+
+static inline int
+sol_memmap_read_irange(const char *name, struct sol_irange *value)
+{
+    CREATE_BUFFER(value, true);
+
+    return sol_memmap_read_raw(name, &buf);
+}
+
+static inline int
+sol_memmap_write_irange(const char *name, struct sol_irange *value)
+{
+    CREATE_BUFFER(value, false);
+
+    return sol_memmap_write_raw(name, &buf);
+}
+
+static inline int
+sol_memmap_read_drange(const char *name, struct sol_drange *value)
+{
+    CREATE_BUFFER(value, true);
+
+    return sol_memmap_read_raw(name, &buf);
+}
+
+static inline int
+sol_memmap_write_drange(const char *name, struct sol_drange *value)
+{
+    CREATE_BUFFER(value, false);
+
+    return sol_memmap_write_raw(name, &buf);
+}
+
+static inline int
+sol_memmap_read_double(const char *name, double *value)
+{
+    CREATE_BUFFER(value, true);
+
+    return sol_memmap_read_raw(name, &buf);
+}
+
+static inline int
+sol_memmap_write_double(const char *name, double value)
+{
+    CREATE_BUFFER(&value, false);
+
+    return sol_memmap_write_raw(name, &buf);
+}
+
+static inline int
+sol_memmap_read_string(const char *name, char **value)
+{
+    struct sol_buffer buf = SOL_BUFFER_INIT_EMPTY;
+    int r;
+
+    r = sol_memmap_read_raw(name, &buf);
+    if (r < 0) {
+        sol_buffer_fini(&buf);
+        return r;
+    }
+
+    *value = sol_buffer_steal(&buf, NULL);
+
+    return 0;
+}
+
+static inline int
+sol_memmap_write_string(const char *name, const char *value)
+{
+    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS((void *)value, strlen(value),
+        SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
+
+    buf.used = buf.capacity;
+
+    return sol_memmap_write_raw(name, &buf);
+}
+
+/**
+ * @}
+ */
+
+#undef CREATE_BUFFER
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/lib/io/sol-efivarfs-storage.c
+++ b/src/lib/io/sol-efivarfs-storage.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "efivarfs-storage.h"
+#include "sol-efivarfs-storage.h"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -62,12 +62,15 @@ check_realpath(const char *path)
     return false;
 }
 
-int
-efivars_write_raw(const char *name, struct sol_buffer *buffer)
+SOL_API int
+sol_efivars_write_raw(const char *name, struct sol_buffer *buffer)
 {
     FILE *file;
     char path[PATH_MAX];
     int r;
+
+    SOL_NULL_CHECK(name, -EINVAL);
+    SOL_NULL_CHECK(buffer, -EINVAL);
 
     r = snprintf(path, sizeof(path), EFIVARFS_VAR_PATH, name);
     if (r < 0 || r >= PATH_MAX) {
@@ -107,14 +110,17 @@ end:
     return r;
 }
 
-int
-efivars_read_raw(const char *name, struct sol_buffer *buffer)
+SOL_API int
+sol_efivars_read_raw(const char *name, struct sol_buffer *buffer)
 {
     int r, fd;
     char path[PATH_MAX];
     uint32_t b;
     struct sol_buffer attr = SOL_BUFFER_INIT_FLAGS(&b, sizeof(uint32_t),
         SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
+
+    SOL_NULL_CHECK(name, -EINVAL);
+    SOL_NULL_CHECK(buffer, -EINVAL);
 
     r = snprintf(path, sizeof(path), EFIVARFS_VAR_PATH, name);
     if (r < 0 || r >= PATH_MAX) {

--- a/src/lib/io/sol-fs-storage.c
+++ b/src/lib/io/sol-fs-storage.c
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "fs-storage.h"
+#include "sol-fs-storage.h"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -44,11 +44,14 @@
 #include "sol-util.h"
 #include "sol-util-file.h"
 
-int
-fs_write_raw(const char *name, struct sol_buffer *buffer)
+SOL_API int
+sol_fs_write_raw(const char *name, struct sol_buffer *buffer)
 {
     FILE *file;
     int ret = 0;
+
+    SOL_NULL_CHECK(name, -EINVAL);
+    SOL_NULL_CHECK(buffer, -EINVAL);
 
     file = fopen(name, "w+e");
     if (!file) {
@@ -70,10 +73,13 @@ fs_write_raw(const char *name, struct sol_buffer *buffer)
     return ret;
 }
 
-int
-fs_read_raw(const char *name, struct sol_buffer *buffer)
+SOL_API int
+sol_fs_read_raw(const char *name, struct sol_buffer *buffer)
 {
     int r, fd;
+
+    SOL_NULL_CHECK(name, -EINVAL);
+    SOL_NULL_CHECK(buffer, -EINVAL);
 
     fd = open(name, O_RDONLY | O_CLOEXEC);
     if (fd < 0) {

--- a/src/lib/io/sol-memmap-storage.c
+++ b/src/lib/io/sol-memmap-storage.c
@@ -1,0 +1,366 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sol-memmap-storage.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "sol-buffer.h"
+#include "sol-log.h"
+#include "sol-str-slice.h"
+#include "sol-str-table.h"
+#include "sol-util.h"
+#include "sol-util-file.h"
+
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+static struct sol_ptr_vector memory_maps = SOL_PTR_VECTOR_INIT;
+static struct sol_ptr_vector checked_maps = SOL_PTR_VECTOR_INIT;
+
+static bool
+get_entry_metadata_on_map(const char *name, const struct sol_memmap_map *map, const struct sol_memmap_entry **entry, uint64_t *mask)
+{
+    uint32_t bit_size;
+
+    if (sol_str_table_ptr_lookup(map->entries, sol_str_slice_from_str(name), entry)) {
+        bit_size = (*entry)->bit_size;
+        /* No mask if bit_size equal or greater than 64. Such data should not be read as an int */
+        if (bit_size && (bit_size != (*entry)->size * 8) && bit_size < 64)
+            *mask = (((uint64_t)1 << bit_size) - 1) << (*entry)->bit_offset;
+        else
+            *mask = 0;
+
+        return true;
+    }
+
+    return false;
+}
+
+static bool
+get_entry_metadata(const char *name, const struct sol_memmap_map **map, const struct sol_memmap_entry **entry, uint64_t *mask)
+{
+    int i;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&memory_maps, *map, i) {
+        if (get_entry_metadata_on_map(name, *map, entry, mask))
+            return true;
+    }
+
+    entry = NULL;
+    map = NULL;
+
+    return false;
+}
+
+static int
+sol_memmap_read_raw_do(const char *path, const struct sol_memmap_entry *entry, uint64_t mask, struct sol_buffer *buffer)
+{
+    int fd, ret = 0;
+    bool add_ending_char = buffer->capacity == 0;
+    struct sol_str_slice ending_slice = SOL_STR_SLICE_EMPTY;
+    uint64_t value = 0;
+    uint32_t i, j;
+
+    fd = open(path, O_RDWR | O_CLOEXEC);
+    if (fd < 0) {
+        SOL_WRN("Could not open memory file [%s]", path);
+        return -errno;
+    }
+
+    if (lseek(fd, entry->offset, SEEK_SET) < 0)
+        goto error;
+
+    if (sol_util_fill_buffer(fd, buffer, entry->size) < 0)
+        goto error;
+
+    if (mask) {
+        for (i = 0, j = 0; i < entry->size; i++, j += 8)
+            value |= (uint64_t)((uint8_t *)buffer->data)[i] << j;
+
+        value &= mask;
+        value >>= entry->bit_offset;
+
+        memset(buffer->data, 0, buffer->capacity);
+        for (i = 0; i < entry->size; i++, value >>= 8)
+            ((uint8_t *)buffer->data)[i] = value & 0xff;
+    } else if (add_ending_char) {
+        if (sol_buffer_append_slice(buffer, ending_slice) < 0)
+            goto error;
+    }
+
+    if (close(fd) < 0)
+        return -errno;
+
+    return 0;
+
+error:
+    ret = -errno;
+    close(fd);
+
+    return ret;
+}
+
+static int
+sol_memmap_write_raw_do(const char *path, const struct sol_memmap_entry *entry, uint64_t mask, struct sol_buffer *buffer)
+{
+    FILE *file;
+    int ret = 0;
+
+    file = fopen(path, "r+e");
+    if (!file) {
+        SOL_WRN("Could not open memory file [%s]", path);
+        return -errno;
+    }
+
+    if (fseek(file, entry->offset, SEEK_SET) < 0)
+        goto error;
+
+    if (mask) {
+        uint64_t value = 0, old_value;
+        uint32_t i, j;
+
+        for (i = 0, j = 0; i < entry->size; i++, j += 8)
+            value |= (uint64_t)((uint8_t *)buffer->data)[i] << j;
+
+        ret = fread(&old_value, entry->size, 1, file);
+        if (!ret || ferror(file) || feof(file)) {
+            errno = EIO;
+            goto error;
+        }
+
+        /* We just read from file, let's rewind */
+        if (fseek(file, entry->offset, SEEK_SET) < 0)
+            goto error;
+
+        value <<= entry->bit_offset;
+        value &= mask;
+        value |= (old_value & ~mask);
+        fwrite(&value, entry->size, 1, file);
+    } else {
+        fwrite(buffer->data, MIN(entry->size, buffer->used), 1, file);
+    }
+
+    if (ferror(file)) {
+        errno = EIO;
+        goto error;
+    }
+
+    if (fclose(file) != 0)
+        return -errno;
+
+    return 0;
+
+error:
+    ret = -errno;
+    fclose(file);
+
+    return ret;
+}
+
+static bool
+check_version(const struct sol_memmap_map *map)
+{
+    uint8_t version = 0;
+    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(&version, sizeof(uint8_t),
+        SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
+    struct sol_memmap_map *iter;
+    const struct sol_memmap_entry *entry;
+    int ret, i;
+    uint64_t mask;
+
+    if (!map->version) {
+        SOL_WRN("Invalid memory_map_version. Should not be zero");
+        return false;
+    }
+
+    /* Check if already checked.
+     * TODO Maybe have a hash on soletta?*/
+    SOL_PTR_VECTOR_FOREACH_IDX (&checked_maps, iter, i)
+        if (iter == map) return true;
+
+    if (!get_entry_metadata_on_map(MEMMAP_VERSION_ENTRY, map, &entry, &mask)) {
+        SOL_WRN("No entry on memory map to property [%s]", MEMMAP_VERSION_ENTRY);
+        return false;
+    }
+
+    ret = sol_memmap_read_raw_do(map->path, entry, mask, &buf);
+    if (ret >= 0 && version == 0) {
+        /* No version on file, we should be initialising it */
+        version = map->version;
+        if (sol_memmap_write_raw_do(map->path, entry, mask, &buf) < 0) {
+            SOL_WRN("Could not write current map version to file");
+            return false;
+        }
+    } else if (ret < 0) {
+        SOL_WRN("Could not read current map version");
+        return false;
+    }
+
+    if (version != map->version) {
+        SOL_WRN("Memory map version mismatch. Expected %d but found %d",
+            map->version, version);
+        return false;
+    }
+
+    return sol_ptr_vector_append(&checked_maps, (void *)map) == 0;
+}
+
+SOL_API int
+sol_memmap_write_raw(const char *name, struct sol_buffer *buffer)
+{
+    const struct sol_memmap_map *map;
+    const struct sol_memmap_entry *entry;
+    uint64_t mask;
+
+    SOL_NULL_CHECK(name, -EINVAL);
+    SOL_NULL_CHECK(buffer, -EINVAL);
+
+    if (!get_entry_metadata(name, &map, &entry, &mask)) {
+        SOL_WRN("No entry on memory map to property [%s]", name);
+        return -ENOENT;
+    }
+
+    if (!check_version(map))
+        return -EINVAL;
+
+    if (buffer->used > entry->size)
+        SOL_INF("Mapped size for [%s] is %ld, smaller than buffer contents: %ld",
+            name, entry->size, buffer->used);
+
+    return sol_memmap_write_raw_do(map->path, entry, mask, buffer);
+}
+
+SOL_API int
+sol_memmap_read_raw(const char *name, struct sol_buffer *buffer)
+{
+    uint64_t mask;
+    const struct sol_memmap_map *map;
+    const struct sol_memmap_entry *entry;
+
+    SOL_NULL_CHECK(name, -EINVAL);
+    SOL_NULL_CHECK(buffer, -EINVAL);
+
+    if (!get_entry_metadata(name, &map, &entry, &mask)) {
+        SOL_WRN("No entry on memory map to property [%s]", name);
+        return -ENOENT;
+    }
+
+    if (!check_version(map))
+        return -EINVAL;
+
+    return sol_memmap_read_raw_do(map->path, entry, mask, buffer);
+}
+
+static bool
+check_entry(const struct sol_memmap_map *map,
+    const struct sol_memmap_entry *entry,
+    const char **failed_entry)
+{
+    int32_t bit_start, bit_end, other_start, other_end;
+    const struct sol_str_table_ptr *iter;
+    const struct sol_memmap_entry *other;
+
+    bit_start = (entry->offset * 8) + entry->bit_offset;
+    bit_end = bit_start + (entry->bit_size ? : entry->size * 8) - 1;
+
+    for (iter = map->entries; iter->key; iter++) {
+        if (iter->val == entry) continue;
+        other = iter->val;
+
+        other_start = (other->offset * 8) + other->bit_offset;
+        other_end = other_start + (other->bit_size ? : other->size * 8) - 1;
+
+        if (!((bit_start > other_end) || (bit_end < other_start))) {
+            *failed_entry = iter->key;
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static bool
+check_map(const struct sol_memmap_map *map)
+{
+    const struct sol_str_table_ptr *iter;
+    const char *failed_entry;
+    struct sol_memmap_entry *entry;
+    uint32_t last_offset = 0;
+
+    /* First, calculate any offset that was not set */
+    for (iter = map->entries; iter->key; iter++) {
+        entry = (void *)iter->val;
+        if (entry->bit_offset > 7) {
+            SOL_WRN("Entry [%s] bit_offset greater than 7, found: %d",
+                iter->key, entry->bit_offset);
+            return false;
+        }
+        if (!entry->offset)
+            entry->offset = last_offset;
+        last_offset = entry->offset + entry->size;
+
+        SOL_DBG("Entry [%s] starting on offset [%lu] with size [%lu]", iter->key,
+            entry->offset, entry->size);
+    }
+
+    /* Now check for overlaps */
+    for (iter = map->entries; iter->key; iter++) {
+        if (!check_entry(map, iter->val, &failed_entry)) {
+            SOL_WRN("Entry [%s] overlaps entry [%s] on map", iter->key,
+                failed_entry);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+SOL_API int
+sol_memmap_add_map(const struct sol_memmap_map *map)
+{
+    if (!check_map(map)) {
+        SOL_WRN("Invalid memory map");
+        return -EINVAL;
+    }
+
+    return sol_ptr_vector_append(&memory_maps, (void *)map);
+}
+
+SOL_API int
+sol_memmap_remove_map(const struct sol_memmap_map *map)
+{
+    return sol_ptr_vector_remove(&memory_maps, map);
+}

--- a/src/modules/flow/persistence/Kconfig
+++ b/src/modules/flow/persistence/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_PERSISTENCE
 	tristate "Node type: persistence"
-	depends on PLATFORM_LINUX && (USE_EFIVARS || USE_FILESYSTEM)
+	depends on PLATFORM_LINUX && (USE_EFIVARS || USE_FILESYSTEM || USE_MEMMAP)
 	default m

--- a/src/modules/flow/persistence/Kconfig
+++ b/src/modules/flow/persistence/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_PERSISTENCE
 	tristate "Node type: persistence"
-	depends on PLATFORM_LINUX
+	depends on PLATFORM_LINUX && (USE_EFIVARS || USE_FILESYSTEM)
 	default m

--- a/src/modules/flow/persistence/Makefile
+++ b/src/modules/flow/persistence/Makefile
@@ -1,6 +1,4 @@
 obj-$(FLOW_NODE_TYPE_PERSISTENCE) += persistence.mod
 obj-persistence-$(FLOW_NODE_TYPE_PERSISTENCE) := persistence.json \
-	persistence.o \
-	fs-storage.o \
-	efivarfs-storage.o
+	persistence.o
 obj-persistence-$(FLOW_NODE_TYPE_PERSISTENCE)-type := flow

--- a/src/modules/flow/persistence/efivarfs-storage.c
+++ b/src/modules/flow/persistence/efivarfs-storage.c
@@ -63,7 +63,7 @@ check_realpath(const char *path)
 }
 
 int
-efivars_write(const char *name, struct sol_buffer *buffer)
+efivars_write_raw(const char *name, struct sol_buffer *buffer)
 {
     FILE *file;
     char path[PATH_MAX];
@@ -108,7 +108,7 @@ end:
 }
 
 int
-efivars_read(const char *name, struct sol_buffer *buffer)
+efivars_read_raw(const char *name, struct sol_buffer *buffer)
 {
     int r, fd;
     char path[PATH_MAX];

--- a/src/modules/flow/persistence/efivarfs-storage.h
+++ b/src/modules/flow/persistence/efivarfs-storage.h
@@ -31,8 +31,142 @@
  */
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "sol-buffer.h"
+#include "sol-types.h"
 
-int efivars_write(const char *name, struct sol_buffer *buffer);
-int efivars_read(const char *name, struct sol_buffer *buffer);
+int efivars_write_raw(const char *name, struct sol_buffer *buffer);
+int efivars_read_raw(const char *name, struct sol_buffer *buffer);
+
+#define CREATE_BUFFER(_val, _empty) \
+    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val,\
+        sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED); \
+    buf.capacity = sizeof(*(_val)); \
+    buf.used = (_empty) ? 0 : sizeof(*(_val));
+
+static inline int
+efivars_read_uint8_t(const char *name, uint8_t *value)
+{
+    CREATE_BUFFER(value, true);
+
+    return efivars_read_raw(name, &buf);
+}
+
+static inline int
+efivars_write_uint8_t(const char *name, uint8_t value)
+{
+    CREATE_BUFFER(&value, false);
+
+    return efivars_write_raw(name, &buf);
+}
+
+static inline int
+efivars_read_bool(const char *name, bool *value)
+{
+    CREATE_BUFFER(value, true);
+
+    return efivars_read_raw(name, &buf);
+}
+
+static inline int
+efivars_write_bool(const char *name, bool value)
+{
+    CREATE_BUFFER(&value, false);
+
+    return efivars_write_raw(name, &buf);
+}
+
+static inline int
+efivars_read_int32_t(const char *name, int32_t *value)
+{
+    CREATE_BUFFER(value, true);
+
+    return efivars_read_raw(name, &buf);
+}
+
+static inline int
+efivars_write_int32_t(const char *name, int32_t value)
+{
+    CREATE_BUFFER(&value, false);
+
+    return efivars_write_raw(name, &buf);
+}
+
+static inline int
+efivars_read_irange(const char *name, struct sol_irange *value)
+{
+    CREATE_BUFFER(value, true);
+
+    return efivars_read_raw(name, &buf);
+}
+
+static inline int
+efivars_write_irange(const char *name, struct sol_irange *value)
+{
+    CREATE_BUFFER(value, false);
+
+    return efivars_write_raw(name, &buf);
+}
+
+static inline int
+efivars_read_drange(const char *name, struct sol_drange *value)
+{
+    CREATE_BUFFER(value, true);
+
+    return efivars_read_raw(name, &buf);
+}
+
+static inline int
+efivars_write_drange(const char *name, struct sol_drange *value)
+{
+    CREATE_BUFFER(value, false);
+
+    return efivars_write_raw(name, &buf);
+}
+
+static inline int
+efivars_read_double(const char *name, double *value)
+{
+    CREATE_BUFFER(value, true);
+
+    return efivars_read_raw(name, &buf);
+}
+
+static inline int
+efivars_write_double(const char *name, double value)
+{
+    CREATE_BUFFER(&value, false);
+
+    return efivars_write_raw(name, &buf);
+}
+
+static inline int
+efivars_read_string(const char *name, char **value)
+{
+    struct sol_buffer buf = SOL_BUFFER_INIT_EMPTY;
+    int r;
+
+    r = efivars_read_raw(name, &buf);
+    if (r < 0) {
+        sol_buffer_fini(&buf);
+        return r;
+    }
+
+    *value = sol_buffer_steal(&buf, NULL);
+
+    return 0;
+}
+
+static inline int
+efivars_write_string(const char *name, const char *value)
+{
+    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS((void *)value, strlen(value),
+        SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
+
+    buf.used = buf.capacity;
+
+    return efivars_write_raw(name, &buf);
+}
+
+#undef CREATE_BUFFER

--- a/src/modules/flow/persistence/fs-storage.c
+++ b/src/modules/flow/persistence/fs-storage.c
@@ -45,7 +45,7 @@
 #include "sol-util-file.h"
 
 int
-fs_write(const char *name, struct sol_buffer *buffer)
+fs_write_raw(const char *name, struct sol_buffer *buffer)
 {
     FILE *file;
     int ret = 0;
@@ -71,7 +71,7 @@ fs_write(const char *name, struct sol_buffer *buffer)
 }
 
 int
-fs_read(const char *name, struct sol_buffer *buffer)
+fs_read_raw(const char *name, struct sol_buffer *buffer)
 {
     int r, fd;
 

--- a/src/modules/flow/persistence/fs-storage.h
+++ b/src/modules/flow/persistence/fs-storage.h
@@ -31,8 +31,142 @@
  */
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "sol-buffer.h"
+#include "sol-types.h"
 
-int fs_write(const char *name,  struct sol_buffer *buffer);
-int fs_read(const char *name, struct sol_buffer *buffer);
+int fs_write_raw(const char *name,  struct sol_buffer *buffer);
+int fs_read_raw(const char *name, struct sol_buffer *buffer);
+
+#define CREATE_BUFFER(_val, _empty) \
+    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val,\
+        sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED); \
+    buf.capacity = sizeof(*(_val)); \
+    buf.used = (_empty) ? 0 : sizeof(*(_val));
+
+static inline int
+fs_read_uint8_t(const char *name, uint8_t *value)
+{
+    CREATE_BUFFER(value, true);
+
+    return fs_read_raw(name, &buf);
+}
+
+static inline int
+fs_write_uint8_t(const char *name, uint8_t value)
+{
+    CREATE_BUFFER(&value, false);
+
+    return fs_write_raw(name, &buf);
+}
+
+static inline int
+fs_read_bool(const char *name, bool *value)
+{
+    CREATE_BUFFER(value, true);
+
+    return fs_read_raw(name, &buf);
+}
+
+static inline int
+fs_write_bool(const char *name, bool value)
+{
+    CREATE_BUFFER(&value, false);
+
+    return fs_write_raw(name, &buf);
+}
+
+static inline int
+fs_read_int32_t(const char *name, int32_t *value)
+{
+    CREATE_BUFFER(value, true);
+
+    return fs_read_raw(name, &buf);
+}
+
+static inline int
+fs_write_int32_t(const char *name, int32_t value)
+{
+    CREATE_BUFFER(&value, false);
+
+    return fs_write_raw(name, &buf);
+}
+
+static inline int
+fs_read_irange(const char *name, struct sol_irange *value)
+{
+    CREATE_BUFFER(value, true);
+
+    return fs_read_raw(name, &buf);
+}
+
+static inline int
+fs_write_irange(const char *name, struct sol_irange *value)
+{
+    CREATE_BUFFER(value, false);
+
+    return fs_write_raw(name, &buf);
+}
+
+static inline int
+fs_read_drange(const char *name, struct sol_drange *value)
+{
+    CREATE_BUFFER(value, true);
+
+    return fs_read_raw(name, &buf);
+}
+
+static inline int
+fs_write_drange(const char *name, struct sol_drange *value)
+{
+    CREATE_BUFFER(value, false);
+
+    return fs_write_raw(name, &buf);
+}
+
+static inline int
+fs_read_double(const char *name, double *value)
+{
+    CREATE_BUFFER(value, true);
+
+    return fs_read_raw(name, &buf);
+}
+
+static inline int
+fs_write_double(const char *name, double value)
+{
+    CREATE_BUFFER(&value, false);
+
+    return fs_write_raw(name, &buf);
+}
+
+static inline int
+fs_read_string(const char *name, char **value)
+{
+    struct sol_buffer buf = SOL_BUFFER_INIT_EMPTY;
+    int r;
+
+    r = fs_read_raw(name, &buf);
+    if (r < 0) {
+        sol_buffer_fini(&buf);
+        return r;
+    }
+
+    *value = sol_buffer_steal(&buf, NULL);
+
+    return 0;
+}
+
+static inline int
+fs_write_string(const char *name, const char *value)
+{
+    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS((void *)value, strlen(value),
+        SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
+
+    buf.used = buf.capacity;
+
+    return fs_write_raw(name, &buf);
+}
+
+#undef CREATE_BUFFER

--- a/src/modules/flow/persistence/persistence.c
+++ b/src/modules/flow/persistence/persistence.c
@@ -418,8 +418,9 @@ static int
 persist_irange_packet_send(struct sol_flow_node *node)
 {
     struct persist_irange_data *mdata = sol_flow_node_get_private_data(node);
+    struct sol_irange *val = mdata->base.value_ptr;
 
-    if (mdata->store_only_val) {
+    if (mdata->store_only_val || (!val->step && !val->min && !val->max)) {
         struct sol_irange value = {
             .val = *(int32_t *)mdata->base.value_ptr,
             .step = mdata->default_value.step,
@@ -433,8 +434,7 @@ persist_irange_packet_send(struct sol_flow_node *node)
     }
 
     return sol_flow_send_irange_packet
-               (node, SOL_FLOW_NODE_TYPE_PERSISTENCE_INT__OUT__OUT,
-               (struct sol_irange *)mdata->base.value_ptr);
+               (node, SOL_FLOW_NODE_TYPE_PERSISTENCE_INT__OUT__OUT, val);
 }
 
 static struct sol_flow_packet *
@@ -500,8 +500,12 @@ static int
 persist_drange_packet_send(struct sol_flow_node *node)
 {
     struct persist_drange_data *mdata = sol_flow_node_get_private_data(node);
+    struct sol_drange *val = mdata->base.value_ptr;
+    bool no_defaults = sol_drange_val_equal(val->step, 0) &&
+        sol_drange_val_equal(val->min, 0) &&
+        sol_drange_val_equal(val->min, 0);
 
-    if (mdata->store_only_val) {
+    if (mdata->store_only_val || no_defaults) {
         struct sol_drange value = {
             .val = *(double *)mdata->base.value_ptr,
             .step = mdata->default_value.step,
@@ -515,8 +519,7 @@ persist_drange_packet_send(struct sol_flow_node *node)
     }
 
     return sol_flow_send_drange_packet
-               (node, SOL_FLOW_NODE_TYPE_PERSISTENCE_FLOAT__OUT__OUT,
-               (struct sol_drange *)mdata->base.value_ptr);
+               (node, SOL_FLOW_NODE_TYPE_PERSISTENCE_FLOAT__OUT__OUT, val);
 }
 
 static struct sol_flow_packet *

--- a/src/modules/flow/persistence/persistence.c
+++ b/src/modules/flow/persistence/persistence.c
@@ -124,6 +124,7 @@ persist_do(struct persist_data *mdata, struct sol_flow_node *node, void *value)
 
     /* No packet_data_size means dynamic content (string). Let's reallocate if needed */
     if (!mdata->packet_data_size) {
+        size++; //To include the null terminating char
         if (!mdata->value_ptr || strlen(mdata->value_ptr) + 1 < size) {
             void *tmp = realloc(mdata->value_ptr, size);
             SOL_NULL_CHECK(tmp, -ENOMEM);

--- a/src/modules/flow/persistence/persistence.c
+++ b/src/modules/flow/persistence/persistence.c
@@ -221,7 +221,9 @@ persist_open(struct sol_flow_node *node,
     }
     if (r == -ENOENT) {
         /* No file. Send default value */
-        return persist_reset(mdata, node);
+        r = persist_reset(mdata, node);
+        SOL_INT_CHECK_GOTO(r, < 0, err);
+        return r;
     }
     SOL_INT_CHECK_GOTO(r, < 0, err);
 

--- a/src/modules/flow/persistence/persistence.c
+++ b/src/modules/flow/persistence/persistence.c
@@ -65,13 +65,13 @@ struct persist_data {
 };
 
 static const struct storage_fn fs_fn = {
-    .write = fs_write,
-    .read = fs_read
+    .write = fs_write_raw,
+    .read = fs_read_raw
 };
 
 static const struct storage_fn efivars_fn = {
-    .write = efivars_write,
-    .read = efivars_read
+    .write = efivars_write_raw,
+    .read = efivars_read_raw
 };
 
 static const struct sol_str_table_ptr storage_fn_table[] = {

--- a/src/modules/flow/persistence/persistence.c
+++ b/src/modules/flow/persistence/persistence.c
@@ -48,6 +48,10 @@
 #include "sol-efivarfs-storage.h"
 #endif
 
+#ifdef USE_MEMMAP
+#include "sol-memmap-storage.h"
+#endif
+
 struct storage_fn {
     int (*write)(const char *name, struct sol_buffer *buffer);
     int (*read)(const char *name, struct sol_buffer *buffer);
@@ -83,12 +87,22 @@ static const struct storage_fn efivars_fn = {
 };
 #endif
 
+#ifdef USE_MEMMAP
+static const struct storage_fn memmap_fn = {
+    .write = sol_memmap_write_raw,
+    .read = sol_memmap_read_raw
+};
+#endif
+
 static const struct sol_str_table_ptr storage_fn_table[] = {
 #ifdef USE_FILESYSTEM
     SOL_STR_TABLE_PTR_ITEM("fs", &fs_fn),
 #endif
 #ifdef USE_EFIVARS
     SOL_STR_TABLE_PTR_ITEM("efivars", &efivars_fn),
+#endif
+#ifdef USE_MEMMAP
+    SOL_STR_TABLE_PTR_ITEM("memmap", &memmap_fn),
 #endif
     { }
 };

--- a/src/modules/flow/persistence/persistence.json
+++ b/src/modules/flow/persistence/persistence.json
@@ -146,6 +146,12 @@
             "default": 0.0,
             "description": "Default value for this node, when there's no previous value persisted",
             "name": "default_value"
+          },
+          {
+            "data_type": "boolean",
+            "default": false,
+            "description": "Store only drange val, discarding min, max and step values",
+            "name": "store_only_val"
           }
         ],
         "version": 1
@@ -203,6 +209,12 @@
             "default": 0,
             "description": "Default value for this node, when there's no previous value persisted",
             "name": "default_value"
+          },
+          {
+            "data_type": "boolean",
+            "default": false,
+            "description": "Store only irange val, discarding min, max and step values",
+            "name": "store_only_val"
           }
         ],
         "version": 1

--- a/src/modules/flow/test/Makefile
+++ b/src/modules/flow/test/Makefile
@@ -3,4 +3,5 @@ obj-test-$(FLOW_NODE_TYPE_TEST) += boolean-generator.o boolean-validator.o
 obj-test-$(FLOW_NODE_TYPE_TEST) += int-generator.o int-validator.o
 obj-test-$(FLOW_NODE_TYPE_TEST) += result.o test.o test.json float-validator.o
 obj-test-$(FLOW_NODE_TYPE_TEST) += float-generator.o blob-validator.o
+obj-test-$(FLOW_NODE_TYPE_TEST) += string-validator.o
 obj-test-$(FLOW_NODE_TYPE_TEST)-type := flow

--- a/src/modules/flow/test/string-validator.c
+++ b/src/modules/flow/test/string-validator.c
@@ -1,0 +1,140 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ctype.h>
+#include <errno.h>
+#include <string.h>
+
+#include "sol-flow.h"
+#include "sol-log-internal.h"
+#include "sol-mainloop.h"
+#include "sol-str-slice.h"
+#include "sol-util.h"
+
+#include "string-validator.h"
+#include "sol-flow/test.h"
+
+static int
+_populate_values(void *data)
+{
+    struct string_validator_data *mdata = data;
+    char *it;
+    struct sol_str_slice *val;
+    size_t len = 0;
+
+    sol_vector_init(&mdata->values, sizeof(struct sol_str_slice));
+    it = mdata->sequence;
+    do {
+        val = sol_vector_append(&mdata->values);
+        SOL_NULL_CHECK(val, -errno);
+
+        val->data = it;
+        while (*it != '\0') {
+            if (*it == '|') {
+                val->len = len;
+                len = 0;
+                it++;
+                break; // Go back to 'do...while'
+            }
+            it++;
+            len++;
+        }
+    } while (*it != '\0');
+
+    val->len = len;
+
+    return 0;
+}
+
+int
+string_validator_open(
+    struct sol_flow_node *node,
+    void *data,
+    const struct sol_flow_node_options *options)
+{
+    struct string_validator_data *mdata = data;
+    const struct sol_flow_node_type_test_string_validator_options *opts =
+        (const struct sol_flow_node_type_test_string_validator_options *)options;
+
+    mdata->done = false;
+
+    if (opts->sequence == NULL || *opts->sequence == '\0') {
+        SOL_ERR("Option 'sequence' is either NULL or empty.");
+        return -EINVAL;
+    }
+    mdata->sequence = strdup(opts->sequence);
+    SOL_NULL_CHECK(mdata->sequence, -errno);
+
+    return _populate_values(data);
+}
+
+int
+string_validator_process(
+    struct sol_flow_node *node,
+    void *data,
+    uint16_t port,
+    uint16_t conn_id,
+    const struct sol_flow_packet *packet)
+{
+    struct string_validator_data *mdata = data;
+    struct sol_str_slice *next;
+    bool match;
+    const char *val = NULL;
+    int r;
+
+    if (mdata->done) {
+        sol_flow_send_error_packet(node, ECANCELED,
+            "Input stream already deviated from expected data, ignoring packets.");
+        return 0;
+    }
+    r = sol_flow_packet_get_string(packet, &val);
+    SOL_INT_CHECK(r, < 0, r);
+    next = sol_vector_get(&mdata->values, mdata->next_index);
+    match = sol_str_slice_str_eq(*next, val);
+    mdata->next_index++;
+
+    if (mdata->next_index == mdata->values.len || !match) {
+        sol_flow_send_boolean_packet(node,
+            SOL_FLOW_NODE_TYPE_TEST_STRING_VALIDATOR__OUT__OUT, match);
+        mdata->done = true;
+    }
+    return 0;
+}
+
+void
+string_validator_close(struct sol_flow_node *node, void *data)
+{
+    struct string_validator_data *mdata = data;
+
+    sol_vector_clear(&mdata->values);
+    free(mdata->sequence);
+}

--- a/src/modules/flow/test/string-validator.h
+++ b/src/modules/flow/test/string-validator.h
@@ -30,26 +30,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <float.h>
-
-
-#include "sol-util.h"
-#include "sol-log-internal.h"
-
 #include "test-module.h"
+#include "sol-vector.h"
 
-#include "sol-flow/test.h"
+struct string_validator_data {
+    bool done;
+    char *sequence;
+    uint16_t next_index;
+    struct sol_vector values;
+};
 
-SOL_LOG_INTERNAL_DECLARE(_test_log_domain, "flow-test");
-
-#include "result.h"
-#include "boolean-generator.h"
-#include "boolean-validator.h"
-#include "float-generator.h"
-#include "float-validator.h"
-#include "int-validator.h"
-#include "int-generator.h"
-#include "blob-validator.h"
-#include "string-validator.h"
-
-#include "test-gen.c"
+DECLARE_OPEN_FUNCTION(string_validator_open);
+DECLARE_CLOSE_FUNCTION(string_validator_close);
+DECLARE_PROCESS_FUNCTION(string_validator_process);

--- a/src/modules/flow/test/test.json
+++ b/src/modules/flow/test/test.json
@@ -314,6 +314,44 @@
       ],
       "private_data_type": "blob_validator_data",
       "url": "http://solettaproject.org/doc/latest/components/blob-validator.html"
+    },
+    {
+      "category": "test",
+      "description": "Matches an expected sequence of strings.",
+      "methods": {
+        "close": "string_validator_close",
+        "open": "string_validator_open"
+      },
+      "name": "test/string-validator",
+      "in_ports": [
+        {
+          "data_type": "string",
+          "description": "Where to receive the expected sequence.",
+          "methods": {
+            "process": "string_validator_process"
+          },
+          "name": "IN"
+        }
+      ],
+      "options": {
+        "members": [
+          {
+            "data_type": "string",
+            "description": "Expected sequence to be matched, formatted as 'string 1|string 2|string 3'",
+            "name": "sequence"
+          }
+         ],
+        "version": 1
+      },
+      "out_ports": [
+        {
+          "data_type": "boolean",
+          "description": "Outputs true if there is a match, false otherwise.",
+          "name": "OUT"
+        }
+      ],
+      "private_data_type": "string_validator_data",
+      "url": "http://solettaproject.org/doc/latest/components/string-validator.html"
     }
   ]
 }

--- a/src/samples/flow/misc/persistence.fbp
+++ b/src/samples/flow/misc/persistence.fbp
@@ -46,7 +46,7 @@ map_byte OUT -> IN byte_persist(persistence/byte:storage="fs",name="save_byte") 
 wallclock OUT -> IN int_persist(persistence/int:storage="fs",name="save_int",default_value=-1) OUT -> IN console_int(console:prefix="persist int: ")
 
 wallclock OUT -> IN map_float(converter/int-to-float)
-map_float OUT -> IN float_persist(persistence/float:storage="fs",name="save_float") OUT -> IN console_float(console:prefix="persist float: ")
+map_float OUT -> IN float_persist(persistence/float:storage="fs",name="save_float",store_only_val=true) OUT -> IN console_float(console:prefix="persist float: ")
 
 wallclock OUT -> IN map_string(converter/int-to-string)
 map_string OUT -> IN string_persist(persistence/string:storage="fs",name="save_string") OUT -> IN console_string(console:prefix="persist string: ")

--- a/src/test-fbp/persistence-fs-2.fbp
+++ b/src/test-fbp/persistence-fs-2.fbp
@@ -1,0 +1,119 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This test will read from following files:
+# int, int_only_val, irange, byte, boolean, string, double, double_only_val,
+# drange, int_def, irange_def, byte_def, boolean_def, string_def, double_def,
+# drange_def
+# Those files need to have been created by persistence-fs.fbp
+
+## TEST-SKIP-COMPILE This test uses some files, but path resolution is not decided yet
+## TEST-SKIP-VALGRIND Some float operations yield to [-]NaN on valgrind
+
+validator_int(test/int-validator:sequence="-12")
+validator_int_def(test/int-validator:sequence="-12")
+validator_irange(test/int-validator:sequence="-13")
+validator_irange_def(test/int-validator:sequence="-13")
+validator_byte(test/int-validator:sequence="73")
+validator_byte_def(test/int-validator:sequence="73")
+validator_boolean(test/boolean-validator:sequence="T")
+validator_boolean_def(test/boolean-validator:sequence="T")
+validator_string(test/string-validator:sequence="string")
+validator_string_def(test/string-validator:sequence="string")
+validator_double(test/float-validator:sequence="2.568")
+validator_double_def(test/float-validator:sequence="2.568")
+validator_float_map(test/float-validator:sequence="50.0")
+validator_float_def_map(test/float-validator:sequence="50.0")
+validator_float_val_only_map(test/float-validator:sequence="0.0")
+validator_drange(test/float-validator:sequence="5.5")
+validator_drange_map(test/float-validator:sequence="56.0")
+validator_drange_def(test/float-validator:sequence="5.5")
+validator_drange_def_map(test/float-validator:sequence="56.0")
+validator_int_map(test/int-validator:sequence="49")
+validator_int_val_only_map(test/int-validator:sequence="0")
+validator_int_map_def(test/int-validator:sequence="49")
+validator_irange_map(test/int-validator:sequence="37")
+validator_irange_map_def(test/int-validator:sequence="37")
+
+int_map(int/map:output_range=min:0|max:100|step:1)
+int_def_map(int/map:output_range=min:0|max:100|step:1)
+int_only_val_map(int/map:output_range=min:0|max:100|step:1)
+irange_map(int/map:output_range=min:0|max:100|step:1)
+irange_def_map(int/map:output_range=min:0|max:100|step:1)
+
+double_map(float/map:output_range=min:0|max:100|step:1)
+double_def_map(float/map:output_range=min:0|max:100|step:1)
+double_only_val_map(float/map:output_range=min:0|max:100|step:1)
+drange_map(float/map:output_range=min:0|max:100|step:1)
+drange_def_map(float/map:output_range=min:0|max:100|step:1)
+
+persist_int(persistence/int:storage="fs",name="int")
+persist_int_only_val(persistence/int:storage="fs",name="int_only_val",store_only_val=true,default_value=30|-12|30|1)
+persist_irange(persistence/int:storage="fs",name="irange")
+persist_byte(persistence/byte:storage="fs",name="byte")
+persist_boolean(persistence/boolean:storage="fs",name="boolean")
+persist_string(persistence/string:storage="fs",name="string")
+persist_double(persistence/float:storage="fs",name="double")
+persist_double_only_val(persistence/float:storage="fs",name="double_only_val",store_only_val=true,default_value=1023.22|1|1024|0.5)
+persist_drange(persistence/float:storage="fs",name="drange")
+persist_int_def(persistence/int:storage="fs",name="int_def",default_value=400000000)
+persist_irange_def(persistence/int:storage="fs",name="irange_def",default_value=-50|-50|-40|1)
+persist_byte_def(persistence/byte:storage="fs",name="byte_def",default_value=7)
+persist_boolean_def(persistence/boolean:storage="fs",name="boolean_def",default_value=true)
+persist_string_def(persistence/string:storage="fs",name="string_def",default_value="default")
+persist_double_def(persistence/float:storage="fs",name="double_def",default_value=-DBL_MAX)
+persist_drange_def(persistence/float:storage="fs",name="drange_def",default_value=-4.5|-5.0|5.0|0.5)
+
+persist_int OUT -> IN validator_int OUT -> RESULT _(test/result)
+persist_irange OUT -> IN validator_irange OUT -> RESULT _(test/result)
+persist_byte OUT -> IN _(converter/byte-to-int) OUT -> IN validator_byte OUT -> RESULT _(test/result)
+persist_boolean OUT -> IN validator_boolean OUT -> RESULT _(test/result)
+persist_string OUT -> IN validator_string OUT -> RESULT _(test/result)
+persist_double OUT -> IN validator_double OUT -> RESULT _(test/result)
+persist_drange OUT -> IN validator_drange OUT -> RESULT _(test/result)
+persist_int_def OUT -> IN validator_int_def OUT -> RESULT _(test/result)
+persist_irange_def OUT -> IN validator_irange_def OUT -> RESULT _(test/result)
+persist_byte_def OUT -> IN _(converter/byte-to-int) OUT -> IN validator_byte_def OUT -> RESULT _(test/result)
+persist_boolean_def OUT -> IN validator_boolean_def OUT -> RESULT _(test/result)
+persist_string_def OUT -> IN validator_string_def OUT -> RESULT _(test/result)
+persist_double_def OUT -> IN validator_double_def OUT -> RESULT _(test/result)
+persist_drange_def OUT -> IN validator_drange_def OUT -> RESULT _(test/result)
+
+persist_int OUT -> IN int_map OUT -> IN validator_int_map OUT -> RESULT _(test/result)
+persist_irange OUT -> IN irange_map OUT -> IN validator_irange_map OUT -> RESULT _(test/result)
+persist_double OUT -> IN double_map OUT -> IN validator_float_map OUT -> RESULT _(test/result)
+persist_drange OUT -> IN drange_map OUT -> IN validator_drange_map OUT -> RESULT _(test/result)
+persist_int_def OUT -> IN int_def_map OUT -> IN validator_int_map_def OUT -> RESULT _(test/result)
+persist_irange_def OUT -> IN irange_def_map OUT -> IN validator_irange_map_def OUT -> RESULT _(test/result)
+persist_double_def OUT -> IN double_def_map OUT -> IN validator_float_def_map OUT -> RESULT _(test/result)
+persist_drange_def OUT -> IN drange_def_map OUT -> IN validator_drange_def_map OUT -> RESULT _(test/result)
+
+persist_int_only_val OUT -> IN int_only_val_map OUT -> IN validator_int_val_only_map OUT -> RESULT _(test/result)
+persist_double_only_val OUT -> IN double_only_val_map OUT -> IN validator_float_val_only_map OUT -> RESULT _(test/result)

--- a/src/test-fbp/persistence-fs.fbp
+++ b/src/test-fbp/persistence-fs.fbp
@@ -1,0 +1,144 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This test will write to following files:
+# int, int_only_val, irange, byte, boolean, string, double, double_only_val,
+# drange, int_def, irange_def, byte_def, boolean_def, string_def, double_def,
+# drange_def
+# Those files need to not exist (or have size 0) prior running this test 
+
+## TEST-PRECONDITION rm int int_only_val irange byte boolean string double double_only_val drange int_def irange_def byte_def boolean_def string_def double_def drange_def
+## TEST-SKIP-COMPILE This test uses some files, but path resolution is not decided yet
+## TEST-SKIP-VALGRIND Some float operations yield to [-]NaN on valgrind
+
+int(constant/int:value=-12)
+irange(constant/int:value=-13|-50|50|3)
+byte(constant/byte:value=73)
+boolean(constant/boolean:value=true)
+string(constant/string:value="string")
+double(constant/float:value=2.568)
+drange(constant/float:value=5.5|-40.0|40.0|0.4)
+
+validator_int(test/int-validator:sequence="0 -12")
+validator_int_def(test/int-validator:sequence="400000000 -12")
+validator_irange(test/int-validator:sequence="0 -13")
+validator_irange_def(test/int-validator:sequence="-50 -13")
+validator_byte(test/int-validator:sequence="0 73")
+validator_byte_def(test/int-validator:sequence="7 73")
+validator_boolean(test/boolean-validator:sequence="FT")
+validator_boolean_def(test/boolean-validator:sequence="TT")
+validator_string(test/string-validator:sequence="|string")
+validator_string_def(test/string-validator:sequence="default|string")
+validator_double(test/float-validator:sequence="0 2.568")
+validator_double_def(test/float-validator:sequence="-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.000000 2.568")
+
+int_map(int/map:output_range=min:0|max:100|step:1)
+int_def_map(int/map:output_range=min:0|max:100|step:1)
+int_only_val_map(int/map:output_range=min:0|max:100|step:1)
+irange_map(int/map:output_range=min:0|max:100|step:1)
+irange_def_map(int/map:output_range=min:0|max:100|step:1)
+
+validator_int_map(test/int-validator:sequence="50 49")
+validator_int_val_only_map(test/int-validator:sequence="100 0")
+validator_int_map_def(test/int-validator:sequence="59 49")
+validator_irange_map(test/int-validator:sequence="50 37")
+validator_irange_map_def(test/int-validator:sequence="0 37")
+
+double_map(float/map:output_range=min:0|max:100|step:1)
+double_def_map(float/map:output_range=min:0|max:100|step:1)
+double_only_val_map(float/map:output_range=min:0|max:100|step:1)
+drange_map(float/map:output_range=min:0|max:100|step:1)
+drange_def_map(float/map:output_range=min:0|max:100|step:1)
+
+validator_float_map(test/float-validator:sequence="50.0 50.0")
+validator_float_def_map(test/float-validator:sequence="0.0 50.0")
+validator_float_val_only_map(test/float-validator:sequence="99.0 0.0")
+validator_drange(test/float-validator:sequence="0.0 5.5")
+validator_drange_map(test/float-validator:sequence="50.0 56.0")
+validator_drange_def(test/float-validator:sequence="-4.5 5.5")
+validator_drange_def_map(test/float-validator:sequence="5.0 56.0")
+
+persist_int(persistence/int:storage="fs",name="int")
+int OUT -> IN persist_int OUT -> IN validator_int OUT -> RESULT _(test/result)
+persist_int OUT -> IN int_map OUT -> IN validator_int_map OUT -> RESULT _(test/result)
+
+persist_int_only_val(persistence/int:storage="fs",name="int_only_val",store_only_val=true,default_value=30|-12|30|1)
+int OUT -> IN persist_int_only_val OUT -> IN int_only_val_map OUT -> IN validator_int_val_only_map OUT -> RESULT _(test/result)
+
+persist_irange(persistence/int:storage="fs",name="irange")
+irange OUT -> IN persist_irange OUT -> IN validator_irange OUT -> RESULT _(test/result)
+persist_irange OUT -> IN irange_map OUT -> IN validator_irange_map OUT -> RESULT _(test/result)
+
+persist_byte(persistence/byte:storage="fs",name="byte")
+byte OUT -> IN persist_byte OUT -> IN _(converter/byte-to-int) OUT -> IN validator_byte OUT -> RESULT _(test/result)
+
+persist_boolean(persistence/boolean:storage="fs",name="boolean")
+boolean OUT -> IN persist_boolean OUT -> IN validator_boolean OUT -> RESULT _(test/result)
+
+persist_string(persistence/string:storage="fs",name="string")
+string OUT -> IN persist_string OUT -> IN validator_string OUT -> RESULT _(test/result)
+
+persist_double(persistence/float:storage="fs",name="double")
+double OUT -> IN persist_double OUT -> IN validator_double OUT -> RESULT _(test/result)
+persist_double OUT -> IN double_map OUT -> IN validator_float_map OUT -> RESULT _(test/result)
+
+persist_double_only_val(persistence/float:storage="fs",name="double_only_val",store_only_val=true,default_value=1023.22|1|1024|0.5)
+double OUT -> IN persist_double_only_val OUT -> IN double_only_val_map OUT -> IN validator_float_val_only_map OUT -> RESULT _(test/result)
+
+persist_drange(persistence/float:storage="fs",name="drange")
+drange OUT -> IN persist_drange OUT -> IN validator_drange OUT -> RESULT _(test/result)
+persist_drange OUT -> IN drange_map OUT -> IN validator_drange_map OUT -> RESULT _(test/result)
+
+# -----------------------------------------------------------------------------
+
+persist_int_def(persistence/int:storage="fs",name="int_def",default_value=400000000)
+int OUT -> IN persist_int_def OUT -> IN validator_int_def OUT -> RESULT _(test/result)
+persist_int_def OUT -> IN int_def_map OUT -> IN validator_int_map_def OUT -> RESULT _(test/result)
+
+persist_irange_def(persistence/int:storage="fs",name="irange_def",default_value=-50|-50|-40|1)
+irange OUT -> IN persist_irange_def OUT -> IN validator_irange_def OUT -> RESULT _(test/result)
+persist_irange_def OUT -> IN irange_def_map OUT -> IN validator_irange_map_def OUT -> RESULT _(test/result)
+
+persist_byte_def(persistence/byte:storage="fs",name="byte_def",default_value=7)
+byte OUT -> IN persist_byte_def OUT -> IN _(converter/byte-to-int) OUT -> IN validator_byte_def OUT -> RESULT _(test/result)
+
+persist_boolean_def(persistence/boolean:storage="fs",name="boolean_def",default_value=true)
+boolean OUT -> IN persist_boolean_def OUT -> IN validator_boolean_def OUT -> RESULT _(test/result)
+
+persist_string_def(persistence/string:storage="fs",name="string_def",default_value="default")
+string OUT -> IN persist_string_def OUT -> IN validator_string_def OUT -> RESULT _(test/result)
+
+persist_double_def(persistence/float:storage="fs",name="double_def",default_value=-DBL_MAX)
+double OUT -> IN persist_double_def OUT -> IN validator_double_def OUT -> RESULT _(test/result)
+persist_double_def OUT -> IN double_def_map OUT -> IN validator_float_def_map OUT -> RESULT _(test/result)
+
+persist_drange_def(persistence/float:storage="fs",name="drange_def",default_value=-4.5|-5.0|5.0|0.5)
+drange OUT -> IN persist_drange_def OUT -> IN validator_drange_def OUT -> RESULT _(test/result)
+persist_drange_def OUT -> IN drange_def_map OUT -> IN validator_drange_def_map OUT -> RESULT _(test/result)

--- a/src/test-fbp/persistence-memmap-2.fbp
+++ b/src/test-fbp/persistence-memmap-2.fbp
@@ -1,0 +1,92 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This test will write to following file:
+# memmap-test.bin
+# This test also depends on test-memmap-map.json, which should
+# be passed as argumento to sol-fbp-runner or sol-fbp-generator (-m option).
+# memmap-test.bin need to exist and have previously written by
+# persistence-memmap.fbp
+# Note: memory mapped storage does not support default values. They are
+# meant to be sent when there's no previous saved value. However, memory mapped
+# storage does not support 'not previously saved value', as we only get a bunch
+# of zeros and have no way to know if they mean something or not.
+
+## TEST-EXTRA-ARGS -m test-memmap-map.json
+## TEST-SKIP-COMPILE This test uses some files, but path resolution is not decided yet
+## TEST-SKIP-VALGRIND Some float operations yield to [-]NaN on valgrind
+
+validator_int(test/int-validator:sequence="-12")
+validator_irange(test/int-validator:sequence="-13")
+validator_byte(test/int-validator:sequence="73")
+validator_boolean(test/boolean-validator:sequence="T")
+validator_string(test/string-validator:sequence="string")
+validator_double(test/float-validator:sequence="2.568")
+validator_float_map(test/float-validator:sequence="50.0")
+validator_float_val_only_map(test/float-validator:sequence="0.0")
+validator_drange(test/float-validator:sequence="5.5")
+validator_drange_map(test/float-validator:sequence="56.0")
+validator_int_map(test/int-validator:sequence="49")
+validator_int_val_only_map(test/int-validator:sequence="100")
+validator_irange_map(test/int-validator:sequence="37")
+
+int_map(int/map:output_range=min:0|max:100|step:1)
+int_only_val_map(int/map:output_range=min:0|max:100|step:1)
+irange_map(int/map:output_range=min:0|max:100|step:1)
+
+double_map(float/map:output_range=min:0|max:100|step:1)
+double_only_val_map(float/map:output_range=min:0|max:100|step:1)
+drange_map(float/map:output_range=min:0|max:100|step:1)
+
+persist_int(persistence/int:storage="memmap",name="int")
+persist_int_only_val(persistence/int:storage="memmap",name="int_only_val",store_only_val=true,default_value=30|-12|30|1)
+persist_irange(persistence/int:storage="memmap",name="irange")
+persist_byte(persistence/byte:storage="memmap",name="byte")
+persist_boolean(persistence/boolean:storage="memmap",name="boolean")
+persist_string(persistence/string:storage="memmap",name="string")
+persist_double(persistence/float:storage="memmap",name="double")
+persist_double_only_val(persistence/float:storage="memmap",name="double_only_val",store_only_val=true,default_value=1023.22|1|1024|0.5)
+persist_drange(persistence/float:storage="memmap",name="drange")
+
+persist_int OUT -> IN validator_int OUT -> RESULT _(test/result)
+persist_irange OUT -> IN validator_irange OUT -> RESULT _(test/result)
+persist_byte OUT -> IN _(converter/byte-to-int) OUT -> IN validator_byte OUT -> RESULT _(test/result)
+persist_boolean OUT -> IN validator_boolean OUT -> RESULT _(test/result)
+persist_string OUT -> IN validator_string OUT -> RESULT _(test/result)
+persist_double OUT -> IN validator_double OUT -> RESULT _(test/result)
+persist_drange OUT -> IN validator_drange OUT -> RESULT _(test/result)
+
+persist_int OUT -> IN int_map OUT -> IN validator_int_map OUT -> RESULT _(test/result)
+persist_irange OUT -> IN irange_map OUT -> IN validator_irange_map OUT -> RESULT _(test/result)
+persist_double OUT -> IN double_map OUT -> IN validator_float_map OUT -> RESULT _(test/result)
+persist_drange OUT -> IN drange_map OUT -> IN validator_drange_map OUT -> RESULT _(test/result)
+
+persist_int_only_val OUT -> IN int_only_val_map OUT -> IN validator_int_val_only_map OUT -> RESULT _(test/result)
+persist_double_only_val OUT -> IN double_only_val_map OUT -> IN validator_float_val_only_map OUT -> RESULT _(test/result)

--- a/src/test-fbp/persistence-memmap.fbp
+++ b/src/test-fbp/persistence-memmap.fbp
@@ -1,0 +1,109 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This test will write to following file:
+# memmap-test.bin
+# This test also depends on test-memmap-map.json, which should
+# be passed as argumento to sol-fbp-runner or sol-fbp-generator (-m option).
+# memmap-test.bin need to exist and be zeroed (or have size 0) prior to
+# running this test
+# Note: memory mapped storage does not support default values. They are
+# meant to be sent when there's no previous saved value. However, memory mapped
+# storage does not support 'not previously saved value', as we only get a bunch
+# of zeros and have no way to know if they mean something or not.
+
+## TEST-EXTRA-ARGS -m test-memmap-map.json
+## TEST-PRECONDITION truncate -s0 memmap-test.bin
+## TEST-SKIP-COMPILE This test uses some files, but path resolution is not decided yet
+## TEST-SKIP-VALGRIND Some float operations yield to [-]NaN on valgrind
+
+int(constant/int:value=-12)
+int_only(constant/int:value=30)
+irange(constant/int:value=-13|-50|50|3)
+byte(constant/byte:value=73)
+boolean(constant/boolean:value=true)
+string(constant/string:value="string")
+double(constant/float:value=2.568)
+drange(constant/float:value=5.5|-40.0|40.0|0.4)
+
+validator_int(test/int-validator:sequence="0 -12")
+validator_irange(test/int-validator:sequence="0 -13")
+validator_byte(test/int-validator:sequence="0 73")
+validator_boolean(test/boolean-validator:sequence="FT")
+validator_string(test/string-validator:sequence="|string")
+validator_double(test/float-validator:sequence="0 2.568")
+
+int_map(int/map:output_range=min:0|max:100|step:1)
+int_only_val_map(int/map:output_range=min:0|max:100|step:1)
+irange_map(int/map:output_range=min:0|max:100|step:1)
+
+validator_int_map(test/int-validator:sequence="50 49")
+validator_int_val_only_map(test/int-validator:sequence="28 100")
+validator_irange_map(test/int-validator:sequence="50 37")
+
+double_map(float/map:output_range=min:0|max:100|step:1)
+double_only_val_map(float/map:output_range=min:0|max:100|step:1)
+drange_map(float/map:output_range=min:0|max:100|step:1)
+
+validator_float_map(test/float-validator:sequence="50.0 50.0")
+validator_float_val_only_map(test/float-validator:sequence="0.0 0.0")
+validator_drange(test/float-validator:sequence="0.0 5.5")
+validator_drange_map(test/float-validator:sequence="50.0 56.0")
+
+persist_int(persistence/int:storage="memmap",name="int")
+int OUT -> IN persist_int OUT -> IN validator_int OUT -> RESULT _(test/result)
+persist_int OUT -> IN int_map OUT -> IN validator_int_map OUT -> RESULT _(test/result)
+
+persist_int_only_val(persistence/int:storage="memmap",name="int_only_val",store_only_val=true,default_value=30|-12|30|1)
+int_only OUT -> IN persist_int_only_val OUT -> IN int_only_val_map OUT -> IN validator_int_val_only_map OUT -> RESULT _(test/result)
+
+persist_irange(persistence/int:storage="memmap",name="irange")
+irange OUT -> IN persist_irange OUT -> IN validator_irange OUT -> RESULT _(test/result)
+persist_irange OUT -> IN irange_map OUT -> IN validator_irange_map OUT -> RESULT _(test/result)
+
+persist_byte(persistence/byte:storage="memmap",name="byte")
+byte OUT -> IN persist_byte OUT -> IN _(converter/byte-to-int) OUT -> IN validator_byte OUT -> RESULT _(test/result)
+
+persist_boolean(persistence/boolean:storage="memmap",name="boolean")
+boolean OUT -> IN persist_boolean OUT -> IN validator_boolean OUT -> RESULT _(test/result)
+
+persist_string(persistence/string:storage="memmap",name="string")
+string OUT -> IN persist_string OUT -> IN validator_string OUT -> RESULT _(test/result)
+
+persist_double(persistence/float:storage="memmap",name="double")
+double OUT -> IN persist_double OUT -> IN validator_double OUT -> RESULT _(test/result)
+persist_double OUT -> IN double_map OUT -> IN validator_float_map OUT -> RESULT _(test/result)
+
+persist_double_only_val(persistence/float:storage="memmap",name="double_only_val",store_only_val=true,default_value=1023.22|1|1024|0.5)
+double OUT -> IN persist_double_only_val OUT -> IN double_only_val_map OUT -> IN validator_float_val_only_map OUT -> RESULT _(test/result)
+
+persist_drange(persistence/float:storage="memmap",name="drange")
+drange OUT -> IN persist_drange OUT -> IN validator_drange OUT -> RESULT _(test/result)
+persist_drange OUT -> IN drange_map OUT -> IN validator_drange_map OUT -> RESULT _(test/result)

--- a/src/test-fbp/test-memmap-map.json
+++ b/src/test-fbp/test-memmap-map.json
@@ -1,0 +1,90 @@
+{
+    "meta": {
+        "author": "Intel Corporation",
+        "license": "BSD-3-Clause",
+        "version": "1"
+    },
+    "maps": [
+        {
+            "version": 1,
+            "path": "memmap-test.bin",
+            "entries": [
+                {
+                    "name": "_version",
+                    "offset": 2,
+                    "size": 1
+                },
+                {
+                    "name": "boolean",
+                    "offset": 3,
+                    "size": 1,
+                    "bit_size": 1,
+                    "bit_offset": 0
+                },
+                {
+                    "name": "int_only_val",
+                    "offset": 3,
+                    "size": 4,
+                    "bit_size": 30,
+                    "bit_offset": 1
+                },
+                {
+                    "name": "byte",
+                    "size": 1
+                },
+                {
+                    "name": "int",
+                    "size": 16
+                },
+                {
+                    "name": "irange",
+                    "size": 16
+                },
+                {
+                    "name": "string",
+                    "size": 10
+                },
+                {
+                    "name": "double",
+                    "size": 32
+                },
+                {
+                    "name": "double_only_val",
+                    "size": 8
+                },
+                {
+                    "name": "drange",
+                    "size": 32
+                },
+                {
+                    "name": "int_def",
+                    "size": 16
+                },
+                {
+                    "name": "irange_def",
+                    "size": 16
+                },
+                {
+                    "name": "byte_def",
+                    "size": 1
+                },
+                {
+                    "name": "boolean_def",
+                    "size": 1
+                },
+                {
+                    "name": "string_def",
+                    "size": 10
+                },
+                {
+                    "name": "double_def",
+                    "size": 32
+                },
+                {
+                    "name": "drange_def",
+                    "size": 32
+                }
+            ]
+        }
+    ]
+}

--- a/tools/run-fbp-tests
+++ b/tools/run-fbp-tests
@@ -72,6 +72,8 @@ class FbpTest:
         self.output_regex = False
         self.output_spec = ""
         self.exit_code = 0
+        self.extra_args = ""
+        self.precondition = ""
 
         self._parse_test()
 
@@ -84,7 +86,7 @@ class FbpTest:
             self.skip_msg = splitted[2]
 
     def _parse_command(self, line):
-        splitted = line.split(None, 2)
+        splitted = line.split(None)
         cmd = splitted[1]
 
         if cmd == "TEST-OUTPUT-REGEX":
@@ -95,6 +97,10 @@ class FbpTest:
             self.exit_code = 1
         elif cmd.startswith("TEST-SKIP"):
             self._parse_skip(cmd, splitted)
+        elif cmd.startswith("TEST-EXTRA-ARGS"):
+            self.extra_args = splitted[2:]
+        elif cmd.startswith("TEST-PRECONDITION"):
+            self.precondition = splitted[2:]
         else:
             logging.info("Ignoring unknown test command '%s' in test %s" %
                          (cmd, self.test_file))
@@ -232,12 +238,23 @@ def run_tests(args):
             continue
 
         if not args.compiled:
-            cmd = cmd_prefix + [runner, path["file"]]
+            cmd = cmd_prefix + [runner]
+
+            if curr.extra_args:
+                cmd += curr.extra_args
+
+            cmd += [path["file"]]
             test_cwd = path["dir"]
         else:
             exe = os.path.join(args.compiled_dir, path["file"].replace(".fbp", ""))
             cmd = cmd_prefix + [exe]
             test_cwd = "./"
+
+        if curr.precondition:
+            out, code = sh(curr.precondition, cwd=test_cwd)
+            if code != 0:
+                logging.warning("Precondition failed for test %s: %d",
+                        curr.test_file, code)
 
         out, code = sh(cmd, cwd=test_cwd)
         result = curr.show_result_status(out, code)


### PR DESCRIPTION
v3:
Now with proper tests. Some other issues pointed by @lpereira were also addressed. Issues found by tests addressed as well =D
To have the tests, some modifications on run-fbp-tests were necessary: TEST-PRECONDITION and TEST-EXTRA-ARGS. Tests are disabled for compile, as they touch file system, and for valgrind, as double mappings fail on it (some NaNs appear).

v2:
Issues pointed on v1 should be addressed, highlights:

On json map, using offset 0 will indicate that we should calculate offset based on previous entry;
Some doc;
Able to handle int with arbitrary number of bits, up to 64;
Using sol_arena to simplify allocations and deallocations;
Using sol_token_to_slice
Fixes on build;
store_only_val fixes;
Still missing proper tests, will be addressed soon.

This series moves persistence node backing storage functions to lib/io, so they can be used anywhere, adding some helpers to write double our sol_drange and introduces a new backing storage: memmap.
This storage fits media where we only have a block to write stuff. To associate what is where on the media, a map should be provided. It can be created via C API or sent to sol-fbp-generator (or runner) via -m option. On the first, the output C file will contain the mapping, on the later it will be loaded on the fly.
There's doubt if we should keep the separated option for this map file, or if it should be part of conffile. Let's hope that with this PR, people can settle on a conclusion.
It includes also a commit that shall not be integrated: one for those who really want to test (or see how it should be used) the new features.
