### PR TITLE
Use uname(2) on get_os_version [v2]

### DIFF
--- a/src/lib/common/sol-mainloop.c
+++ b/src/lib/common/sol-mainloop.c
@@ -132,7 +132,9 @@ sol_init(void)
         goto comms_error;
 #endif
 
-    SOL_DBG("Soletta %s initialized", sol_platform_get_sw_version());
+    SOL_DBG("Soletta %s, running os %s-%s, initialized",
+        sol_platform_get_sw_version(), BASE_OS,
+        sol_platform_get_os_version());
 
     return 0;
 

--- a/src/lib/common/sol-platform-impl-contiki.c
+++ b/src/lib/common/sol-platform-impl-contiki.c
@@ -110,9 +110,9 @@ sol_platform_impl_get_serial_number(char **number)
     return -ENOTSUP;
 }
 
-char *
-sol_platform_impl_get_os_version(void)
+int
+sol_platform_impl_get_os_version(char **version)
 {
     SOL_WRN("Not implemented");
-    return NULL;
+    return -ENOTSUP;
 }

--- a/src/lib/common/sol-platform-impl-dummy.c
+++ b/src/lib/common/sol-platform-impl-dummy.c
@@ -110,9 +110,9 @@ sol_platform_impl_get_serial_number(char **number)
     return -ENOTSUP;
 }
 
-char *
-sol_platform_impl_get_os_version(void)
+int
+sol_platform_impl_get_os_version(char **version)
 {
     SOL_WRN("Not implemented");
-    return NULL;
+    return -ENOTSUP;
 }

--- a/src/lib/common/sol-platform-impl-linux-micro.c
+++ b/src/lib/common/sol-platform-impl-linux-micro.c
@@ -846,16 +846,10 @@ sol_platform_impl_get_serial_number(char **number)
     return r;
 }
 
-char *
-sol_platform_impl_get_os_version(void)
+int
+sol_platform_impl_get_os_version(char **version)
 {
-    char *ret = NULL;
-    int r;
-
-    r = sol_util_get_os_version(&ret);
-    SOL_INT_CHECK(r, < 0, NULL);
-
-    return ret;
+    return sol_platform_linux_get_os_version(version);
 }
 
 SOL_API void

--- a/src/lib/common/sol-platform-impl-riot.c
+++ b/src/lib/common/sol-platform-impl-riot.c
@@ -181,8 +181,14 @@ sol_platform_impl_get_serial_number(char **number)
 #endif
 }
 
-char *
-sol_platform_impl_get_os_version(void)
+int
+sol_platform_impl_get_os_version(char **version)
 {
-    return strdup(RIOT_VERSION);
+    SOL_NULL_CHECK(version, -EINVAL);
+
+    *version = strdup(RIOT_VERSION);
+    if (*version)
+        return -ENOMEM;
+
+    return 0;
 }

--- a/src/lib/common/sol-platform-impl-systemd.c
+++ b/src/lib/common/sol-platform-impl-systemd.c
@@ -446,6 +446,7 @@ int
 sol_platform_impl_get_machine_id(char id[static 33])
 {
     int r;
+
     r = sol_util_read_file("/etc/machine-id", "%32s", id);
     /* that id should have already been validated by systemd */
 
@@ -469,16 +470,10 @@ sol_platform_impl_get_serial_number(char **number)
     return r;
 }
 
-char *
-sol_platform_impl_get_os_version(void)
+int
+sol_platform_impl_get_os_version(char **version)
 {
-    char *ret = NULL;
-    int r;
-
-    r = sol_util_get_os_version(&ret);
-    SOL_INT_CHECK(r, < 0, NULL);
-
-    return ret;
+    return sol_platform_linux_get_os_version(version);
 }
 
 int

--- a/src/lib/common/sol-platform-impl.h
+++ b/src/lib/common/sol-platform-impl.h
@@ -54,7 +54,7 @@ int sol_platform_impl_set_target(const char *target) SOL_ATTR_NONNULL(1);
 
 int sol_platform_impl_get_machine_id(char id[static 33]);
 int sol_platform_impl_get_serial_number(char **number);
-char *sol_platform_impl_get_os_version(void);
+int sol_platform_impl_get_os_version(char **version);
 
 /* callbacks into generic platform abstraction */
 void sol_platform_inform_state_monitors(enum sol_platform_state state);

--- a/src/lib/common/sol-platform-linux-common.c
+++ b/src/lib/common/sol-platform-linux-common.c
@@ -32,8 +32,10 @@
 
 #include <errno.h>
 #include <signal.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#include <sys/utsname.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -242,4 +244,22 @@ SOL_API void
 sol_platform_linux_fork_run_exit(int status)
 {
     _exit(status);
+}
+
+int
+sol_platform_linux_get_os_version(char **out)
+{
+    int r;
+    struct utsname hostinfo;
+
+    SOL_NULL_CHECK(out, -EINVAL);
+
+    r = uname(&hostinfo);
+    SOL_INT_CHECK(r, == -1, -errno);
+
+    r = asprintf(out, "%s", hostinfo.release);
+    if (r == -1)
+        return -ENOMEM;
+
+    return 0;
 }

--- a/src/lib/common/sol-platform-linux.h
+++ b/src/lib/common/sol-platform-linux.h
@@ -159,6 +159,17 @@ uint64_t sol_platform_linux_fork_run_get_pid(const struct sol_platform_linux_for
  */
 void sol_platform_linux_fork_run_exit(int status) SOL_ATTR_NORETURN;
 
+/**
+ * Retrieve Linux kernel version.
+ *
+ * @param out Where to store the version string, that conforms to
+ *            uname(2)'s return (release utsname struct field). Must
+ *            de freed after usage.
+ *
+ * @return 0 on success, negative error code otherwise.
+ */
+int sol_platform_linux_get_os_version(char **out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/common/sol-platform.c
+++ b/src/lib/common/sol-platform.c
@@ -51,6 +51,7 @@
 SOL_LOG_INTERNAL_DECLARE(_sol_platform_log_domain, "platform");
 
 static char *board_name = NULL;
+static char *os_version = NULL;
 
 struct service_monitor {
     struct sol_monitors_entry base;
@@ -85,6 +86,7 @@ void
 sol_platform_shutdown(void)
 {
     free(board_name);
+    free(os_version);
     sol_monitors_clear(&_ctx.state_monitors);
     sol_monitors_clear(&_ctx.service_monitors);
     sol_platform_impl_shutdown();
@@ -394,7 +396,14 @@ sol_platform_get_sw_version(void)
 SOL_API char *
 sol_platform_get_os_version(void)
 {
-    return sol_platform_impl_get_os_version();
+    int r;
+    char *out;
+
+    if (os_version) return os_version;
+    r = sol_platform_impl_get_os_version(&out);
+    SOL_INT_CHECK(r, < 0, NULL);
+    os_version = out;
+    return os_version;
 }
 
 void

--- a/src/shared/sol-util-file.c
+++ b/src/shared/sol-util-file.c
@@ -372,46 +372,6 @@ sol_util_get_rootdir(char *out, size_t size)
 }
 
 int
-sol_util_get_os_version(char **out)
-{
-    char *ptr, *end, *str;
-    static const char version[] = "VERSION_ID";
-
-    SOL_NULL_CHECK(out, -EINVAL);
-
-    str = sol_util_load_file_string("/etc/os-release", NULL);
-    if (!str) {
-        str = sol_util_load_file_string("/usr/lib/os-release", NULL);
-        if (!str)
-            goto err;
-    }
-
-    ptr = strstr(str, version);
-    if (!ptr)
-        goto err;
-
-    ptr += sizeof(version);
-
-    if (!*ptr)
-        goto err;
-
-    end = strstr(ptr, "\n");
-    if (!end || end == ptr)
-        goto err;
-
-    *out = strndup(ptr, end - ptr);
-    if (!*out)
-        goto err;
-
-    free(str);
-    return 0;
-
-err:
-    free(str);
-    return -ENOTSUP;
-}
-
-int
 sol_util_fd_set_flag(int fd, int flag)
 {
     int flags;

--- a/src/shared/sol-util-file.h
+++ b/src/shared/sol-util-file.h
@@ -51,7 +51,6 @@ struct sol_buffer *sol_util_load_file_raw(const int fd) SOL_ATTR_WARN_UNUSED_RES
 char *sol_util_load_file_string(const char *filename, size_t *size) SOL_ATTR_WARN_UNUSED_RESULT;
 char *sol_util_load_file_fd_string(const int fd, size_t *size) SOL_ATTR_WARN_UNUSED_RESULT;
 int sol_util_get_rootdir(char *out, size_t size) SOL_ATTR_WARN_UNUSED_RESULT;
-int sol_util_get_os_version(char **out) SOL_ATTR_WARN_UNUSED_RESULT;
 int sol_util_fd_set_flag(int fd, int flag) SOL_ATTR_WARN_UNUSED_RESULT;
 
 /**


### PR DESCRIPTION
Changes since #754:

- -impl- files kept as is
- common code moved to platform-linux
- os_version string persisted till shutdown
- base_os and os_version now printed for dgb

Also moving common linux code on that to a sol_platform_linux function,
that is now more suitable.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>