### PR TITLE
strings: add string/slice node, with tests [v2]

### DIFF
--- a/src/modules/flow/string/string-icu.c
+++ b/src/modules/flow/string/string-icu.c
@@ -336,6 +336,130 @@ string_compare(struct sol_flow_node *node,
         SOL_FLOW_NODE_TYPE_STRING_COMPARE__OUT__OUT, result);
 }
 
+struct string_slice_data {
+    struct sol_flow_node *node;
+    UChar *str;
+    int idx[2];
+};
+
+static int
+get_slice_idx_by_port(const struct sol_flow_packet *packet,
+    uint16_t port,
+    struct string_slice_data *mdata)
+{
+    int32_t in_value;
+    int r;
+
+    r = sol_flow_packet_get_irange_value(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    mdata->idx[port] = in_value;
+
+    return 0;
+}
+
+static int
+slice_do(struct string_slice_data *mdata)
+{
+    struct sol_str_slice slice;
+    int32_t start = mdata->idx[0], end = mdata->idx[1],
+        len = u_strlen(mdata->str);
+    char *outstr = NULL;
+    UErrorCode err;
+    int r;
+
+    if (start < 0) start = len + start;
+    if (end < 0) end = len + end;
+    start = sol_util_int32_clamp(0, len, start);
+    end = sol_util_int32_clamp(0, len, end);
+
+    slice = SOL_STR_SLICE_STR((char *)(mdata->str + start), end - start);
+
+    r = utf8_from_icu_str_slice((const UChar *)slice.data, slice.len,
+        &outstr, &err);
+    if (r < 0) {
+        sol_flow_send_error_packet(mdata->node, -r, u_errorName(err));
+        return r;
+    }
+
+    return sol_flow_send_string_take_packet(mdata->node,
+        SOL_FLOW_NODE_TYPE_STRING_SLICE__OUT__OUT, outstr);
+}
+
+static int
+string_slice_input(struct sol_flow_node *node,
+    void *data,
+    uint16_t port,
+    uint16_t conn_id,
+    const struct sol_flow_packet *packet)
+{
+    struct string_slice_data *mdata = data;
+    const char *in_value;
+    UErrorCode err;
+    int r;
+
+    r = sol_flow_packet_get_string(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    free(mdata->str);
+    mdata->str = NULL;
+    r = icu_str_from_utf8(in_value, &mdata->str, &err);
+    if (r < 0) {
+        sol_flow_send_error_packet(mdata->node, -r, u_errorName(err));
+        return r;
+    }
+
+    return slice_do(mdata);
+}
+
+static int
+string_slice(struct sol_flow_node *node,
+    void *data,
+    uint16_t port,
+    uint16_t conn_id,
+    const struct sol_flow_packet *packet)
+{
+    struct string_slice_data *mdata = data;
+    int r;
+
+    r = get_slice_idx_by_port(packet, port, mdata);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (mdata->str)
+        return slice_do(mdata);
+
+    return 0;
+}
+
+static int
+string_slice_open(struct sol_flow_node *node,
+    void *data,
+    const struct sol_flow_node_options *options)
+{
+    struct string_slice_data *mdata = data;
+
+    const struct sol_flow_node_type_string_slice_options *opts;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_STRING_SLICE_OPTIONS_API_VERSION, -EINVAL);
+
+    opts = (const struct sol_flow_node_type_string_slice_options *)options;
+
+    mdata->idx[0] = opts->start.val;
+    mdata->idx[1] = opts->end.val;
+    mdata->node = node;
+
+    return 0;
+}
+
+static void
+string_slice_close(struct sol_flow_node *node, void *data)
+{
+    struct string_slice_data *mdata = data;
+
+    free(mdata->str);
+}
+
 struct string_length_data {
     uint32_t n;
 };

--- a/src/modules/flow/string/string.json
+++ b/src/modules/flow/string/string.json
@@ -142,6 +142,67 @@
     },
     {
       "category": "string",
+      "description": "Extract a slice from a given string",
+      "in_ports": [
+        {
+          "data_type": "int",
+          "description": "Start index of the slice (counting starts from 0). Negative values are relative to the end of the input string. If the given indexes are not valid for the input string, an empty string output is produced.",
+          "methods": {
+            "process": "string_slice"
+          },
+          "name": "START"
+        },
+        {
+          "data_type": "int",
+          "description": "End index of the slice (counting starts from 0). Negative values are relative to the end of the input string. If the given indexes are not valid for the input string, an empty string output is produced.",
+          "methods": {
+            "process": "string_slice"
+          },
+          "name": "END"
+        },
+        {
+          "data_type": "string",
+          "description": "Input string to be sliced.",
+          "methods": {
+            "process": "string_slice_input"
+          },
+          "name": "IN"
+        }
+      ],
+      "methods": {
+        "close": "string_slice_close",
+        "open": "string_slice_open"
+      },
+      "name": "string/slice",
+      "options": {
+        "members": [
+          {
+            "data_type": "int",
+            "default": 0,
+            "description": "Start index of the slice (counting starts from 0). Negative values are relative to the end of the input string. If the given indexes are not valid for the input string, an empty string output is produced. It can be overriden by values received on 'START' port.",
+            "name": "start"
+          },
+          {
+            "data_type": "int",
+            "default": 0,
+            "description": "End index of the slice (counting starts from 0). Negative values are relative to the end of the input string. If the given indexes are not valid for the input string, an empty string output is produced. It can be overriden by values received on 'END' port.",
+            "name": "end"
+          }
+        ],
+        "version": 1
+      },
+      "out_ports": [
+        {
+          "data_type": "string",
+          "description": "String slice given by the indexes in the IDX port array.",
+          "name": "OUT"
+        }
+      ],
+      "private_data_type": "string_slice_data",
+      "url": "http://solettaproject.org/doc/latest/node_types/string/slice.html"
+    },
+    {
+      "category": "string",
       "description": "Split a string given a separator.",
       "in_ports": [
         {

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -361,3 +361,13 @@ sol_util_uuid_str_valid(const char *str)
 
     return true;
 }
+
+static inline int32_t
+sol_util_int32_clamp(int32_t start, int32_t end, int32_t value)
+{
+    if (value < start)
+        return start;
+    if (value > end)
+        return end;
+    return value;
+}

--- a/src/test-fbp/string-slice.fbp
+++ b/src/test-fbp/string-slice.fbp
@@ -1,0 +1,73 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+str(constant/string:value="0★2★4★6★8★")
+
+str OUT -> IN slice_01(string/slice:start=0,end=10)
+slice_01 OUT -> IN[0] cmp_01(string/compare)
+str OUT -> IN[1] cmp_01
+cmp_01 EQUAL -> RESULT result_01(test/result)
+
+str OUT -> IN slice_02(string/slice:start=0,end=3)
+slice_02 OUT -> IN[0] cmp_02(string/compare)
+_(constant/string:value="0★2") OUT -> IN[1] cmp_02
+cmp_02 EQUAL -> RESULT result_02(test/result)
+
+str OUT -> IN slice_03(string/slice:start=0,end=-3)
+slice_03 OUT -> IN[0] cmp_03(string/compare)
+_(constant/string:value="0★2★4★6") OUT -> IN[1] cmp_03
+cmp_03 EQUAL -> RESULT result_03(test/result)
+
+str OUT -> IN slice_04(string/slice:start=-7,end=-3)
+slice_04 OUT -> IN[0] cmp_04(string/compare)
+_(constant/string:value="★4★6") OUT -> IN[1] cmp_04
+cmp_04 EQUAL -> RESULT result_04(test/result)
+
+str OUT -> IN slice_05(string/slice:start=-22342,end=10)
+slice_05 OUT -> IN[0] cmp_05(string/compare)
+str OUT -> IN[1] cmp_05
+cmp_05 EQUAL -> RESULT result_05(test/result)
+
+str OUT -> IN slice_06(string/slice:start=0,end=-12)
+slice_06 OUT -> IN[0] cmp_06(string/compare)
+_(constant/string:value="") OUT -> IN[1] cmp_06
+cmp_06 EQUAL -> RESULT result_06(test/result)
+
+str OUT -> IN slice_07(string/slice:start=666,end=888)
+slice_07 OUT -> IN[0] cmp_07(string/compare)
+_(constant/string:value="") OUT -> IN[1] cmp_07
+cmp_07 EQUAL -> RESULT result_07(test/result)
+
+str OUT -> IN slice_08(string/slice:start=0,end=666)
+slice_08 OUT -> IN[0] cmp_08(string/compare)
+str OUT -> IN[1] cmp_08
+cmp_08 EQUAL -> RESULT result_08(test/result)
+
+


### PR DESCRIPTION
Changes since #759:

- sol_util_int32_clamp() now used
- strdup() return checks squashed.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>