### PR TITLE
test-fbp: enable some disabled tests

### DIFF
--- a/src/test-fbp/converter-float-boolean.fbp
+++ b/src/test-fbp/converter-float-boolean.fbp
@@ -28,8 +28,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-## TEST-SKIP-COMPILE Generator failing to properly generate code
-
 below_min(constant/float:value=9.9)
 above_max(constant/float:value=20.001)
 within_range(constant/float:value=15.38)

--- a/src/test-fbp/converter-float-direction-vector.fbp
+++ b/src/test-fbp/converter-float-direction-vector.fbp
@@ -28,8 +28,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-## TEST-SKIP-COMPILE Generator failing to properly generate code
-
 XFloat(constant/float:value=20|0|100|1)
 YFloat(constant/float:value=40|0|100|1)
 ZFloat(constant/float:value=70|0|100|1)

--- a/src/test-fbp/converter-float-empty.fbp
+++ b/src/test-fbp/converter-float-empty.fbp
@@ -28,8 +28,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-## TEST-SKIP-COMPILE Generator failing to properly generate code
-
 float_to_empty(converter/float-to-empty:range=min:0|max:20)
 match_ten(constant/float:value=10)
 

--- a/src/test-fbp/converter-float-rgb.fbp
+++ b/src/test-fbp/converter-float-rgb.fbp
@@ -28,8 +28,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-## TEST-SKIP-COMPILE Generator failing to properly generate code
-
 RedFloat(constant/float:value=20|0|100|1)
 GreenFloat(constant/float:value=40|0|100|1)
 BlueFloat(constant/float:value=70|0|100|1)

--- a/src/test-fbp/converter-int-direction-vector.fbp
+++ b/src/test-fbp/converter-int-direction-vector.fbp
@@ -28,8 +28,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-## TEST-SKIP-COMPILE Generator failing to properly generate code
-
 XInt(constant/int:value=20|0|100|1)
 YInt(constant/int:value=40|0|100|1)
 ZInt(constant/int:value=70|0|100|1)

--- a/src/test-fbp/drange-math.fbp
+++ b/src/test-fbp/drange-math.fbp
@@ -28,8 +28,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-## TEST-SKIP-COMPILE Generator failing to properly generate code
-
 negative_val(constant/float:value=-365.017)
 positive_val(constant/float:value=183784.872)
 absolute_val(constant/float:value=365.017)

--- a/src/test-fbp/rgb.fbp
+++ b/src/test-fbp/rgb.fbp
@@ -28,8 +28,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-## TEST-SKIP-COMPILE Generator failing to properly generate code
-
 Color(color/luminance-rgb:color=255|100|0|255|255|255)
 Luminance(constant/int:value=50|0|100|1) OUT -> IN Color
 

--- a/src/test-fbp/wave-generator.fbp
+++ b/src/test-fbp/wave-generator.fbp
@@ -28,8 +28,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-## TEST-SKIP-COMPILE Generator failing to properly generate code
-
 # 15 samples for each
 tick_gen(test/boolean-generator:sequence="TTTTTTTTTTTTTTT",interval=0)
 


### PR DESCRIPTION
Collaterally some tests were already fixed, this patch enables them for
check-fbp-bin target.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>