### PR TITLE
generator: irange values are divergent

### DIFF
--- a/src/test-fbp/converter-string-int.fbp
+++ b/src/test-fbp/converter-string-int.fbp
@@ -28,8 +28,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-## TEST-SKIP-COMPILE Generator failing to properly generate code
-
 const_int(constant/int:value=666)
 const_int_str(constant/string:value="666")
 


### PR DESCRIPTION
If we run an fbp with sol-fbp-runner and the options has no sub-option
the values for .min, .max and step are set to INT32_MIN, INT32_MAX and 1
respectively, but the code generated by sol-fbp-generator doesn't set
those values by default.

The converter-string-int.fbp excercises the problem, i.e:

The following fbp fragment when generated + built + compiled should
produce the output string "003 / -2147483648.000 / 17777777777 / 0x1",
instead it produces "003 / 0.000 / 0 / 0x0":

_(constant/int:value=3) OUT -> IN
_(converter/int-to-string:format_spec="{val:03d} / {min:.3f} / {max:o} /
{step:#x}") OUT -> IN[0] fmt_test_cmp(string/compare)

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>