### PR TITLE
pin-mux: Keep track of open gpios...

### DIFF
--- a/src/modules/pin-mux/intel-common/intel-common.h
+++ b/src/modules/pin-mux/intel-common/intel-common.h
@@ -41,7 +41,7 @@ extern "C" {
 /**
  * Pin logical value to be used
  */
-enum pin_val {
+enum mux_pin_val {
     PIN_LOW = 0, /**< Logical zero */
     PIN_HIGH, /**< Logical one */
     PIN_NONE, /**< Pin should be disable i.e. set to high impedance input */
@@ -56,7 +56,7 @@ enum pin_val {
 /**
  * Mode in which the pin will be set to operate
  */
-enum mode {
+enum mux_mode {
     MODE_GPIO_INPUT_PULLUP = 0x01, /**< GPIO Input (Pull-up) */
     MODE_GPIO_INPUT_PULLDOWN = 0x02, /**< GPIO Input (Pull-down) */
     MODE_GPIO_INPUT_HIZ = 0x04, /**< GPIO Input (High impedance) */
@@ -76,8 +76,8 @@ enum mode {
 
 struct mux_description {
     int gpio_pin; /**< GPIO pin that controls the mux */
-    enum pin_val val; /**< Pin value */
-    enum mode mode; /**< Combination of possible pin operation modes */
+    enum mux_pin_val val; /**< Pin value */
+    enum mux_mode mode; /**< Combination of possible pin operation modes */
 }; /**< Description of a rule to be applied to setup the multiplexer of a given pin */
 
 /**
@@ -89,14 +89,18 @@ struct mux_controller {
     struct mux_description **recipe; /**< A list of mux recipes for each pin */
 };
 
-int set_aio(const int device, const int pin, const struct mux_controller *ctl_list, const int s);
+void mux_shutdown(void);
 
-int set_gpio(const int pin, const enum sol_gpio_direction dir,
+int mux_set_aio(const int device, const int pin, const struct mux_controller *ctl_list,
+    const int s);
+
+int mux_set_gpio(const int pin, const enum sol_gpio_direction dir,
     struct mux_description **const desc_list, const int s);
 
-int set_i2c(const uint8_t bus, struct mux_description * (*const desc_list)[2], const unsigned int s);
+int mux_set_i2c(const uint8_t bus, struct mux_description * (*const desc_list)[2],
+    const unsigned int s);
 
-int set_pwm(const int device, const int channel, const struct mux_controller *ctl_list,
+int mux_set_pwm(const int device, const int channel, const struct mux_controller *ctl_list,
     const int s);
 
 #ifdef __cplusplus

--- a/src/modules/pin-mux/intel-edison-rev-c/intel-edison-rev-c.c
+++ b/src/modules/pin-mux/intel-edison-rev-c/intel-edison-rev-c.c
@@ -373,29 +373,30 @@ static struct mux_controller pwm_controller_list[] = {
 static int
 _set_aio(const int device, const int pin)
 {
-    return set_aio(device, pin, aio_controller_list, (int)ARRAY_SIZE(aio_controller_list));
+    return mux_set_aio(device, pin, aio_controller_list, (int)ARRAY_SIZE(aio_controller_list));
 }
 
 static int
 _set_gpio(const int pin, const enum sol_gpio_direction dir)
 {
-    return set_gpio(pin, dir, gpio_dev_0, (int)ARRAY_SIZE(gpio_dev_0));
+    return mux_set_gpio(pin, dir, gpio_dev_0, (int)ARRAY_SIZE(gpio_dev_0));
 }
 
 static int
 _set_i2c(const uint8_t bus)
 {
-    return set_i2c(bus, i2c_dev_0, ARRAY_SIZE(i2c_dev_0));
+    return mux_set_i2c(bus, i2c_dev_0, ARRAY_SIZE(i2c_dev_0));
 }
 
 static int
 _set_pwm(const int device, const int channel)
 {
-    return set_pwm(device, channel, pwm_controller_list, (int)ARRAY_SIZE(pwm_controller_list));
+    return mux_set_pwm(device, channel, pwm_controller_list, (int)ARRAY_SIZE(pwm_controller_list));
 }
 
 SOL_PIN_MUX_DECLARE(INTEL_EDISON_REV_C,
     .plat_name = "intel-edison-rev-c",
+    .shutdown = mux_shutdown,
     .aio = _set_aio,
     .gpio = _set_gpio,
     .i2c = _set_i2c,

--- a/src/modules/pin-mux/intel-galileo-rev-d/intel-galileo-rev-d.c
+++ b/src/modules/pin-mux/intel-galileo-rev-d/intel-galileo-rev-d.c
@@ -176,29 +176,30 @@ static struct mux_controller pwm_controller_list[] = {
 static int
 _set_aio(const int device, const int pin)
 {
-    return set_aio(device, pin, aio_controller_list, (int)ARRAY_SIZE(aio_controller_list));
+    return mux_set_aio(device, pin, aio_controller_list, (int)ARRAY_SIZE(aio_controller_list));
 }
 
 static int
 _set_gpio(const int pin, const enum sol_gpio_direction dir)
 {
-    return set_gpio(pin, dir, gpio_dev_0, (int)ARRAY_SIZE(gpio_dev_0));
+    return mux_set_gpio(pin, dir, gpio_dev_0, (int)ARRAY_SIZE(gpio_dev_0));
 }
 
 static int
 _set_i2c(const uint8_t bus)
 {
-    return set_i2c(bus, i2c_dev_0, ARRAY_SIZE(i2c_dev_0));
+    return mux_set_i2c(bus, i2c_dev_0, ARRAY_SIZE(i2c_dev_0));
 }
 
 static int
 _set_pwm(const int device, const int channel)
 {
-    return set_pwm(device, channel, pwm_controller_list, (int)ARRAY_SIZE(pwm_controller_list));
+    return mux_set_pwm(device, channel, pwm_controller_list, (int)ARRAY_SIZE(pwm_controller_list));
 }
 
 SOL_PIN_MUX_DECLARE(INTEL_GALILEO_REV_D,
     .plat_name = "intel-galileo-rev-d",
+    .shutdown = mux_shutdown,
     .aio = _set_aio,
     .gpio = _set_gpio,
     .i2c = _set_i2c,

--- a/src/modules/pin-mux/intel-galileo-rev-g/intel-galileo-rev-g.c
+++ b/src/modules/pin-mux/intel-galileo-rev-g/intel-galileo-rev-g.c
@@ -317,29 +317,30 @@ static struct mux_controller pwm_controller_list[] = {
 static int
 _set_aio(const int device, const int pin)
 {
-    return set_aio(device, pin, aio_controller_list, (int)ARRAY_SIZE(aio_controller_list));
+    return mux_set_aio(device, pin, aio_controller_list, (int)ARRAY_SIZE(aio_controller_list));
 }
 
 static int
 _set_gpio(const int pin, const enum sol_gpio_direction dir)
 {
-    return set_gpio(pin, dir, gpio_dev_0, (int)ARRAY_SIZE(gpio_dev_0));
+    return mux_set_gpio(pin, dir, gpio_dev_0, (int)ARRAY_SIZE(gpio_dev_0));
 }
 
 static int
 _set_i2c(const uint8_t bus)
 {
-    return set_i2c(bus, i2c_dev_0, ARRAY_SIZE(i2c_dev_0));
+    return mux_set_i2c(bus, i2c_dev_0, ARRAY_SIZE(i2c_dev_0));
 }
 
 static int
 _set_pwm(const int device, const int channel)
 {
-    return set_pwm(device, channel, pwm_controller_list, (int)ARRAY_SIZE(pwm_controller_list));
+    return mux_set_pwm(device, channel, pwm_controller_list, (int)ARRAY_SIZE(pwm_controller_list));
 }
 
 SOL_PIN_MUX_DECLARE(INTEL_GALILEO_REV_G,
     .plat_name = "intel-galileo-rev-g",
+    .shutdown = mux_shutdown,
     .aio = _set_aio,
     .gpio = _set_gpio,
     .i2c = _set_i2c,


### PR DESCRIPTION
...so struct sol_gpio won't leak and we can close them on shutdown.

We were avoiding to do this since introduces extra complexity on code
that should be straight and simple.

Primary reason is that we cannot close those gpios after usage
because they lose the state and multiplexer does not work. So at first
we were leaving them open since there wasn't any major drawbacks.

But, by doing this, 'sol_gpio' structures started to leak what bring
us to this fix :(

Also took the opportunity to add some missing 'mux' namespace on
intel-common.{c,h}.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>