### PR TITLE
conffile: implement fallback lookup

### DIFF
--- a/src/shared/sol-conffile.c
+++ b/src/shared/sol-conffile.c
@@ -31,17 +31,20 @@
  */
 
 #include <errno.h>
+#include <libgen.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <limits.h>
 
-#include "sol-file-reader.h"
 #include "sol-conffile.h"
+#include "sol-file-reader.h"
+#include "sol-json.h"
 #include "sol-log.h"
+#include "sol-mainloop.h"
+#include "sol-platform.h"
 #include "sol-util.h"
 #include "sol-vector.h"
-#include "sol-json.h"
 
 static struct sol_ptr_vector _conffile_entry_vector; /* entries created by conffiles */
 static struct sol_ptr_vector _conffiles_loaded; /* paths of the currently loaded conffiles */
@@ -246,11 +249,25 @@ err:
     return -ENOMEM;
 }
 
+static struct sol_str_slice *
+_vector_append_string_as_str_slice(struct sol_vector *pv, char *str)
+{
+    struct sol_str_slice *slice;
+
+    slice = sol_vector_append(pv);
+    if (!slice)
+        return NULL;
+
+    slice->data = str;
+    slice->len = strlen(str);
+    return slice;
+}
+
 static void
 _get_json_include_paths(
     struct sol_json_scanner json_scanner,
     char **include,
-    char **include_fallbacks)
+    struct sol_vector *include_fallbacks)
 {
     static const char *include_group = "config_includes";
     static const char *include_str = "include";
@@ -285,9 +302,20 @@ _get_json_include_paths(
             continue;
         }
         if (sol_json_token_str_eq(&key, include_fallback, strlen(include_fallback))) {
-            *include_fallbacks = strndup(value.start + 1, sol_json_token_get_size(&value) - 2);
-            if (!*include_fallbacks)
+            char *buff;
+            struct sol_str_slice *s;
+            sol_json_token_remove_quotes(&value);
+            buff = strndup(value.start, sol_json_token_get_size(&value));
+            if (!buff) {
                 SOL_DBG("Error: couldn't allocate memory for string.");
+                continue;
+            }
+
+            s = _vector_append_string_as_str_slice(include_fallbacks, buff);
+            if (!s) {
+                SOL_WRN("Couldn't append patth to include_fallbacks vector.");
+                free(buff);
+            }
             continue;
         }
     }
@@ -386,7 +414,7 @@ _clear_data(void)
 
 static struct sol_str_slice
 _load_json_from_paths(const char *path,
-    const char *fallback_paths,
+    struct sol_vector *fallback_paths,
     char **full_path,
     struct sol_file_reader **file_reader)
 {
@@ -398,23 +426,26 @@ _load_json_from_paths(const char *path,
     if (fallback_paths && !config_file_contents.len) {
         uint16_t idx;
         struct sol_str_slice *s_ptr;
-        struct sol_vector str_splitted = sol_util_str_split(sol_str_slice_from_str(fallback_paths), ";", 0);
-        SOL_VECTOR_FOREACH_IDX (&str_splitted, s_ptr, idx) {
+        SOL_VECTOR_FOREACH_IDX (fallback_paths, s_ptr, idx) {
+            SOL_DBG("Trying to load conffile: %s", s_ptr->data);
             config_file_contents = _load_json_from_dirs(s_ptr->data, full_path, file_reader);
-            if (config_file_contents.len)
+            if (config_file_contents.len) {
+                SOL_DBG("Successfully loaded conffile: %s", s_ptr->data);
                 break;
+            }
         }
-        sol_vector_clear(&str_splitted);
     }
     return config_file_contents;
 }
 
 static void
-_fill_vector(const char *path, const char *fallback_paths)
+_fill_vector(const char *path, struct sol_vector *fallback_paths)
 {
     char *full_path = NULL;
     char *include = NULL;
-    char *include_fallbacks = NULL;
+    struct sol_str_slice *slice;
+    uint16_t i;
+    struct sol_vector include_fallbacks = SOL_VECTOR_INIT(struct sol_str_slice);
     struct sol_str_slice config_file_contents = SOL_STR_SLICE_EMPTY;
     struct sol_file_reader *file_reader = NULL;
     struct sol_json_scanner json_scanner;
@@ -432,28 +463,115 @@ _fill_vector(const char *path, const char *fallback_paths)
     if (_json_to_vector(json_scanner) != 0)
         goto free_for_all;
 
-    if (include || include_fallbacks)
-        _fill_vector(include, include_fallbacks);
+    if (include || include_fallbacks.len) {
+        _fill_vector(include, &include_fallbacks);
+    }
 
 free_for_all:
     sol_file_reader_close(file_reader);
     free(full_path);
     free(include);
-    free(include_fallbacks);
+
+    SOL_VECTOR_FOREACH_IDX (&include_fallbacks, slice, i) {
+        free((char *)slice->data);
+    }
+
+    sol_vector_clear(&include_fallbacks);
+}
+
+static void
+_add_formated_lookup_path(struct sol_vector *vector, const char *fmt, ...)
+{
+    va_list ap;
+    char *buff;
+    int r;
+    struct sol_str_slice *slice;
+
+    va_start(ap, fmt);
+    r = vasprintf(&buff, fmt, ap);
+    va_end(ap);
+    if (r < 0 || !buff)
+        return;
+
+    slice = _vector_append_string_as_str_slice(vector, buff);
+    if (!slice) {
+        SOL_WRN("Couldn't append file path to vector.");
+        free(buff);
+    }
+}
+
+static void
+_add_lookup_path(struct sol_vector *vector, char *appname, char *appdir, const char *board_name)
+{
+    size_t i;
+    struct sol_vector files = SOL_VECTOR_INIT(struct sol_str_slice);
+    struct sol_str_slice *curr_file;
+    uint16_t idx;
+
+    const char *search_dirs[] = {
+        ".", /* $PWD */
+        appdir, /* appdir */
+        PKGSYSCONFDIR, /* i.e /etc/soletta/ */
+    };
+
+    if (appname && board_name) {
+        _add_formated_lookup_path(&files, "sol-flow-%s-%s.json", appname, board_name);
+    }
+
+    if (appname) {
+        _add_formated_lookup_path(&files, "sol-flow-%s.json", appname);
+    }
+
+    if (board_name) {
+        _add_formated_lookup_path(&files, "sol-flow-%s.json", board_name);
+    }
+
+    _add_formated_lookup_path(&files, "sol-flow.json");
+
+    for (i = 0; i < ARRAY_SIZE(search_dirs); i++) {
+        if (!search_dirs[i])
+            continue;
+
+        SOL_VECTOR_FOREACH_IDX (&files, curr_file, idx) {
+            _add_formated_lookup_path(vector, "%s/%s", search_dirs[i], curr_file->data);
+        }
+    }
+
+    SOL_VECTOR_FOREACH_IDX (&files, curr_file, idx) {
+        free((char *)curr_file->data);
+    }
+
+    sol_vector_clear(&files);
 }
 
 static void
 _load_vector_defaults(void)
 {
+    char *appdir, *appname, **argv;
+    const char *board_name;
+    uint16_t i;
+    struct sol_str_slice *slice;
+    struct sol_vector fallback_paths = SOL_VECTOR_INIT(struct sol_str_slice);
+
+    board_name = sol_platform_get_board_name();
+    argv = sol_argv();
+    appname = NULL;
+
+    if (argv) {
+        appname = basename(argv[0]);
+        appdir = dirname(argv[0]);
+    }
+
+    _add_lookup_path(&fallback_paths, appname, appdir, board_name);
+
     _fill_vector(getenv("SOL_FLOW_MODULE_RESOLVER_CONFFILE"),
-        "sol-flow.json");
-    /*
-     * TODO: Add the following fill priority:
-     * 1. Envvar
-     * 2. Arg0
-     * 3. Platform
-     * 4. Common/Fallback
-     */
+        &fallback_paths);
+
+    SOL_VECTOR_FOREACH_IDX (&fallback_paths, slice, i) {
+        free((char *)slice->data);
+    }
+
+    sol_vector_clear(&fallback_paths);
 }
 
 static void


### PR DESCRIPTION
## Changes ##

  + v2 (since #766):
    - Changed the lookup order interleaved dirs and priorities - as remembered by @barbieri ;
    - Since touching the code make use of ```sol_json_token_remove_quotes(&value);``` on ```_get_json_include_paths()``` function  - as suggested by @barbieri ;
    - Fixed memory leak - spotted by @glima ;
  + v3 (since #769):
    - fixed leak on ```sol_vector_append()``` error - spotted by @lpereira ;
  + v4 (since #772):
    - got rid of ```ADD_FMT_PATH``` macro - as suggested by @lpereira ;
  + v5 (since #774):
    - fixed issue with ARRAY_SIZE on pointer instead of array - spotted by @edersondisouza and @lpereira ;

## Rationale ##
This patch implements a set of conffile fallback lookup. It considers
the following:

  1. sol-flow-$APP-$BOARD.json
  2. sol-flow-$APP.json
  3. sol-flow-$BOARD.json
  4. sol-flow.json

Also doing so in the following dirs:

  1. $PWD
  2. app's dir
  3. $PKGSYSCONFIG

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>