### PR TITLE
Helper to load modules or find symbols built-in

### DIFF
--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -815,22 +815,23 @@ generate(struct sol_vector *fbp_data_vector)
 
     if (!args.export_symbol) {
         out(
+            "static const struct sol_flow_node_type *root_type;\n"
             "static struct sol_flow_node *flow;\n"
             "\n"
             "static void\n"
             "startup(void)\n"
             "{\n"
-            "    const struct sol_flow_node_type *type;\n\n"
             "    initialize_types();\n"
-            "    type = create_0_root_type();\n"
-            "    if (!type)\n"
+            "    root_type = create_0_root_type();\n"
+            "    if (!root_type)\n"
             "        return;\n\n"
-            "    flow = sol_flow_node_new(NULL, NULL, type, NULL);\n"
+            "    flow = sol_flow_node_new(NULL, NULL, root_type, NULL);\n"
             "}\n\n"
             "static void\n"
             "shutdown(void)\n"
             "{\n"
             "    sol_flow_node_del(flow);\n"
+            "    sol_flow_node_type_del((struct sol_flow_node_type *)root_type);\n"
             "}\n\n"
             "SOL_MAIN_DEFAULT(startup, shutdown);\n");
     } else {

--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -83,6 +83,12 @@ struct declared_fbp_type {
     int id;
 };
 
+struct node_data {
+    struct type_description *desc;
+    int type_index;
+    bool is_declared;
+};
+
 static struct port_description error_port = {
     .name = (char *)SOL_FLOW_NODE_PORT_ERROR_NAME,
     .data_type = (char *)"error",
@@ -109,9 +115,11 @@ static struct type_description *
 get_node_type_description(const struct fbp_data *data, uint16_t i)
 {
     struct sol_fbp_node *n = sol_vector_get(&data->graph.nodes, i);
+    struct node_data *nd;
 
     assert(n);
-    return n->user_data;
+    nd = n->user_data;
+    return nd->desc;
 }
 
 static void
@@ -336,6 +344,23 @@ sol_fbp_generator_resolve_type(struct type_store *common_store, struct type_stor
     return type_store_find(parent_store, type_name);
 }
 
+static struct node_data *
+get_node_data(struct type_store *common_store, struct type_store *parent_store, struct sol_fbp_node *n, const char *fbp_file)
+{
+    struct node_data *nd;
+
+    nd = calloc(1, sizeof(*nd));
+    SOL_NULL_CHECK(nd, NULL);
+
+    nd->desc = sol_fbp_generator_resolve_type(common_store, parent_store, n, fbp_file);
+    SOL_NULL_CHECK_GOTO(nd->desc, resolve_error);
+
+    return nd;
+resolve_error:
+    free(nd);
+    return NULL;
+}
+
 static int
 compare_conn_specs(const void *a, const void *b)
 {
@@ -422,7 +447,7 @@ generate_options(const struct fbp_data *data)
     uint16_t i, j;
 
     SOL_VECTOR_FOREACH_IDX (&data->graph.nodes, n, i) {
-        struct type_description *desc = n->user_data;
+        struct type_description *desc = ((struct node_data *)n->user_data)->desc;
 
         if (n->meta.len <= 0)
             continue;
@@ -633,8 +658,12 @@ generate_node_type_assignments(const struct fbp_data *data)
     out("\n");
 
     SOL_VECTOR_FOREACH_IDX (&data->graph.nodes, n, i) {
-        struct type_description *desc = n->user_data;
-        out("    nodes[%d].type = %s;\n", i, desc->symbol);
+        struct node_data *nd = n->user_data;
+
+        if (nd->is_declared)
+            out("    nodes[%d].type = %s;\n", i, nd->desc->symbol);
+        else
+            out("    nodes[%d].type = external_types[%d];\n", i, nd->type_index);
     }
 
     SOL_VECTOR_FOREACH_IDX (&data->declared_fbp_types, dec_type, i) {
@@ -683,6 +712,11 @@ struct generate_context {
     struct sol_vector types_to_initialize;
 };
 
+struct type_to_init {
+    struct sol_str_slice symbol;
+    struct sol_str_slice module;
+};
+
 static bool
 is_declared_type(struct fbp_data *data, const struct sol_str_slice name)
 {
@@ -697,14 +731,16 @@ is_declared_type(struct fbp_data *data, const struct sol_str_slice name)
 }
 
 static bool
-contains_slice(const struct sol_vector *v, const struct sol_str_slice name)
+contains_slice(const struct sol_vector *v, const struct sol_str_slice name, uint16_t *idx)
 {
     struct sol_str_slice *slice;
     uint16_t i;
 
     SOL_VECTOR_FOREACH_IDX (v, slice, i) {
-        if (sol_str_slice_eq(*slice, name))
+        if (sol_str_slice_eq(*slice, name)) {
+            *idx = i;
             return true;
+        }
     }
     return false;
 }
@@ -716,28 +752,34 @@ collect_context_info(struct generate_context *ctx, struct fbp_data *data)
     uint16_t i;
 
     SOL_VECTOR_FOREACH_IDX (&data->graph.nodes, node, i) {
+        struct node_data *nd;
         struct type_description *desc;
         const char *sep;
         struct sol_str_slice name, module, symbol;
+        struct type_to_init *t = NULL;
+        uint16_t idx;
 
         /* Need to go via descriptions to get the real resolved name,
          * after conffile pass. */
-        desc = node->user_data;
+        nd = node->user_data;
+        desc = nd->desc;
         name = sol_str_slice_from_str(desc->name);
 
         /* Ignore since these are completely defined in the generated code. */
         if (is_declared_type(data, name)) {
+            nd->is_declared = true;
             continue;
         }
 
         symbol = sol_str_slice_from_str(desc->symbol);
-        if (!contains_slice(&ctx->types_to_initialize, symbol)) {
-            struct sol_str_slice *t;
+        if (!contains_slice(&ctx->types_to_initialize, symbol, &idx)) {
             t = sol_vector_append(&ctx->types_to_initialize);
             if (!t)
                 return false;
-            *t = symbol;
+            t->symbol = symbol;
+            idx = ctx->types_to_initialize.len - 1;
         }
+        nd->type_index = idx;
 
         module = name;
         sep = strstr(name.data, "/");
@@ -745,7 +787,10 @@ collect_context_info(struct generate_context *ctx, struct fbp_data *data)
             module.len = sep - module.data;
         }
 
-        if (!contains_slice(&ctx->modules, module)) {
+        if (t)
+            t->module = module;
+
+        if (!contains_slice(&ctx->modules, module, &idx)) {
             struct sol_str_slice *m;
             m = sol_vector_append(&ctx->modules);
             if (!m)
@@ -762,11 +807,13 @@ generate(struct sol_vector *fbp_data_vector)
 {
     struct generate_context _ctx = {
         .modules = SOL_VECTOR_INIT(struct sol_str_slice),
-        .types_to_initialize = SOL_VECTOR_INIT(struct sol_str_slice),
+        .types_to_initialize = SOL_VECTOR_INIT(struct type_to_init),
     }, *ctx = &_ctx;
 
     struct fbp_data *data;
-    struct sol_str_slice *module, *symbol;
+    struct sol_str_slice *module;
+    struct type_to_init *type;
+    int types_count;
     uint16_t i;
     int r;
 
@@ -790,6 +837,9 @@ generate(struct sol_vector *fbp_data_vector)
         out("#include \"sol-flow/%.*s.h\"\n", SOL_STR_SLICE_PRINT(*module));
     }
 
+    types_count = ctx->types_to_initialize.len;
+    out("\nstatic const struct sol_flow_node_type *external_types[%d];\n", types_count);
+
     /* Reverse since the dependencies appear later in the vector. */
     SOL_VECTOR_FOREACH_REVERSE_IDX (fbp_data_vector, data, i) {
         if (!generate_create_type_function(data)) {
@@ -800,17 +850,23 @@ generate(struct sol_vector *fbp_data_vector)
     }
 
     out(
-        "static void\n"
+        "static bool\n"
         "initialize_types(void)\n"
-        "{\n");
-    SOL_VECTOR_FOREACH_IDX (&ctx->types_to_initialize, symbol, i) {
+        "{\n"
+        "    const struct sol_flow_node_type *t;\n"
+        "    int i = 0;\n\n");
+    SOL_VECTOR_FOREACH_IDX (&ctx->types_to_initialize, type, i) {
         out(
-            "    if (%.*s->init_type)\n"
-            "        %.*s->init_type();\n",
-            SOL_STR_SLICE_PRINT(*symbol),
-            SOL_STR_SLICE_PRINT(*symbol));
+            "    if (sol_flow_get_node_type(\"%.*s\", %.*s, &t) < 0)\n"
+            "        return false;\n"
+            "    if (t->init_type)\n"
+            "        t->init_type();\n"
+            "    external_types[i++] = t;\n",
+            SOL_STR_SLICE_PRINT(type->module),
+            SOL_STR_SLICE_PRINT(type->symbol));
     }
     out(
+        "    return true;\n"
         "}\n\n");
 
     if (!args.export_symbol) {
@@ -821,7 +877,8 @@ generate(struct sol_vector *fbp_data_vector)
             "static void\n"
             "startup(void)\n"
             "{\n"
-            "    initialize_types();\n"
+            "    if (!initialize_types())\n"
+            "        return;\n"
             "    root_type = create_0_root_type();\n"
             "    if (!root_type)\n"
             "        return;\n\n"
@@ -840,7 +897,8 @@ generate(struct sol_vector *fbp_data_vector)
             "%s(void) {\n"
             "    static const struct sol_flow_node_type *type = NULL;\n"
             "    if (!type) {\n"
-            "        initialize_types();\n"
+            "        if (!initialize_types())\n"
+            "            return NULL;\n"
             "        type = create_0_root_type();\n"
             "    }\n"
             "\n"
@@ -1210,7 +1268,7 @@ resolve_node(struct fbp_data *data, struct type_store *common_store)
     uint16_t i;
 
     SOL_VECTOR_FOREACH_IDX (&data->graph.nodes, n, i) {
-        n->user_data = sol_fbp_generator_resolve_type(common_store, data->store, n, data->filename);
+        n->user_data = get_node_data(common_store, data->store, n, data->filename);
         if (!n->user_data)
             return false;
         SOL_DBG("Node %.*s resolved", SOL_STR_SLICE_PRINT(n->name));

--- a/src/lib/common/sol-common-buildopts.h.in
+++ b/src/lib/common/sol-common-buildopts.h.in
@@ -42,6 +42,10 @@ st.on_value("PLATFORM_CONTIKI", "y", "#define SOL_PLATFORM_CONTIKI 1", "")
 st.on_value("LOG", "y", "#define SOL_LOG_ENABLED 1", "")
 }}
 
+{{
+st.on_value("MODULES", "y", "#define SOL_DYNAMIC_MODULES 1", "")
+}}
+
 #ifdef SOL_PLATFORM_LINUX
 #define SOL_MAINLOOP_FD_ENABLED 1
 #define SOL_MAINLOOP_FORK_WATCH_ENABLED 1

--- a/src/lib/flow/Makefile
+++ b/src/lib/flow/Makefile
@@ -13,6 +13,7 @@ obj-flow-$(NODE_DESCRIPTION) += \
     sol-flow-builder.o
 
 obj-flow-$(ENABLE_DYNAMIC_MODULES) += \
+    sol-flow-modules.o \
     sol-flow-parser-dynamic.o
 
 ifeq (y,$(RESOLVER_CONFFILE))

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -457,6 +457,27 @@ struct sol_flow_port_type_in {
     int (*disconnect)(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id); /**< member function issued everytime a connection is unmade on the port */
 };
 
+#ifdef SOL_DYNAMIC_MODULES
+
+/**
+ * Gets the specified node type, loading the necessary module if required.
+ *
+ * Checks if the node type @a _type is built-in, if not, it loads the module
+ * @a _mod and fetches the type's symbol there. The result is stored in @a _var.
+ *
+ * @param _mod The name of the module to load if the symbol is not built-in.
+ * @param _type The node type's symbol.
+ * @param _var Variable where to store the type.
+ *
+ * @return 0 on success, < 0 on error.
+ */
+#define sol_flow_get_node_type(_mod, _type, _var) sol_flow_int_get_node_type(_mod, #_type, _var)
+
+int sol_flow_int_get_node_type(const char *module, const char *symbol, const struct sol_flow_node_type **type);
+#else
+#define sol_flow_get_node_type(_mod, _type, _var) ({ (*(_var)) = _type; 0; })
+#endif /* SOL_DYNAMIC_MODULES */
+
 /**
  * @}
  */

--- a/src/lib/flow/sol-flow-buildopts.h.in
+++ b/src/lib/flow/sol-flow-buildopts.h.in
@@ -32,6 +32,8 @@
 
 #pragma once
 
+#include "sol-common-buildopts.h"
+
 {{
 st.on_value("NODE_DESCRIPTION", "y", "#define SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED 1", "")
 st.on_value("INSPECTOR", "y", "#define SOL_FLOW_INSPECTOR_ENABLED 1", "")

--- a/src/lib/flow/sol-flow-internal.h
+++ b/src/lib/flow/sol-flow-internal.h
@@ -293,6 +293,8 @@ int sol_flow_builder_add_node_taking_options(
     const struct sol_flow_node_options *options);
 
 #ifdef ENABLE_DYNAMIC_MODULES
+void sol_flow_modules_cache_shutdown(void);
+
 sol_flow_metatype_create_type_func get_dynamic_create_type_func(const struct sol_str_slice name);
 void loaded_metatype_cache_shutdown(void);
 #endif

--- a/src/lib/flow/sol-flow-modules.c
+++ b/src/lib/flow/sol-flow-modules.c
@@ -1,0 +1,196 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "sol-flow-internal.h"
+
+struct module_cache {
+    char *name;
+    void *handle;
+};
+
+static struct sol_vector modules = SOL_VECTOR_INIT(struct module_cache);
+
+static void
+clear_modules_cache(struct sol_vector *cache)
+{
+    struct module_cache *mod;
+    uint16_t i;
+
+    SOL_VECTOR_FOREACH_IDX (cache, mod, i) {
+        dlclose(mod->handle);
+        free(mod->name);
+    }
+    sol_vector_clear(cache);
+}
+
+static int
+get_symbol(void *handle, const char *symbol_name, const struct sol_flow_node_type **type)
+{
+    void **symbol;
+
+    symbol = dlsym(handle, symbol_name);
+    if (!symbol || !(*symbol))
+        return -ENOENT;
+
+    *type = *symbol;
+
+    return 0;
+}
+
+static int
+get_internal_symbol(const char *symbol_name, const struct sol_flow_node_type **type)
+{
+    int ret;
+
+    if ((ret = get_symbol(RTLD_DEFAULT, symbol_name, type)) < 0) {
+        SOL_DBG("Symbol '%s' is not built-in: %s", symbol_name, dlerror());
+        return ret;
+    }
+
+    SOL_INF("Symbol '%s' found built-in", symbol_name);
+
+    return 0;
+}
+
+static int
+get_module_path(char *buf, size_t len, const char *modname)
+{
+    static char rootdir[PATH_MAX] = { };
+
+    if (unlikely(!*rootdir)) {
+        int ret;
+
+        ret = sol_util_get_rootdir(rootdir, sizeof(rootdir));
+        SOL_INT_CHECK(ret, >= (int)sizeof(rootdir), ret);
+        SOL_INT_CHECK(ret, < 0, ret);
+    }
+
+    return snprintf(buf, len, "%s%s/%s.so", rootdir, FLOWMODULESDIR, modname);
+}
+
+static void *
+get_module_handle(const char *modname)
+{
+    char path[PATH_MAX];
+    void *handle;
+    int ret;
+
+    ret = get_module_path(path, sizeof(path), modname);
+    SOL_INT_CHECK(ret, >= (int)sizeof(path), NULL);
+    SOL_INT_CHECK(ret, < 0, NULL);
+
+    SOL_INF("Loading module '%s'", path);
+
+    handle = dlopen(path, RTLD_LAZY | RTLD_LOCAL | RTLD_NODELETE);
+    if (!handle)
+        SOL_WRN("Could not open module '%s' (%s): %s", modname, path, dlerror());
+    return handle;
+}
+
+static struct module_cache *
+get_module(const char *module)
+{
+    struct module_cache *mod;
+    uint16_t i;
+
+    SOL_VECTOR_FOREACH_IDX (&modules, mod, i) {
+        if (streq(mod->name, module)) {
+            SOL_INF("Module '%s' found cached", module);
+            return mod;
+        }
+    }
+
+    mod = sol_vector_append(&modules);
+    SOL_NULL_CHECK(mod, NULL);
+
+    mod->name = strdup(module);
+    SOL_NULL_CHECK_GOTO(mod->name, strdup_error);
+
+    mod->handle = get_module_handle(mod->name);
+    SOL_NULL_CHECK_GOTO(mod->handle, dlopen_error);
+
+    return mod;
+
+dlopen_error:
+    free(mod->name);
+strdup_error:
+    sol_vector_del(&modules, modules.len - 1);
+    return NULL;
+}
+
+static int
+get_module_symbol(const char *modname, const char *symbol_name, const struct sol_flow_node_type **type)
+{
+    struct module_cache *mod;
+    int ret;
+
+    mod = get_module(modname);
+    SOL_NULL_CHECK(mod, -ENOMEM);
+
+    if ((ret = get_symbol(mod->handle, symbol_name, type)) < 0) {
+        char path[PATH_MAX];
+
+        get_module_path(path, sizeof(path), modname);
+        SOL_WRN("Symbol '%s' not found in module '%s' (%s): %s",
+            symbol_name, modname, path, dlerror());
+        return ret;
+    }
+
+    return 0;
+}
+
+SOL_API int
+sol_flow_int_get_node_type(const char *modname, const char *symbol, const struct sol_flow_node_type **type)
+{
+    int ret;
+
+    SOL_DBG("Trying for symbol '%s' internally", symbol);
+    if ((ret = get_internal_symbol(symbol, type)) < 0) {
+        SOL_DBG("Trying for symbol '%s' in module '%s'", symbol, modname);
+        if ((ret = get_module_symbol(modname, symbol, type)) < 0)
+            SOL_WRN("Symbol '%s' of module '%s' not found.", symbol, modname);
+    }
+
+    return ret;
+}
+
+void
+sol_flow_modules_cache_shutdown(void)
+{
+    clear_modules_cache(&modules);
+}

--- a/src/lib/flow/sol-flow.c
+++ b/src/lib/flow/sol-flow.c
@@ -55,6 +55,7 @@ sol_flow_shutdown(void)
 {
 #ifdef ENABLE_DYNAMIC_MODULES
     loaded_metatype_cache_shutdown();
+    sol_flow_modules_cache_shutdown();
 #endif
 }
 

--- a/src/modules/flow/calamari/Kconfig
+++ b/src/modules/flow/calamari/Kconfig
@@ -1,4 +1,4 @@
 config FLOW_NODE_TYPE_CALAMARI
 	tristate "Node type: calamari"
-	depends on (FLOW_NODE_TYPE_GPIO = y) && USE_PWM && USE_SPI
+	depends on FLOW_NODE_TYPE_GPIO && USE_PWM && USE_SPI
 	default m

--- a/src/modules/flow/calamari/Makefile
+++ b/src/modules/flow/calamari/Makefile
@@ -1,4 +1,3 @@
 obj-$(FLOW_NODE_TYPE_CALAMARI) += calamari.mod
 obj-calamari-$(FLOW_NODE_TYPE_CALAMARI) := calamari.json calamari.o
-obj-calamari-$(FLOW_NODE_TYPE_CALAMARI)-deps := flow/gpio.mod
 obj-calamari-$(FLOW_NODE_TYPE_CALAMARI)-type := flow

--- a/src/modules/flow/calamari/calamari.c
+++ b/src/modules/flow/calamari/calamari.c
@@ -241,6 +241,7 @@ static void
 calamari_7seg_new_type(const struct sol_flow_node_type **current)
 {
     struct sol_flow_node_type *type;
+    const struct sol_flow_node_type *gpio_writer;
 
     static struct sol_flow_static_node_spec nodes[] = {
         [SEG_CTL] = { NULL, "segments-ctl", NULL },
@@ -273,8 +274,13 @@ calamari_7seg_new_type(const struct sol_flow_node_type **current)
         .child_opts_set = calamari_7seg_child_opts_set,
     };
 
+    if (sol_flow_get_node_type("gpio", SOL_FLOW_NODE_TYPE_GPIO_WRITER, &gpio_writer) < 0) {
+        *current = NULL;
+        return;
+    }
+
     nodes[SEG_CTL].type = SOL_FLOW_NODE_TYPE_CALAMARI_SEGMENTS_CTL;
-    nodes[SEG_CLEAR].type = nodes[SEG_LATCH].type = nodes[SEG_CLOCK].type = nodes[SEG_DATA].type = SOL_FLOW_NODE_TYPE_GPIO_WRITER;
+    nodes[SEG_CLEAR].type = nodes[SEG_LATCH].type = nodes[SEG_CLOCK].type = nodes[SEG_DATA].type = gpio_writer;
 
     type = sol_flow_static_new_type(&spec);
     SOL_NULL_CHECK(type);
@@ -569,6 +575,7 @@ static void
 calamari_rgb_led_new_type(const struct sol_flow_node_type **current)
 {
     struct sol_flow_node_type *type;
+    const struct sol_flow_node_type *gpio_writer;
 
     static struct sol_flow_static_node_spec nodes[] = {
         [RGB_LED_CTL] = { NULL, "rgb-ctl", NULL },
@@ -600,8 +607,13 @@ calamari_rgb_led_new_type(const struct sol_flow_node_type **current)
         .child_opts_set = calamari_rgb_child_opts_set,
     };
 
+    if (sol_flow_get_node_type("gpio", SOL_FLOW_NODE_TYPE_GPIO_WRITER, &gpio_writer) < 0) {
+        *current = NULL;
+        return;
+    }
+
     nodes[RGB_LED_CTL].type = SOL_FLOW_NODE_TYPE_CALAMARI_RGB_CTL;
-    nodes[RGB_LED_RED].type = nodes[RGB_LED_GREEN].type = nodes[RGB_LED_BLUE].type = SOL_FLOW_NODE_TYPE_GPIO_WRITER;
+    nodes[RGB_LED_RED].type = nodes[RGB_LED_GREEN].type = nodes[RGB_LED_BLUE].type = gpio_writer;
 
     type = sol_flow_static_new_type(&spec);
     SOL_NULL_CHECK(type);

--- a/src/modules/flow/grove/grove.c
+++ b/src/modules/flow/grove/grove.c
@@ -80,6 +80,7 @@ static void
 grove_rotary_sensor_new_type(const struct sol_flow_node_type **current)
 {
     struct sol_flow_node_type *type;
+    const struct sol_flow_node_type *aio_reader;
 
     static struct sol_flow_static_node_spec nodes[] = {
         { NULL, "rotary-converter", NULL },
@@ -107,8 +108,13 @@ grove_rotary_sensor_new_type(const struct sol_flow_node_type **current)
         .child_opts_set = rotary_child_opts_set,
     };
 
+    if (sol_flow_get_node_type("aio", SOL_FLOW_NODE_TYPE_AIO_READER, &aio_reader) < 0) {
+        *current = NULL;
+        return;
+    }
+
     nodes[0].type = SOL_FLOW_NODE_TYPE_GROVE_ROTARY_CONVERTER;
-    nodes[1].type = SOL_FLOW_NODE_TYPE_AIO_READER;
+    nodes[1].type = aio_reader;
 
     type = sol_flow_static_new_type(&spec);
     SOL_NULL_CHECK(type);
@@ -208,6 +214,7 @@ static void
 grove_light_sensor_new_type(const struct sol_flow_node_type **current)
 {
     struct sol_flow_node_type *type;
+    const struct sol_flow_node_type *aio_reader;
 
     static struct sol_flow_static_node_spec nodes[] = {
         { NULL, "light-converter", NULL },
@@ -234,8 +241,13 @@ grove_light_sensor_new_type(const struct sol_flow_node_type **current)
         .child_opts_set = light_child_opts_set,
     };
 
+    if (sol_flow_get_node_type("aio", SOL_FLOW_NODE_TYPE_AIO_READER, &aio_reader) < 0) {
+        *current = NULL;
+        return;
+    }
+
     nodes[0].type = SOL_FLOW_NODE_TYPE_GROVE_LIGHT_CONVERTER;
-    nodes[1].type = SOL_FLOW_NODE_TYPE_AIO_READER;
+    nodes[1].type = aio_reader;
 
     type = sol_flow_static_new_type(&spec);
     SOL_NULL_CHECK(type);
@@ -380,6 +392,7 @@ static void
 grove_temperature_sensor_new_type(const struct sol_flow_node_type **current)
 {
     struct sol_flow_node_type *type;
+    const struct sol_flow_node_type *aio_reader;
 
     static struct sol_flow_static_node_spec nodes[] = {
         { NULL, "temperature-converter", NULL },
@@ -406,8 +419,13 @@ grove_temperature_sensor_new_type(const struct sol_flow_node_type **current)
         .child_opts_set = temperature_child_opts_set,
     };
 
+    if (sol_flow_get_node_type("aio", SOL_FLOW_NODE_TYPE_AIO_READER, &aio_reader) < 0) {
+        *current = NULL;
+        return;
+    }
+
     nodes[0].type = SOL_FLOW_NODE_TYPE_GROVE_TEMPERATURE_CONVERTER;
-    nodes[1].type = SOL_FLOW_NODE_TYPE_AIO_READER;
+    nodes[1].type = aio_reader;
 
     type = sol_flow_static_new_type(&spec);
     SOL_NULL_CHECK(type);

--- a/src/samples/flow/basics/Makefile
+++ b/src/samples/flow/basics/Makefile
@@ -1,34 +1,14 @@
 sample-$(FLOW_BASICS_CMDLINE_ARGS_SAMPLE) += cmdline-args
 sample-cmdline-args-$(FLOW_BASICS_CMDLINE_ARGS_SAMPLE) := cmdline-args.fbp
-sample-cmdline-args-$(FLOW_BASICS_CMDLINE_ARGS_SAMPLE)-deps := flow/boolean.mod flow/app.mod flow/console.mod
-sample-cmdline-args-$(FLOW_BASICS_CMDLINE_ARGS_SAMPLE)-deps += flow/int.mod flow/constant.mod
-sample-cmdline-args-$(FLOW_BASICS_CMDLINE_ARGS_SAMPLE)-deps += flow/converter.mod
 
 sample-$(FLOW_BASICS_FIBONACCI_SAMPLE) += fibonacci
 sample-fibonacci-$(FLOW_BASICS_FIBONACCI_SAMPLE) := fibonacci.fbp
-sample-fibonacci-$(FLOW_BASICS_FIBONACCI_SAMPLE)-deps := \
-	flow/app.mod \
-	flow/boolean.mod \
-	flow/console.mod \
-	flow/constant.mod \
-	flow/converter.mod \
-	flow/int.mod \
-	flow/switcher.mod
 
 sample-$(FLOW_BASICS_PLATORM_SERVICE_SAMPLE) += platform-service
 sample-platform-service-$(FLOW_BASICS_PLATORM_SERVICE_SAMPLE) := platform-service.fbp
-sample-platform-service-$(FLOW_BASICS_PLATORM_SERVICE_SAMPLE)-deps := \
-	flow/console.mod \
-	flow/platform.mod \
-	flow/timer.mod
 
 sample-$(FLOW_BASICS_SIMPLE_SAMPLE) += simple-fbp
 sample-simple-fbp-$(FLOW_BASICS_SIMPLE_SAMPLE) := simple.fbp
-sample-simple-fbp-$(FLOW_BASICS_SIMPLE_SAMPLE)-deps := flow/timer.mod flow/boolean.mod flow/console.mod
 
 sample-$(FLOW_BASICS_SUBPROCESS_BC_SAMPLE) += subprocess-bc
 sample-subprocess-bc-$(FLOW_BASICS_SUBPROCESS_BC_SAMPLE) := subprocess_bc.fbp
-sample-subprocess-bc-$(FLOW_BASICS_SUBPROCESS_BC_SAMPLE)-deps := \
-	flow/console.mod \
-	flow/constant.mod \
-	flow/process.mod

--- a/src/samples/flow/c-api/Makefile
+++ b/src/samples/flow/c-api/Makefile
@@ -11,7 +11,6 @@ sample-$(FLOW_C_API_LOWLEVEL_SAMPLE) += lowlevel
 sample-lowlevel-$(FLOW_C_API_LOWLEVEL_SAMPLE) := lowlevel.c
 sample-lowlevel-$(FLOW_C_API_LOWLEVEL_SAMPLE) += custom-node-types.json
 sample-lowlevel-$(FLOW_C_API_LOWLEVEL_SAMPLE)-deps := \
-	flow/console.mod \
 	sample-custom-node-types
 
 sample-$(FLOW_C_API_SIMPLECTYPE_SAMPLE) += simplectype

--- a/src/samples/flow/c-api/lowlevel.c
+++ b/src/samples/flow/c-api/lowlevel.c
@@ -38,13 +38,6 @@
 
 #include "sol-flow-static.h"
 #include "custom-node-types-gen.h"
-/* TODO: how to know if console is builtin?
- * before we had console-gen.h included by sol-flow-node-types.h,
- * that was created based on builtins list.
- *
- * Since we're at the low-level API we can't use the foreach
- * functions, as they rely on node type descriptions.
- */
 #include "sol-flow/console.h"
 #include "sol-mainloop.h"
 
@@ -127,6 +120,11 @@ static struct sol_flow_node *flow;
 static void
 startup(void)
 {
+    const struct sol_flow_node_type *console_type;
+
+    if (sol_flow_get_node_type("console", SOL_FLOW_NODE_TYPE_CONSOLE, &console_type) < 0)
+        return;
+
     /*
      * Since these symbols will be relocated in runtime, we can't
      * initialize them in the vector initialization, we must assign
@@ -135,7 +133,7 @@ startup(void)
     nodes[0 /* reader */].type = SOL_FLOW_NODE_TYPE_CUSTOM_NODE_TYPES_READER;
     nodes[1 /* logic */].type = SOL_FLOW_NODE_TYPE_CUSTOM_NODE_TYPES_LOGIC;
     nodes[2 /* writer */].type = SOL_FLOW_NODE_TYPE_CUSTOM_NODE_TYPES_WRITER;
-    nodes[3 /* console */].type = SOL_FLOW_NODE_TYPE_CONSOLE;
+    nodes[3 /* console */].type = console_type;
 
     flow = sol_flow_static_new(NULL, nodes, conns);
 }

--- a/src/samples/flow/c-api/lowlevel.c
+++ b/src/samples/flow/c-api/lowlevel.c
@@ -96,10 +96,8 @@ static struct sol_flow_static_node_spec nodes[] = {
             "logic", NULL },
     [2] = { NULL /* placeholder SOL_FLOW_NODE_TYPE_CUSTOM_NODE_TYPES_WRITER */,
             "writer", &writer_opts.base },
-#ifdef SOL_FLOW_NODE_TYPE_CONSOLE_DEFINED
     [3] = { NULL /* placeholder SOL_FLOW_NODE_TYPE_CONSOLE */,
             "console", NULL },
-#endif
     SOL_FLOW_STATIC_NODE_SPEC_GUARD
 };
 
@@ -115,16 +113,12 @@ static struct sol_flow_static_node_spec nodes[] = {
 static const struct sol_flow_static_conn_spec conns[] = {
     { 0 /* reader */, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_TYPES_READER__OUT__OUT,
       1 /* logic */, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_TYPES_LOGIC__IN__IN },
-#ifdef SOL_FLOW_NODE_TYPE_CONSOLE_DEFINED
     { 0 /* reader */, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_TYPES_READER__OUT__OUT,
       3 /* console */, SOL_FLOW_NODE_TYPE_CONSOLE__IN__IN },
-#endif
     { 1 /* logic */, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_TYPES_LOGIC__OUT__OUT,
       2 /* writer */, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_TYPES_WRITER__IN__IN },
-#ifdef SOL_FLOW_NODE_TYPE_CONSOLE_DEFINED
     { 1 /* logic */, SOL_FLOW_NODE_TYPE_CUSTOM_NODE_TYPES_LOGIC__OUT__OUT,
       3 /* console */, SOL_FLOW_NODE_TYPE_CONSOLE__IN__IN },
-#endif
     SOL_FLOW_STATIC_CONN_SPEC_GUARD
 };
 
@@ -141,9 +135,7 @@ startup(void)
     nodes[0 /* reader */].type = SOL_FLOW_NODE_TYPE_CUSTOM_NODE_TYPES_READER;
     nodes[1 /* logic */].type = SOL_FLOW_NODE_TYPE_CUSTOM_NODE_TYPES_LOGIC;
     nodes[2 /* writer */].type = SOL_FLOW_NODE_TYPE_CUSTOM_NODE_TYPES_WRITER;
-#ifdef SOL_FLOW_NODE_TYPE_CONSOLE_DEFINED
     nodes[3 /* console */].type = SOL_FLOW_NODE_TYPE_CONSOLE;
-#endif
 
     flow = sol_flow_static_new(NULL, nodes, conns);
 }

--- a/src/samples/flow/compass/Makefile
+++ b/src/samples/flow/compass/Makefile
@@ -1,7 +1,2 @@
 sample-$(FLOW_COMPASS_LSM303_SAMPLE) += compass-lsm303
 sample-compass-lsm303-$(FLOW_COMPASS_LSM303_SAMPLE) := lsm303.fbp
-sample-compass-lsm303-$(FLOW_COMPASS_LSM303_SAMPLE)-deps := \
-	flow/accelerometer.mod \
-	flow/compass.mod \
-	flow/console.mod \
-	flow/magnetometer.mod

--- a/src/samples/flow/foosball/Makefile
+++ b/src/samples/flow/foosball/Makefile
@@ -2,10 +2,4 @@ sample-$(FLOW_FOOSBALL_SAMPLE) += foosball
 sample-foosball-$(FLOW_FOOSBALL_SAMPLE) := \
 	foosball.fbp
 sample-foosball-$(FLOW_FOOSBALL_SAMPLE)-deps := \
-	flow/boolean.mod \
-	flow/constant.mod \
-	flow/converter.mod \
-	flow/int.mod \
-	flow/timer.mod \
-	gtk.mod \
 	tracker.fbp

--- a/src/samples/flow/galileo-grove-kit/Makefile
+++ b/src/samples/flow/galileo-grove-kit/Makefile
@@ -1,36 +1,19 @@
 sample-$(FLOW_GALILEO_GROVE_BUTTON_SAMPLE) += grove-button
 sample-grove-button-$(FLOW_GALILEO_GROVE_BUTTON_SAMPLE) := grove-button.fbp
 sample-grove-button-$(FLOW_GALILEO_GROVE_BUTTON_SAMPLE)-conffile := galileo-grove-kit.json
-sample-grove-button-$(FLOW_GALILEO_GROVE_BUTTON_SAMPLE)-deps := \
-	flow/gpio.mod
 
 sample-$(FLOW_GALILEO_GROVE_BUZZER_SAMPLE) += grove-buzzer
 sample-grove-buzzer-$(FLOW_GALILEO_GROVE_BUZZER_SAMPLE) := grove-buzzer.fbp
 sample-grove-buzzer-$(FLOW_GALILEO_GROVE_BUZZER_SAMPLE)-conffile := galileo-grove-kit.json
-sample-grove-buzzer-$(FLOW_GALILEO_GROVE_BUZZER_SAMPLE)-deps := flow/piezo-speaker.mod
 
 sample-$(FLOW_GALILEO_GROVE_LED_ACCUMULATOR_SAMPLE) += grove-led-accumulator
 sample-grove-led-accumulator-$(FLOW_GALILEO_GROVE_LED_ACCUMULATOR_SAMPLE) := grove-led-accumulator.fbp
 sample-grove-led-accumulator-$(FLOW_GALILEO_GROVE_LED_ACCUMULATOR_SAMPLE)-conffile := galileo-grove-kit.json
-sample-grove-led-accumulator-$(FLOW_GALILEO_GROVE_LED_ACCUMULATOR_SAMPLE)-deps := \
-	flow/boolean.mod \
-	flow/constant.mod \
-	flow/converter.mod \
-	flow/int.mod \
-	flow/pwm.mod \
-	flow/timer.mod
 
 sample-$(FLOW_GALILEO_GROVE_RELAY_SAMPLE) += grove-relay
 sample-grove-relay-$(FLOW_GALILEO_GROVE_RELAY_SAMPLE) := grove-relay.fbp
 sample-grove-relay-$(FLOW_GALILEO_GROVE_RELAY_SAMPLE)-conffile := galileo-grove-kit.json
-sample-grove-relay-$(FLOW_GALILEO_GROVE_RELAY_SAMPLE)-deps := \
-	flow/gpio.mod
 
 sample-$(FLOW_GALILEO_GROVE_SOUND_SENSOR_SAMPLE) += grove-sound-sensor
 sample-grove-sound-sensor-$(FLOW_GALILEO_GROVE_SOUND_SENSOR_SAMPLE) := grove-sound-sensor.fbp
 sample-grove-sound-sensor-$(FLOW_GALILEO_GROVE_SOUND_SENSOR_SAMPLE)-conffile := galileo-grove-kit.json
-sample-grove-sound-sensor-$(FLOW_GALILEO_GROVE_SOUND_SENSOR_SAMPLE)-deps := \
-	flow/aio.mod \
-	flow/constant.mod \
-	flow/gpio.mod \
-	flow/int.mod

--- a/src/samples/flow/galileo-grove-kit/lcd/Makefile
+++ b/src/samples/flow/galileo-grove-kit/lcd/Makefile
@@ -1,88 +1,31 @@
 sample-$(FLOW_GALILEO_GROVE_LCD_AUTOSCROLL_SAMPLE) += grove-lcd-autoscroll
 sample-grove-lcd-autoscroll-$(FLOW_GALILEO_GROVE_LCD_AUTOSCROLL_SAMPLE) := grove-lcd-autoscroll.fbp
 sample-grove-lcd-autoscroll-$(FLOW_GALILEO_GROVE_LCD_AUTOSCROLL_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-autoscroll-$(FLOW_GALILEO_GROVE_LCD_AUTOSCROLL_SAMPLE)-deps := \
-	flow/aio.mod \
-	flow/boolean.mod \
-	flow/constant.mod \
-	flow/converter.mod \
-	flow/grove.mod \
-	flow/int.mod \
-	flow/timer.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_BLINK_SAMPLE) += grove-lcd-blink
 sample-grove-lcd-blink-$(FLOW_GALILEO_GROVE_LCD_BLINK_SAMPLE) := grove-lcd-blink.fbp
 sample-grove-lcd-blink-$(FLOW_GALILEO_GROVE_LCD_BLINK_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-blink-$(FLOW_GALILEO_GROVE_LCD_BLINK_SAMPLE)-deps := \
-	flow/aio.mod \
-	flow/boolean.mod \
-	flow/constant.mod \
-	flow/converter.mod \
-	flow/grove.mod \
-	flow/timer.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_CURSOR_SAMPLE) += grove-lcd-cursor
 sample-grove-lcd-cursor-$(FLOW_GALILEO_GROVE_LCD_CURSOR_SAMPLE) := grove-lcd-cursor.fbp
 sample-grove-lcd-cursor-$(FLOW_GALILEO_GROVE_LCD_CURSOR_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-cursor-$(FLOW_GALILEO_GROVE_LCD_CURSOR_SAMPLE)-deps := \
-	flow/aio.mod \
-	flow/boolean.mod \
-	flow/constant.mod \
-	flow/grove.mod \
-	flow/timer.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_DISPLAY_SAMPLE) += grove-lcd-display
 sample-grove-lcd-display-$(FLOW_GALILEO_GROVE_LCD_DISPLAY_SAMPLE) := grove-lcd-display.fbp
 sample-grove-lcd-display-$(FLOW_GALILEO_GROVE_LCD_DISPLAY_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-display-$(FLOW_GALILEO_GROVE_LCD_DISPLAY_SAMPLE)-deps := \
-	flow/aio.mod \
-	flow/boolean.mod \
-	flow/constant.mod \
-	flow/grove.mod \
-	flow/timer.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_HELLO_WORLD_SAMPLE) += grove-lcd-hello-world
 sample-grove-lcd-hello-world-$(FLOW_GALILEO_GROVE_LCD_HELLO_WORLD_SAMPLE) := grove-lcd-hello-world.fbp
 sample-grove-lcd-hello-world-$(FLOW_GALILEO_GROVE_LCD_HELLO_WORLD_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-hello-world-$(FLOW_GALILEO_GROVE_LCD_HELLO_WORLD_SAMPLE)-deps := \
-	flow/aio.mod \
-	flow/constant.mod \
-	flow/converter.mod \
-	flow/grove.mod \
-	flow/int.mod \
-	flow/timer.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_SCROLL_SAMPLE) += grove-lcd-scroll
 sample-grove-lcd-scroll-$(FLOW_GALILEO_GROVE_LCD_SCROLL_SAMPLE) := grove-lcd-scroll.fbp
 sample-grove-lcd-scroll-$(FLOW_GALILEO_GROVE_LCD_SCROLL_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-scroll-$(FLOW_GALILEO_GROVE_LCD_SCROLL_SAMPLE)-deps := \
-	flow/aio.mod \
-	flow/boolean.mod \
-	flow/constant.mod \
-	flow/converter.mod \
-	flow/grove.mod \
-	flow/int.mod \
-	flow/timer.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_SET_CURSOR_SAMPLE) += grove-lcd-set-cursor
 sample-grove-lcd-set-cursor-$(FLOW_GALILEO_GROVE_LCD_SET_CURSOR_SAMPLE) := grove-lcd-set-cursor.fbp
 sample-grove-lcd-set-cursor-$(FLOW_GALILEO_GROVE_LCD_SET_CURSOR_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-set-cursor-$(FLOW_GALILEO_GROVE_LCD_SET_CURSOR_SAMPLE)-deps := \
-	flow/aio.mod \
-	flow/constant.mod \
-	flow/converter.mod \
-	flow/grove.mod \
-	flow/int.mod \
-	flow/timer.mod
 
 sample-$(FLOW_GALILEO_GROVE_LCD_TEXT_DIRECTION_SAMPLE) += grove-lcd-text-direction
 sample-grove-lcd-text-direction-$(FLOW_GALILEO_GROVE_LCD_TEXT_DIRECTION_SAMPLE) := grove-lcd-text-direction.fbp
 sample-grove-lcd-text-direction-$(FLOW_GALILEO_GROVE_LCD_TEXT_DIRECTION_SAMPLE)-conffile := ../galileo-grove-kit.json
-sample-grove-lcd-text-direction-$(FLOW_GALILEO_GROVE_LCD_TEXT_DIRECTION_SAMPLE)-deps := \
-	flow/aio.mod \
-	flow/boolean.mod \
-	flow/constant.mod \
-	flow/converter.mod \
-	flow/grove.mod \
-	flow/int.mod \
-	flow/timer.mod

--- a/src/samples/flow/gtk-gallery/Makefile
+++ b/src/samples/flow/gtk-gallery/Makefile
@@ -1,3 +1,2 @@
 sample-$(FLOW_GTK_GALLERY_SAMPLE) += gtk-sample
 sample-gtk-sample-$(FLOW_GTK_GALLERY_SAMPLE) := gtk-gallery.fbp
-sample-gtk-sample-$(FLOW_GTK_GALLERY_SAMPLE)-deps := flow/gtk.mod

--- a/src/samples/flow/http-server/Makefile
+++ b/src/samples/flow/http-server/Makefile
@@ -6,21 +6,12 @@ sample-$(FLOW_HTTP_SERVER_SAMPLE) += \
 
 sample-boolean-$(FLOW_HTTP_SERVER_SAMPLE) := \
 	boolean.fbp
-sample-boolean-$(FLOW_HTTP_SERVER_SAMPLE)-deps := \
-	flow/http-server.mod \
-	flow/keyboard.mod
 
 sample-drange-$(FLOW_HTTP_SERVER_SAMPLE) := \
 	drange.fbp
-sample-drange-$(FLOW_HTTP_SERVER_SAMPLE)-deps := \
-	flow/http-server.mod
 
 sample-irange-$(FLOW_HTTP_SERVER_SAMPLE) := \
 	irange.fbp
-sample-irange-$(FLOW_HTTP_SERVER_SAMPLE)-deps := \
-	flow/http-server.mod
 
 sample-string-$(FLOW_HTTP_SERVER_SAMPLE) := \
 	string.fbp
-sample-string-$(FLOW_HTTP_SERVER_SAMPLE)-deps := \
-	flow/http-server.mod

--- a/src/samples/flow/iio/Makefile
+++ b/src/samples/flow/iio/Makefile
@@ -1,6 +1,2 @@
 sample-$(FLOW_IIO_SAMPLE) += iio-gyro
 sample-iio-gyro-$(FLOW_IIO_SAMPLE) := gyroscope.fbp
-sample-iio-gyro-$(FLOW_IIO_SAMPLE)-deps := \
-	flow/iio.mod \
-	flow/timer.mod \
-	flow/console.mod

--- a/src/samples/flow/io/Makefile
+++ b/src/samples/flow/io/Makefile
@@ -4,22 +4,10 @@ sample-$(FLOW_IO_SAMPLE) += \
 
 sample-io-pwm-$(FLOW_IO_SAMPLE) := \
 	pwm.fbp
-sample-io-pwm-$(FLOW_IO_SAMPLE)-deps := \
-	flow/boolean.mod \
-	flow/console.mod \
-	flow/int.mod \
-	flow/pwm.mod \
-	flow/timer.mod
 sample-io-pwm-$(FLOW_IO_SAMPLE)-conffile := \
 	pwm.json
 
 sample-io-servo-motor-$(FLOW_IO_SAMPLE) := \
 	servo-motor.fbp
-sample-io-servo-motor-$(FLOW_IO_SAMPLE)-deps := \
-	flow/console.mod \
-	flow/converter.mod \
-	flow/int.mod \
-	flow/servo-motor.mod \
-	flow/timer.mod
 sample-io-servo-motor-$(FLOW_IO_SAMPLE)-conffile := \
 	servo-motor.json

--- a/src/samples/flow/led-strip/Makefile
+++ b/src/samples/flow/led-strip/Makefile
@@ -1,9 +1,2 @@
 sample-$(FLOW_LD_STRIP_LPD8806_SAMPLE) += lpd8806
 sample-lpd8806-$(FLOW_LD_STRIP_LPD8806_SAMPLE) := lpd8806.fbp
-sample-lpd8806-$(FLOW_LD_STRIP_LPD8806_SAMPLE)-deps := \
-	flow/boolean.mod \
-	flow/converter.mod \
-	flow/int.mod \
-	flow/led-strip.mod \
-	flow/random.mod \
-	flow/timer.mod

--- a/src/samples/flow/minnow-calamari/Makefile
+++ b/src/samples/flow/minnow-calamari/Makefile
@@ -1,29 +1,24 @@
 sample-$(FLOW_CALAMARI_7SEG_SEGMENTS_SAMPLE) += calamari-7seg-segments
 sample-calamari-7seg-segments-$(FLOW_CALAMARI_7SEG_SEGMENTS_SAMPLE) := calamari-7seg-segments.fbp
 sample-calamari-7seg-segments-$(FLOW_CALAMARI_7SEG_SEGMENTS_SAMPLE)-conffile := sol-flow-new.json
-sample-calamari-7seg-segments-$(FLOW_CALAMARI_7SEG_SEGMENTS_SAMPLE)-deps := flow/calamari.mod
 
 sample-$(FLOW_CALAMARI_7SEG_VALUE_SAMPLE) += calamari-7seg-value
 sample-calamari-7seg-value-$(FLOW_CALAMARI_7SEG_VALUE_SAMPLE) := calamari-7seg-value.fbp
 sample-calamari-7seg-value-$(FLOW_CALAMARI_7SEG_VALUE_SAMPLE)-conffile := sol-flow-new.json
-sample-calamari-7seg-value-$(FLOW_CALAMARI_7SEG_VALUE_SAMPLE)-deps := flow/calamari.mod
 
 sample-$(FLOW_CALAMARI_BUTTONS_RGB_LED_SAMPLE) += calamari-buttons-rgb-led
 sample-calamari-buttons-rgb-led-$(FLOW_CALAMARI_BUTTONS_RGB_LED_SAMPLE) := calamari-buttons-rgb-led.fbp
 sample-calamari-buttons-rgb-led-$(FLOW_CALAMARI_BUTTONS_RGB_LED_SAMPLE)-conffile := sol-flow-new.json
-sample-calamari-buttons-rgb-led-$(FLOW_CALAMARI_BUTTONS_RGB_LED_SAMPLE)-deps := flow/calamari.mod
 
 sample-$(FLOW_CALAMARI_LED_SAMPLE) += calamari-led
 sample-calamari-led-$(FLOW_CALAMARI_LED_SAMPLE) := calamari-led.fbp
 sample-calamari-led-$(FLOW_CALAMARI_LED_SAMPLE)-conffile := sol-flow-new.json
-sample-calamari-led-$(FLOW_CALAMARI_LED_SAMPLE)-deps := flow/calamari.mod
 
 sample-$(FLOW_CALAMARI_LEVER_SAMPLE) += calamari-lever
 sample-calamari-lever-$(FLOW_CALAMARI_LEVER_SAMPLE) := calamari-lever.fbp
 sample-calamari-lever-$(FLOW_CALAMARI_LEVER_SAMPLE)-conffile := sol-flow-new.json
-sample-calamari-lever-$(FLOW_CALAMARI_LEVER_SAMPLE)-deps := flow/calamari.mod
 
 sample-$(FLOW_CALAMARI_RGB_LED_SAMPLE) += calamari-rgb-led
 sample-calamari-rgb-led-$(FLOW_CALAMARI_RGB_LED_SAMPLE) := calamari-rgb-led.fbp
 sample-calamari-rgb-led-$(FLOW_CALAMARI_RGB_LED_SAMPLE)-conffile := sol-flow-new.json
-sample-calamari-rgb-led-$(FLOW_CALAMARI_RGB_LED_SAMPLE)-deps := flow/calamari.mod
+

--- a/src/samples/flow/misc/Makefile
+++ b/src/samples/flow/misc/Makefile
@@ -1,30 +1,11 @@
 sample-$(FLOW_MISC_FILE_COPY_SAMPLE) += file-copy
 sample-file-copy-$(FLOW_MISC_FILE_COPY_SAMPLE) := file-copy.fbp
-sample-file-copy-$(FLOW_MISC_FILE_COPY_SAMPLE)-deps := \
-	flow/app.mod \
-	flow/console.mod \
-	flow/constant.mod \
-	flow/converter.mod \
-	flow/file.mod \
-	flow/int.mod \
-	flow/timer.mod
 
 sample-$(FLOW_MISC_FS_PERSISTENCE_SAMPLE) += fs-persistence
 sample-fs-persistence-$(FLOW_MISC_FS_PERSISTENCE_SAMPLE) := fs-persitence.fbp
-sample-fs-persistence-$(FLOW_MISC_FS_PERSISTENCE_SAMPLE)-deps := flow/fs.mod
 
 sample-$(FLOW_MISC_RANDOM_NUMBERS_SAMPLE) += random-numbers
 sample-random-numbers-$(FLOW_MISC_RANDOM_NUMBERS_SAMPLE) := random-numbers.fbp
-sample-random-numbers-$(FLOW_MISC_RANDOM_NUMBERS_SAMPLE)-deps := \
-	flow/console.mod \
-	flow/random.mod \
-	flow/timer.mod
 
 sample-$(FLOW_MISC_TICKETS_QUEUE_SAMPLE) += tickets-queue
 sample-tickets-queue-$(FLOW_MISC_TICKETS_QUEUE_SAMPLE) := tickets_queue.fbp
-sample-tickets-queue-$(FLOW_MISC_TICKETS_QUEUE_SAMPLE)-deps := \
-	flow/boolean.mod \
-	flow/console.mod \
-	flow/converter.mod \
-	flow/int.mod \
-	flow/keyboard.mod

--- a/src/samples/flow/oic/Makefile
+++ b/src/samples/flow/oic/Makefile
@@ -4,17 +4,10 @@ sample-$(FLOW_OIC_SAMPLE) += \
 
 sample-light-client-$(FLOW_OIC_SAMPLE) := \
 	light-client.fbp
-sample-light-client-$(FLOW_OIC_SAMPLE)-deps := \
-	flow/boolean.mod \
-	flow/timer.mod \
-	oic.mod
 sample-light-client-$(FLOW_OIC_SAMPLE)-conffile := \
 	light-client.json
 
 sample-light-server-$(FLOW_OIC_SAMPLE) := \
 	light-server.fbp
-sample-light-server-$(FLOW_OIC_SAMPLE)-deps := \
-	oic.mod \
-	flow/console.mod
 sample-light-server-$(FLOW_OIC_SAMPLE)-conffile := \
 	light-server.json

--- a/src/samples/flow/trash-disposer/Makefile
+++ b/src/samples/flow/trash-disposer/Makefile
@@ -1,11 +1,3 @@
 sample-$(FLOW_TRASH_DISPOSER) += trash-disposer
 sample-trash-disposer-$(FLOW_TRASH_DISPOSER) := trash-disposer.fbp
 sample-trash-disposer-$(FLOW_TRASH_DISPOSER)-conffile := contiki-config.json
-sample-trash-disposer-$(FLOW_TRASH_DISPOSER)-deps := \
-	flow/boolean.mod \
-	flow/console.mod \
-	flow/constant.mod \
-	flow/converter.mod \
-	flow/gpio.mod \
-	flow/servo-motor.mod \
-	flow/timer.mod

--- a/src/samples/flow/unix-socket/Makefile
+++ b/src/samples/flow/unix-socket/Makefile
@@ -16,104 +16,42 @@ sample-$(FLOW_UNIX_SOCKET_SAMPLE) += \
 
 sample-boolean-reader-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	boolean-reader.fbp
-sample-boolean-reader-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
-	flow/console.mod \
-	flow/unix-socket.mod
 
 sample-boolean-writer-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	boolean-writer.fbp
-sample-boolean-writer-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
-	flow/keyboard.mod \
-	flow/unix-socket.mod
 
 sample-byte-reader-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	byte-reader.fbp
-sample-byte-reader-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
-	flow/console.mod \
-	flow/unix-socket.mod
 
 sample-byte-writer-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	byte-writer.fbp
-sample-byte-writer-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
-	flow/converter.mod \
-	flow/int.mod \
-	flow/keyboard.mod \
-	flow/timer.mod \
-	flow/unix-socket.mod
 
 sample-direction-vector-reader-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	direction-vector-reader.fbp
-sample-direction-vector-reader-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
-	flow/console.mod \
-	flow/unix-socket.mod
 
 sample-direction-vector-writer-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	direction-vector-writer.fbp
-sample-direction-vector-writer-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
-	flow/constant.mod \
-	flow/converter.mod \
-	flow/int.mod \
-	flow/keyboard.mod \
-	flow/timer.mod \
-	flow/unix-socket.mod
 
 sample-float-reader-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	float-reader.fbp
-sample-float-reader-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
-	flow/console.mod \
-	flow/unix-socket.mod
 
 sample-float-writer-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	float-writer.fbp
-sample-float-writer-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
-	flow/converter.mod \
-	flow/int.mod \
-	flow/keyboard.mod \
-	flow/timer.mod \
-	flow/unix-socket.mod
 
 sample-int-reader-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	int-reader.fbp
-sample-int-reader-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
-	flow/console.mod \
-	flow/keyboard.mod \
-	flow/unix-socket.mod
 
 sample-int-writer-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	int-writer.fbp
-sample-int-writer-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
-	flow/int.mod \
-	flow/keyboard.mod \
-	flow/timer.mod \
-	flow/unix-socket.mod
 
 sample-rgb-reader-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	rgb-reader.fbp
-sample-rgb-reader-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
-	flow/console.mod \
-	flow/unix-socket.mod
 
 sample-rgb-writer-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	rgb-writer.fbp
-sample-rgb-writer-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
-	flow/constant.mod \
-	flow/converter.mod \
-	flow/int.mod \
-	flow/keyboard.mod \
-	flow/timer.mod \
-	flow/unix-socket.mod
 
 sample-string-reader-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	string-reader.fbp
-sample-string-reader-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
-	flow/console.mod \
-	flow/unix-socket.mod
 
 sample-string-writer-$(FLOW_UNIX_SOCKET_SAMPLE) := \
 	string-writer.fbp
-sample-string-writer-$(FLOW_UNIX_SOCKET_SAMPLE)-deps := \
-	flow/converter.mod \
-	flow/int.mod \
-	flow/keyboard.mod \
-	flow/timer.mod \
-	flow/unix-socket.mod

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -13,14 +13,12 @@ test-test-fbp-scanner-$(TEST_FBP_SCANNER) := test.c test-fbp-scanner.c
 
 test-$(TEST_FLOW) += test-flow
 test-test-flow-$(TEST_FLOW) := test.c test-flow.c
-test-test-flow-$(TEST_FLOW)-deps := flow/timer.mod flow/pwm.mod flow/console.mod
 
 test-$(TEST_FLOW_BUILDER) += test-flow-builder
 test-test-flow-builder-$(TEST_FLOW_BUILDER) := test.c test-flow-builder.c
 
 test-$(TEST_FLOW_PARSER) += test-flow-parser
 test-test-flow-parser-$(TEST_FLOW_PARSER) := test.c test-flow-parser.c
-test-test-flow-parser-$(TEST_FLOW_PARSER)-deps := flow/boolean.mod
 
 test-$(TEST_JAVASCRIPT) += test-javascript
 test-test-javascript-$(TEST_JAVASCRIPT) := test.c test-javascript.c

--- a/src/test/test-flow.c
+++ b/src/test/test-flow.c
@@ -1151,12 +1151,14 @@ named_options_init_from_strv(void)
 {
     struct sol_flow_node_named_options named_opts;
     struct sol_flow_node_named_options_member *m;
+    const struct sol_flow_node_type *node_type;
     int r;
 
+    ASSERT(sol_flow_get_node_type("timer", SOL_FLOW_NODE_TYPE_TIMER, &node_type) == 0);
     {
         const char *strv[] = { "interval=1000", NULL };
 
-        r = sol_flow_node_named_options_init_from_strv(&named_opts, SOL_FLOW_NODE_TYPE_TIMER, strv);
+        r = sol_flow_node_named_options_init_from_strv(&named_opts, node_type, strv);
         ASSERT(r >= 0);
         ASSERT_INT_EQ(named_opts.count, ARRAY_SIZE(strv) - 1);
 
@@ -1171,7 +1173,7 @@ named_options_init_from_strv(void)
     {
         const char *strv[] = { "interval=50|20|60|2", NULL };
 
-        r = sol_flow_node_named_options_init_from_strv(&named_opts, SOL_FLOW_NODE_TYPE_TIMER, strv);
+        r = sol_flow_node_named_options_init_from_strv(&named_opts, node_type, strv);
         ASSERT(r >= 0);
         ASSERT_INT_EQ(named_opts.count, ARRAY_SIZE(strv) - 1);
 
@@ -1189,7 +1191,7 @@ named_options_init_from_strv(void)
     {
         const char *strv[2] = { "interval=val:100|min:10|max:200|step:5", NULL };
 
-        r = sol_flow_node_named_options_init_from_strv(&named_opts, SOL_FLOW_NODE_TYPE_TIMER, strv);
+        r = sol_flow_node_named_options_init_from_strv(&named_opts, node_type, strv);
         ASSERT(r >= 0);
         ASSERT_INT_EQ(named_opts.count, ARRAY_SIZE(strv) - 1);
 
@@ -1204,11 +1206,26 @@ named_options_init_from_strv(void)
         sol_flow_node_named_options_fini(&named_opts);
     }
 
+    {
+        const char *strv[] = { "this_is_not_a_valid_field=100", NULL };
+
+        r = sol_flow_node_named_options_init_from_strv(&named_opts, node_type, strv);
+        ASSERT(r < 0);
+    }
+
+    {
+        const char *wrong_formatting_strv[] = { "interval = 1000", NULL };
+
+        r = sol_flow_node_named_options_init_from_strv(&named_opts, node_type, wrong_formatting_strv);
+        ASSERT(r < 0);
+    }
+
 #ifdef USE_PWM
+    ASSERT(sol_flow_get_node_type("pwm", SOL_FLOW_NODE_TYPE_PWM, &node_type) == 0);
     {
         const char *strv[] = { "chip=2", "pin=7", "enabled=true", "period=42", "duty_cycle=88", NULL };
 
-        r = sol_flow_node_named_options_init_from_strv(&named_opts, SOL_FLOW_NODE_TYPE_PWM, strv);
+        r = sol_flow_node_named_options_init_from_strv(&named_opts, node_type, strv);
         ASSERT(r >= 0);
         ASSERT_INT_EQ(named_opts.count, ARRAY_SIZE(strv) - 1);
 
@@ -1241,10 +1258,11 @@ named_options_init_from_strv(void)
     }
 #endif
 
+    ASSERT(sol_flow_get_node_type("console", SOL_FLOW_NODE_TYPE_CONSOLE, &node_type) == 0);
     {
         const char *strv[] = { "prefix=console prefix:", "suffix=. suffix!", "output_on_stdout=true", NULL };
 
-        r = sol_flow_node_named_options_init_from_strv(&named_opts, SOL_FLOW_NODE_TYPE_CONSOLE, strv);
+        r = sol_flow_node_named_options_init_from_strv(&named_opts, node_type, strv);
         ASSERT(r >= 0);
         ASSERT_INT_EQ(named_opts.count, ARRAY_SIZE(strv) - 1);
 
@@ -1264,20 +1282,6 @@ named_options_init_from_strv(void)
         ASSERT(m->boolean);
 
         sol_flow_node_named_options_fini(&named_opts);
-    }
-
-    {
-        const char *strv[] = { "this_is_not_a_valid_field=100", NULL };
-
-        r = sol_flow_node_named_options_init_from_strv(&named_opts, SOL_FLOW_NODE_TYPE_TIMER, strv);
-        ASSERT(r < 0);
-    }
-
-    {
-        const char *wrong_formatting_strv[] = { "interval = 1000", NULL };
-
-        r = sol_flow_node_named_options_init_from_strv(&named_opts, SOL_FLOW_NODE_TYPE_TIMER, wrong_formatting_strv);
-        ASSERT(r < 0);
     }
 }
 
@@ -1321,22 +1325,37 @@ node_options_new(void)
     struct sol_flow_node_type_console_options *console_opts;
     struct sol_flow_node_options *opts;
     struct sol_flow_node_named_options named_opts;
+    const struct sol_flow_node_type *node_type;
     int r;
 
     /* One option */
+    ASSERT(sol_flow_get_node_type("timer", SOL_FLOW_NODE_TYPE_TIMER, &node_type) == 0);
     named_opts.members = one_option;
     named_opts.count = ARRAY_SIZE(one_option);
-    r = sol_flow_node_options_new(SOL_FLOW_NODE_TYPE_TIMER, &named_opts, &opts);
+    r = sol_flow_node_options_new(node_type, &named_opts, &opts);
     ASSERT(r >= 0);
     timer_opts = (struct sol_flow_node_type_timer_options *)opts;
     ASSERT_INT_EQ(timer_opts->interval.val, 1000);
-    sol_flow_node_options_del(SOL_FLOW_NODE_TYPE_TIMER, opts);
+    sol_flow_node_options_del(node_type, opts);
+
+    /* Unknown option */
+    named_opts.members = unknown_option;
+    named_opts.count = ARRAY_SIZE(unknown_option);
+    r = sol_flow_node_options_new(node_type, &named_opts, &opts);
+    ASSERT(r < 0);
+
+    /* Wrong type */
+    named_opts.members = wrong_type;
+    named_opts.count = ARRAY_SIZE(wrong_type);
+    r = sol_flow_node_options_new(node_type, &named_opts, &opts);
+    ASSERT(r < 0);
 
 #ifdef USE_PWM
     /* Multiple options */
+    ASSERT(sol_flow_get_node_type("pwm", SOL_FLOW_NODE_TYPE_PWM, &node_type) == 0);
     named_opts.members = multiple_options;
     named_opts.count = ARRAY_SIZE(multiple_options);
-    r = sol_flow_node_options_new(SOL_FLOW_NODE_TYPE_PWM, &named_opts, &opts);
+    r = sol_flow_node_options_new(node_type, &named_opts, &opts);
     ASSERT(r >= 0);
     pwm_opts = (struct sol_flow_node_type_pwm_options *)opts;
     ASSERT_INT_EQ(pwm_opts->chip.val, 2);
@@ -1344,31 +1363,20 @@ node_options_new(void)
     ASSERT_INT_EQ(pwm_opts->enabled, true);
     ASSERT_INT_EQ(pwm_opts->period.val, 42);
     ASSERT_INT_EQ(pwm_opts->duty_cycle.val, 88);
-    sol_flow_node_options_del(SOL_FLOW_NODE_TYPE_PWM, opts);
+    sol_flow_node_options_del(node_type, opts);
 #endif
 
     /* String options */
+    ASSERT(sol_flow_get_node_type("console", SOL_FLOW_NODE_TYPE_CONSOLE, &node_type) == 0);
     named_opts.members = string_options;
     named_opts.count = ARRAY_SIZE(string_options);
-    r = sol_flow_node_options_new(SOL_FLOW_NODE_TYPE_CONSOLE, &named_opts, &opts);
+    r = sol_flow_node_options_new(node_type, &named_opts, &opts);
     ASSERT(r >= 0);
     console_opts = (struct sol_flow_node_type_console_options *)opts;
     ASSERT(streq(console_opts->prefix, "console prefix:"));
     ASSERT(streq(console_opts->suffix, ". suffix!"));
     ASSERT_INT_EQ(console_opts->output_on_stdout, true);
-    sol_flow_node_options_del(SOL_FLOW_NODE_TYPE_CONSOLE, opts);
-
-    /* Unknown option */
-    named_opts.members = unknown_option;
-    named_opts.count = ARRAY_SIZE(unknown_option);
-    r = sol_flow_node_options_new(SOL_FLOW_NODE_TYPE_TIMER, &named_opts, &opts);
-    ASSERT(r < 0);
-
-    /* Wrong type */
-    named_opts.members = wrong_type;
-    named_opts.count = ARRAY_SIZE(wrong_type);
-    r = sol_flow_node_options_new(SOL_FLOW_NODE_TYPE_TIMER, &named_opts, &opts);
-    ASSERT(r < 0);
+    sol_flow_node_options_del(node_type, opts);
 }
 
 

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -289,7 +289,7 @@ define make-test-fbp-bin
 $($(1)-out): $(SOL_LIB_OUTPUT) $($(1)-src) $(modules-out)
 	$(Q)echo "     " CC"   "$$@
 	$(Q)$(MKDIR) -p $(dir $($(1)-out))
-	$(Q)$(TARGETCC) $(SAMPLE_CFLAGS) $($(1)-src) -o $($(1)-out) $(SAMPLE_LDFLAGS) $(modules-out)
+	$(Q)$(TARGETCC) $(SAMPLE_CFLAGS) $($(1)-src) -o $($(1)-out) $(SAMPLE_LDFLAGS)
 endef
 $(foreach test-fbp-bin,$(all-tests-fbp-bin),$(eval $(call make-test-fbp-bin,$(test-fbp-bin))))
 

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -276,7 +276,7 @@ sample-out = $(if $(filter %.o,$(sample-$(1)-out)), -c -o $(sample-$(1)-out),-o 
 sample-src = $(filter-out %.json,$(filter-out %.h,$(sample-$(1)-srcs)))
 
 define make-sample
-$(sample-$(1)-out): $(SOL_LIB_OUTPUT) $(sample-$(1)-srcs) $(call find-deps,$(1)) $(addprefix $($(1)-dir),$(filter %.fbp,$($(1)-deps)))
+$(sample-$(1)-out): $(SOL_LIB_OUTPUT) $(modules-out) $(sample-$(1)-srcs) $(call find-deps,$(1)) $(addprefix $($(1)-dir),$(filter %.fbp,$($(1)-deps)))
 	$(Q)echo "     "SMP"   "$$@
 	$(Q)$(MKDIR) -p $(dir $(sample-$(1)-out))
 	$(Q)$(TARGETCC) $(SAMPLE_CFLAGS) $(sample-$(1)-cflags) $(sample-$(1)-includedir) $(sample-src) \


### PR DESCRIPTION
Differences since v2:
 * Moved from common to flow, since it's unlikely that it will be
   helpful for the generic case.

Differences since v1:
 * Avois fetching symbols more than once in fbp-generator
 * Better error checking if symbol is not found in fbp-generator
 * Work with types created from DECLARE keywords in fbp-generator
 * init/shutdown are internal functions
 * Better error handling and reporting

Consists of a function that checks if a symbol is built-in, if not, it tries
to load the corresponding module. A macro wraps said function to be able to
work when dynamic modules support is disabled.

With these and the required changes in the respective code, programs created
with the fbp-generator no longer need to explicitly link to the modules they
use, since Soletta will take care of loading them if required.