### PR TITLE
modules/gtk: add more ports to gtk label

### DIFF
--- a/src/modules/flow/gtk/gtk.json
+++ b/src/modules/flow/gtk/gtk.json
@@ -36,6 +36,22 @@
             "process": "gtk_label_in_process"
           },
           "name": "IN"
+        },
+        {
+          "data_type": "any",
+          "description": "Prints the packet's value to a label widget",
+          "methods": {
+            "process": "gtk_label_in_process"
+          },
+          "name": "VALUE"
+        },
+        {
+          "data_type": "any",
+          "description": "Prints the packet's value to a label widget",
+          "methods": {
+            "process": "gtk_label_in_process"
+          },
+          "name": "SEGMENTS"
         }
       ],
       "methods": {


### PR DESCRIPTION
So it can be used to simulate led 7 segments.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>