### PR TITLE
conffile: Fix memory leak

### DIFF
--- a/src/shared/sol-conffile.c
+++ b/src/shared/sol-conffile.c
@@ -639,6 +639,8 @@ _load_json_from_dirs(const char *file, char **full_path, struct sol_file_reader 
             free(filename);
             sol_file_reader_close(*file_reader);
             *file_reader = NULL;
+        } else {
+            free(filename);
         }
     }
 


### PR DESCRIPTION
filename was leaking in case of sol_file_reader_open() returns NULL.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>