### PR TITLE
flow: fix issues when node type desc is not enabled

### DIFF
--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -366,10 +366,12 @@ struct sol_flow_node_type {
 #endif
 };
 
+#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
 int sol_flow_node_named_options_parse_member(
     struct sol_flow_node_named_options_member *m,
     const char *value,
     const struct sol_flow_node_options_member_description *mdesc);
+#endif
 
 /**
  * Get a node type's input port definiton struct, given a port index.

--- a/src/test/test-flow.c
+++ b/src/test/test-flow.c
@@ -1144,6 +1144,7 @@ send_packets_match_packet_types(void)
 }
 
 
+#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
 DEFINE_TEST(named_options_init_from_strv);
 
 static void
@@ -1280,8 +1281,10 @@ named_options_init_from_strv(void)
         ASSERT(r < 0);
     }
 }
+#endif
 
 
+#ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
 DEFINE_TEST(node_options_new);
 
 static void
@@ -1370,7 +1373,7 @@ node_options_new(void)
     r = sol_flow_node_options_new(SOL_FLOW_NODE_TYPE_TIMER, &named_opts, &opts);
     ASSERT(r < 0);
 }
-
+#endif
 
 DEFINE_TEST(need_a_valid_type_to_create_packets);
 

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -3,16 +3,26 @@ check: $(SOL_LIB_OUTPUT) $(tests-out) $(modules-out)
 
 PHONY += check
 
-check-fbp: $(SOL_LIB_OUTPUT) $(bins-out) $(modules-out)
+ifeq (y,$(FBP_RUNNER))
+check-fbp: $(SOL_LIB_OUTPUT) $(SOL_FBP_RUNNER_BIN) $(modules-out)
 	$(Q)$(PYTHON) $(TEST_FBP_SCRIPT) --runner="$(abspath $(SOL_FBP_RUNNER_BIN))"
+else
+check-fbp:
+	$(Q)echo "Could not run check-fbp, sol-fbp-runner is not enabled, enable it and run "
+	$(Q)echo "check-fbp target again"
+endif
 
-PHONY += check-fbp
-
-check-fbp-bin: $(SOL_LIB_OUTPUT) $(bins-out) $(modules-out) $(all-tests-fbp-bin-out)
+ifeq (y, $(FBP_GENERATOR))
+check-fbp-bin: $(SOL_LIB_OUTPUT) $(SOL_FBP_GENERATOR_BIN) $(modules-out) $(all-tests-fbp-bin-out)
 	$(Q)$(PYTHON) $(TEST_FBP_SCRIPT) --compiled --compiled-dir $(abspath $(build_stagedir)test-fbp/) \
 		--skip SKIP_SIMPLE SKIP_COMPILE SKIP_VALGRIND
+else
+check-fbp-bin:
+	$(Q)echo "Could not run check-fbp-bin, sol-fbp-generator is not enabled, enable it and run "
+	$(Q)echo "check-fbp-bin target again"
+endif
 
-PHONY += check-fbp-bin
+PHONY += check-fbp check-fbp-bin
 
 ifeq (y,$(HAVE_VALGRIND))
 check-valgrind: $(SOL_LIB_OUTPUT) $(tests-out)


### PR DESCRIPTION
If node type description is not enabled the function
sol_flow_node_named_options_parse_member() is never run and its prototype
becomes broken since struct sol_flow_node_options_member_description is
never declared in that case.

Also the sol-fbp-runner and sol-fbp-generator both depend on description
if it's not present the targets check-fbp and check-fbp-bin should never
run due the lacking of the over mentioned binaries.

In the test/sol-flow.c we should also not build the description tests if
it's not enabled, otherwise the tests will fail at all.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>