### PR TITLE
flow/test: Fix crash in float-validator

### DIFF
--- a/src/modules/flow/test/float-validator.c
+++ b/src/modules/flow/test/float-validator.c
@@ -113,6 +113,7 @@ float_validator_process(
     r = sol_flow_packet_get_drange(packet, &input);
     SOL_INT_CHECK(r, < 0, r);
     op = sol_vector_get(&mdata->values, mdata->next_index);
+    SOL_NULL_CHECK(op, -EINVAL);
     match = sol_drange_val_equal(input.val, *op);
     mdata->next_index++;
 


### PR DESCRIPTION
If item couldn't be found in sequence, `op` would be NULL, causing
a NULL pointer dereference in the next line.
