### PR TITLE
mqtt: Allow user and password to be set

### DIFF
--- a/src/lib/comms/include/sol-mqtt.h
+++ b/src/lib/comms/include/sol-mqtt.h
@@ -306,6 +306,16 @@ struct sol_mqtt_config {
     const char *client_id;
 
     /**
+     * NULL terminated string with the username
+     */
+    const char *username;
+
+    /**
+     * NULL terminated string with the password
+     */
+    const char *password;
+
+    /**
      * A message that the broker should send when the client disconnects.
      */
     const struct sol_mqtt_message *will;

--- a/src/lib/comms/sol-mqtt-impl-mosquitto.c
+++ b/src/lib/comms/sol-mqtt-impl-mosquitto.c
@@ -381,6 +381,15 @@ sol_mqtt_connect(const char *host, int port, const struct sol_mqtt_config *confi
         }
     }
 
+    if (config->username && config->password) {
+        r = mosquitto_username_pw_set(mqtt->mosq, config->username, config->password);
+
+        if (r != MOSQ_ERR_SUCCESS) {
+            SOL_WRN("Unable to set username and password");
+            goto error;
+        }
+    }
+
     mqtt->connection_status = SOL_MQTT_DISCONNECTED;
 
     r = mosquitto_connect_async(mqtt->mosq, host, port, mqtt->keepalive);


### PR DESCRIPTION
For brokers that implement MQTT spec 3.1, it may be required that a user
and a password to be provided for authentication. This patch adds
support for this feature.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>