### PR TITLE
http-client: Allow custom data to be sent on POST

### DIFF
--- a/src/lib/comms/include/sol-http.h
+++ b/src/lib/comms/include/sol-http.h
@@ -61,7 +61,8 @@ enum sol_http_param_type {
     SOL_HTTP_PARAM_AUTH_BASIC,
     SOL_HTTP_PARAM_ALLOW_REDIR,
     SOL_HTTP_PARAM_TIMEOUT,
-    SOL_HTTP_PARAM_VERBOSE
+    SOL_HTTP_PARAM_VERBOSE,
+    SOL_HTTP_PARAM_POST_DATA
 };
 
 enum sol_http_status_code {
@@ -100,6 +101,9 @@ struct sol_http_param_value {
         struct {
             int value;
         } integer;
+        struct {
+            struct sol_buffer *value;
+        } data;
     } value;
 };
 
@@ -181,6 +185,12 @@ struct sol_http_response {
     (struct sol_http_param_value) { \
         .type = SOL_HTTP_PARAM_TIMEOUT, \
         .value.integer.value = (setting_) \
+    }
+
+#define SOL_HTTP_REQUEST_PARAM_POST_DATA(data_) \
+    (struct sol_http_param_value) { \
+        .type = SOL_HTTP_PARAM_POST_DATA, \
+        .value.data.value = (data_) \
     }
 
 #define SOL_HTTP_PARAM_FOREACH_IDX(param, itrvar, idx) \

--- a/src/lib/comms/sol-http-client-impl-curl.c
+++ b/src/lib/comms/sol-http-client-impl-curl.c
@@ -685,6 +685,53 @@ set_post_fields_from_params(CURL *curl, struct sol_arena *arena,
 }
 
 static bool
+set_post_data_from_params(CURL *curl, struct sol_arena *arena,
+    const struct sol_http_param *params)
+{
+    struct sol_buffer *data = NULL;
+    struct sol_http_param_value *iter;
+    uint16_t idx;
+    char *tmp;
+    bool type_set = false;
+
+    SOL_VECTOR_FOREACH_IDX (&params->params, iter, idx) {
+        const char *key = iter->value.key_value.key;
+        struct sol_buffer *value = iter->value.data.value;
+
+        if (iter->type == SOL_HTTP_PARAM_POST_FIELD) {
+            SOL_WRN("SOL_HTTP_PARAM_POST_FIELD and SOL_HTTP_PARAM_POST_DATA found in parameters."
+                   " Only one can be used at a time");
+            return false;
+        } else if (iter->type == SOL_HTTP_PARAM_HEADER) {
+            type_set = type_set || strcmp(key, "content-type");
+        } else  if (iter->type == SOL_HTTP_PARAM_POST_DATA) {
+            if (data) {
+                SOL_WRN("More than one SOL_HTTP_PARAM_POST_DATA found.");
+                return false;
+            }
+
+            data = value;
+        }
+    }
+
+    if (!data)
+        return false;
+
+    if (!type_set)
+        SOL_WRN("POST request has data but no content-type was set");
+
+    tmp = strndup((char *)data->data, (int)data->used);
+    if (!tmp)
+        goto cleanup;
+
+    return set_string_option(curl, CURLOPT_POSTFIELDS, arena, tmp);
+
+cleanup:
+    errno = ENOMEM;
+    return false;
+}
+
+static bool
 check_param_api_version(const struct sol_http_param *params)
 {
     if (unlikely(params->api_version != SOL_HTTP_PARAM_API_VERSION)) {
@@ -766,8 +813,9 @@ sol_http_client_request(enum sol_http_method method,
     }
 
     if (method == SOL_HTTP_METHOD_POST) {
-        if (!set_post_fields_from_params(curl, arena, params)) {
-            SOL_WRN("Could not set POST fields from params");
+        if (!set_post_fields_from_params(curl, arena, params) &&
+                !set_post_data_from_params(curl, arena, params)) {
+            SOL_WRN("Could not set POST fields or data from params");
             goto invalid_option;
         }
     }
@@ -776,6 +824,9 @@ sol_http_client_request(enum sol_http_method method,
         switch (value->type) {
         case SOL_HTTP_PARAM_POST_FIELD:
             /* already handled by set_post_fields_from_params() */
+            continue;
+        case SOL_HTTP_PARAM_POST_DATA:
+            /* already handled by set_post_data_from_params() */
             continue;
         case SOL_HTTP_PARAM_QUERY_PARAM:
             /* already handled by set_uri_from_params() */


### PR DESCRIPTION
This patch allows custom data to be sent on POST operations, expanding
from the key=value restriction that we had up to this point. It relies
on content-type to be set via SOL_HTTP_PARAM_HEADER.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>