### PR TITLE
flow/string-format: Don't crash if precision is 0

### DIFF
--- a/src/modules/flow/converter/string-format.c
+++ b/src/modules/flow/converter/string-format.c
@@ -1299,7 +1299,7 @@ ensure_decimal_point(struct sol_buffer *buffer, int precision)
                string. */
             assert(*p == '\0');
         } else {
-            assert(precision == -1 || digit_count < precision);
+            assert(precision <= 0 || digit_count < precision);
             chars_to_insert = ".0";
             insert_count = 2;
         }


### PR DESCRIPTION
Another one found with the fuzzer.


@glima, could you please take a look here, since you wrote this code?