### PR TITLE
flow/file: Fix segmentation fault while sending error packet

### DIFF
--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -149,7 +149,7 @@ int sol_flow_send_packet(struct sol_flow_node *src, uint16_t src_port, struct so
 /* Works exaclty as @sol_flow_send_packet(). This function is a helper
  * to send an error packet.
  */
-int sol_flow_send_error_packet(struct sol_flow_node *src, int code, const char *msg_fmt, ...);
+int sol_flow_send_error_packet(struct sol_flow_node *src, int code, const char *msg_fmt, ...) SOL_ATTR_PRINTF(3, 4);
 
 /* Helper functions to create and send packets of specific types. They
  * work like sol_flow_send_packet(), but besides creating, sending and

--- a/src/modules/flow-metatype/js/js.c
+++ b/src/modules/flow-metatype/js/js.c
@@ -419,7 +419,7 @@ send_error_packet(duk_context *ctx)
         return 0;
     }
 
-    r = sol_flow_send_error_packet(node, value_code, value_msg);
+    r = sol_flow_send_error_packet(node, value_code, "%s", value_msg);
     if (r < 0)
         duk_error(ctx, DUK_ERR_ERROR, "Couldn't send error packet.");
 

--- a/src/modules/flow/converter/string-format.c
+++ b/src/modules/flow/converter/string-format.c
@@ -2097,7 +2097,7 @@ get_integer_field(struct string_converter *mdata,
             break;
         default:
             sol_flow_send_error_packet(mdata->node, EINVAL,
-                "Field index %d does not exist for integer type", index);
+                "Field index %zd does not exist for integer type", index);
         }
     }
 
@@ -2152,7 +2152,7 @@ get_float_field(struct string_converter *mdata,
             break;
         default:
             sol_flow_send_error_packet(mdata->node, EINVAL,
-                "Field index %d does not exist for float type", index);
+                "Field index %zd does not exist for float type", index);
         }
     }
 

--- a/src/modules/flow/file/file.c
+++ b/src/modules/flow/file/file.c
@@ -110,10 +110,8 @@ file_reader_load(struct file_reader_data *mdata)
 
     reader = sol_file_reader_open(mdata->path);
     if (!reader) {
-        char errmsg[1024];
-        snprintf(errmsg, sizeof(errmsg), "Could not load \"%s\": %s",
-            mdata->path, sol_util_strerrora(errno));
-        sol_flow_send_error_packet(mdata->node, errno, errmsg);
+        sol_flow_send_error_packet(mdata->node, errno,
+            "Could not load \"%s\": %s", mdata->path, sol_util_strerrora(errno));
         return -errno;
     }
     slice = sol_file_reader_get_all(reader);
@@ -280,7 +278,7 @@ file_writer_worker_thread_setup(void *data)
         char *msg;
         mdata->error = errno;
         msg = sol_util_strerrora(errno);
-        sol_flow_send_error_packet(mdata->node, mdata->error, msg);
+        sol_flow_send_error_packet(mdata->node, mdata->error, "%s", msg);
         SOL_WRN("could not open '%s': %s", mdata->path, msg);
         return false;
     }
@@ -336,7 +334,7 @@ file_writer_worker_thread_iterate(void *data)
             msg = sol_util_strerrora(errno);
             SOL_WRN("could not write %zd bytes to fd=%d (%s): %s",
                 todo, mdata->fd, mdata->path, msg);
-            sol_flow_send_error_packet(mdata->node, mdata->error, msg);
+            sol_flow_send_error_packet(mdata->node, mdata->error, "%s", msg);
             return false;
         }
     }

--- a/src/modules/flow/filter-repeated/filter-repeated.c
+++ b/src/modules/flow/filter-repeated/filter-repeated.c
@@ -144,12 +144,12 @@ error_filter(struct sol_flow_node *node, void *data, uint16_t port, uint16_t con
     free(mdata->msg);
     mdata->msg = strdup(in_value);
     if (!mdata->msg) {
-        sol_flow_send_error_packet(node, errno, sol_util_strerrora(errno));
+        sol_flow_send_error_packet(node, errno, "%s", sol_util_strerrora(errno));
         return -errno;
     }
     mdata->code = code_value;
 
-    return sol_flow_send_error_packet(node, code_value, in_value);
+    return sol_flow_send_error_packet(node, code_value, "%s", in_value);
 }
 
 static int
@@ -258,7 +258,7 @@ string_filter(struct sol_flow_node *node, void *data, uint16_t port, uint16_t co
     free(mdata->value);
     mdata->value = strdup(in_value);
     if (!mdata->value) {
-        sol_flow_send_error_packet(node, errno, sol_util_strerrora(errno));
+        sol_flow_send_error_packet(node, errno, "%s", sol_util_strerrora(errno));
         return -errno;
     }
 

--- a/src/modules/flow/float/float.c
+++ b/src/modules/flow/float/float.c
@@ -96,7 +96,7 @@ operator_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t
     r = sol_flow_packet_get_drange(packet, &value);
 
     if (r < 0) {
-        sol_flow_send_error_packet(node, -r, sol_util_strerrora(-r));
+        sol_flow_send_error_packet(node, -r, "%s", sol_util_strerrora(-r));
         return r;
     }
 
@@ -174,7 +174,7 @@ multiple_operator_process(struct sol_flow_node *node, void *data, uint16_t port,
             result = alloca(sizeof(*result));
             if (!result) {
                 r = ENOMEM;
-                sol_flow_send_error_packet(node, r, sol_util_strerrora(r));
+                sol_flow_send_error_packet(node, r, "%s", sol_util_strerrora(r));
                 return -r;
             }
             *result = mdata->var[i];
@@ -182,7 +182,7 @@ multiple_operator_process(struct sol_flow_node *node, void *data, uint16_t port,
         } else {
             r = type->func(result, &mdata->var[i], result);
             if (r < 0) {
-                sol_flow_send_error_packet(node, -r, sol_util_strerrora(-r));
+                sol_flow_send_error_packet(node, -r, "%s", sol_util_strerrora(-r));
                 return r;
             }
         }

--- a/src/modules/flow/iio/nodes.c
+++ b/src/modules/flow/iio/nodes.c
@@ -81,7 +81,7 @@ reader_cb(void *data, struct sol_iio_device *device)
     return;
 
 error:
-    sol_flow_send_error_packet(mdata->node, EIO, errmsg);
+    sol_flow_send_error_packet(mdata->node, EIO, "%s", errmsg);
     SOL_WRN("%s", errmsg);
 }
 
@@ -178,7 +178,7 @@ gyroscope_tick(struct sol_flow_node *node, void *data, uint16_t port, uint16_t c
     return 0;
 
 error:
-    sol_flow_send_error_packet(node, EIO, errmsg);
+    sol_flow_send_error_packet(node, EIO, "%s", errmsg);
     SOL_WRN("%s", errmsg);
 
     return -EIO;

--- a/src/modules/flow/int/int.c
+++ b/src/modules/flow/int/int.c
@@ -398,7 +398,7 @@ operator_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t
         sol_flow_node_get_type(node);
     r = type->func(&mdata->var0, &mdata->var1, &value);
     if (r < 0) {
-        sol_flow_send_error_packet(node, -r, sol_util_strerrora(-r));
+        sol_flow_send_error_packet(node, -r, "%s", sol_util_strerrora(-r));
         return r;
     }
 
@@ -459,7 +459,7 @@ multiple_operator_process(struct sol_flow_node *node, void *data, uint16_t port,
             result = alloca(sizeof(*result));
             if (!result) {
                 r = ENOMEM;
-                sol_flow_send_error_packet(node, r, sol_util_strerrora(r));
+                sol_flow_send_error_packet(node, r, "%s", sol_util_strerrora(r));
                 return -r;
             }
             *result = mdata->var[i];
@@ -467,7 +467,7 @@ multiple_operator_process(struct sol_flow_node *node, void *data, uint16_t port,
         } else {
             r = type->func(result, &mdata->var[i], result);
             if (r < 0) {
-                sol_flow_send_error_packet(node, -r, sol_util_strerrora(-r));
+                sol_flow_send_error_packet(node, -r, "%s", sol_util_strerrora(-r));
                 return r;
             }
         }

--- a/src/modules/flow/string/string-icu.c
+++ b/src/modules/flow/string/string-icu.c
@@ -250,7 +250,7 @@ string_concat(struct sol_flow_node *node,
     r = utf8_from_icu_str_slice(dest, len, &final, &err);
     if (r < 0) {
         free(dest);
-        sol_flow_send_error_packet(node, -r, u_errorName(err));
+        sol_flow_send_error_packet(node, -r, "%s", u_errorName(err));
         return r;
     }
 
@@ -379,7 +379,7 @@ slice_do(struct string_slice_data *mdata)
     r = utf8_from_icu_str_slice((const UChar *)slice.data, slice.len,
         &outstr, &err);
     if (r < 0) {
-        sol_flow_send_error_packet(mdata->node, -r, u_errorName(err));
+        sol_flow_send_error_packet(mdata->node, -r, "%s", u_errorName(err));
         return r;
     }
 
@@ -406,7 +406,7 @@ string_slice_input(struct sol_flow_node *node,
     mdata->str = NULL;
     r = icu_str_from_utf8(in_value, &mdata->str, &err);
     if (r < 0) {
-        sol_flow_send_error_packet(mdata->node, -r, u_errorName(err));
+        sol_flow_send_error_packet(mdata->node, -r, "%s", u_errorName(err));
         return r;
     }
 
@@ -817,7 +817,7 @@ string_change_case(struct sol_flow_node *node,
 
     r = icu_str_from_utf8(value, &u_orig, &err);
     if (r < 0) {
-        sol_flow_send_error_packet(node, -r, u_errorName(err));
+        sol_flow_send_error_packet(node, -r, "%s", u_errorName(err));
         return -errno;
     }
 
@@ -835,7 +835,7 @@ string_change_case(struct sol_flow_node *node,
     if (U_FAILURE(err) && err != U_BUFFER_OVERFLOW_ERROR) {
         errno = EINVAL;
         free(u_orig);
-        sol_flow_send_error_packet(node, errno, u_errorName(err));
+        sol_flow_send_error_packet(node, errno, "%s", u_errorName(err));
         return -errno;
     }
     u_lower = calloc(u_changed_sz + 1, sizeof(*u_lower));
@@ -852,7 +852,7 @@ string_change_case(struct sol_flow_node *node,
         errno = EINVAL;
         free(u_orig);
         free(u_lower);
-        sol_flow_send_error_packet(node, errno, u_errorName(err));
+        sol_flow_send_error_packet(node, errno, "%s", u_errorName(err));
         return -errno;
     }
 
@@ -860,7 +860,7 @@ string_change_case(struct sol_flow_node *node,
     if (r < 0) {
         free(u_orig);
         free(u_lower);
-        sol_flow_send_error_packet(node, -r, u_errorName(err));
+        sol_flow_send_error_packet(node, -r, "%s", u_errorName(err));
         return r;
     }
 

--- a/src/modules/flow/switcher/switcher.c
+++ b/src/modules/flow/switcher/switcher.c
@@ -219,7 +219,7 @@ error_forward(struct sol_flow_node *node, void *data, uint16_t port, uint16_t co
     r = sol_flow_packet_get_error(packet, &code_value, &msg);
     SOL_INT_CHECK(r, < 0, r);
 
-    return sol_flow_send_error_packet(node, code_value, msg);
+    return sol_flow_send_error_packet(node, code_value, "%s", msg);
 }
 
 static int

--- a/src/modules/flow/test/boolean-generator.c
+++ b/src/modules/flow/test/boolean-generator.c
@@ -55,7 +55,8 @@ timer_tick(void *data)
         out_packet = false;
     } else {
         sol_flow_send_error_packet(node, ECANCELED,
-            "Unknown sample: %c. Option 'sequence' must be composed by 'T' and/or 'F' chars.");
+            "Unknown sample: %c. Option 'sequence' must be composed by 'T' and/or 'F' chars.",
+            *mdata->it);
         return false;
     }
 


### PR DESCRIPTION
Functions taking a printf-style formatting string should never be
allowed to receive user-supplied strings.  In this case, a string has
been sent to `sol_flow_send_error_packet()` after being formatted by
`snprintf()` -- with `%s` and all -- causing the program to crash.

Modify the prototype for `sol_flow_send_error_packet()` so that it's
declared with `__attribute__((printf))`; this way, the compiler should
warn of other potential similar problems.