### PR TITLE
Do not use alloca() with user-supplied sizes

### DIFF
--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -148,7 +148,6 @@ handle_suboptions(const struct sol_fbp_meta *meta,
     char *p, *remaining;
 
     remaining = strndupa(meta->value.data, meta->value.len);
-    SOL_NULL_CHECK(remaining);
 
     while (remaining) {
         p = memchr(remaining, '|', strlen(remaining));

--- a/src/lib/common/sol-platform-impl-linux-micro.c
+++ b/src/lib/common/sol-platform-impl-linux-micro.c
@@ -315,7 +315,7 @@ load_initial_services_internal(struct sol_file_reader *reader)
         }
     }
     if (err == 0 && start < end)
-        err = load_initial_services_entry(start, end - start); ;
+        err = load_initial_services_entry(start, end - start);
 
     return err;
 }

--- a/src/lib/datatypes/sol-str-slice.c
+++ b/src/lib/datatypes/sol-str-slice.c
@@ -47,8 +47,6 @@ sol_str_slice_to_int(const struct sol_str_slice s, int *value)
         return -EINVAL;
 
     tmp = strndupa(s.data, s.len);
-    if (!tmp)
-        return -errno;
 
     errno = 0;
     v = strtol(tmp, &endptr, 0);

--- a/src/modules/flow/converter/string-format.c
+++ b/src/modules/flow/converter/string-format.c
@@ -492,19 +492,16 @@ fast_fill(struct sol_buffer *buffer,
     ssize_t length,
     unsigned char fill_char)
 {
-    char *str = NULL;
-    struct sol_str_slice slice;
+    int r;
 
     assert(start >= 0);
 
-    str = alloca(length + 1);
-    SOL_NULL_CHECK(str, -ENOMEM);
-    memset(str, fill_char, length);
-    str[length] = 0;
+    r = sol_buffer_ensure(buffer, buffer->used + length + 1);
+    SOL_INT_CHECK(r, < 0, r);
 
-    slice = SOL_STR_SLICE_STR(str, strlen(str));
+    memset(sol_buffer_at(buffer, start), fill_char, length);
 
-    return sol_buffer_set_slice_at(buffer, start, slice);
+    return sol_buffer_ensure_nul_byte(buffer);
 }
 
 static int
@@ -594,14 +591,16 @@ insert_numbers(struct sol_buffer *out,
     SOL_INT_CHECK(r, < 0, r);
 
     if (n_zeros) {
-        char *str = alloca(n_zeros + 1);
+        char *str;
 
-        SOL_NULL_CHECK(str, -ENOMEM);
-        r = snprintf(str, n_zeros + 1, "%0*d", (int)(long)n_zeros, 0);
-        SOL_INT_CHECK(r, < 0, r);
+        r = asprintf(&str, "%0*d", (int)(long)n_zeros, 0);
+        SOL_INT_CHECK(r, < 0, -ENOMEM);
 
-        slice = SOL_STR_SLICE_STR(str, strlen(str));
-        return sol_buffer_insert_slice(out, pos, slice);
+        slice = SOL_STR_SLICE_STR(str, r);
+        r = sol_buffer_insert_slice(out, pos, slice);
+
+        free(str);
+        return r;
     }
 
     return 0;

--- a/src/modules/flow/flower-power/flower-power.c
+++ b/src/modules/flow/flower-power/flower-power.c
@@ -402,16 +402,15 @@ get_timestamp(struct sol_json_token *value, struct timespec *timestamp)
     struct tm time_tm = { 0 };
     time_t tmp_timestamp;
     char *timestamp_str;
+    char *p;
 
     sol_json_token_remove_quotes(value);
-    timestamp_str = strndupa(value->start, sol_json_token_get_size(value));
-    if (!timestamp_str) {
-        SOL_WRN("Failed to get timestamp");
-        return -EINVAL;
-    }
 
-    timestamp_str = strptime(timestamp_str, "%Y-%m-%dT%H:%M:%SZ", &time_tm);
-    if (!timestamp_str) {
+    timestamp_str = strndup(value->start, sol_json_token_get_size(value));
+    p = strptime(timestamp_str, "%Y-%m-%dT%H:%M:%SZ", &time_tm);
+    free(timestamp_str);
+
+    if (!p || !*p) {
         SOL_WRN("Failed to convert timestamp");
         return -EINVAL;
     }
@@ -514,7 +513,8 @@ http_get_cb(void *data, const struct sol_http_client_connection *connection,
                     if (!get_measure(&value, &fpd.fertilizer,
                         &fpd.fertilizer_min, &fpd.fertilizer_max)) {
                         SOL_WRN("Failed to get fertilizer info");
-                        goto error;
+                        r = -EINVAL;
+                        goto fpd_error;
                     }
                 } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key, "light")) {
                     INIT_LIGHT(fpd.light);
@@ -524,7 +524,8 @@ http_get_cb(void *data, const struct sol_http_client_connection *connection,
                     if (!get_measure(&value, &fpd.light,
                         &fpd.light_min, &fpd.light_max)) {
                         SOL_WRN("Failed to get light info");
-                        goto error;
+                        r = -EINVAL;
+                        goto fpd_error;
                     }
                 } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key,
                     "air_temperature")) {
@@ -535,7 +536,8 @@ http_get_cb(void *data, const struct sol_http_client_connection *connection,
                     if (!get_measure(&value, &fpd.temperature,
                         &fpd.temperature_min, &fpd.temperature_max)) {
                         SOL_WRN("Failed to get temperature info");
-                        goto error;
+                        r = -EINVAL;
+                        goto fpd_error;
                     }
 
                     /* convert from Celsius to Kelvin */
@@ -554,26 +556,26 @@ http_get_cb(void *data, const struct sol_http_client_connection *connection,
                     if (!get_measure(&value, &fpd.water, &fpd.water_min,
                         &fpd.water_max)) {
                         SOL_WRN("Failed to get water info");
-                        goto error;
+                        r = -EINVAL;
+                        goto fpd_error;
                     }
                 } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key,
                     "location_identifier")) {
                     sol_json_token_remove_quotes(&value);
-                    fpd.id = strndupa(value.start,
+                    fpd.id = strndup(value.start,
                         sol_json_token_get_size(&value));
-                    if (!fpd.id) {
-                        SOL_WRN("Failed to get id");
-                        goto error;
-                    }
+                    SOL_NULL_CHECK_GOTO(fpd.id, fpd_error);
                 } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key,
                     "last_sample_upload")) {
                     r = get_timestamp(&value, &fpd.timestamp);
-                    SOL_INT_CHECK_GOTO(r, < 0, error);
+                    SOL_INT_CHECK_GOTO(r, < 0, fpd_error);
                 }
             }
             r = sol_flower_power_send_packet(mdata->node,
                 SOL_FLOW_NODE_TYPE_FLOWER_POWER_HTTP_GET__OUT__OUT,
                 &fpd);
+fpd_error:
+            free(fpd.id);
             SOL_INT_CHECK_GOTO(r, < 0, error);
         }
     }
@@ -600,31 +602,30 @@ http_get_cb(void *data, const struct sol_http_client_connection *connection,
                             if (sol_json_token_get_double(&value,
                                 &battery_level.val)) {
                                 SOL_DBG("Failed to get battery level");
-                                goto error;
+                                goto sensor_error;
                             }
                         } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key,
                             "battery_end_of_life_date_utc")) {
                             r = get_timestamp(&value, &battery_end_of_life);
-                            SOL_INT_CHECK_GOTO(r, < 0, error);
+                            SOL_INT_CHECK_GOTO(r, < 0, sensor_error);
                         }
                     }
                 } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key,
                     "sensor_serial")) {
                     sol_json_token_remove_quotes(&value);
-                    id = strndupa(value.start, sol_json_token_get_size(&value));
-                    if (!id) {
-                        SOL_WRN("Failed to get id");
-                        goto error;
-                    }
+                    id = strndup(value.start, sol_json_token_get_size(&value));
+                    SOL_NULL_CHECK_GOTO(id, error);
                 } else if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&key,
                     "last_upload_datetime_utc")) {
                     r = get_timestamp(&value, &timestamp);
-                    SOL_INT_CHECK_GOTO(r, < 0, error);
+                    SOL_INT_CHECK_GOTO(r, < 0, sensor_error);
                 }
             }
             r = sol_flower_power_sensor_send_packet_components(mdata->node,
                 SOL_FLOW_NODE_TYPE_FLOWER_POWER_HTTP_GET__OUT__DEVICE_INFO,
                 id, &timestamp, &battery_end_of_life, &battery_level);
+sensor_error:
+            free(id);
             SOL_INT_CHECK_GOTO(r, < 0, error);
         }
     }

--- a/src/modules/flow/persistence/persistence.c
+++ b/src/modules/flow/persistence/persistence.c
@@ -185,6 +185,8 @@ persist_process(struct sol_flow_node *node,
     int r;
 
     if (mdata->packet_data_size) {
+        /* Using alloca() is OK here since packet_data_size is always a sizeof()
+         * of a fixed struct. */
         value = alloca(mdata->packet_data_size);
         r = mdata->packet_data_get_fn(packet, value);
     } else

--- a/src/modules/flow/string/string-regexp.c
+++ b/src/modules/flow/string/string-regexp.c
@@ -122,7 +122,7 @@ string_regexp_search_and_split(struct string_regexp_search_data *mdata)
     SOL_INT_CHECK(r, < 0, v);
 
     match_sz = (sub_match_count + 1) * 3;
-    match_vector = alloca(match_sz * sizeof(*match_vector));
+    match_vector = calloc(match_sz, sizeof(*match_vector));
 
     r = pcre_exec(compiled_re, p_extra, mdata->string, str_len,
         0, 0, match_vector, match_sz);
@@ -158,6 +158,7 @@ err:
     if (p_extra != NULL)
         pcre_free(p_extra);
     pcre_free(compiled_re);
+    free(match_vector);
 
     return v;
 #undef CREATE_SLICE

--- a/src/modules/flow/thingspeak/thingspeak.c
+++ b/src/modules/flow/thingspeak/thingspeak.c
@@ -144,9 +144,12 @@ thingspeak_execute_poll_finished(void *data,
         return;
     }
 
-    body = strndupa(response->content.data, response->content.used);
+    body = strndup(response->content.data, response->content.used);
+    SOL_NULL_CHECK(body);
+
     sol_flow_send_string_packet(mdata->node,
         SOL_FLOW_NODE_TYPE_THINGSPEAK_TALKBACK_EXECUTE__OUT__OUT, body);
+    free(body);
 }
 
 static bool

--- a/src/modules/linux-micro/fstab/fstab.c
+++ b/src/modules/linux-micro/fstab/fstab.c
@@ -66,15 +66,14 @@ join_unknown_mnt_opts(struct sol_ptr_vector *vec, char *to)
 static unsigned long
 get_mountflags(char *mnt_opts, bool *should_mount)
 {
-    char *p, *remaining;
+    char *remaining, *p;
     struct sol_ptr_vector specific_opts;
     unsigned long options = 0;
 
     sol_ptr_vector_init(&specific_opts);
 
     remaining = strdupa(mnt_opts);
-
-    while (remaining) {
+    do {
         p = strchr(remaining, ',');
         if (p) {
             *p = '\0';
@@ -125,12 +124,7 @@ get_mountflags(char *mnt_opts, bool *should_mount)
         } else {
             sol_ptr_vector_append(&specific_opts, remaining);
         }
-
-        if (!p)
-            break;
-
-        remaining = p;
-    }
+    } while ((remaining = p));
 
     join_unknown_mnt_opts(&specific_opts, mnt_opts);
 

--- a/src/shared/sol-util-file.c
+++ b/src/shared/sol-util-file.c
@@ -354,7 +354,7 @@ strrstr(const char *haystack, const char *needle)
 int
 sol_util_get_rootdir(char *out, size_t size)
 {
-    char progname[PATH_MAX] = { 0 }, *prefix;
+    char progname[PATH_MAX] = { 0 };
     const char *substr;
     int r;
 
@@ -370,11 +370,8 @@ sol_util_get_rootdir(char *out, size_t size)
         return -1;
     }
 
-    prefix = strndupa(progname, strlen(progname) - strlen(substr));
-    if (!prefix)
-        return -1;
-
-    return snprintf(out, size, "%s/", prefix);
+    r = snprintf(out, size, "%.*s/", (int)(strlen(progname) - strlen(substr)), progname);
+    return (r < 0 || r > (int)size) ? -ENOMEM : r;
 }
 
 int

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -31,6 +31,8 @@
  */
 
 #include <errno.h>
+#include <float.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -98,6 +100,11 @@ sol_util_strtodn(const char *nptr, char **endptr, ssize_t len, bool use_locale)
 
     if (len < 0)
         len = (ssize_t)strlen(nptr);
+
+    if (unlikely(len > (DBL_MANT_DIG - DBL_MIN_EXP + 3))) {
+        errno = EINVAL;
+        return FP_NAN;
+    }
 
     /* NOTE: Using a copy to ensure trailing \0 and strtod() so we
      * properly parse numbers with large precision.


### PR DESCRIPTION
This function does not have defined behavior when allocation fails, so
checking for NULL is not going to work.  Review all usages of alloca(),
strndupa() and strdupa() throughout the code base, reducing the amount
of damage that could happen if the allocation were to fail.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>