### PR TITLE
Eeprom v2

### DIFF
--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -834,8 +834,8 @@ generate_memory_map_struct(const struct sol_ptr_vector *maps, int *elements)
     SOL_PTR_VECTOR_FOREACH_IDX (maps, map, i) {
         out("\nstatic const struct sol_memmap_map _memmap%d = {\n", i);
         out("   .version = %d,\n"
-            "   .path = \"%s\"\n"
-            "   .entries {\n",
+            "   .path = \"%s\",\n"
+            "   .entries = {\n",
             map->version, map->path);
 
         for (iter = map->entries; iter->key; iter++) {

--- a/src/lib/io/include/sol-memmap-storage.h
+++ b/src/lib/io/include/sol-memmap-storage.h
@@ -79,7 +79,7 @@ extern "C" {
 
 struct sol_memmap_map {
     uint8_t version; /**< Version of map. Functions will refuse to read/write on storage if this version and the one storad differs */
-    char *path; /**< Where to find the storage. Under Linux, it is the file mapping the storage, like @c /dev/nvram */
+    const char *path; /**< Where to find the storage. Under Linux, it is the file mapping the storage, like @c /dev/nvram */
     struct sol_str_table_ptr entries[]; /**< Entries on map, containing name, offset and size */
 };
 

--- a/src/lib/io/include/sol-memmap-storage.h
+++ b/src/lib/io/include/sol-memmap-storage.h
@@ -79,7 +79,14 @@ extern "C" {
 
 struct sol_memmap_map {
     uint8_t version; /**< Version of map. Functions will refuse to read/write on storage if this version and the one storad differs */
-    const char *path; /**< Where to find the storage. Under Linux, it is the file mapping the storage, like @c /dev/nvram */
+    const char *path; /**< Where to find the storage. Under Linux, it is the file mapping the storage, like @c /dev/nvram.
+                       * Optionally, it can also be of form <tt> create,\<bus_type\>,\<rel_path\>,\<devnumber\>,\<devname\> </tt>, where:
+                       * @arg @a bus_type is the bus type, supported values are: i2c
+                       * @arg @a rel_path is the relative path for device on '/sys/devices',
+                       * like 'platform/80860F41:05'
+                       * @arg @a devnumber is device number on bus, like 0x50
+                       * @arg @a devname is device name, the one recognized by its driver
+                       */
     struct sol_str_table_ptr entries[]; /**< Entries on map, containing name, offset and size */
 };
 

--- a/src/lib/io/sol-memmap-storage.c
+++ b/src/lib/io/sol-memmap-storage.c
@@ -40,15 +40,31 @@
 
 #include "sol-buffer.h"
 #include "sol-log.h"
+#include "sol-mainloop.h"
 #include "sol-str-slice.h"
 #include "sol-str-table.h"
 #include "sol-util.h"
 #include "sol-util-file.h"
+#include "sol-vector.h"
+
+#ifdef USE_I2C
+#include <sol-i2c.h>
+#endif
 
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 
+#define REL_PATH_IDX 2
+#define DEV_NUMBER_IDX 3
+#define DEV_NAME_IDX 4
+
+struct map_resolved_path {
+    const struct sol_memmap_map *map;
+    char *resolved_path;
+};
+
 static struct sol_ptr_vector memory_maps = SOL_PTR_VECTOR_INIT;
 static struct sol_ptr_vector checked_maps = SOL_PTR_VECTOR_INIT;
+static struct sol_ptr_vector resolved_path_maps = SOL_PTR_VECTOR_INIT;
 
 static bool
 get_entry_metadata_on_map(const char *name, const struct sol_memmap_map *map, const struct sol_memmap_entry **entry, uint64_t *mask)
@@ -83,6 +99,20 @@ get_entry_metadata(const char *name, const struct sol_memmap_map **map, const st
     map = NULL;
 
     return false;
+}
+
+static char *
+get_resolved_path(const struct sol_memmap_map *map)
+{
+    struct map_resolved_path *iter;
+    int i;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&resolved_path_maps, iter, i) {
+        if (iter->map == map)
+            return iter->resolved_path;
+    }
+
+    return NULL;
 }
 
 static int
@@ -211,11 +241,11 @@ check_version(const struct sol_memmap_map *map)
         return false;
     }
 
-    ret = sol_memmap_read_raw_do(map->path, entry, mask, &buf);
+    ret = sol_memmap_read_raw_do(get_resolved_path(map), entry, mask, &buf);
     if (ret >= 0 && version == 0) {
         /* No version on file, we should be initialising it */
         version = map->version;
-        if (sol_memmap_write_raw_do(map->path, entry, mask, &buf) < 0) {
+        if (sol_memmap_write_raw_do(get_resolved_path(map), entry, mask, &buf) < 0) {
             SOL_WRN("Could not write current map version to file");
             return false;
         }
@@ -255,7 +285,7 @@ sol_memmap_write_raw(const char *name, const struct sol_buffer *buffer)
         SOL_INF("Mapped size for [%s] is %zd, smaller than buffer contents: %zd",
             name, entry->size, buffer->used);
 
-    return sol_memmap_write_raw_do(map->path, entry, mask, buffer);
+    return sol_memmap_write_raw_do(get_resolved_path(map), entry, mask, buffer);
 }
 
 SOL_API int
@@ -276,7 +306,7 @@ sol_memmap_read_raw(const char *name, struct sol_buffer *buffer)
     if (!check_version(map))
         return -EINVAL;
 
-    return sol_memmap_read_raw_do(map->path, entry, mask, buffer);
+    return sol_memmap_read_raw_do(get_resolved_path(map), entry, mask, buffer);
 }
 
 static bool
@@ -315,6 +345,8 @@ check_map(const struct sol_memmap_map *map)
     struct sol_memmap_entry *entry;
     uint32_t last_offset = 0;
 
+    SOL_DBG("Using memory file at [%s]", get_resolved_path(map));
+
     /* First, calculate any offset that was not set */
     for (iter = map->entries; iter->key; iter++) {
         entry = (void *)iter->val;
@@ -343,19 +375,155 @@ check_map(const struct sol_memmap_map *map)
     return true;
 }
 
+#ifdef USE_I2C
+static char *
+sol_slice_to_str(const struct sol_str_slice *slice)
+{
+    char *result = calloc(1, slice->len + 1);
+
+    SOL_NULL_CHECK(result, NULL);
+
+    memcpy(result, slice->data, slice->len);
+
+    return result;
+}
+#endif
+
+static int
+resolve_i2c_path(const struct sol_memmap_map *map, struct map_resolved_path *map_resolved_path)
+{
+#ifndef USE_I2C
+    SOL_WRN("No support for i2c");
+    return -ENOTSUP;
+#else
+    char *rel_path = NULL, *dev_number_s = NULL, *dev_name = NULL, *end_ptr;
+    unsigned int dev_number;
+    struct sol_vector instructions;
+    struct sol_buffer result_path = SOL_BUFFER_INIT_EMPTY;
+    struct sol_str_slice command = sol_str_slice_from_str(map->path);
+    int ret = -EINVAL;
+
+    instructions = sol_util_str_split(command, ",", 5);
+    if (instructions.len < 5) {
+        SOL_WRN("Invalid create device path. Expected 'create,i2c,<rel_path>,"
+            "<devnumber>,<devname>'");
+        goto end;
+    }
+
+    rel_path = sol_slice_to_str(sol_vector_get(&instructions, REL_PATH_IDX));
+    SOL_NULL_CHECK_GOTO(rel_path, end);
+
+    dev_number_s = sol_slice_to_str(sol_vector_get(&instructions, DEV_NUMBER_IDX));
+    SOL_NULL_CHECK_GOTO(dev_number_s, end);
+
+    errno = 0;
+    dev_number = strtoul(dev_number_s, &end_ptr, 0);
+    if (errno || *end_ptr != '\0')
+        goto end;
+
+    dev_name = sol_slice_to_str(sol_vector_get(&instructions, DEV_NAME_IDX));
+    SOL_NULL_CHECK_GOTO(dev_name, end);
+
+    ret = sol_i2c_create_device(rel_path, dev_name, dev_number,
+        &result_path);
+
+    if (ret >= 0 || ret == -EEXIST) {
+        const struct sol_str_slice ending = SOL_STR_SLICE_LITERAL("/eeprom");
+        struct timespec start;
+        struct stat st;
+
+        ret = sol_buffer_append_slice(&result_path, ending);
+        if (ret < 0)
+            goto end;
+
+        map_resolved_path->resolved_path = sol_buffer_steal(&result_path, NULL);
+
+        ret = 0;
+        start = sol_util_timespec_get_current();
+        while (stat(map_resolved_path->resolved_path, &st)) {
+            struct timespec elapsed, now = sol_util_timespec_get_current();
+
+            sol_util_timespec_sub(&now, &start, &elapsed);
+            /* Let's wait up to one second */
+            if (elapsed.tv_sec > 0) {
+                ret = -ENODEV;
+                goto end;
+            }
+        }
+    }
+
+end:
+    free(rel_path);
+    free(dev_number_s);
+    free(dev_name);
+    sol_vector_clear(&instructions);
+
+    return ret;
+#endif
+}
+
 SOL_API int
 sol_memmap_add_map(const struct sol_memmap_map *map)
 {
-    if (!check_map(map)) {
-        SOL_WRN("Invalid memory map. Map->path: [%s]", map->path);
-        return -EINVAL;
+    struct map_resolved_path *map_resolved_path;
+    int r;
+
+    SOL_NULL_CHECK(map, -EINVAL);
+
+    map_resolved_path = calloc(1, sizeof(struct map_resolved_path));
+    SOL_NULL_CHECK(map, -ENOMEM);
+
+    map_resolved_path->map = map;
+
+    if (strstartswith(map->path, "create,i2c,")) {
+        if (resolve_i2c_path(map, map_resolved_path) < 0) {
+            SOL_WRN("Could not create i2c EEPROM device using command [%s]", map->path);
+            r = -EINVAL;
+            goto error;
+        }
+    } else {
+        map_resolved_path->resolved_path = (void *)map->path;
     }
 
-    return sol_ptr_vector_append(&memory_maps, (void *)map);
+    r = sol_ptr_vector_append(&resolved_path_maps, map_resolved_path);
+    SOL_INT_CHECK_GOTO(r, < 0, error);
+
+    if (!check_map(map)) {
+        SOL_WRN("Invalid memory map. Map->path: [%s]", map->path);
+        r = -EINVAL;
+        goto error;
+    }
+
+    r = sol_ptr_vector_append(&memory_maps, (void *)map);
+    SOL_INT_CHECK_GOTO(r, < 0, error);
+
+    return 0;
+
+error:
+    free(map_resolved_path);
+
+    return r;
 }
 
 SOL_API int
 sol_memmap_remove_map(const struct sol_memmap_map *map)
 {
+    struct map_resolved_path *iter;
+    int i;
+
+    SOL_NULL_CHECK(map, -EINVAL);
+
+    SOL_PTR_VECTOR_FOREACH_REVERSE_IDX (&resolved_path_maps, iter, i) {
+        if (iter->map == map) {
+            if (iter->resolved_path != map->path)
+                free(iter->resolved_path);
+
+            sol_ptr_vector_del(&resolved_path_maps, i);
+            free(iter);
+
+            break;
+        }
+    }
+
     return sol_ptr_vector_remove(&memory_maps, map);
 }

--- a/src/modules/flow/int/int.json
+++ b/src/modules/flow/int/int.json
@@ -123,6 +123,14 @@
             "process": "reset_process"
           },
           "name": "RESET"
+        },
+        {
+          "data_type": "int",
+          "description": "Set accumulator value.",
+          "methods": {
+            "process": "set_process"
+          },
+          "name": "SET"
         }
       ],
       "methods": {
@@ -141,6 +149,12 @@
             },
             "description": "The initial value, range and step to be used in operations. Only positive step values are allowed.",
             "name": "setup_value"
+          },
+          {
+            "data_type": "boolean",
+            "default": true,
+            "description": "If true, a packet containing initial value will be sent during initialization",
+            "name": "send_initial_packet"
           }
         ],
         "version": 1

--- a/src/modules/flow/persistence/persistence.c
+++ b/src/modules/flow/persistence/persistence.c
@@ -144,14 +144,13 @@ persist_do(struct persist_data *mdata, struct sol_flow_node *node, void *value)
     if (mdata->packet_data_size)
         size = mdata->packet_data_size;
     else
-        size = strlen(value);
+        size = strlen(value) + 1; //To include the null terminating char
 
     r = storage_write(mdata, value, size);
     SOL_INT_CHECK(r, < 0, r);
 
     /* No packet_data_size means dynamic content (string). Let's reallocate if needed */
     if (!mdata->packet_data_size) {
-        size++; //To include the null terminating char
         if (!mdata->value_ptr || strlen(mdata->value_ptr) + 1 < size) {
             void *tmp = realloc(mdata->value_ptr, size);
             SOL_NULL_CHECK(tmp, -ENOMEM);

--- a/src/samples/flow/minnow-calamari/calamari-button-accumulator-persistence.fbp
+++ b/src/samples/flow/minnow-calamari/calamari-button-accumulator-persistence.fbp
@@ -1,0 +1,57 @@
+#!/usr/bin/env sol-fbp-runner
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This example showcases persistence usage. By clicking on Buttons 1 & 2,
+# one can increase/decrease a counter, that is displayed on 7 seg display.
+# Each change is also persisted to Calamari EEPROM, so this sample will, on
+# a second run, remembers counter last value.
+# Note that on sol-flow.json in this directory is defined the memory map used
+# to store information on EEPROM. Property 'path' contains the instructions
+# to 'create' the i2c device. Alternatively, it could be a path to EEPROM file
+# on sysfs, considering it's already created. In this case, path would be
+# '/sys/bus/i2c/devices/7-0050/eeprom'
+# Note also that for this sample to work, one must zero at least EEPROM position
+# where offset is saved (byte 200). Or use 255 as map version on sol-flow.json.
+
+btn1(Button1)
+btn2(Button2)
+accumulator(int/accumulator:send_initial_packet=false,setup_value=val:0|min:0|max:15|step:1)
+seg(SevenSegments)
+persistence(persistence/int:storage="memmap",name="accumulated",default_value=0)
+
+persistence OUT -> SET accumulator
+
+btn1 OUT -> IN _(boolean/filter) TRUE -> INC accumulator
+btn2 OUT -> IN _(boolean/filter) TRUE -> DEC accumulator
+
+accumulator OUT -> IN persistence
+
+persistence OUT -> VALUE seg

--- a/src/samples/flow/minnow-calamari/sol-flow-new.json
+++ b/src/samples/flow/minnow-calamari/sol-flow-new.json
@@ -112,5 +112,22 @@
    },
    "type": "calamari/lever"
   }
+ ],
+ "maps": [
+     {
+         "version": 1,
+         "path": "create,i2c,platform/80860F41:05,0x50,24c256",
+         "entries": [
+             {
+                 "name": "_version",
+                 "offset": 200,
+                 "size": 1
+             },
+             {
+                 "name": "accumulated",
+                 "size": 16
+             }
+         ]
+     }
  ]
 }

--- a/src/samples/flow/minnow-calamari/sol-flow.json
+++ b/src/samples/flow/minnow-calamari/sol-flow.json
@@ -112,5 +112,22 @@
    },
    "type": "calamari/lever"
   }
+ ],
+ "maps": [
+     {
+         "version": 1,
+         "path": "create,i2c,platform/80860F41:05,0x50,24c256",
+         "entries": [
+             {
+                 "name": "_version",
+                 "offset": 200,
+                 "size": 1
+             },
+             {
+                 "name": "accumulated",
+                 "size": 16
+             }
+         ]
+     }
  ]
 }


### PR DESCRIPTION
v2:
Keep generated memory mapped map `const`.
No more internal data on user available struct: keeping an internal array with resolved i2c paths.

After some tests with memmap persistence on Calamari EEPROM, some patches:
int/accumulator: Now with an option to send initial packet and a port to set its initial value (useful to use an accumulator with persisted data).
persistence: Saving ending NUL on strings. Memmap has a fixed size for string fields, so we need to write terminating NUL byte to avoid issues on overwrite.
memmap-storage: path property now accepts create,i2c,... commands (the same from IIO) to create an I2C device - useful for Calamari EEPROM.
And finally, a sample was added to show persistence on Calamari.