### PR TITLE
http-client: Allow custom data to be sent on POST

### DIFF
--- a/src/lib/comms/include/sol-http.h
+++ b/src/lib/comms/include/sol-http.h
@@ -61,7 +61,8 @@ enum sol_http_param_type {
     SOL_HTTP_PARAM_AUTH_BASIC,
     SOL_HTTP_PARAM_ALLOW_REDIR,
     SOL_HTTP_PARAM_TIMEOUT,
-    SOL_HTTP_PARAM_VERBOSE
+    SOL_HTTP_PARAM_VERBOSE,
+    SOL_HTTP_PARAM_POST_DATA
 };
 
 enum sol_http_status_code {
@@ -100,6 +101,9 @@ struct sol_http_param_value {
         struct {
             int value;
         } integer;
+        struct {
+            const struct sol_str_slice value;
+        } data;
     } value;
 };
 
@@ -181,6 +185,12 @@ struct sol_http_response {
     (struct sol_http_param_value) { \
         .type = SOL_HTTP_PARAM_TIMEOUT, \
         .value.integer.value = (setting_) \
+    }
+
+#define SOL_HTTP_REQUEST_PARAM_POST_DATA(data_) \
+    (struct sol_http_param_value) { \
+        .type = SOL_HTTP_PARAM_POST_DATA, \
+        .value.data.value = (data_) \
     }
 
 #define SOL_HTTP_PARAM_FOREACH_IDX(param, itrvar, idx) \


### PR DESCRIPTION
This patch allows custom data to be sent on POST operations, expanding
from the key=value restriction that we had up to this point. It relies
on content-type to be set via SOL_HTTP_PARAM_HEADER.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>