### PR TITLE
Eeprom v3

### DIFF
--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -832,21 +832,22 @@ generate_memory_map_struct(const struct sol_ptr_vector *maps, int *elements)
     *elements = 0;
 
     SOL_PTR_VECTOR_FOREACH_IDX (maps, map, i) {
-        out("\nstatic const struct sol_memmap_map _memmap%d = {\n", i);
-        out("   .version = %d,\n"
-            "   .path = \"%s\",\n"
-            "   .entries = {\n",
-            map->version, map->path);
-
+        out("\nstatic const struct sol_str_table_ptr _memmap%d_entries[] = {\n", i);
         for (iter = map->entries; iter->key; iter++) {
             entry = iter->val;
-            out("       SOL_MEMMAP_ENTRY_BIT_SIZE(\"%s\", %zu, %zu, %u, %u),\n",
+            out("   SOL_MEMMAP_ENTRY_BIT_SIZE(\"%s\", %zu, %zu, %u, %u),\n",
                 iter->key, entry->offset, entry->size, entry->bit_offset,
                 entry->bit_size);
         }
-
-        out("    }\n"
+        out("   (const struct sol_str_table_ptr) { }\n"
             "};\n");
+
+        out("\nstatic const struct sol_memmap_map _memmap%d = {\n"
+            "   .version = %d,\n"
+            "   .path = \"%s\",\n"
+            "   .entries = _memmap%d_entries\n"
+            "};\n",
+            i, map->version, map->path, i);
     }
 
     *elements = i;

--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -834,8 +834,8 @@ generate_memory_map_struct(const struct sol_ptr_vector *maps, int *elements)
     SOL_PTR_VECTOR_FOREACH_IDX (maps, map, i) {
         out("\nstatic const struct sol_memmap_map _memmap%d = {\n", i);
         out("   .version = %d,\n"
-            "   .path = \"%s\"\n"
-            "   .entries {\n",
+            "   .path = \"%s\",\n"
+            "   .entries = {\n",
             map->version, map->path);
 
         for (iter = map->entries; iter->key; iter++) {

--- a/src/lib/io/include/sol-memmap-storage.h
+++ b/src/lib/io/include/sol-memmap-storage.h
@@ -79,7 +79,7 @@ extern "C" {
 
 struct sol_memmap_map {
     uint8_t version; /**< Version of map. Functions will refuse to read/write on storage if this version and the one storad differs */
-    char *path; /**< Where to find the storage. Under Linux, it is the file mapping the storage, like @c /dev/nvram */
+    const char *path; /**< Where to find the storage. Under Linux, it is the file mapping the storage, like @c /dev/nvram */
     struct sol_str_table_ptr entries[]; /**< Entries on map, containing name, offset and size */
 };
 

--- a/src/lib/io/include/sol-memmap-storage.h
+++ b/src/lib/io/include/sol-memmap-storage.h
@@ -68,19 +68,26 @@ extern "C" {
 
 #define MEMMAP_VERSION_ENTRY "_version" /**< Name of property which contains stored map version */
 
+#define SOL_MEMMAP_ENTRY_BIT_SIZE(_name, _offset, _size, _bit_offset, _bit_size) \
+    (const struct sol_str_table_ptr)SOL_STR_TABLE_PTR_ITEM(_name, &((struct sol_memmap_entry){.offset = (_offset), .size = (_size), .bit_offset = (_bit_offset), .bit_size = (_bit_size) }))
+
 #define SOL_MEMMAP_ENTRY(_name, _offset, _size) \
-    SOL_STR_TABLE_PTR_ITEM(_name, &((struct sol_memmap_entry){.offset = (_offset), .size = (_size) }))
+    SOL_MEMMAP_ENTRY_BIT_SIZE(_name, _offset, _size, 0, 0)
 
 #define SOL_MEMMAP_BOOL_ENTRY(_name, _offset, _bit_offset) \
-    SOL_STR_TABLE_PTR_ITEM(_name, &((struct sol_memmap_entry){.offset = (_offset), .size = 1, .bit_offset = (_bit_offset), .bit_size = 1 }))
-
-#define SOL_MEMMAP_ENTRY_BIT_SIZE(_name, _offset, _size, _bit_offset, _bit_size) \
-    SOL_STR_TABLE_PTR_ITEM(_name, &((struct sol_memmap_entry){.offset = (_offset), .size = (_size), .bit_offset = (_bit_offset), .bit_size = (_bit_size) }))
+    SOL_MEMMAP_ENTRY_BIT_SIZE(_name, _offset, 1, _bit_offset, 1)
 
 struct sol_memmap_map {
     uint8_t version; /**< Version of map. Functions will refuse to read/write on storage if this version and the one storad differs */
-    const char *path; /**< Where to find the storage. Under Linux, it is the file mapping the storage, like @c /dev/nvram */
-    struct sol_str_table_ptr entries[]; /**< Entries on map, containing name, offset and size */
+    const char *path; /**< Where to find the storage. Under Linux, it is the file mapping the storage, like @c /dev/nvram.
+                       * Optionally, it can also be of form <tt> create,\<bus_type\>,\<rel_path\>,\<devnumber\>,\<devname\> </tt>, where:
+                       * @arg @a bus_type is the bus type, supported values are: i2c
+                       * @arg @a rel_path is the relative path for device on '/sys/devices',
+                       * like 'platform/80860F41:05'
+                       * @arg @a devnumber is device number on bus, like 0x50
+                       * @arg @a devname is device name, the one recognized by its driver
+                       */
+    const struct sol_str_table_ptr *entries; /**< Entries on map, containing name, offset and size */
 };
 
 struct sol_memmap_entry {

--- a/src/lib/io/sol-memmap-storage.c
+++ b/src/lib/io/sol-memmap-storage.c
@@ -40,15 +40,31 @@
 
 #include "sol-buffer.h"
 #include "sol-log.h"
+#include "sol-mainloop.h"
 #include "sol-str-slice.h"
 #include "sol-str-table.h"
 #include "sol-util.h"
 #include "sol-util-file.h"
+#include "sol-vector.h"
+
+#ifdef USE_I2C
+#include <sol-i2c.h>
+#endif
 
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 
+#define REL_PATH_IDX 2
+#define DEV_NUMBER_IDX 3
+#define DEV_NAME_IDX 4
+
+struct map_resolved_path {
+    const struct sol_memmap_map *map;
+    char *resolved_path;
+};
+
 static struct sol_ptr_vector memory_maps = SOL_PTR_VECTOR_INIT;
 static struct sol_ptr_vector checked_maps = SOL_PTR_VECTOR_INIT;
+static struct sol_ptr_vector resolved_maps_to_free = SOL_PTR_VECTOR_INIT;
 
 static bool
 get_entry_metadata_on_map(const char *name, const struct sol_memmap_map *map, const struct sol_memmap_entry **entry, uint64_t *mask)
@@ -315,6 +331,8 @@ check_map(const struct sol_memmap_map *map)
     struct sol_memmap_entry *entry;
     uint32_t last_offset = 0;
 
+    SOL_DBG("Using memory file at [%s]", map->path);
+
     /* First, calculate any offset that was not set */
     for (iter = map->entries; iter->key; iter++) {
         entry = (void *)iter->val;
@@ -343,19 +361,160 @@ check_map(const struct sol_memmap_map *map)
     return true;
 }
 
+#ifdef USE_I2C
+static char *
+sol_slice_to_str(const struct sol_str_slice *slice)
+{
+    char *result = calloc(1, slice->len + 1);
+
+    SOL_NULL_CHECK(result, NULL);
+
+    memcpy(result, slice->data, slice->len);
+
+    return result;
+}
+
+static int
+resolve_i2c_path(const char *path, struct sol_memmap_map *map)
+{
+    char *rel_path = NULL, *dev_number_s = NULL, *dev_name = NULL, *end_ptr;
+    unsigned int dev_number;
+    struct sol_vector instructions;
+    struct sol_buffer result_path = SOL_BUFFER_INIT_EMPTY;
+    struct sol_str_slice command = sol_str_slice_from_str(path);
+    int ret = -EINVAL;
+
+    instructions = sol_util_str_split(command, ",", 5);
+    if (instructions.len < 5) {
+        SOL_WRN("Invalid create device path. Expected 'create,i2c,<rel_path>,"
+            "<devnumber>,<devname>'");
+        goto end;
+    }
+
+    rel_path = sol_slice_to_str(sol_vector_get(&instructions, REL_PATH_IDX));
+    SOL_NULL_CHECK_GOTO(rel_path, end);
+
+    dev_number_s = sol_slice_to_str(sol_vector_get(&instructions, DEV_NUMBER_IDX));
+    SOL_NULL_CHECK_GOTO(dev_number_s, end);
+
+    errno = 0;
+    dev_number = strtoul(dev_number_s, &end_ptr, 0);
+    if (errno || *end_ptr != '\0')
+        goto end;
+
+    dev_name = sol_slice_to_str(sol_vector_get(&instructions, DEV_NAME_IDX));
+    SOL_NULL_CHECK_GOTO(dev_name, end);
+
+    ret = sol_i2c_create_device(rel_path, dev_name, dev_number,
+        &result_path);
+
+    if (ret >= 0 || ret == -EEXIST) {
+        const struct sol_str_slice ending = SOL_STR_SLICE_LITERAL("/eeprom");
+        struct timespec start;
+        struct stat st;
+
+        ret = sol_buffer_append_slice(&result_path, ending);
+        if (ret < 0)
+            goto end;
+
+        map->path = sol_buffer_steal(&result_path, NULL);
+
+        ret = 0;
+        start = sol_util_timespec_get_current();
+        while (stat(map->path, &st)) {
+            struct timespec elapsed, now = sol_util_timespec_get_current();
+
+            sol_util_timespec_sub(&now, &start, &elapsed);
+            /* Let's wait up to one second */
+            if (elapsed.tv_sec > 0) {
+                ret = -ENODEV;
+                goto end;
+            }
+        }
+    }
+
+end:
+    free(rel_path);
+    free(dev_number_s);
+    free(dev_name);
+    sol_vector_clear(&instructions);
+
+    return ret;
+}
+#endif
+
+static struct sol_memmap_map *
+resolve_map(const struct sol_memmap_map *map)
+{
+#ifdef USE_I2C
+    struct sol_memmap_map *resolved_map = NULL;
+    int r;
+
+    if (strstartswith(map->path, "create,i2c,")) {
+        resolved_map = calloc(1, sizeof(struct sol_memmap_map));
+        SOL_NULL_CHECK(resolved_map, NULL);
+
+        resolved_map->version = map->version;
+        resolved_map->entries = map->entries;
+
+        if (resolve_i2c_path(map->path, resolved_map) < 0) {
+            SOL_WRN("Could not create i2c EEPROM device using command [%s]", map->path);
+            goto error;
+        }
+
+        r = sol_ptr_vector_append(&resolved_maps_to_free, resolved_map);
+        SOL_INT_CHECK_GOTO(r, < 0, error);
+
+        return resolved_map;
+    }
+
+    return (void *)map;
+
+error:
+    free(resolved_map);
+    return NULL;
+#else
+    return (void *)map;
+#endif
+}
+
 SOL_API int
 sol_memmap_add_map(const struct sol_memmap_map *map)
 {
-    if (!check_map(map)) {
-        SOL_WRN("Invalid memory map. Map->path: [%s]", map->path);
+    struct sol_memmap_map *resolved_map;
+    int r;
+
+    SOL_NULL_CHECK(map, -EINVAL);
+
+    resolved_map = resolve_map(map);
+    SOL_NULL_CHECK(resolved_map, -EINVAL);
+
+    if (!check_map(resolved_map)) {
+        SOL_WRN("Invalid memory map. Map->path: [%s]", resolved_map->path);
         return -EINVAL;
     }
 
-    return sol_ptr_vector_append(&memory_maps, (void *)map);
+    r = sol_ptr_vector_append(&memory_maps, (void *)resolved_map);
+    SOL_INT_CHECK(r, < 0, r);
+
+    return 0;
 }
 
 SOL_API int
 sol_memmap_remove_map(const struct sol_memmap_map *map)
 {
+    struct sol_memmap_map *iter;
+    int i;
+
+    SOL_NULL_CHECK(map, -EINVAL);
+
+    SOL_PTR_VECTOR_FOREACH_REVERSE_IDX (&resolved_maps_to_free, iter, i) {
+        if (iter->entries == map->entries) {
+            sol_ptr_vector_del(&resolved_maps_to_free, i);
+            free(iter);
+            break;
+        }
+    }
+
     return sol_ptr_vector_remove(&memory_maps, map);
 }

--- a/src/modules/flow/int/int.json
+++ b/src/modules/flow/int/int.json
@@ -123,6 +123,14 @@
             "process": "reset_process"
           },
           "name": "RESET"
+        },
+        {
+          "data_type": "int",
+          "description": "Set accumulator value.",
+          "methods": {
+            "process": "set_process"
+          },
+          "name": "SET"
         }
       ],
       "methods": {
@@ -141,6 +149,12 @@
             },
             "description": "The initial value, range and step to be used in operations. Only positive step values are allowed.",
             "name": "setup_value"
+          },
+          {
+            "data_type": "boolean",
+            "default": true,
+            "description": "If true, a packet containing initial value will be sent during initialization",
+            "name": "send_initial_packet"
           }
         ],
         "version": 1

--- a/src/modules/flow/persistence/persistence.c
+++ b/src/modules/flow/persistence/persistence.c
@@ -144,14 +144,13 @@ persist_do(struct persist_data *mdata, struct sol_flow_node *node, void *value)
     if (mdata->packet_data_size)
         size = mdata->packet_data_size;
     else
-        size = strlen(value);
+        size = strlen(value) + 1; //To include the null terminating char
 
     r = storage_write(mdata, value, size);
     SOL_INT_CHECK(r, < 0, r);
 
     /* No packet_data_size means dynamic content (string). Let's reallocate if needed */
     if (!mdata->packet_data_size) {
-        size++; //To include the null terminating char
         if (!mdata->value_ptr || strlen(mdata->value_ptr) + 1 < size) {
             void *tmp = realloc(mdata->value_ptr, size);
             SOL_NULL_CHECK(tmp, -ENOMEM);

--- a/src/samples/flow/minnow-calamari/calamari-button-accumulator-persistence.fbp
+++ b/src/samples/flow/minnow-calamari/calamari-button-accumulator-persistence.fbp
@@ -1,0 +1,57 @@
+#!/usr/bin/env sol-fbp-runner
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This example showcases persistence usage. By clicking on Buttons 1 & 2,
+# one can increase/decrease a counter, that is displayed on 7 seg display.
+# Each change is also persisted to Calamari EEPROM, so this sample will, on
+# a second run, remembers counter last value.
+# Note that on sol-flow.json in this directory is defined the memory map used
+# to store information on EEPROM. Property 'path' contains the instructions
+# to 'create' the i2c device. Alternatively, it could be a path to EEPROM file
+# on sysfs, considering it's already created. In this case, path would be
+# '/sys/bus/i2c/devices/7-0050/eeprom'
+# Note also that for this sample to work, one must zero at least EEPROM position
+# where offset is saved (byte 200). Or use 255 as map version on sol-flow.json.
+
+btn1(Button1)
+btn2(Button2)
+accumulator(int/accumulator:send_initial_packet=false,setup_value=val:0|min:0|max:15|step:1)
+seg(SevenSegments)
+persistence(persistence/int:storage="memmap",name="accumulated",default_value=0)
+
+persistence OUT -> SET accumulator
+
+btn1 OUT -> IN _(boolean/filter) TRUE -> INC accumulator
+btn2 OUT -> IN _(boolean/filter) TRUE -> DEC accumulator
+
+accumulator OUT -> IN persistence
+
+persistence OUT -> VALUE seg

--- a/src/samples/flow/minnow-calamari/sol-flow-new.json
+++ b/src/samples/flow/minnow-calamari/sol-flow-new.json
@@ -112,5 +112,22 @@
    },
    "type": "calamari/lever"
   }
+ ],
+ "maps": [
+     {
+         "version": 1,
+         "path": "create,i2c,platform/80860F41:05,0x50,24c256",
+         "entries": [
+             {
+                 "name": "_version",
+                 "offset": 200,
+                 "size": 1
+             },
+             {
+                 "name": "accumulated",
+                 "size": 16
+             }
+         ]
+     }
  ]
 }

--- a/src/samples/flow/minnow-calamari/sol-flow.json
+++ b/src/samples/flow/minnow-calamari/sol-flow.json
@@ -112,5 +112,22 @@
    },
    "type": "calamari/lever"
   }
+ ],
+ "maps": [
+     {
+         "version": 1,
+         "path": "create,i2c,platform/80860F41:05,0x50,24c256",
+         "entries": [
+             {
+                 "name": "_version",
+                 "offset": 200,
+                 "size": 1
+             },
+             {
+                 "name": "accumulated",
+                 "size": 16
+             }
+         ]
+     }
  ]
 }

--- a/src/shared/sol-conffile.c
+++ b/src/shared/sol-conffile.c
@@ -318,6 +318,7 @@ _parse_maps(struct sol_json_token token)
     SOL_JSON_SCANNER_ARRAY_LOOP (&scanner, &token, SOL_JSON_TYPE_OBJECT_START, reason) {
         struct sol_str_slice path = { };
         uint32_t version = 0;
+        void *entries_destination;
 
         map = NULL;
 
@@ -357,7 +358,9 @@ _parse_maps(struct sol_json_token token)
         map->path = sol_arena_strdup_slice(str_arena, path);
         SOL_NULL_CHECK_GOTO(map->path, error);
         data = sol_vector_take_data(&entries_vector);
-        memmove(map->entries, data, entries_vector_size);
+        entries_destination = &map->entries + 1;
+        memmove(entries_destination, data, entries_vector_size);
+        map->entries = entries_destination;
         free(data);
 
         if (sol_ptr_vector_append(&_memory_maps, map) < 0) {


### PR DESCRIPTION
v3:
To avoid simplify i2c paths, now keeping a 'shadow' map with resolved path. To avoid duplicating entries, `sol_memmap_map` structure was changed to have `entries` as a pointer to an array. So, generator and conffile were changed accordingly.

v2:
Keep generated memory mapped map const.
No more internal data on user available struct: keeping an internal array with resolved i2c paths.

After some tests with memmap persistence on Calamari EEPROM, some patches:
int/accumulator: Now with an option to send initial packet and a port to set its initial value (useful to use an accumulator with persisted data).
persistence: Saving ending NUL on strings. Memmap has a fixed size for string fields, so we need to write terminating NUL byte to avoid issues on overwrite.
memmap-storage: path property now accepts create,i2c,... commands (the same from IIO) to create an I2C device - useful for Calamari EEPROM.
And finally, a sample was added to show persistence on Calamari.
