### PR TITLE
Update OIC implementation to current version of the spec

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/thirdparty/duktape"]
 	path = src/thirdparty/duktape
 	url = https://github.com/solettaproject/duktape-release.git
+[submodule "src/thirdparty/tinycbor"]
+	path = src/thirdparty/tinycbor
+	url = https://github.com/01org/tinycbor/

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -482,6 +482,17 @@
       "type": "pkg-config",
       "pkgname": "libmicrohttpd",
       "atleast-version": "0.9.43"
+    },
+    {
+      "dependency": "tinycbor_src",
+      "type": "filesystem",
+      "files": [
+        "cbor.h"
+      ],
+      "path": {
+        "in-tree": "{TOP_SRCDIR}/src/thirdparty/tinycbor/src",
+        "out-of-tree": "{TINYCBOR_SRC}"
+      }
     }
   ]
 }

--- a/data/oic/core.brightlight.json
+++ b/data/oic/core.brightlight.json
@@ -5,6 +5,10 @@
     "core.brightlight": {
       "type": "object",
       "properties": {
+        "name": {
+          "type": "string",
+          "description": "Friendly device name (e.g. Kitchen Light)"
+        },
         "power": {
           "type": "integer",
           "description": "Current sensed or set value for Brightness"

--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -140,67 +140,65 @@ def object_fields_common_c(state_struct_name, name, props):
 
     return '\n'.join(fields)
 
-def generate_object_serialize_fn_common_c(state_struct_name, name, props, client):
-    fmtstrings = []
-    for prop_name, prop_descr in props.items():
-        if client and prop_descr['read_only']:
-            continue
-
-        if 'enum' in prop_descr:
-            fmtstrings.append('\\"%s\\":\\"%%s\\"' % prop_name)
-        elif prop_descr['type'] == 'string':
-            fmtstrings.append('\\"%s\\":\\"%%s\\"' % prop_name)
-        elif prop_descr['type'] == 'boolean':
-            fmtstrings.append('\\"%s\\":%%s' % prop_name)
-        elif prop_descr['type'] == 'integer':
-            fmtstrings.append('\\"%s\\":%%d' % prop_name)
-        elif prop_descr['type'] == 'number':
-            fmtstrings.append('\\"%s\\":%%f' % prop_name)
-        else:
-            raise ValueError("invalid property type: %s" % prop_descr['type'])
-
+def generate_object_to_repr_vec_fn_common_c(state_struct_name, name, props, client):
     fields = []
     for prop_name, prop_descr in props.items():
         if client and prop_descr['read_only']:
             continue
 
         if 'enum' in prop_descr:
-            fields.append('%s_%s_tbl[state->state.%s].key' % (state_struct_name, prop_name, prop_name))
+            tbl = '%s_%s_tbl' % (state_struct_name, prop_name)
+            val = '%s[state->state.%s]' % (tbl, prop_name)
+            vallen = 'strlen(%s)' % val
+
+            ftype = 'SOL_OIC_REPR_TEXT_STRING'
+            fargs = (val, vallen)
         elif prop_descr['type'] == 'boolean':
-            fields.append('(state->state.%s)?"true":"false"' % prop_name)
+            val = 'state->state.%s' % prop_name
+        
+            ftype = 'SOL_OIC_REPR_BOOLEAN'
+            fargs = (val, )
         elif prop_descr['type'] == 'string':
-            fields.append('ESCAPE_STRING(state->state.%s)' % prop_name)
+            val = 'state->state.%s' % prop_name
+            vallen = 'strlen(%s)' % val
+
+            ftype = 'SOL_OIC_REPR_TEXT_STRING'
+            fargs = (val, vallen)
+        elif prop_descr['type'] == 'integer':
+            val = 'state->state.%s' % prop_name
+
+            ftype = 'SOL_OIC_REPR_INT'
+            fargs = (val, )
+        elif prop_descr['type'] == 'number':
+            val = 'state->state.%s' % prop_name
+
+            ftype = 'SOL_OIC_REPR_DOUBLE'
+            fargs = (val, )
         else:
-            fields.append('state->state.%s' % prop_name)
+            raise ValueError('unknown field type: %s' % prop['type'])
+
+        fields.append('''f = sol_vector_append(repr);
+SOL_NULL_CHECK(f, false);
+*f = %(ftype)s("%(key)s", %(fargs)s);
+''' % { 'ftype': ftype, 'key': prop_name, 'fargs': ', '.join(fargs) })
 
     if not fields:
         return ''
 
-    return '''static uint8_t *
-%(struct_name)s_serialize(struct %(type)s_resource *resource, uint16_t *length)
+    return '''static bool
+%(struct_name)s_to_repr_vec(const struct %(type)s_resource *resource, struct sol_vector *repr)
 {
     struct %(struct_name)s *state = (struct %(struct_name)s *)resource;
-    char *payload;
-    int r;
+    struct sol_oic_repr_field *f;
 
-    r = asprintf(&payload, "{%(fmtstrings)s}", %(fields)s);
-    if (r < 0)
-        return NULL;
+    %(fields)s
 
-    if (r >= 0xffff) {
-        free(payload);
-        errno = -ENOMEM;
-        return NULL;
-    }
-
-    *length = (uint16_t)r;
-    return (uint8_t *)payload;
+    return true;
 }
 ''' % {
     'type': 'client' if client else 'server',
     'struct_name': name,
-    'fmtstrings': ','.join(fmtstrings),
-    'fields': ','.join(fields)
+    'fields': '\n'.join(fields)
     }
 
 def get_type_from_property(prop):
@@ -210,13 +208,13 @@ def get_type_from_property(prop):
         return 'enum:%s' % ','.join(prop['enum'])
     raise ValueError('Unknown type for property')
 
-def object_serialize_fn_common_c(state_struct_name, name, props, client, equivalent={}):
+def object_to_repr_vec_fn_common_c(state_struct_name, name, props, client, equivalent={}):
     for item_name, item_props in equivalent.items():
         if item_props[0] == client and props_are_equivalent(props, item_props[1]):
-            return '''static uint8_t *
-%(struct_name)s_serialize(struct %(type)s_resource *resource, uint16_t *length)
+            return '''static bool
+%(struct_name)s_to_repr_vec(const struct %(type)s_resource *resource, struct sol_vector *repr)
 {
-    return %(item_name)s_serialize(resource, length); /* %(item_name)s is equivalent to %(struct_name)s */
+    return %(item_name)s_to_repr_vec(resource, repr); /* %(item_name)s is equivalent to %(struct_name)s */
 }
 ''' % {
         'item_name': item_name,
@@ -225,19 +223,24 @@ def object_serialize_fn_common_c(state_struct_name, name, props, client, equival
     }
 
     equivalent[name] = (client, props)
-    return generate_object_serialize_fn_common_c(state_struct_name, name, props, client)
+    return generate_object_to_repr_vec_fn_common_c(state_struct_name, name, props, client)
 
-def object_serialize_fn_client_c(state_struct_name, name, props):
-    return object_serialize_fn_common_c(state_struct_name, name, props, True)
+def object_to_repr_vec_fn_client_c(state_struct_name, name, props):
+    return object_to_repr_vec_fn_common_c(state_struct_name, name, props, True)
 
-def object_serialize_fn_server_c(state_struct_name, name, props):
-    return object_serialize_fn_common_c(state_struct_name, name, props, False)
+def object_to_repr_vec_fn_server_c(state_struct_name, name, props):
+    return object_to_repr_vec_fn_common_c(state_struct_name, name, props, False)
 
 def get_field_integer_client_c(id, name, prop):
-    return '''if (decode_mask & (1<<%(id)d) && sol_json_token_str_eq(&key, "%(field_name)s", %(field_name_len)d)) {
-    int r = sol_json_token_get_int32(&value, &fields.%(field_name)s);
-    if (r < 0)
-        RETURN_ERROR(r);
+    return '''if (decode_mask & (1<<%(id)d) && streq(field->key, "%(field_name)s")) {
+    if (field->type == SOL_OIC_REPR_TYPE_UINT)
+        fields.%(field_name)s = field->v_uint;
+    else if (field->type == SOL_OIC_REPR_TYPE_INT)
+        fields.%(field_name)s = field->v_int;
+    else if (field->type == SOL_OIC_REPR_TYPE_SIMPLE)
+        fields.%(field_name)s = field->v_simple;
+    else
+        RETURN_ERROR(-EINVAL);
     decode_mask &= ~(1<<%(id)d);
     continue;
 }
@@ -248,10 +251,13 @@ def get_field_integer_client_c(id, name, prop):
     }
 
 def get_field_number_client_c(id, name, prop):
-    return '''if (decode_mask & (1<<%(id)d) && sol_json_token_str_eq(&key, "%(field_name)s", %(field_name_len)d)) {
-    int r = sol_json_token_get_double(&value, &fields.%(field_name)s);
-    if (r < 0)
-        RETURN_ERROR(r);
+    return '''if (decode_mask & (1<<%(id)d) && streq(field->key, "%(field_name)s")) {
+    if (field->type == SOL_OIC_REPR_TYPE_DOUBLE)
+        fields.%(field_name)s = field->v_double;
+    else if (field->type == SOL_OIC_REPR_TYPE_FLOAT)
+        fields.%(field_name)s = field->v_float;
+    else
+        RETURN_ERROR(-EINVAL);
     decode_mask &= ~(1<<%(id)d);
     continue;
 }
@@ -262,8 +268,12 @@ def get_field_number_client_c(id, name, prop):
     }
 
 def get_field_string_client_c(id, name, prop):
-    return '''if (decode_mask & (1<<%(id)d) && sol_json_token_str_eq(&key, "%(field_name)s", %(field_name_len)d)) {
-    if (!json_token_to_string(&value, &fields.%(field_name)s))
+    return '''if (decode_mask & (1<<%(id)d) && streq(field->key, "%(field_name)s")) {
+    if (field->type != SOL_OIC_REPR_TYPE_TEXT_STRING)
+        RETURN_ERROR(-EINVAL);
+    free(fields.%(field_name)s);
+    fields.%(field_name)s = strndup(field->v_slice.data, field->v_slice.len);
+    if (!fields.%(field_name)s)
         RETURN_ERROR(-EINVAL);
     decode_mask &= ~(1<<%(id)d);
     continue;
@@ -275,9 +285,10 @@ def get_field_string_client_c(id, name, prop):
     }
 
 def get_field_boolean_client_c(id, name, prop):
-    return '''if (decode_mask & (1<<%(id)d) && sol_json_token_str_eq(&key, "%(field_name)s", %(field_name_len)d)) {
-    if (!json_token_to_bool(&value, &fields.%(field_name)s))
+    return '''if (decode_mask & (1<<%(id)d) && streq(field->key, "%(field_name)s")) {
+    if (field->type != SOL_OIC_REPR_TYPE_BOOLEAN)
         RETURN_ERROR(-EINVAL);
+    fields.%(field_name)s = field->v_boolean;
     decode_mask &= ~(1<<%(id)d);
     continue;
 }
@@ -288,9 +299,14 @@ def get_field_boolean_client_c(id, name, prop):
     }
 
 def get_field_enum_client_c(id, struct_name, name, prop):
-    return '''if (decode_mask & (1<<%(id)d) && sol_json_token_str_eq(&key, "%(field_name)s", %(field_name_len)d)) {
-    int16_t val = sol_str_table_lookup_fallback(%(struct_name)s_%(field_name)s_tbl,
-        SOL_STR_SLICE_STR(value.start, value.end - value.start), -1);
+    return '''if (decode_mask & (1<<%(id)d) && streq(field->key, "%(field_name)s")) {
+    int val;
+
+    if (field->type != SOL_OIC_REPR_TYPE_TEXT_STRING)
+        RETURN_ERROR(-EINVAL);
+
+    val = sol_str_table_lookup_fallback(%(struct_name)s_%(field_name)s_tbl,
+        field->v_slice, -1);
     if (val < 0)
         RETURN_ERROR(-EINVAL);
     fields.%(field_name)s = (enum %(struct_name)s_%(field_name)s)val;
@@ -304,7 +320,7 @@ def get_field_enum_client_c(id, struct_name, name, prop):
         'id': id
     }
 
-def object_fields_deserializer(name, props):
+def object_fields_from_repr_vec(name, props):
     id = 0
     fields = []
     for prop_name, prop in props.items():
@@ -323,7 +339,7 @@ def object_fields_deserializer(name, props):
         id += 1
     return '\n'.join(fields)
 
-def generate_object_deserialize_fn_common_c(name, props):
+def generate_object_from_repr_vec_fn_common_c(name, props):
     fields_init = []
     for field_name, field_props in props.items():
         if 'enum' in field_props:
@@ -346,26 +362,20 @@ def generate_object_deserialize_fn_common_c(name, props):
             update_state.append('free(state->%s);' % field_name)
         update_state.append('state->%s = fields.%s;' % (field_name, field_name))
 
-    return '''static int
-%(struct_name)s_deserialize(struct %(struct_name)s *state,
-    const uint8_t *payload, uint16_t payload_len, uint32_t decode_mask)
+    return '''static bool
+%(struct_name)s_from_repr_vec(struct %(struct_name)s *state,
+    const struct sol_vector *repr, uint32_t decode_mask)
 {
-#define RETURN_ERROR(errcode) do { err = (errcode); goto out; } while(0)
-
-    struct sol_json_scanner scanner;
-    struct sol_json_token token, key, value;
-    enum sol_json_loop_reason reason;
+    struct sol_oic_repr_field *field;
+    uint16_t idx;
     int err = 0;
     struct %(struct_name)s fields = {
         %(fields_init)s
     };
 
-    sol_json_scanner_init(&scanner, payload, payload_len);
-    SOL_JSON_SCANNER_OBJECT_LOOP(&scanner, &token, &key, &value, reason) {
-        %(deserializers)s
+    SOL_VECTOR_FOREACH_IDX (repr, field, idx) {
+        %(fields)s
     }
-    if (reason != SOL_JSON_LOOP_REASON_OK)
-        RETURN_ERROR(-EINVAL);
 
     %(update_state)s
 
@@ -374,28 +384,24 @@ def generate_object_deserialize_fn_common_c(name, props):
 out:
     %(free_fields)s
     return err;
-
-#undef RETURN_ERROR
 }
 ''' % {
         'struct_name': name,
-        'fields': object_fields_common_c(name, name, props),
         'fields_init': '\n'.join(fields_init),
-        'deserializers': object_fields_deserializer(name, props),
+        'fields': object_fields_from_repr_vec(name, props),
         'free_fields': '\n'.join(fields_free),
         'update_state': '\n'.join(update_state)
     }
 
-def object_deserialize_fn_common_c(name, props, equivalent={}):
-
+def object_from_repr_vec_fn_common_c(name, props, equivalent={}):
     for item_name, item_props in equivalent.items():
         if props_are_equivalent(props, item_props):
-            return '''static int
-%(struct_name)s_deserialize(struct %(struct_name)s *state,
-    const uint8_t *payload, uint16_t payload_len, uint32_t decode_mask)
+            return '''static bool
+%(struct_name)s_from_repr_vec(struct %(struct_name)s *state,
+    const sol_vector *repr, uint32_t decode_mask)
 {
     /* %(item_name)s is equivalent to %(struct_name)s */
-    return %(item_name)s_deserialize((struct %(item_name)s *)state, payload, payload_len, decode_mask);
+    return %(item_name)s_from_repr_vec((struct %(item_name)s *)state, repr, decode_mask);
 }
 ''' % {
         'item_name': item_name,
@@ -403,22 +409,22 @@ def object_deserialize_fn_common_c(name, props, equivalent={}):
     }
 
     equivalent[name] = props
-    return generate_object_deserialize_fn_common_c(name, props)
+    return generate_object_from_repr_vec_fn_common_c(name, props)
 
 
-def object_deserialize_fn_client_c(state_struct_name, name, props):
-    return '''static int
-%(struct_name)s_deserialize(struct client_resource *resource, const uint8_t *payload, uint16_t payload_len)
+def object_from_repr_vec_fn_client_c(state_struct_name, name, props):
+    return '''static bool
+%(struct_name)s_from_repr_vec(struct client_resource *resource, const struct sol_vector *repr)
 {
     struct %(struct_name)s *res = (struct %(struct_name)s *)resource;
-    return %(state_struct_name)s_deserialize(&res->state, payload, payload_len, ~0);
+    return %(state_struct_name)s_from_repr_vec(&res->state, repr, ~0);
 }
 ''' % {
         'struct_name': name,
         'state_struct_name': state_struct_name
     }
 
-def object_deserialize_fn_server_c(state_struct_name, name, props):
+def object_from_repr_vec_fn_server_c(state_struct_name, name, props):
     decode_mask = 0
     id = 0
     for field_name, field_props in props.items():
@@ -429,11 +435,11 @@ def object_deserialize_fn_server_c(state_struct_name, name, props):
     if not decode_mask:
         return ''
 
-    return '''static int
-%(struct_name)s_deserialize(struct server_resource *resource, const uint8_t *payload, uint16_t payload_len)
+    return '''static bool
+%(struct_name)s_from_repr_vec(struct server_resource *resource, const struct sol_vector *repr)
 {
     struct %(struct_name)s *res = (struct %(struct_name)s *)resource;
-    return %(state_struct_name)s_deserialize(&res->state, payload, payload_len, 0x%(decode_mask)x);
+    return %(state_struct_name)s_from_repr_vec(&res->state, repr, 0x%(decode_mask)x);
 }
 ''' % {
         'struct_name': name,
@@ -495,9 +501,9 @@ def object_open_fn_client_c(state_struct_name, resource_type, name, props):
 
     no_inputs = all(field_props['read_only'] for field_name, field_props in props.items())
     if no_inputs:
-        serialize_fn = 'NULL'
+        to_repr_vec_fn = 'NULL'
     else:
-        serialize_fn = '%s_serialize' % name
+        to_repr_vec_fn = '%s_to_repr_vec' % name
 
     return '''static int
 %(struct_name)s_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
@@ -505,8 +511,8 @@ def object_open_fn_client_c(state_struct_name, resource_type, name, props):
     const struct sol_flow_node_type_%(struct_name)s_options *node_opts =
         (const struct sol_flow_node_type_%(struct_name)s_options *)options;
     static const struct client_resource_funcs funcs = {
-        .serialize = %(serialize_fn)s,
-        .deserialize = %(struct_name)s_deserialize,
+        .to_repr_vec = %(to_repr_vec_fn)s,
+        .from_repr_vec = %(struct_name)s_from_repr_vec,
         .inform_flow = %(struct_name)s_inform_flow,
         .found_port = SOL_FLOW_NODE_TYPE_%(STRUCT_NAME)s__OUT__FOUND
     };
@@ -525,7 +531,7 @@ def object_open_fn_client_c(state_struct_name, resource_type, name, props):
         'STRUCT_NAME': name.upper(),
         'resource_type': resource_type,
         'field_init': '\n'.join(field_init),
-        'serialize_fn': serialize_fn
+        'to_repr_vec_fn': to_repr_vec_fn
     }
 
 def object_open_fn_server_c(state_struct_name, resource_type, name, props, definitions={'id':0}):
@@ -534,10 +540,10 @@ def object_open_fn_server_c(state_struct_name, resource_type, name, props, defin
 
     no_inputs = all(field_props['read_only'] for field_name, field_props in props.items())
     if no_inputs:
-        deserialize_fn_name = 'NULL'
+        from_repr_vec_fn_name = 'NULL'
         inform_flow_fn_name = 'NULL'
     else:
-        deserialize_fn_name = '%s_deserialize' % name
+        from_repr_vec_fn_name = '%s_from_repr_vec' % name
         inform_flow_fn_name = '%s_inform_flow' % name
 
     field_init = []
@@ -557,8 +563,8 @@ def object_open_fn_server_c(state_struct_name, resource_type, name, props, defin
     static const struct sol_str_slice rt_slice = SOL_STR_SLICE_LITERAL("%(resource_type)s");
     static const struct sol_str_slice def_slice = SOL_STR_SLICE_LITERAL("/etta/%(def_id)x");
     static const struct server_resource_funcs funcs = {
-        .serialize = %(struct_name)s_serialize,
-        .deserialize = %(deserialize_fn_name)s,
+        .to_repr_vec = %(struct_name)s_to_repr_vec,
+        .from_repr_vec = %(from_repr_vec_fn_name)s,
         .inform_flow = %(inform_flow_fn_name)s
     };
     struct %(struct_name)s *resource = data;
@@ -575,7 +581,7 @@ def object_open_fn_server_c(state_struct_name, resource_type, name, props, defin
         'struct_name': name,
         'resource_type': resource_type,
         'def_id': def_id,
-        'deserialize_fn_name': deserialize_fn_name,
+        'from_repr_vec_fn_name': from_repr_vec_fn_name,
         'inform_flow_fn_name': inform_flow_fn_name,
         'field_init': '\n'.join(field_init)
     }
@@ -716,8 +722,8 @@ def generate_object_client_c(resource_type, state_struct_name, name, props):
     struct %(state_struct_name)s state;
 };
 
-%(serialize_fn)s
-%(deserialize_fn)s
+%(to_repr_vec_fn)s
+%(from_repr_vec_fn)s
 %(inform_flow_fn)s
 %(open_fn)s
 %(close_fn)s
@@ -725,8 +731,8 @@ def generate_object_client_c(resource_type, state_struct_name, name, props):
 """ % {
     'state_struct_name': state_struct_name,
     'struct_name': name,
-    'serialize_fn': object_serialize_fn_client_c(state_struct_name, name, props),
-    'deserialize_fn': object_deserialize_fn_client_c(state_struct_name, name, props),
+    'to_repr_vec_fn': object_to_repr_vec_fn_client_c(state_struct_name, name, props),
+    'from_repr_vec_fn': object_from_repr_vec_fn_client_c(state_struct_name, name, props),
     'inform_flow_fn': object_inform_flow_fn_client_c(state_struct_name, name, props),
     'open_fn': object_open_fn_client_c(state_struct_name, resource_type, name, props),
     'close_fn': object_close_fn_client_c(name, props),
@@ -739,8 +745,8 @@ def generate_object_server_c(resource_type, state_struct_name, name, props):
     struct %(state_struct_name)s state;
 };
 
-%(serialize_fn)s
-%(deserialize_fn)s
+%(to_repr_vec_fn)s
+%(from_repr_vec_fn)s
 %(inform_flow_fn)s
 %(open_fn)s
 %(close_fn)s
@@ -748,8 +754,8 @@ def generate_object_server_c(resource_type, state_struct_name, name, props):
 """ % {
     'struct_name': name,
     'state_struct_name': state_struct_name,
-    'serialize_fn': object_serialize_fn_server_c(state_struct_name, name, props),
-    'deserialize_fn': object_deserialize_fn_server_c(state_struct_name, name, props),
+    'to_repr_vec_fn': object_to_repr_vec_fn_server_c(state_struct_name, name, props),
+    'from_repr_vec_fn': object_from_repr_vec_fn_server_c(state_struct_name, name, props),
     'inform_flow_fn': object_inform_flow_fn_server_c(state_struct_name, name, props),
     'open_fn': object_open_fn_server_c(state_struct_name, resource_type, name, props),
     'close_fn': object_close_fn_server_c(name, props),
@@ -761,12 +767,12 @@ def generate_object_common_c(name, props):
 struct %(struct_name)s {
     %(struct_fields)s
 };
-%(deserialize_fn)s
+%(from_repr_vec_fn)s
 """ % {
         'enums': generate_enums_common_c(name, props),
         'struct_name': name,
         'struct_fields': object_fields_common_c(name, name, props),
-        'deserialize_fn': object_deserialize_fn_common_c(name, props),
+        'from_repr_vec_fn': object_from_repr_vec_fn_common_c(name, props),
     }
 
 def generate_object_json(resource_type, struct_name, node_name, title, props, server):
@@ -899,6 +905,7 @@ def master_json_as_string(generated, json_name):
 def master_c_as_string(generated, oic_gen_c, oic_gen_h):
     generated = list(generated)
     code = '''#include <arpa/inet.h>
+#include <assert.h>
 #include <errno.h>
 #include <math.h>
 #include <netinet/in.h>
@@ -909,12 +916,13 @@ def master_c_as_string(generated, oic_gen_c, oic_gen_h):
 #include "%(oic_gen_h)s"
 
 #include "sol-coap.h"
-#include "sol-json.h"
 #include "sol-mainloop.h"
+#include "sol-oic-common.h"
 #include "sol-oic-client.h"
 #include "sol-oic-server.h"
 #include "sol-str-slice.h"
 #include "sol-str-table.h"
+#include "sol-util.h"
 
 #define DEFAULT_UDP_PORT 5683
 #define MULTICAST_ADDRESS_IPv4 "224.0.1.187"
@@ -927,15 +935,15 @@ struct client_resource;
 struct server_resource;
 
 struct client_resource_funcs {
-    uint8_t *(*serialize)(struct client_resource *resource, uint16_t *length);
-    int (*deserialize)(struct client_resource *resource, const uint8_t *payload, uint16_t payload_len);
+    bool (*to_repr_vec)(const struct client_resource *resource, struct sol_vector *repr_vec);
+    bool (*from_repr_vec)(struct client_resource *resource, const struct sol_vector *repr);
     void (*inform_flow)(struct client_resource *resource);
     int found_port;
 };
 
 struct server_resource_funcs {
-    uint8_t *(*serialize)(struct server_resource *resource, uint16_t *length);
-    int (*deserialize)(struct server_resource *resource, const uint8_t *payload, uint16_t payload_len);
+    bool (*to_repr_vec)(const struct server_resource *resource, struct sol_vector *repr_vec);
+    bool (*from_repr_vec)(struct server_resource *resource, const struct sol_vector *repr);
     void (*inform_flow)(struct server_resource *resource);
 };
 
@@ -943,7 +951,7 @@ struct client_resource {
     struct sol_flow_node *node;
     const struct client_resource_funcs *funcs;
 
-    struct sol_oic_resource *resource, *tentative_resource;
+    struct sol_oic_resource *resource;
 
     struct sol_timeout *find_timeout;
     struct sol_timeout *update_schedule_timeout;
@@ -958,19 +966,19 @@ struct server_resource {
     struct sol_flow_node *node;
     const struct server_resource_funcs *funcs;
 
-    struct sol_coap_resource *coap;
+    struct sol_oic_server_resource *resource;
     struct sol_timeout *update_schedule_timeout;
-    char *endpoint;
 
-    struct sol_oic_resource_type oic;
+    struct sol_oic_resource_type type;
 };
 
 static struct sol_network_link_addr multicast_ipv4, multicast_ipv6_local, multicast_ipv6_site;
-static bool multicast_addresses_initialized = false;
 
 static bool
 initialize_multicast_addresses_once(void)
 {
+    static bool multicast_addresses_initialized = false;
+
     if (multicast_addresses_initialized)
         return true;
 
@@ -1011,10 +1019,9 @@ client_resource_implements_type(struct sol_oic_resource *oic_res, const char *re
 
 static void
 state_changed(struct sol_oic_client *oic_cli, const struct sol_network_link_addr *cliaddr,
-    const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data)
+    const struct sol_str_slice *href, const struct sol_vector *reprs, void *data)
 {
     struct client_resource *resource = data;
-    int r;
 
     if (!sol_str_slice_eq(*href, resource->resource->href)) {
         SOL_WRN("Received response to href=`%%.*s`, but resource href is `%%.*s`",
@@ -1040,54 +1047,8 @@ state_changed(struct sol_oic_client *oic_cli, const struct sol_network_link_addr
         return;
     }
 
-    r = resource->funcs->deserialize(resource, (const uint8_t *)payload->data, payload->len);
-    if (r >= 0)
+    if (resource->funcs->from_repr_vec(resource, reprs))
         resource->funcs->inform_flow(resource);
-}
-
-static void
-server_info_received(struct sol_oic_client *oic_cli, const struct sol_oic_server_information *info,
-    void *data)
-{
-    struct client_resource *resource = data;
-    int r;
-
-    /* Some OIC device sent this node a discovery response packet but node's already set up. */
-    if (resource->resource)
-        return;
-
-    if (info->api_version != SOL_OIC_SERVER_INFORMATION_API_VERSION) {
-        SOL_WRN("OIC server information API version mismatch");
-        goto out;
-    }
-
-    if (!info->device.id.len) {
-        SOL_WRN("No device ID present in server info");
-        goto out;
-    }
-
-    if (!sol_str_slice_str_eq(info->device.id, resource->device_id)) {
-        /* Not the droid we're looking for. */
-        return;
-    }
-
-    SOL_INF("Found resource matching device_id %%s", resource->device_id);
-    resource->resource = resource->tentative_resource;
-    resource->tentative_resource = NULL;
-
-    if (resource->find_timeout) {
-        sol_timeout_del(resource->find_timeout);
-        resource->find_timeout = NULL;
-    }
-
-    r = sol_oic_client_resource_set_observable(oic_cli, resource->resource, state_changed, resource, true);
-    if (!r)
-        SOL_WRN("Could not observe resource as requested, will try again");
-
-out:
-    r = sol_flow_send_boolean_packet(resource->node, resource->funcs->found_port, !!resource->resource);
-    if (r < 0)
-        SOL_WRN("Could not send flow packet, will try again");
 }
 
 static void
@@ -1097,23 +1058,38 @@ found_resource(struct sol_oic_client *oic_cli, struct sol_oic_resource *oic_res,
     int r;
 
     /* Some OIC device sent this node a discovery response packet but node's already set up. */
-    if (resource->resource)
-        goto out;
+    if (resource->resource) {
+        SOL_DBG("Received discovery packet when resource already set up, ignoring");
+        return;
+    }
+
+    if (!sol_str_slice_str_eq(oic_res->device_id, resource->device_id)) {
+        /* Not the droid we're looking for. */
+        SOL_DBG("Received resource with an unknown device_id, ignoring");
+        return;
+    }
 
     /* FIXME: Should this check move to sol-oic-client? Does it actually make sense? */
     if (resource->rt && !client_resource_implements_type(oic_res, resource->rt)) {
-        SOL_WRN("Received resource that does not implement rt=%%s, ignoring", resource->rt);
-        goto out;
+        SOL_DBG("Received resource that does not implement rt=%%s, ignoring", resource->rt);
+        return;
     }
 
-    resource->tentative_resource = sol_oic_resource_ref(oic_res);
-    if (sol_oic_client_get_server_info(oic_cli, oic_res, server_info_received, data))
-        return;
+    if (resource->find_timeout) {
+        sol_timeout_del(resource->find_timeout);
+        resource->find_timeout = NULL;
+    }
 
-    SOL_WRN("Could not create packet to obtain server information");
+    if (!sol_oic_client_resource_set_observable(oic_cli, resource->resource,
+        state_changed, resource, true)) {
+        SOL_WRN("Could not observe resource as requested, will try again");
+    }
 
-out:
-    r = sol_flow_send_boolean_packet(resource->node, resource->funcs->found_port, false);
+    SOL_INF("Found resource matching device_id %%s", resource->device_id);
+    resource->resource = sol_oic_resource_ref(oic_res);
+
+    r = sol_flow_send_boolean_packet(resource->node,
+        resource->funcs->found_port, true);
     if (r < 0)
         SOL_WRN("Could not send flow packet, will try again");
 }
@@ -1144,35 +1120,21 @@ find_timer(void *data)
     return true;
 }
 
-static char *
-create_endpoint(void)
-{
-    static int endpoint_id = 0;
-    char *endpoint;
-
-    if (asprintf(&endpoint, "/sol/%%x", endpoint_id) < 0)
-        return NULL;
-
-    endpoint_id++;
-    return endpoint;
-}
-
 static bool
 server_resource_perform_update(void *data)
 {
     struct server_resource *resource = data;
-    uint8_t *payload;
-    uint16_t payload_len;
+    struct sol_vector repr = SOL_VECTOR_INIT(struct sol_oic_repr_field);
 
-    SOL_NULL_CHECK(resource->funcs->serialize, false);
-    payload = resource->funcs->serialize(resource, &payload_len);
-    if (!payload) {
+    SOL_NULL_CHECK(resource->funcs->to_repr_vec, false);
+    if (!resource->funcs->to_repr_vec(resource, &repr)) {
         SOL_WRN("Error while serializing update message");
     } else {
         resource->funcs->inform_flow(resource);
-        sol_oic_notify_observers(resource->coap, payload, payload_len);
-        free(payload);
+        sol_oic_notify_observers(resource->resource, &repr);
     }
+
+    sol_vector_clear(&repr);
 
     resource->update_schedule_timeout = NULL;
     return false;
@@ -1190,46 +1152,33 @@ server_resource_schedule_update(struct server_resource *resource)
 
 static sol_coap_responsecode_t
 server_handle_put(const struct sol_network_link_addr *cliaddr, const void *data,
-    uint8_t *payload, uint16_t *payload_len)
+    const struct sol_vector *input, struct sol_vector *output)
 {
-    const struct server_resource *resource = data;
-    int r;
+    struct server_resource *resource = (struct server_resource *)data;
 
-    if (!resource->funcs->deserialize)
+    if (!resource->funcs->from_repr_vec)
         return SOL_COAP_RSPCODE_NOT_IMPLEMENTED;
 
-    r = resource->funcs->deserialize((struct server_resource *)resource, payload, *payload_len);
-    if (!r) {
-        server_resource_schedule_update((struct server_resource *)resource);
-        *payload_len = 0;
+    if (resource->funcs->from_repr_vec(resource, input)) {
+        server_resource_schedule_update(resource);
         return SOL_COAP_RSPCODE_CHANGED;
     }
+
     return SOL_COAP_RSPCODE_PRECONDITION_FAILED;
 }
 
 static sol_coap_responsecode_t
 server_handle_get(const struct sol_network_link_addr *cliaddr, const void *data,
-    uint8_t *payload, uint16_t *payload_len)
+    const struct sol_vector *input, struct sol_vector *output)
 {
     const struct server_resource *resource = data;
-    uint16_t serialized_len;
-    uint8_t *serialized;
 
-    if (!resource->funcs->serialize)
+    if (!resource->funcs->to_repr_vec)
         return SOL_COAP_RSPCODE_NOT_IMPLEMENTED;
 
-    serialized = resource->funcs->serialize((struct server_resource*)resource, &serialized_len);
-    if (!serialized)
+    if (!resource->funcs->to_repr_vec(resource, output))
         return SOL_COAP_RSPCODE_INTERNAL_ERROR;
 
-    if (serialized_len > *payload_len) {
-        free(serialized);
-        return SOL_COAP_RSPCODE_INTERNAL_ERROR;
-    }
-
-    memcpy(payload, serialized, serialized_len);
-    *payload_len = serialized_len;
-    free(serialized);
     return SOL_COAP_RSPCODE_CONTENT;
 }
 
@@ -1241,8 +1190,6 @@ server_resource_init(struct server_resource *resource, struct sol_flow_node *nod
     struct sol_str_slice resource_type, struct sol_str_slice defn_endpoint,
     const struct server_resource_funcs *funcs)
 {
-    struct sol_oic_device_definition *def;
-
     log_init();
 
     if (sol_oic_server_init(DEFAULT_UDP_PORT) != 0) {
@@ -1250,37 +1197,24 @@ server_resource_init(struct server_resource *resource, struct sol_flow_node *nod
         return -ENOTCONN;
     }
 
-    resource->endpoint = create_endpoint();
-    SOL_NULL_CHECK(resource->endpoint, -ENOMEM);
-
     resource->node = node;
     resource->update_schedule_timeout = NULL;
     resource->funcs = funcs;
 
-    resource->oic = (struct sol_oic_resource_type) {
+    resource->type = (struct sol_oic_resource_type) {
         .api_version = SOL_OIC_RESOURCE_TYPE_API_VERSION,
-        .endpoint = sol_str_slice_from_str(resource->endpoint),
         .resource_type = resource_type,
-        .iface = SOL_STR_SLICE_LITERAL("oc.mi.def"),
+        .interface = SOL_STR_SLICE_LITERAL("oc.mi.def"),
         .get = { .handle = server_handle_get },
         .put = { .handle = server_handle_put },
     };
 
-    def = sol_oic_server_register_definition(defn_endpoint, resource_type,
-        SOL_COAP_FLAGS_OC_CORE | SOL_COAP_FLAGS_WELL_KNOWN);
-    if (!def)
-        goto out;
+    resource->resource = sol_oic_server_add_resource(&resource->type,
+        resource, SOL_OIC_FLAG_DISCOVERABLE | SOL_OIC_FLAG_OBSERVABLE | SOL_OIC_FLAG_ACTIVE);
+    if (resource->resource)
+        return 0;
 
-    resource->coap = sol_oic_device_definition_register_resource_type(def,
-        &resource->oic, resource, SOL_COAP_FLAGS_OC_CORE | SOL_COAP_FLAGS_OBSERVABLE);
-    if (!resource->coap)
-        goto out;
-
-    return 0;
-
-out:
     sol_oic_server_release();
-    free(resource->endpoint);
     return -EINVAL;
 }
 
@@ -1289,7 +1223,7 @@ server_resource_close(struct server_resource *resource)
 {
     if (resource->update_schedule_timeout)
         sol_timeout_del(resource->update_schedule_timeout);
-    free(resource->endpoint);
+    sol_oic_server_del_resource(resource->resource);
     sol_oic_server_release();
 }
 
@@ -1298,6 +1232,7 @@ client_resource_init(struct sol_flow_node *node, struct client_resource *resourc
     const char *device_id, const struct client_resource_funcs *funcs)
 {
     log_init();
+
     if (!initialize_multicast_addresses_once()) {
         SOL_ERR("Could not initialize multicast addresses");
         return -ENOTCONN;
@@ -1305,7 +1240,7 @@ client_resource_init(struct sol_flow_node *node, struct client_resource *resourc
 
     assert(resource_type);
 
-    if (!device_id)
+    if (!device_id || strlen(device_id) != 32)
         return -EINVAL;
 
     resource->client.api_version = SOL_OIC_CLIENT_API_VERSION;
@@ -1366,23 +1301,23 @@ static bool
 client_resource_perform_update(void *data)
 {
     struct client_resource *resource = data;
-    uint8_t *payload;
-    uint16_t payload_len;
+    struct sol_vector repr = SOL_VECTOR_INIT(struct sol_oic_repr_field);
 
     SOL_NULL_CHECK_GOTO(resource->resource, disable_timeout);
-    SOL_NULL_CHECK_GOTO(resource->funcs->serialize, disable_timeout);
-    payload = resource->funcs->serialize(resource, &payload_len);
-    if (!payload) {
+    SOL_NULL_CHECK_GOTO(resource->funcs->to_repr_vec, disable_timeout);
+
+    if (!resource->funcs->to_repr_vec(resource, &repr)) {
         SOL_WRN("Error while serializing update message");
     } else {
         int r = sol_oic_client_resource_request(&resource->client, resource->resource,
-            SOL_COAP_METHOD_PUT, payload, payload_len, NULL, NULL);
-        free(payload);
+            SOL_COAP_METHOD_PUT, &repr, NULL, NULL);
         if (r < 0) {
             SOL_WRN("Could not send update request to resource, will try again");
             return true;
         }
     }
+
+    sol_vector_clear(&repr);
 
 disable_timeout:
     resource->update_schedule_timeout = NULL;
@@ -1399,74 +1334,13 @@ client_resource_schedule_update(struct client_resource *resource)
         client_resource_perform_update, resource);
 }
 
-static const char escapable_chars[] = {'\\\\', '\\"', '/', '\\b', '\\f', '\\n', '\\r', '\\t'};
-
-SOL_ATTR_USED static size_t
-calculate_escaped_len(const char *s)
-{
-    size_t len = 0;
-    for (; *s; s++) {
-        if (memchr(escapable_chars, *s, sizeof(escapable_chars)))
-            len++;
-        len++;
-    }
-    return len + 1;
-}
-
-SOL_ATTR_USED static char *
-escape_json_string(const char *s, char *buf)
-{
-    char *out = buf;
-
-    for (; *s; s++) {
-        if (memchr(escapable_chars, *s, sizeof(escapable_chars))) {
-            *buf++ = '\\\\';
-            switch (*s) {
-            case '"':  *buf++ = '"'; break;
-            case '\\\\': *buf++ = '\\\\'; break;
-            case '/':  *buf++ = '/'; break;
-            case '\\b': *buf++ = 'b'; break;
-            case '\\f': *buf++ = 'f'; break;
-            case '\\n': *buf++ = 'n'; break;
-            case '\\r': *buf++ = 'r'; break;
-            case '\\t': *buf++ = 't'; break;
-            }
-        } else {
-            *buf++ = *s;
-        }
-    }
-    *buf++ = '\\0';
-    return out;
-}
-
-#define ESCAPE_STRING(s) \
-    escape_json_string(s, alloca(calculate_escaped_len(s)))
-
-SOL_ATTR_USED static bool
-json_token_to_string(struct sol_json_token *token, char **out)
-{
-    if (sol_json_token_get_type(token) != SOL_JSON_TYPE_STRING)
-        return false;
-    free(*out);
-    *out = strndup(token->start, token->end - token->start);
-    return !!*out;
-}
-
-SOL_ATTR_USED static bool
-json_token_to_bool(struct sol_json_token *token, bool *out)
-{
-    if (sol_json_token_get_type(token) == SOL_JSON_TYPE_TRUE)
-        *out = true;
-    else if (sol_json_token_get_type(token) == SOL_JSON_TYPE_FALSE)
-        *out = false;
-    else
-        return false;
-    return true;
-}
+#define RETURN_ERROR(errcode) do { err = (errcode); goto out; } while(0)
 
 %(generated_c_common)s
 %(generated_c_client)s
 %(generated_c_server)s
+
+#undef RETURN_ERROR
 
 #include "%(oic_gen_c)s"
 ''' % {

--- a/src/lib/common/include/sol-platform.h
+++ b/src/lib/common/include/sol-platform.h
@@ -103,10 +103,10 @@ const char *sol_platform_get_sw_version(void);
  * Retrieves the operating system's version that Soletta is running
  * on top of.
  *
- * @return On success, it returns the version string, that must be
- * freed after usage. On error, it returns @c NULL.
+ * @return On success, it returns the version string. This string should
+ * not be freed after usage. On error, it returns @c NULL.
  */
-char *sol_platform_get_os_version(void);
+const char *sol_platform_get_os_version(void);
 
 enum sol_platform_state {
     SOL_PLATFORM_STATE_INITIALIZING,

--- a/src/lib/common/sol-platform.c
+++ b/src/lib/common/sol-platform.c
@@ -393,7 +393,7 @@ sol_platform_get_sw_version(void)
     return VERSION;
 }
 
-SOL_API char *
+SOL_API const char *
 sol_platform_get_os_version(void)
 {
     int r;

--- a/src/lib/comms/Kconfig
+++ b/src/lib/comms/Kconfig
@@ -39,7 +39,7 @@ config COAP
 config OIC
 	bool "OIC"
 	default y
-	depends on COAP
+	depends on COAP && HAVE_TINYCBOR_SRC
 	help
             Implementation of protocol defined by Open Interconnect Consortium
             (OIC - http://openinterconnect.org/)

--- a/src/lib/comms/Makefile
+++ b/src/lib/comms/Makefile
@@ -16,8 +16,20 @@ obj-networking-$(COAP) += \
     sol-coap.o
 
 obj-networking-$(OIC) += \
+    sol-oic-cbor.o \
     sol-oic-client.o \
-    sol-oic-server.o
+    sol-oic-server.o \
+    $(TINYCBOR_SRC_PATH)/cborencoder.o \
+    $(TINYCBOR_SRC_PATH)/cborerrorstrings.o \
+    $(TINYCBOR_SRC_PATH)/cborparser.o \
+    $(TINYCBOR_SRC_PATH)/cborpretty.o
+
+obj-networking-$(OIC)-extra-cflags := \
+    -I$(TINYCBOR_SRC_PATH) \
+    -Wno-cpp \
+    -Wno-declaration-after-statement \
+    -Wno-float-equal \
+    -Wno-undef
 
 obj-networking-$(HTTP) += \
     sol-http-common.o
@@ -53,8 +65,10 @@ headers-networking-$(COAP) += \
     include/sol-coap.h
 
 headers-networking-$(OIC) += \
+    include/sol-oic-common.h \
     include/sol-oic-client.h \
-    include/sol-oic-server.h
+    include/sol-oic-server.h \
+    sol-oic-cbor.h
 
 headers-networking-$(HTTP) += \
     include/sol-http.h

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -204,11 +204,6 @@ struct sol_coap_packet *sol_coap_packet_notification_new(struct sol_coap_server 
 struct sol_coap_packet *sol_coap_packet_ref(struct sol_coap_packet *pkt);
 void sol_coap_packet_unref(struct sol_coap_packet *pkt);
 
-/* FIXME - remove this function.
- * Some refactory will be needed before removing it, so it's exposed this
- * way by now - DO NOT add other users for this function. */
-int sol_coap_packet_get_buf(struct sol_coap_packet *pkt, uint8_t **buf, uint16_t *len);
-
 int sol_coap_packet_get_payload(struct sol_coap_packet *pkt, uint8_t **buf, uint16_t *len);
 int sol_coap_packet_set_payload_used(struct sol_coap_packet *pkt, uint16_t len);
 bool sol_coap_packet_has_payload(struct sol_coap_packet *pkt);

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -144,11 +144,7 @@ typedef enum {
 enum sol_coap_flags {
     SOL_COAP_FLAGS_NONE       = 0,
     /* If the resource should be exported in the CoRE well-known registry. */
-    SOL_COAP_FLAGS_WELL_KNOWN = (1 << 1),
-    /* If the resource should be exported in the OIC well-known registry. */
-    SOL_COAP_FLAGS_OC_CORE    = (1 << 2),
-    /* If the resource is observable, i.e. it is able to notified. */
-    SOL_COAP_FLAGS_OBSERVABLE = (1 << 3)
+    SOL_COAP_FLAGS_WELL_KNOWN = (1 << 1)
 };
 
 struct sol_coap_packet;

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -137,6 +137,7 @@ typedef enum {
     SOL_COAP_CONTENTTYPE_NONE = -1,
     SOL_COAP_CONTENTTYPE_TEXT_PLAIN = 0,
     SOL_COAP_CONTENTTYPE_APPLICATION_LINKFORMAT = 40,
+    SOL_COAP_CONTENTTYPE_APPLICATION_CBOR = 60, /* RFC7049 */
     SOL_COAP_CONTENTTYPE_APPLICATION_JSON = 50,
 } sol_coap_content_type_t;
 
@@ -219,7 +220,7 @@ bool sol_coap_packet_has_payload(struct sol_coap_packet *pkt);
 int sol_coap_add_option(struct sol_coap_packet *pkt, uint16_t code, const void *value, uint16_t len);
 int sol_coap_packet_add_uri_path_option(struct sol_coap_packet *pkt, const char *uri);
 
-const void *sol_coap_find_first_option(struct sol_coap_packet *pkt, uint16_t code, uint16_t *len);
+const void *sol_coap_find_first_option(const struct sol_coap_packet *pkt, uint16_t code, uint16_t *len);
 
 int sol_coap_send_packet(struct sol_coap_server *server, struct sol_coap_packet *pkt,
     const struct sol_network_link_addr *cliaddr);

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -235,6 +235,8 @@ int sol_coap_packet_send_notification(struct sol_coap_server *server,
 
 bool sol_coap_server_register_resource(struct sol_coap_server *server,
     const struct sol_coap_resource *resource, void *data);
+int sol_coap_server_unregister_resource(struct sol_coap_server *server,
+    const struct sol_coap_resource *resource);
 
 int sol_coap_uri_path_to_buf(const struct sol_str_slice path[],
     uint8_t *buf, size_t buflen);

--- a/src/lib/comms/include/sol-oic-client.h
+++ b/src/lib/comms/include/sol-oic-client.h
@@ -43,6 +43,8 @@
 extern "C" {
 #endif
 
+#include "sol-oic-common.h"
+
 /**
  * @file
  * @brief Routines to create clients talking OIC protocol.
@@ -73,11 +75,12 @@ struct sol_oic_client {
 };
 
 struct sol_oic_resource {
-#define SOL_OIC_RESOURCE_API_VERSION (1)
+#define SOL_OIC_RESOURCE_API_VERSION (2)
     uint16_t api_version;
     int : 0; /* save possible hole for a future field */
     struct sol_network_link_addr addr;
     struct sol_str_slice href;
+    struct sol_str_slice device_id;
     struct sol_vector types;
     struct sol_vector interfaces;
     struct {
@@ -86,6 +89,9 @@ struct sol_oic_resource {
     } observe;
     int refcnt;
     bool observable : 1;
+    bool active : 1;
+    bool slow : 1;
+    bool secure : 1;
 };
 
 bool sol_oic_client_find_resource(struct sol_oic_client *client,
@@ -95,7 +101,6 @@ bool sol_oic_client_find_resource(struct sol_oic_client *client,
     void *data),
     void *data);
 
-struct sol_oic_server_information;
 bool sol_oic_client_get_server_info(struct sol_oic_client *client,
     struct sol_oic_resource *resource,
     void (*info_received_cb)(struct sol_oic_client *cli,
@@ -103,14 +108,14 @@ bool sol_oic_client_get_server_info(struct sol_oic_client *client,
     void *data);
 
 bool sol_oic_client_resource_request(struct sol_oic_client *client, struct sol_oic_resource *res,
-    sol_coap_method_t method, uint8_t *payload, size_t payload_len,
+    sol_coap_method_t method, const struct sol_vector *reprs,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data),
+    const struct sol_str_slice *href, const struct sol_vector *reprs, void *data),
     void *data);
 
 bool sol_oic_client_resource_set_observable(struct sol_oic_client *client, struct sol_oic_resource *res,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data),
+    const struct sol_str_slice *href, const struct sol_vector *reprs, void *data),
     void *data, bool observe);
 
 struct sol_oic_resource *sol_oic_resource_ref(struct sol_oic_resource *r);

--- a/src/lib/comms/include/sol-oic-common.h
+++ b/src/lib/comms/include/sol-oic-common.h
@@ -1,0 +1,116 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <sol-coap.h>
+#include <sol-vector.h>
+
+struct sol_oic_server_information {
+#define SOL_OIC_SERVER_INFORMATION_API_VERSION (2)
+    uint16_t api_version;
+    int : 0; /* save possible hole for a future field */
+
+    /* All fields are required by the spec.  Some of the fields are
+     * obtained in runtime (such as system time, OS version, device ID),
+     * and are not user-specifiable. */
+    struct sol_str_slice platform_id;
+    struct sol_str_slice manufacturer_name;
+    struct sol_str_slice manufacturer_url;
+    struct sol_str_slice model_number;
+    struct sol_str_slice manufacture_date;
+    struct sol_str_slice platform_version;
+    struct sol_str_slice hardware_version;
+    struct sol_str_slice firmware_version;
+    struct sol_str_slice support_url;
+
+    /* Read-only fields. */
+    struct sol_str_slice os_version;
+    struct sol_str_slice system_time;
+};
+
+enum sol_oic_resource_flag {
+    SOL_OIC_FLAG_DISCOVERABLE = 1 << 0,
+        SOL_OIC_FLAG_OBSERVABLE = 1 << 1,
+        SOL_OIC_FLAG_ACTIVE = 1 << 2,
+        SOL_OIC_FLAG_SLOW = 1 << 3,
+        SOL_OIC_FLAG_SECURE = 1 << 4
+};
+
+enum sol_oic_repr_type {
+    SOL_OIC_REPR_TYPE_UINT,
+    SOL_OIC_REPR_TYPE_INT,
+    SOL_OIC_REPR_TYPE_SIMPLE,
+    SOL_OIC_REPR_TYPE_TEXT_STRING,
+    SOL_OIC_REPR_TYPE_BYTE_STRING,
+    SOL_OIC_REPR_TYPE_HALF_FLOAT,
+    SOL_OIC_REPR_TYPE_FLOAT,
+    SOL_OIC_REPR_TYPE_DOUBLE,
+    SOL_OIC_REPR_TYPE_BOOLEAN
+};
+
+struct sol_oic_repr_field {
+    enum sol_oic_repr_type type;
+    const char *key;
+    union {
+        uint64_t v_uint;
+        int64_t v_int;
+        uint8_t v_simple;
+        struct sol_str_slice v_slice;
+        float v_float;
+        double v_double;
+        void *v_voidptr;
+        bool v_boolean;
+    };
+};
+
+#define SOL_OIC_REPR_FIELD(key_, type_, ...) \
+    (struct sol_oic_repr_field){.type = (type_), .key = (key_), __VA_ARGS__ }
+
+#define SOL_OIC_REPR_UINT(key_, value_) \
+    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_UINT, .v_uint = (value_))
+#define SOL_OIC_REPR_INT(key_, value_) \
+    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_INT, .v_int = (value_))
+#define SOL_OIC_REPR_BOOLEAN(key_, value_) \
+    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_BOOLEAN, .v_boolean = !!(value_))
+#define SOL_OIC_REPR_SIMPLE(key_, value_) \
+    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_SIMPLE, .v_simple = (value_))
+#define SOL_OIC_REPR_TEXT_STRING(key_, value_, len_) \
+    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_TEXT_STRING, .v_slice = SOL_STR_SLICE_STR((value_), (len_)))
+#define SOL_OIC_REPR_BYTE_STRING(key_, value_, len_) \
+    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_BYTE_STRING, .v_slice = SOL_STR_SLICE_STR((value_), (len_)))
+#define SOL_OIC_REPR_HALF_FLOAT(key_, value_) \
+    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_HALF_FLOAT, .v_voidptr = (value_))
+#define SOL_OIC_REPR_FLOAT(key_, value_) \
+    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_FLOAT, .v_float = (value_))
+#define SOL_OIC_REPR_DOUBLE(key_, value_) \
+    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_DOUBLE, .v_double = (value_))

--- a/src/lib/comms/include/sol-oic-server.h
+++ b/src/lib/comms/include/sol-oic-server.h
@@ -39,6 +39,8 @@
 extern "C" {
 #endif
 
+#include "sol-oic-common.h"
+
 /**
  * @file
  * @brief Routines to create servers talking OIC protocol.
@@ -50,95 +52,57 @@ extern "C" {
  * @{
  */
 
-#ifndef OIC_DEVICE_NAME
-#define OIC_DEVICE_NAME "Soletta OIC Device"
-#endif
-#ifndef OIC_DEVICE_RESOURCE_TYPE
-#define OIC_DEVICE_RESOURCE_TYPE "oc.core"
-#endif
 #ifndef OIC_MANUFACTURER_NAME
-#define OIC_MANUFACTURER_NAME "Custom"
+# define OIC_MANUFACTURER_NAME "Soletta"
 #endif
-#ifndef OIC_MANUFACTORER_MODEL
-#define OIC_MANUFACTORER_MODEL "Custom"
+#ifndef OIC_MANUFACTURER_URL
+# define OIC_MANUFACTURER_URL "https://soletta-project.org"
 #endif
-#ifndef OIC_MANUFACTORER_DATE
-#define OIC_MANUFACTORER_DATE "2015-01-01"
+#ifndef OIC_MODEL_NUMBER
+# define OIC_MODEL_NUMBER "Unknown"
 #endif
-#ifndef OIC_INTERFACE_VERSION
-#define OIC_INTERFACE_VERSION "1.0"
+#ifndef OIC_MANUFACTURE_DATE
+# define OIC_MANUFACTURE_DATE "2015-01-01"
 #endif
 #ifndef OIC_PLATFORM_VERSION
-#define OIC_PLATFORM_VERSION "1.0"
+# define OIC_PLATFORM_VERSION "Unknown"
+#endif
+#ifndef OIC_HARDWARE_VERSION
+# define OIC_HARDWARE_VERSION "Unknown"
 #endif
 #ifndef OIC_FIRMWARE_VERSION
-#define OIC_FIRMWARE_VERSION "1.0"
+# define OIC_FIRMWARE_VERSION "Unknown"
 #endif
-#ifndef OIC_SUPPORT_LINK
-#define OIC_SUPPORT_LINK "http://solettaproject.org/support/"
-#endif
-#ifndef OIC_LOCATION
-#define OIC_LOCATION "Unknown"
-#endif
-#ifndef OIC_EPI
-#define OIC_EPI ""
+#ifndef OIC_SUPPORT_URL
+# define OIC_SUPPORT_URL "Unknown"
 #endif
 
-struct sol_oic_device_definition;
-
-struct sol_oic_server_information {
-#define SOL_OIC_SERVER_INFORMATION_API_VERSION (1)
-    uint16_t api_version;
-    int : 0; /* save possible hole for a future field */
-
-    /* All fields are required by the spec. */
-    struct {
-        struct sol_str_slice name;
-        struct sol_str_slice resource_type;
-        struct sol_str_slice id;
-    } device;
-    struct {
-        struct sol_str_slice name;
-        struct sol_str_slice model;
-        struct sol_str_slice date;
-    } manufacturer;
-    struct {
-        struct sol_str_slice version;
-    } interface, platform, firmware;
-    struct sol_str_slice support_link;
-    struct sol_str_slice location;
-    struct sol_str_slice epi;
-};
+struct sol_oic_server_resource;
 
 struct sol_oic_resource_type {
 #define SOL_OIC_RESOURCE_TYPE_API_VERSION (1)
     uint16_t api_version;
     int : 0; /* save possible hole for a future field */
 
-    struct sol_str_slice endpoint;
     struct sol_str_slice resource_type;
-    struct sol_str_slice iface;
+    struct sol_str_slice interface;
 
     struct {
         sol_coap_responsecode_t (*handle)(const struct sol_network_link_addr *cliaddr,
-            const void *data, uint8_t *payload, uint16_t *payload_len);
+            const void *data, const struct sol_vector *input, struct sol_vector *output);
     } get, put, post, delete;
 };
 
 int sol_oic_server_init(int port);
 void sol_oic_server_release(void);
 
-struct sol_oic_device_definition *sol_oic_server_get_definition(struct sol_str_slice endpoint,
-    struct sol_str_slice resource_type_prefix);
-struct sol_oic_device_definition *sol_oic_server_register_definition(struct sol_str_slice endpoint,
-    struct sol_str_slice resource_type_prefix, enum sol_coap_flags flags);
-bool sol_oic_server_unregister_definition(const struct sol_oic_device_definition *definition);
+struct sol_oic_server_resource *sol_oic_server_add_resource(
+    const struct sol_oic_resource_type *rt, const void *handler_data,
+    enum sol_oic_resource_flag flags);
+void sol_oic_server_del_resource(struct sol_oic_server_resource *resource);
 
-struct sol_coap_resource *sol_oic_device_definition_register_resource_type(
-    struct sol_oic_device_definition *definition,
-    const struct sol_oic_resource_type *resource_type,
-    void *handler_data, enum sol_coap_flags flags);
-bool sol_oic_notify_observers(struct sol_coap_resource *resource, uint8_t *msg, uint16_t msg_len);
+bool sol_oic_notify_observers(struct sol_oic_server_resource *resource,
+    const struct sol_vector *repr);
 
 /**
  * @}

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -1285,19 +1285,6 @@ sol_coap_server_new(int port)
 }
 
 SOL_API int
-sol_coap_packet_get_buf(struct sol_coap_packet *pkt, uint8_t **buf, uint16_t *len)
-{
-    SOL_NULL_CHECK(pkt, -EINVAL);
-    SOL_NULL_CHECK(buf, -EINVAL);
-    SOL_NULL_CHECK(len, -EINVAL);
-
-    *buf = pkt->buf;
-    *len = sizeof(pkt->buf);
-
-    return 0;
-}
-
-SOL_API int
 sol_coap_packet_get_payload(struct sol_coap_packet *pkt, uint8_t **buf, uint16_t *len)
 {
     SOL_NULL_CHECK(pkt, -EINVAL);

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -59,15 +59,6 @@ SOL_LOG_INTERNAL_DECLARE(_sol_coap_log_domain, "coap");
 #define IPV6_ALL_COAP_NODES_SCOPE_LOCAL "ff02::fd"
 #define IPV6_ALL_COAP_NODES_SCOPE_SITE "ff05::fd"
 
-#define OC_CORE_JSON_START "{\"oc\":["
-#define OC_CORE_ELEM_JSON_START "{\"href\":\"%s\",\"prop\":{"
-#define OC_CORE_PROP_JSON_STRING "\"%s\":[\"%s\"]"
-#define OC_CORE_PROP_JSON_SLICE "\"%s\":[\"%.*s\"]"
-#define OC_CORE_JSON_SEPARATOR ","
-#define OC_CORE_PROP_JSON_NUMBER "\"%s\":%d"
-#define OC_CORE_ELEM_JSON_END "}}"
-#define OC_CORE_JSON_END "]}"
-
 /*
  * FIXME: use a random number between ACK_TIMEOUT (2000ms)
  * and ACK_TIMEOUT * ACK_RANDOM_FACTOR (3000ms)
@@ -511,6 +502,7 @@ enqueue_packet(struct sol_coap_server *server, struct sol_coap_packet *pkt,
     struct outgoing *outgoing;
     int r;
 
+    SOL_NULL_CHECK(server, -EINVAL);
     SOL_NULL_CHECK(cliaddr, -EINVAL);
 
     outgoing = calloc(1, sizeof(*outgoing));
@@ -813,7 +805,7 @@ sol_coap_packet_add_uri_path_option(struct sol_coap_packet *pkt, const char *uri
 }
 
 SOL_API const void *
-sol_coap_find_first_option(struct sol_coap_packet *pkt, uint16_t code, uint16_t *len)
+sol_coap_find_first_option(const struct sol_coap_packet *pkt, uint16_t code, uint16_t *len)
 {
     struct sol_coap_option_value option = {};
     uint16_t count = 1;
@@ -828,126 +820,6 @@ sol_coap_find_first_option(struct sol_coap_packet *pkt, uint16_t code, uint16_t 
 
     return option.value;
 }
-
-/* This expects that 'errno' is set to zero when it is called. */
-static int
-snprintf_safe(char *ptr, ssize_t len, const char *format, ...)
-{
-    va_list ap;
-    int r;
-
-    if (errno)
-        return 0;
-
-    if (len < 0) {
-        errno = ENOMEM;
-        return 0;
-    }
-
-    va_start(ap, format);
-    r = vsnprintf(ptr, len, format, ap);
-    va_end(ap);
-
-    /* The message got truncated. */
-    if (r >= len) {
-        errno = ENOBUFS;
-        return 0;
-    }
-
-    /* This expects that snprintf() sets errno when the return is negative. */
-    if (r < 0)
-        r = 0;
-
-    return r;
-}
-
-static int
-oc_core_get(const struct sol_coap_resource *resource, struct sol_coap_packet *req,
-    const struct sol_network_link_addr *cliaddr, void *data)
-{
-    struct sol_coap_server *server = data;
-    struct sol_vector *v = &server->contexts;
-    struct sol_coap_packet *resp;
-    uint16_t size, len;
-    uint8_t format_json = SOL_COAP_CONTENTTYPE_APPLICATION_JSON;
-    uint8_t *payload;
-    char *p;
-    int i;
-
-    resp = sol_coap_packet_new(req);
-    SOL_NULL_CHECK(resp, -ENOMEM);
-
-    sol_coap_header_set_type(resp, SOL_COAP_TYPE_ACK);
-    sol_coap_add_option(resp, SOL_COAP_OPTION_CONTENT_FORMAT, &format_json, sizeof(format_json));
-
-    sol_coap_packet_get_payload(resp, &payload, &size);
-    p = (char *)payload;
-
-    errno = 0;
-
-    len = snprintf_safe(p, size, OC_CORE_JSON_START);
-
-    for (i = 0; i < v->len && !errno; i++) {
-        struct resource_context *c = sol_vector_get(v, i);
-        const struct sol_coap_resource *r = c->resource;
-        uint8_t path[64];
-        int obs;
-
-        if (len >= size)
-            break;
-
-        if (!(r->flags & SOL_COAP_FLAGS_OC_CORE))
-            continue;
-
-        memset(&path, 0, sizeof(path));
-        sol_coap_uri_path_to_buf(r->path, path, sizeof(path));
-
-        len += snprintf_safe(p + len, size - len, OC_CORE_ELEM_JSON_START, path);
-
-        if (r->iface.len != 0) {
-            len += snprintf_safe(p + len, size - len, OC_CORE_PROP_JSON_SLICE, "if", r->iface.len, r->iface.data);
-            len += snprintf_safe(p + len, size - len, OC_CORE_JSON_SEPARATOR);
-        }
-
-        if (r->resource_type.len != 0) {
-            len += snprintf_safe(p + len, size - len, OC_CORE_PROP_JSON_SLICE, "rt", r->resource_type.len, r->resource_type.data);
-            len += snprintf_safe(p + len, size - len, OC_CORE_JSON_SEPARATOR);
-        }
-
-        obs = !!(r->flags & SOL_COAP_FLAGS_OBSERVABLE);
-
-        len += snprintf_safe(p + len, size - len, OC_CORE_PROP_JSON_NUMBER, "obs", obs);
-        len += snprintf_safe(p + len, size - len, OC_CORE_ELEM_JSON_END);
-
-        if (i + 1 < v->len)
-            len += snprintf_safe(p + len, size - len, OC_CORE_JSON_SEPARATOR);
-    }
-    len += snprintf_safe(p + len, size - len, OC_CORE_JSON_END);
-
-    /* 'snprintf_safe' sets errno when error occurs. */
-    if (errno) {
-        char addr[SOL_INET_ADDR_STRLEN];
-        sol_network_addr_to_str(cliaddr, addr, sizeof(addr));
-        SOL_WRN("Error building response for /oc/core, server %p client %s: %s", server,
-            addr, sol_util_strerrora(errno));
-
-        sol_coap_header_set_code(resp, SOL_COAP_RSPCODE_INTERNAL_ERROR);
-    } else {
-        sol_coap_header_set_code(resp, SOL_COAP_RSPCODE_CONTENT);
-        sol_coap_packet_set_payload_used(resp, len);
-    }
-
-    return sol_coap_send_packet(server, resp, cliaddr);
-}
-
-static struct sol_coap_resource oc_core = {
-    .path = {
-        SOL_STR_SLICE_LITERAL("oc"),
-        SOL_STR_SLICE_LITERAL("core"),
-        SOL_STR_SLICE_EMPTY
-    },
-    .get = oc_core_get,
-};
 
 static int
 well_known_get(const struct sol_coap_resource *resource, struct sol_coap_packet *req,
@@ -1008,7 +880,7 @@ error:
     return sol_coap_send_packet(server, resp, cliaddr);
 }
 
-static struct sol_coap_resource well_known = {
+static const struct sol_coap_resource well_known = {
     .path = {
         SOL_STR_SLICE_LITERAL(".well-known"),
         SOL_STR_SLICE_LITERAL("core"),
@@ -1164,11 +1036,6 @@ respond_packet(struct sol_coap_server *server, struct sol_coap_packet *req,
         }
         return 0;
     }
-
-    /* /oc/core well known resource */
-    cb = find_resource_cb(req, &oc_core);
-    if (cb)
-        return cb(&oc_core, req, cliaddr, server);
 
     /* /.well-known/core well known resource */
     cb = find_resource_cb(req, &well_known);

--- a/src/lib/comms/sol-oic-cbor.c
+++ b/src/lib/comms/sol-oic-cbor.c
@@ -1,0 +1,236 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sol-log.h"
+#include "sol-oic-cbor.h"
+#include "sol-oic-common.h"
+
+CborError
+sol_oic_encode_cbor_repr(struct sol_coap_packet *pkt,
+    const char *href, const struct sol_vector *repr_vec)
+{
+    CborEncoder encoder, rep_map, array, map;
+    CborError err;
+    uint8_t *payload;
+    uint16_t size;
+
+    if (!repr_vec)
+        return CborNoError;
+
+    if (sol_coap_packet_get_payload(pkt, &payload, &size) < 0) {
+        SOL_WRN("Could not get CoAP payload");
+        return CborUnknownError;
+    }
+
+    cbor_encoder_init(&encoder, payload, size, 0);
+
+    err = cbor_encoder_create_array(&encoder, &array, CborIndefiniteLength);
+    err |= cbor_encode_uint(&array, SOL_OIC_PAYLOAD_REPRESENTATION);
+
+    err |= cbor_encoder_create_map(&array, &map, CborIndefiniteLength);
+
+    err |= cbor_encode_text_stringz(&map, SOL_OIC_KEY_HREF);
+    err |= cbor_encode_text_stringz(&map, href);
+
+    err |= cbor_encode_text_stringz(&map, SOL_OIC_KEY_REPRESENTATION);
+    err |= cbor_encoder_create_map(&map, &rep_map, CborIndefiniteLength);
+
+    if (repr_vec) {
+        struct sol_oic_repr_field *repr;
+        uint16_t idx;
+
+        SOL_VECTOR_FOREACH_IDX (repr_vec, repr, idx) {
+            if (err != CborNoError)
+                break;
+
+            err |= cbor_encode_text_stringz(&rep_map, repr->key);
+
+            switch (repr->type) {
+            case SOL_OIC_REPR_TYPE_UINT:
+                err |= cbor_encode_uint(&rep_map, repr->v_uint);
+                break;
+            case SOL_OIC_REPR_TYPE_INT:
+                err |= cbor_encode_int(&rep_map, repr->v_int);
+                break;
+            case SOL_OIC_REPR_TYPE_SIMPLE:
+                err |= cbor_encode_simple_value(&rep_map, repr->v_simple);
+                break;
+            case SOL_OIC_REPR_TYPE_TEXT_STRING:
+                err |= cbor_encode_text_string(&rep_map, repr->v_slice.data, repr->v_slice.len);
+                break;
+            case SOL_OIC_REPR_TYPE_BYTE_STRING:
+                err |= cbor_encode_byte_string(&rep_map, (const uint8_t *)repr->v_slice.data, repr->v_slice.len);
+                break;
+            case SOL_OIC_REPR_TYPE_HALF_FLOAT:
+                err |= cbor_encode_half_float(&rep_map, repr->v_voidptr);
+                break;
+            case SOL_OIC_REPR_TYPE_FLOAT:
+                err |= cbor_encode_float(&rep_map, repr->v_float);
+                break;
+            case SOL_OIC_REPR_TYPE_DOUBLE:
+                err |= cbor_encode_double(&rep_map, repr->v_double);
+                break;
+            case SOL_OIC_REPR_TYPE_BOOLEAN:
+                err |= cbor_encode_boolean(&rep_map, repr->v_boolean);
+                break;
+            default:
+                if (err == CborNoError)
+                    err = CborErrorUnknownType;
+            }
+        }
+    }
+
+    err |= cbor_encoder_close_container(&map, &rep_map);
+
+    err |= cbor_encoder_close_container(&array, &map);
+
+    err |= cbor_encoder_close_container(&encoder, &array);
+
+    if (err == CborNoError)
+        sol_coap_packet_set_payload_used(pkt, encoder.ptr - payload);
+
+    return err;
+}
+
+CborError
+sol_oic_decode_cbor_repr_map(CborValue *map, struct sol_vector *reprs)
+{
+    struct sol_oic_repr_field *repr;
+    CborValue value;
+    CborError err;
+    size_t len;
+
+    if (!cbor_value_is_map(map))
+        return CborInvalidType;
+
+    err = cbor_value_enter_container(map, &value);
+    for (; cbor_value_is_valid(&value) && err == CborNoError;
+        err |= cbor_value_advance(&value)) {
+        repr = sol_vector_append(reprs);
+        if (!repr)
+            return CborErrorOutOfMemory;
+
+        err |= cbor_value_dup_text_string(&value, (char **)&repr->key, &len, NULL);
+        err |= cbor_value_advance(&value);
+
+        switch (cbor_value_get_type(&value)) {
+        case CborIntegerType:
+            err |= cbor_value_get_int64(&value, &repr->v_int);
+            repr->type = SOL_OIC_REPR_TYPE_INT;
+            break;
+        case CborTextStringType:
+            err |= cbor_value_dup_text_string(&value, (char **)&repr->v_slice.data, &repr->v_slice.len, NULL);
+            if (err != CborNoError)
+                goto harmless;
+            repr->type = SOL_OIC_REPR_TYPE_TEXT_STRING;
+            break;
+        case CborByteStringType:
+            err |= cbor_value_dup_byte_string(&value, (uint8_t **)&repr->v_slice.data, &repr->v_slice.len, NULL);
+            if (err != CborNoError)
+                goto harmless;
+            repr->type = SOL_OIC_REPR_TYPE_BYTE_STRING;
+            break;
+        case CborDoubleType:
+            err |= cbor_value_get_double(&value, &repr->v_double);
+            repr->type = SOL_OIC_REPR_TYPE_DOUBLE;
+            break;
+        case CborFloatType:
+            err |= cbor_value_get_float(&value, &repr->v_float);
+            repr->type = SOL_OIC_REPR_TYPE_FLOAT;
+            break;
+        case CborHalfFloatType:
+            err |= cbor_value_get_half_float(&value, &repr->v_voidptr);
+            repr->type = SOL_OIC_REPR_TYPE_HALF_FLOAT;
+            break;
+        case CborBooleanType:
+            err |= cbor_value_get_boolean(&value, &repr->v_boolean);
+            repr->type = SOL_OIC_REPR_TYPE_BOOLEAN;
+            break;
+        default:
+            SOL_ERR("While parsing representation map, got unexpected type %d",
+                cbor_value_get_type(&value));
+            if (err == CborNoError)
+                err = CborErrorUnknownType;
+
+harmless:
+            /* Initialize repr with harmless data so cleanup works. */
+            repr->v_boolean = false;
+            repr->type = SOL_OIC_REPR_TYPE_BOOLEAN;
+        }
+    }
+
+    return err | cbor_value_leave_container(map, &value);
+}
+
+CborError
+sol_oic_decode_cbor_repr(struct sol_coap_packet *pkt, struct sol_vector *reprs)
+{
+    CborParser parser;
+    CborError err;
+    CborValue root, array;
+    uint8_t *payload;
+    uint16_t size;
+    int payload_type;
+
+    if (sol_coap_packet_get_payload(pkt, &payload, &size) < 0)
+        return CborErrorUnknownLength;
+
+    err = cbor_parser_init(payload, size, 0, &parser, &root);
+    if (err != CborNoError)
+        return err;
+
+    if (!cbor_value_is_array(&root))
+        return CborErrorIllegalType;
+
+    err |= cbor_value_enter_container(&root, &array);
+
+    err |= cbor_value_get_int(&array, &payload_type);
+    err |= cbor_value_advance_fixed(&array);
+    if (err != CborNoError)
+        return err;
+    if (payload_type != SOL_OIC_PAYLOAD_REPRESENTATION)
+        return CborErrorIllegalType;
+
+    err |= sol_oic_decode_cbor_repr_map(&array, reprs);
+    return err | cbor_value_leave_container(&root, &array);
+}
+
+bool
+sol_oic_pkt_has_cbor_content(const struct sol_coap_packet *pkt)
+{
+    const uint8_t *ptr;
+    uint16_t len;
+
+    ptr = sol_coap_find_first_option(pkt, SOL_COAP_OPTION_CONTENT_FORMAT, &len);
+
+    return ptr && len == 1 && *ptr == SOL_COAP_CONTENTTYPE_APPLICATION_CBOR;
+}

--- a/src/lib/comms/sol-oic-cbor.h
+++ b/src/lib/comms/sol-oic-cbor.h
@@ -1,0 +1,72 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "cbor.h"
+#include "sol-coap.h"
+#include "sol-oic-common.h"
+#include "sol-vector.h"
+
+CborError sol_oic_encode_cbor_repr(struct sol_coap_packet *pkt, const char *href, const struct sol_vector *reprs);
+
+CborError sol_oic_decode_cbor_repr(struct sol_coap_packet *pkt, struct sol_vector *reprs);
+CborError sol_oic_decode_cbor_repr_map(CborValue *map, struct sol_vector *reprs);
+
+bool sol_oic_pkt_has_cbor_content(const struct sol_coap_packet *pkt);
+
+enum sol_oic_payload_type {
+    SOL_OIC_PAYLOAD_DISCOVERY = 1,
+    SOL_OIC_PAYLOAD_PLATFORM = 3,
+    SOL_OIC_PAYLOAD_REPRESENTATION = 4,
+};
+
+#define SOL_OIC_KEY_REPRESENTATION "rep"
+#define SOL_OIC_KEY_HREF "href"
+#define SOL_OIC_KEY_PLATFORM_ID "pi"
+#define SOL_OIC_KEY_MANUF_NAME "mnmn"
+#define SOL_OIC_KEY_MANUF_URL "mnml"
+#define SOL_OIC_KEY_MODEL_NUM "mnmo"
+#define SOL_OIC_KEY_MANUF_DATE "mndt"
+#define SOL_OIC_KEY_PLATFORM_VER "mnpv"
+#define SOL_OIC_KEY_OS_VER "mnos"
+#define SOL_OIC_KEY_HW_VER "mnhw"
+#define SOL_OIC_KEY_FIRMWARE_VER "mnfv"
+#define SOL_OIC_KEY_SUPPORT_URL "mnsl"
+#define SOL_OIC_KEY_SYSTEM_TIME "st"
+#define SOL_OIC_KEY_DEVICE_ID "sid"
+#define SOL_OIC_KEY_PROPERTIES "prop"
+#define SOL_OIC_KEY_RESOURCE_TYPES "rt"
+#define SOL_OIC_KEY_INTERFACES "if"
+#define SOL_OIC_KEY_POLICY "p"
+#define SOL_OIC_KEY_BITMAP "bm"
+

--- a/src/lib/comms/sol-oic-client.c
+++ b/src/lib/comms/sol-oic-client.c
@@ -40,14 +40,16 @@
 #include <string.h>
 #include <sys/socket.h>
 
+#include "cbor.h"
 #include "sol-coap.h"
-#include "sol-json.h"
 #include "sol-log-internal.h"
 #include "sol-mainloop.h"
 #include "sol-random.h"
 #include "sol-util.h"
 
 #include "sol-oic-client.h"
+#include "sol-oic-cbor.h"
+#include "sol-oic-common.h"
 #include "sol-oic-server.h"
 
 #define POLL_OBSERVE_TIMEOUT_MS 10000
@@ -82,25 +84,24 @@ struct find_resource_ctx {
     struct sol_oic_client *client;
     void (*cb)(struct sol_oic_client *cli, struct sol_oic_resource *res, void *data);
     void *data;
-    int32_t token;
+    int64_t token;
 };
 
 struct server_info_ctx {
     struct sol_oic_client *client;
     void (*cb)(struct sol_oic_client *cli, const struct sol_oic_server_information *info, void *data);
     void *data;
-    int32_t token;
+    int64_t token;
 };
 
 struct resource_request_ctx {
     struct sol_oic_client *client;
     struct sol_oic_resource *res;
     void (*cb)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-        const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data);
+        const struct sol_str_slice *href, const struct sol_vector *reprs, void *data);
     void *data;
+    int64_t token;
 };
-
-static const char json_type[] = "application/json";
 
 static struct sol_random *random_gen;
 
@@ -109,7 +110,7 @@ SOL_LOG_INTERNAL_DECLARE(_sol_oic_client_log_domain, "oic-client");
 static int32_t
 _get_random_token(void)
 {
-    int32_t number;
+    int64_t number;
 
     if (unlikely(!random_gen)) {
         random_gen = sol_random_new(SOL_RANDOM_DEFAULT, 0);
@@ -119,118 +120,71 @@ _get_random_token(void)
         }
     }
 
-    return sol_random_get_int32(random_gen, &number) ? number : 0;
+    return sol_random_get_int64(random_gen, &number) ? number : 0;
 }
 
 static bool
-_parse_json_array(const char *data, unsigned int size, struct sol_vector *vec)
+_pkt_has_same_token(const struct sol_coap_packet *pkt, int64_t token)
 {
-    struct sol_json_scanner scanner;
-    struct sol_json_token token;
-    enum sol_json_loop_reason reason;
+    uint8_t *token_data, token_len;
 
-    sol_json_scanner_init(&scanner, data, size);
-    SOL_JSON_SCANNER_ARRAY_LOOP (&scanner, &token, SOL_JSON_TYPE_STRING, reason) {
-        struct sol_str_slice *slice = sol_vector_append(vec);
+    token_data = sol_coap_header_get_token(pkt, &token_len);
+    if (unlikely(!token_data))
+        return false;
+
+    if (unlikely(token_len != sizeof(token)))
+        return false;
+
+    return likely(memcmp(token_data, &token, sizeof(token)) == 0);
+}
+
+static bool
+_cbor_array_to_vector(CborValue *array, struct sol_vector *vector)
+{
+    CborError err;
+    CborValue iter;
+
+    for (err = cbor_value_enter_container(array, &iter);
+        cbor_value_is_text_string(&iter) && err == CborNoError;
+        err |= cbor_value_advance(&iter)) {
+        struct sol_str_slice *slice = sol_vector_append(vector);
 
         if (!slice) {
-            SOL_WRN("Could not append to vector");
-            return false;
+            err = CborErrorOutOfMemory;
+            break;
         }
-        slice->len = token.end - token.start - 2; /* 2 = "" */
-        slice->data = token.start + 1; /* 1 = " */
+
+        err |= cbor_value_dup_text_string(&iter, (char **)&slice->data, &slice->len, NULL);
     }
 
-    return reason == SOL_JSON_LOOP_REASON_OK;
+    return (err | cbor_value_leave_container(array, &iter)) == CborNoError;
 }
 
 static bool
-_parse_resource_reply_props(const char *data, unsigned int size, struct sol_oic_resource *res)
+_cbor_map_get_array(const CborValue *map, const char *key,
+    struct sol_vector *vector)
 {
-    struct sol_json_scanner scanner;
-    struct sol_json_token token, key, value;
-    enum sol_json_loop_reason reason;
+    CborValue value;
 
-    sol_json_scanner_init(&scanner, data, size);
-    SOL_JSON_SCANNER_OBJECT_LOOP (&scanner, &token, &key, &value, reason) {
-        if (sol_json_token_str_eq(&key, "obs", 3) && sol_json_token_get_type(&value) == SOL_JSON_TYPE_NUMBER) {
-            if (value.end - value.start != 1)
-                goto out;
-            res->observable = (*value.start != '0');
-        } else if (sol_json_token_str_eq(&key, "rt", 2)) {
-            if (!_parse_json_array(value.start, value.end - value.start, &res->types))
-                goto out;
-        } else if (sol_json_token_str_eq(&key, "if", 2)) {
-            if (!_parse_json_array(value.start, value.end - value.start, &res->interfaces))
-                goto out;
-        }
-    }
-    if (reason == SOL_JSON_LOOP_REASON_OK)
-        return true;
+    if (cbor_value_map_find_value(map, key, &value) != CborNoError)
+        return false;
 
-out:
-    SOL_WRN("Invalid JSON");
-    return false;
+    if (!cbor_value_is_array(&value))
+        return false;
+
+    return _cbor_array_to_vector(&value, vector);
 }
 
 static bool
-_get_oc_response_array_from_payload(uint8_t **payload, uint16_t *payload_len)
+_cbor_map_get_str_value(const CborValue *map, const char *key,
+    struct sol_str_slice *slice)
 {
-    struct sol_json_scanner scanner;
-    struct sol_json_token token, key, value;
-    enum sol_json_loop_reason reason;
+    CborValue value;
 
-    sol_json_scanner_init(&scanner, *payload, *payload_len);
-    SOL_JSON_SCANNER_OBJECT_LOOP (&scanner, &token, &key, &value, reason) {
-        if (!sol_json_token_str_eq(&key, "oc", 2))
-            continue;
-        if (sol_json_token_get_type(&value) != SOL_JSON_TYPE_ARRAY_START)
-            goto out;
+    if (cbor_value_map_find_value(map, key, &value) != CborNoError)
+        return false;
 
-        *payload = (uint8_t *)value.start;
-        *payload_len = (uint16_t)(value.end - value.start);
-        return true;
-    }
-
-out:
-    SOL_WRN("Invalid JSON");
-    return false;
-}
-
-static bool
-_parse_resource_reply_payload(struct sol_oic_resource *res, uint8_t *payload, uint16_t payload_len)
-{
-    struct sol_json_scanner scanner;
-    struct sol_json_token token;
-    enum sol_json_loop_reason reason;
-
-    if (!_get_oc_response_array_from_payload(&payload, &payload_len))
-        goto out;
-
-    sol_json_scanner_init(&scanner, payload, payload_len);
-
-    SOL_JSON_SCANNER_ARRAY_LOOP (&scanner, &token, SOL_JSON_TYPE_OBJECT_START, reason) {
-        struct sol_json_token key, value;
-
-        SOL_JSON_SCANNER_OBJECT_LOOP_NEST (&scanner, &token, &key, &value, reason) {
-            if (sol_json_token_str_eq(&key, "href", 4) && sol_json_token_get_type(&value) == SOL_JSON_TYPE_STRING) {
-                res->href = SOL_STR_SLICE_STR(value.start + 1, (value.end - value.start) - 2);
-            } else if (sol_json_token_str_eq(&key, "prop", 4) && sol_json_token_get_type(&value) == SOL_JSON_TYPE_OBJECT_START) {
-                if (!_parse_resource_reply_props(value.start, value.end - value.start, res))
-                    goto out;
-            }
-        }
-
-        if (reason == SOL_JSON_LOOP_REASON_OK && !res->href.len)
-            goto out;
-    }
-
-    if (reason == SOL_JSON_LOOP_REASON_OK)
-        return true;
-
-out:
-    SOL_WRN("Invalid JSON");
-    return false;
+    return cbor_value_dup_text_string(&value, (char **)&slice->data, &slice->len, NULL) == CborNoError;
 }
 
 SOL_API struct sol_oic_resource *
@@ -251,8 +205,20 @@ sol_oic_resource_unref(struct sol_oic_resource *r)
 
     r->refcnt--;
     if (!r->refcnt) {
+        struct sol_str_slice *slice;
+        uint16_t idx;
+
+        free((char *)r->href.data);
+        free((char *)r->device_id.data);
+
+        SOL_VECTOR_FOREACH_IDX (&r->types, slice, idx)
+            free((char *)slice->data);
         sol_vector_clear(&r->types);
+
+        SOL_VECTOR_FOREACH_IDX (&r->interfaces, slice, idx)
+            free((char *)slice->data);
         sol_vector_clear(&r->interfaces);
+
         free(r);
     }
 }
@@ -261,64 +227,62 @@ static bool
 _parse_server_info_payload(struct sol_oic_server_information *info,
     uint8_t *payload, uint16_t payload_len)
 {
-    struct sol_json_scanner scanner;
-    struct sol_json_token token, key, value;
-    enum sol_json_loop_reason reason;
+    CborParser parser;
+    CborError err;
+    CborValue root, array, value, map;
+    int payload_type;
 
-    sol_json_scanner_init(&scanner, payload, payload_len);
-    SOL_JSON_SCANNER_OBJECT_LOOP (&scanner, &token, &key, &value, reason) {
-        if (sol_json_token_get_type(&token) != SOL_JSON_TYPE_STRING)
-            continue;
-
-        sol_json_token_remove_quotes(&value);
-
-        if (sol_json_token_str_eq(&key, "dt", 2)) {
-            info->device.name = sol_json_token_to_slice(&value);
-        } else if (sol_json_token_str_eq(&key, "drt", 3)) {
-            info->device.resource_type = sol_json_token_to_slice(&value);
-        } else if (sol_json_token_str_eq(&key, "id", 2)) {
-            info->device.id = sol_json_token_to_slice(&value);
-        } else if (sol_json_token_str_eq(&key, "mnmn", 4)) {
-            info->manufacturer.name = sol_json_token_to_slice(&value);
-        } else if (sol_json_token_str_eq(&key, "mnmo", 4)) {
-            info->manufacturer.model = sol_json_token_to_slice(&value);
-        } else if (sol_json_token_str_eq(&key, "mndt", 4)) {
-            info->manufacturer.date = sol_json_token_to_slice(&value);
-        } else if (sol_json_token_str_eq(&key, "mnpv", 4)) {
-            info->platform.version = sol_json_token_to_slice(&value);
-        } else if (sol_json_token_str_eq(&key, "mnfv", 4)) {
-            info->firmware.version = sol_json_token_to_slice(&value);
-        } else if (sol_json_token_str_eq(&key, "icv", 3)) {
-            info->interface.version = sol_json_token_to_slice(&value);
-        } else if (sol_json_token_str_eq(&key, "mnsl", 4)) {
-            info->support_link = sol_json_token_to_slice(&value);
-        } else if (sol_json_token_str_eq(&key, "loc", 3)) {
-            info->location = sol_json_token_to_slice(&value);
-        } else if (sol_json_token_str_eq(&key, "epi", 3)) {
-            info->epi = sol_json_token_to_slice(&value);
-        } else {
-            SOL_WRN("Unknown key in JSON payload: %.*s",
-                (int)sol_json_token_get_size(&key), key.start);
-            continue;
-        }
-    }
-
-    return reason == SOL_JSON_LOOP_REASON_OK;
-}
-
-static bool
-_pkt_has_same_token(const struct sol_coap_packet *pkt, int32_t token)
-{
-    uint8_t *token_data, token_len;
-
-    token_data = sol_coap_header_get_token(pkt, &token_len);
-    if (!token_data)
+    err = cbor_parser_init(payload, payload_len, 0, &parser, &root);
+    if (err != CborNoError)
+        return false;
+    if (!cbor_value_is_array(&root))
         return false;
 
-    if (token_len != sizeof(token))
+    err |= cbor_value_enter_container(&root, &array);
+
+    err |= cbor_value_get_int(&array, &payload_type);
+    err |= cbor_value_advance_fixed(&array);
+    if (err != CborNoError)
+        return false;
+    if (payload_type != SOL_OIC_PAYLOAD_PLATFORM)
         return false;
 
-    return memcmp(token_data, &token, sizeof(token)) == 0;
+    if (!cbor_value_is_map(&array))
+        return false;
+
+    /* href is intentionally ignored */
+
+    err |= cbor_value_map_find_value(&map, SOL_OIC_KEY_REPRESENTATION, &value);
+    if (!cbor_value_is_map(&value))
+        return false;
+
+    if (err != CborNoError)
+        return false;
+
+    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_PLATFORM_ID, &info->platform_id))
+        return false;
+    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_MANUF_NAME, &info->manufacturer_name))
+        return false;
+    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_MANUF_URL, &info->manufacturer_url))
+        return false;
+    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_MODEL_NUM, &info->model_number))
+        return false;
+    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_MANUF_DATE, &info->manufacture_date))
+        return false;
+    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_PLATFORM_VER, &info->platform_version))
+        return false;
+    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_OS_VER, &info->os_version))
+        return false;
+    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_HW_VER, &info->hardware_version))
+        return false;
+    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_FIRMWARE_VER, &info->firmware_version))
+        return false;
+    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_SUPPORT_URL, &info->support_url))
+        return false;
+    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_SYSTEM_TIME, &info->system_time))
+        return false;
+
+    return err == CborNoError;
 }
 
 static int
@@ -328,9 +292,7 @@ _server_info_reply_cb(struct sol_coap_packet *req, const struct sol_network_link
     struct server_info_ctx *ctx = data;
     uint8_t *payload;
     uint16_t payload_len;
-    struct sol_oic_server_information info = {
-        .api_version = SOL_OIC_SERVER_INFORMATION_API_VERSION
-    };
+    struct sol_oic_server_information info = { 0 };
     int error = 0;
 
     if (!ctx->cb) {
@@ -344,6 +306,11 @@ _server_info_reply_cb(struct sol_coap_packet *req, const struct sol_network_link
         goto free_ctx;
     }
 
+    if (!sol_oic_pkt_has_cbor_content(req)) {
+        error = -EINVAL;
+        goto free_ctx;
+    }
+
     if (sol_coap_packet_get_payload(req, &payload, &payload_len) < 0) {
         SOL_WRN("Could not get pkt payload");
         error = -ENOMEM;
@@ -351,11 +318,23 @@ _server_info_reply_cb(struct sol_coap_packet *req, const struct sol_network_link
     }
 
     if (_parse_server_info_payload(&info, payload, payload_len)) {
+        info.api_version = SOL_OIC_SERVER_INFORMATION_API_VERSION;
         ctx->cb(ctx->client, &info, ctx->data);
     } else {
         SOL_WRN("Could not parse payload");
         error = -EINVAL;
     }
+
+    free((char *)info.platform_id.data);
+    free((char *)info.manufacturer_name.data);
+    free((char *)info.manufacturer_url.data);
+    free((char *)info.model_number.data);
+    free((char *)info.manufacture_date.data);
+    free((char *)info.platform_version.data);
+    free((char *)info.os_version.data);
+    free((char *)info.hardware_version.data);
+    free((char *)info.support_url.data);
+    free((char *)info.system_time.data);
 
 free_ctx:
     free(ctx);
@@ -369,7 +348,7 @@ sol_oic_client_get_server_info(struct sol_oic_client *client,
     const struct sol_oic_server_information *info, void *data),
     void *data)
 {
-    static const char d_uri[] = "/d";
+    static const char device_uri[] = "/oic/d";
     struct sol_coap_packet *req;
     struct server_info_ctx *ctx;
     int r;
@@ -397,12 +376,10 @@ sol_oic_client_get_server_info(struct sol_oic_client *client,
     sol_coap_header_set_token(req, (uint8_t *)&ctx->token, (uint8_t)sizeof(ctx->token));
     sol_coap_header_set_id(req, SOLETTA_SERVER_INFO_MID);
 
-    if (sol_coap_packet_add_uri_path_option(req, d_uri) < 0) {
-        SOL_WRN("Invalid URI: %s", d_uri);
+    if (sol_coap_packet_add_uri_path_option(req, device_uri) < 0) {
+        SOL_WRN("Invalid URI: %s", device_uri);
         goto out;
     }
-
-    sol_coap_add_option(req, SOL_COAP_OPTION_ACCEPT, json_type, sizeof(json_type) - 1);
 
     r = sol_coap_send_packet_with_reply(client->server, req, &resource->addr, _server_info_reply_cb, ctx);
     if (!r)
@@ -428,6 +405,79 @@ _has_observable_option(struct sol_coap_packet *pkt)
     return ptr && len == 1 && *ptr;
 }
 
+static bool
+_cbor_map_get_bytestr_value(const CborValue *map, const char *key,
+    struct sol_str_slice *slice)
+{
+    CborValue value;
+
+    if (cbor_value_map_find_value(map, key, &value) != CborNoError)
+        return false;
+
+    return cbor_value_dup_byte_string(&value, (uint8_t **)&slice->data, &slice->len, NULL) == CborNoError;
+}
+
+static bool
+_parse_resource_reply_payload(struct sol_oic_resource *res, uint8_t *payload, uint16_t payload_len)
+{
+    CborParser parser;
+    CborError err;
+    CborValue root, array, value, map;
+    int payload_type;
+
+    err = cbor_parser_init(payload, payload_len, 0, &parser, &root);
+    if (err != CborNoError)
+        return false;
+    if (!cbor_value_is_array(&root))
+        return false;
+
+    err |= cbor_value_enter_container(&root, &array);
+
+    err |= cbor_value_get_int(&array, &payload_type);
+    err |= cbor_value_advance_fixed(&array);
+    if (err != CborNoError)
+        return false;
+    if (payload_type != SOL_OIC_PAYLOAD_DISCOVERY)
+        return false;
+
+    if (!cbor_value_is_map(&array))
+        return false;
+
+    if (!_cbor_map_get_str_value(&array, SOL_OIC_KEY_HREF, &res->href))
+        return false;
+    if (!_cbor_map_get_bytestr_value(&array, SOL_OIC_KEY_DEVICE_ID, &res->device_id))
+        return false;
+
+    err |= cbor_value_map_find_value(&array, SOL_OIC_KEY_PROPERTIES, &value);
+    if (!cbor_value_is_map(&value))
+        return false;
+
+    if (!_cbor_map_get_array(&value, SOL_OIC_KEY_RESOURCE_TYPES, &res->types))
+        return false;
+    if (!_cbor_map_get_array(&value, SOL_OIC_KEY_INTERFACES, &res->interfaces))
+        return false;
+
+    err |= cbor_value_map_find_value(&value, SOL_OIC_KEY_POLICY, &map);
+    if (!cbor_value_is_map(&map)) {
+        err = CborErrorUnknownType;
+    } else {
+        CborValue bitmap_value;
+        uint64_t bitmap = 0;
+
+        err |= cbor_value_map_find_value(&map, SOL_OIC_KEY_BITMAP, &bitmap_value);
+        err |= cbor_value_get_uint64(&bitmap_value, &bitmap);
+
+        res->observable = (bitmap & SOL_OIC_FLAG_OBSERVABLE);
+        res->active = (bitmap & SOL_OIC_FLAG_ACTIVE);
+        res->slow = (bitmap & SOL_OIC_FLAG_SLOW);
+        res->secure = (bitmap & SOL_OIC_FLAG_SECURE);
+    }
+
+    /* No need to leave the containers: we're done with this payload. */
+
+    return err == CborNoError;
+}
+
 static int
 _find_resource_reply_cb(struct sol_coap_packet *req, const struct sol_network_link_addr *cliaddr,
     void *data)
@@ -449,25 +499,38 @@ _find_resource_reply_cb(struct sol_coap_packet *req, const struct sol_network_li
         goto free_ctx;
     }
 
+    if (!sol_oic_pkt_has_cbor_content(req)) {
+        error = -EINVAL;
+        goto free_ctx;
+    }
+
     if (sol_coap_packet_get_payload(req, &payload, &payload_len) < 0) {
         SOL_WRN("Could not get pkt payload");
         error = -ENOMEM;
         goto free_ctx;
     }
-    res = malloc(sizeof(*res) + payload_len);
+
+    /* FIXME: Support more than one resource per discovery reply. */
+
+    res = malloc(sizeof(*res));
     if (!res) {
         SOL_WRN("Not enough memory");
         error = -errno;
         goto free_ctx;
     }
 
-    payload = memcpy(res + 1, payload, payload_len);
     res->href = (struct sol_str_slice)SOL_STR_SLICE_EMPTY;
+    res->device_id = (struct sol_str_slice)SOL_STR_SLICE_EMPTY;
     sol_vector_init(&res->types, sizeof(struct sol_str_slice));
     sol_vector_init(&res->interfaces, sizeof(struct sol_str_slice));
 
     res->observe.timeout = NULL;
     res->observe.clear_data = 0;
+
+    res->observable = false;
+    res->slow = false;
+    res->secure = false;
+    res->active = false;
 
     res->refcnt = 1;
 
@@ -485,6 +548,8 @@ _find_resource_reply_cb(struct sol_coap_packet *req, const struct sol_network_li
     sol_oic_resource_unref(res);
 
 free_ctx:
+    /* FIXME: ctx shouldn't be freed here. Add a timeout so it's freed
+     * after a while; maintain a list of pending contexts and check that. */
     free(ctx);
     return error;
 }
@@ -497,7 +562,7 @@ sol_oic_client_find_resource(struct sol_oic_client *client,
     void *data),
     void *data)
 {
-    static const char oc_core_uri[] = "/oc/core";
+    static const char oic_well_known[] = "/oic/res";
     struct sol_coap_packet *req;
     struct find_resource_ctx *ctx;
     int r;
@@ -525,8 +590,8 @@ sol_oic_client_find_resource(struct sol_oic_client *client,
     sol_coap_header_set_token(req, (uint8_t *)&ctx->token, (uint8_t)sizeof(ctx->token));
     sol_coap_header_set_id(req, IOTIVITY_NONCON_REQ_MID);
 
-    if (sol_coap_packet_add_uri_path_option(req, oc_core_uri) < 0) {
-        SOL_WRN("Invalid URI: %s", oc_core_uri);
+    if (sol_coap_packet_add_uri_path_option(req, oic_well_known) < 0) {
+        SOL_WRN("Invalid URI: %s", oic_well_known);
         goto out;
     }
 
@@ -539,8 +604,6 @@ sol_oic_client_find_resource(struct sol_oic_client *client,
 
         sol_coap_add_option(req, SOL_COAP_OPTION_URI_QUERY, query, r);
     }
-
-    sol_coap_add_option(req, SOL_COAP_OPTION_ACCEPT, json_type, sizeof(json_type) - 1);
 
     r = sol_coap_send_packet_with_reply(client->server, req, cliaddr, _find_resource_reply_cb, ctx);
     if (!r)
@@ -555,53 +618,87 @@ out_no_pkt:
     return false;
 }
 
-static void
-_call_request_context_for_response_array(struct resource_request_ctx *ctx,
-    const struct sol_network_link_addr *cliaddr, uint8_t *payload, uint16_t payload_len)
-{
-    struct sol_json_scanner scanner;
-    struct sol_json_token token;
-    enum sol_json_loop_reason reason;
-
-    sol_json_scanner_init(&scanner, payload, payload_len);
-    SOL_JSON_SCANNER_ARRAY_LOOP (&scanner, &token, SOL_JSON_TYPE_OBJECT_START, reason) {
-        struct sol_str_slice href = SOL_STR_SLICE_EMPTY;
-        struct sol_str_slice rep = SOL_STR_SLICE_EMPTY;
-        struct sol_json_token key, value;
-
-        SOL_JSON_SCANNER_OBJECT_LOOP_NEST (&scanner, &token, &key, &value, reason) {
-            if (sol_json_token_get_type(&value) == SOL_JSON_TYPE_STRING && sol_json_token_str_eq(&key, "href", 4)) {
-                href = SOL_STR_SLICE_STR(value.start + 1, value.end - value.start - 2);
-            } else if (sol_json_token_get_type(&value) == SOL_JSON_TYPE_OBJECT_START && sol_json_token_str_eq(&key, "rep", 3)) {
-                rep = sol_json_token_to_slice(&value);
-            }
-        }
-
-        if (reason == SOL_JSON_LOOP_REASON_OK && href.len && rep.len)
-            ctx->cb(ctx->client, cliaddr, &href, &rep, ctx->data);
-    }
-    if (reason != SOL_JSON_LOOP_REASON_OK)
-        SOL_WRN("Invalid JSON");
-}
-
 static int
 _resource_request_cb(struct sol_coap_packet *req, const struct sol_network_link_addr *cliaddr,
     void *data)
 {
     struct resource_request_ctx *ctx = data;
+    CborParser parser;
+    CborValue root, array;
+    CborError err;
     uint8_t *payload;
     uint16_t payload_len;
+    int payload_type;
 
     if (!ctx->cb)
         return -ENOENT;
+    if (!_pkt_has_same_token(req, ctx->token))
+        return -EINVAL;
+    if (!sol_oic_pkt_has_cbor_content(req))
+        return -EINVAL;
     if (!sol_coap_packet_has_payload(req))
         return 0;
     if (sol_coap_packet_get_payload(req, &payload, &payload_len) < 0)
         return 0;
-    if (_get_oc_response_array_from_payload(&payload, &payload_len))
-        _call_request_context_for_response_array(ctx, cliaddr, payload, payload_len);
 
-    return 0;
+    err = cbor_parser_init(payload, payload_len, 0, &parser, &root);
+    if (err != CborNoError)
+        return -EINVAL;
+
+    if (!cbor_value_is_array(&root))
+        return -EINVAL;
+
+    err |= cbor_value_enter_container(&root, &array);
+
+    err |= cbor_value_get_int(&array, &payload_type);
+    err |= cbor_value_advance_fixed(&array);
+    if (err != CborNoError)
+        return -EINVAL;
+    if (payload_type != SOL_OIC_PAYLOAD_REPRESENTATION)
+        return -EINVAL;
+
+    while (cbor_value_is_map(&array) && err == CborNoError) {
+        struct sol_oic_repr_field *repr;
+        struct sol_vector reprs = SOL_VECTOR_INIT(struct sol_oic_repr_field);
+        CborValue value;
+        char *href;
+        size_t len;
+        uint16_t idx;
+
+        err |= cbor_value_map_find_value(&array, SOL_OIC_KEY_HREF, &value);
+        err |= cbor_value_dup_text_string(&value, &href, &len, NULL);
+
+        err |= cbor_value_map_find_value(&array, SOL_OIC_KEY_REPRESENTATION, &value);
+
+        err |= sol_oic_decode_cbor_repr_map(&value, &reprs);
+        if (err == CborNoError) {
+            struct sol_str_slice href_slice = sol_str_slice_from_str(href);
+
+            /* A sentinel item isn't needed since a sol_vector is passed. */
+            ctx->cb(ctx->client, cliaddr, &href_slice, &reprs, ctx->data);
+        }
+
+        free(href);
+        SOL_VECTOR_FOREACH_IDX (&reprs, repr, idx) {
+            free((char *)repr->key);
+
+            if (repr->type != SOL_OIC_REPR_TYPE_TEXT_STRING && repr->type != SOL_OIC_REPR_TYPE_BYTE_STRING)
+                continue;
+
+            free((char *)repr->v_slice.data);
+        }
+        sol_vector_clear(&reprs);
+
+        err |= cbor_value_advance(&array);
+    }
+
+    err |= cbor_value_leave_container(&root, &array);
+
+    if (err == CborNoError)
+        return 0;
+
+    SOL_ERR("Error while parsing CBOR repr packet: %s", cbor_error_string(err));
+    return -EINVAL;
 }
 
 static int
@@ -616,18 +713,23 @@ _one_shot_resource_request_cb(struct sol_coap_packet *req, const struct sol_netw
 
 static bool
 _resource_request(struct sol_oic_client *client, struct sol_oic_resource *res,
-    sol_coap_method_t method, uint8_t *payload, size_t payload_len,
+    sol_coap_method_t method, const struct sol_vector *repr,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data),
+    const struct sol_str_slice *href, const struct sol_vector *reprs, void *data),
     void *data, bool observe)
 {
+    const uint8_t format_cbor = SOL_COAP_CONTENTTYPE_APPLICATION_CBOR;
+    CborError err;
+    char *href;
+
     int (*cb)(struct sol_coap_packet *req, const struct sol_network_link_addr *cliaddr, void *data);
     struct sol_coap_packet *req;
     struct resource_request_ctx *ctx = sol_util_memdup(&(struct resource_request_ctx) {
             .client = client,
             .cb = callback,
             .data = data,
-            .res = res
+            .res = res,
+            .token = _get_random_token()
         }, sizeof(*ctx));
 
     SOL_NULL_CHECK(ctx, false);
@@ -637,6 +739,8 @@ _resource_request(struct sol_oic_client *client, struct sol_oic_resource *res,
         SOL_WRN("Could not create CoAP packet");
         goto out_no_req;
     }
+
+    sol_coap_header_set_token(req, (uint8_t *)&ctx->token, (uint8_t)sizeof(ctx->token));
 
     if (observe) {
         uint8_t reg = 0;
@@ -649,37 +753,21 @@ _resource_request(struct sol_oic_client *client, struct sol_oic_resource *res,
         cb = _one_shot_resource_request_cb;
     }
 
-    if (sol_coap_packet_add_uri_path_option(req, strndupa(res->href.data, res->href.len)) < 0) {
-        SOL_WRN("Invalid URI: %.*s", SOL_STR_SLICE_PRINT(res->href));
+    href = strndupa(res->href.data, res->href.len);
+    if (sol_coap_packet_add_uri_path_option(req, href) < 0) {
+        SOL_WRN("Invalid URI: %s", href);
         goto out;
     }
 
-    if (payload && payload_len) {
-        uint8_t *coap_payload;
-        uint16_t coap_payload_len;
-        int r;
+    sol_coap_add_option(req, SOL_COAP_OPTION_CONTENT_FORMAT, &format_cbor, sizeof(format_cbor));
 
-        sol_coap_add_option(req, SOL_COAP_OPTION_ACCEPT, json_type, sizeof(json_type) - 1);
-
-        if (sol_coap_packet_get_payload(req, &coap_payload, &coap_payload_len) < 0) {
-            SOL_WRN("Could not get CoAP payload");
-            goto out;
-        }
-
-        r = snprintf((char *)coap_payload, coap_payload_len, "{\"oc\":[{\"rep\":%.*s}]}",
-            (int)payload_len, payload);
-        if (r < 0 || r >= coap_payload_len) {
-            SOL_WRN("Could not wrap payload");
-            goto out;
-        }
-
-        if (sol_coap_packet_set_payload_used(req, r) < 0) {
-            SOL_WRN("Request payload too large (have %d, want %zu)", r, payload_len);
-            goto out;
-        }
+    err = sol_oic_encode_cbor_repr(req, href, repr);
+    if (err == CborNoError) {
+        return sol_coap_send_packet_with_reply(client->server, req, &res->addr,
+            cb, ctx) == 0;
     }
 
-    return sol_coap_send_packet_with_reply(client->server, req, &res->addr, cb, ctx) == 0;
+    SOL_ERR("Could not encode CBOR representation: %s", cbor_error_string(err));
 
 out:
     sol_coap_packet_unref(req);
@@ -690,9 +778,9 @@ out_no_req:
 
 SOL_API bool
 sol_oic_client_resource_request(struct sol_oic_client *client, struct sol_oic_resource *res,
-    sol_coap_method_t method, uint8_t *payload, size_t payload_len,
+    sol_coap_method_t method, const struct sol_vector *repr,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data),
+    const struct sol_str_slice *href, const struct sol_vector *reprs, void *data),
     void *data)
 {
     SOL_NULL_CHECK(client, false);
@@ -700,7 +788,7 @@ sol_oic_client_resource_request(struct sol_oic_client *client, struct sol_oic_re
     SOL_NULL_CHECK(res, false);
     OIC_RESOURCE_CHECK_API(res, false);
 
-    return _resource_request(client, res, method, payload, payload_len, callback, data, false);
+    return _resource_request(client, res, method, repr, callback, data, false);
 }
 
 static bool
@@ -715,7 +803,7 @@ _poll_resource(void *data)
         return false;
     }
 
-    r = _resource_request(ctx->client, ctx->res, SOL_COAP_METHOD_GET, NULL, 0, ctx->cb, ctx->data, false);
+    r = _resource_request(ctx->client, ctx->res, SOL_COAP_METHOD_GET, NULL, ctx->cb, ctx->data, false);
     if (!r)
         SOL_WRN("Could not send polling packet to observable resource");
 
@@ -725,7 +813,7 @@ _poll_resource(void *data)
 static bool
 _observe_with_polling(struct sol_oic_client *client, struct sol_oic_resource *res,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data),
+    const struct sol_str_slice *href, const struct sol_vector *reprs, void *data),
     void *data)
 {
     struct resource_request_ctx *ctx = sol_util_memdup(&(struct resource_request_ctx) {
@@ -766,7 +854,7 @@ _stop_observing_with_polling(struct sol_oic_resource *res)
 SOL_API bool
 sol_oic_client_resource_set_observable(struct sol_oic_client *client, struct sol_oic_resource *res,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data),
+    const struct sol_str_slice *href, const struct sol_vector *reprs, void *data),
     void *data, bool observe)
 {
     SOL_NULL_CHECK(client, false);
@@ -777,7 +865,7 @@ sol_oic_client_resource_set_observable(struct sol_oic_client *client, struct sol
     if (observe) {
         if (!res->observable)
             return _observe_with_polling(client, res, callback, data);
-        return _resource_request(client, res, SOL_COAP_METHOD_GET, NULL, 0, callback, data, true);
+        return _resource_request(client, res, SOL_COAP_METHOD_GET, NULL, callback, data, true);
     }
 
     if (res->observe.timeout)
@@ -788,5 +876,5 @@ sol_oic_client_resource_set_observable(struct sol_oic_client *client, struct sol
         return false;
     }
 
-    return _resource_request(client, res, SOL_COAP_METHOD_GET, NULL, 0, callback, data, false);
+    return _resource_request(client, res, SOL_COAP_METHOD_GET, NULL, callback, data, false);
 }

--- a/src/samples/coap/oic-client.c
+++ b/src/samples/coap/oic-client.c
@@ -40,22 +40,60 @@
 
 static void
 got_get_response(struct sol_oic_client *cli, const struct sol_network_link_addr *cliaddr,
-    const struct sol_str_slice *href, const struct sol_str_slice *payload, void *data)
+    const struct sol_str_slice *href, const struct sol_vector *repr, void *data)
 {
+    struct sol_oic_repr_field *field;
     char addr[SOL_INET_ADDR_STRLEN];
+    uint16_t idx;
 
     if (!sol_network_addr_to_str(cliaddr, addr, sizeof(addr))) {
         SOL_WRN("Could not convert network address to string");
         return;
     }
 
-    printf("Received payload for GET from %s (%.*s): %.*s\n",
-        addr, SOL_STR_SLICE_PRINT(*href), SOL_STR_SLICE_PRINT(*payload));
+    printf("Dumping payload received from addr %s {\n", addr);
+    SOL_VECTOR_FOREACH_IDX (repr, field, idx) {
+        printf("\tkey: '%s', value: ", field->key);
+
+        switch (field->type) {
+        case SOL_OIC_REPR_TYPE_UINT:
+            printf("uint(%" PRIu64 ")\n", field->v_uint);
+            break;
+        case SOL_OIC_REPR_TYPE_INT:
+            printf("int(%" PRIi64 ")\n", field->v_int);
+            break;
+        case SOL_OIC_REPR_TYPE_SIMPLE:
+            printf("simple(%d)\n", field->v_simple);
+            break;
+        case SOL_OIC_REPR_TYPE_TEXT_STRING:
+            printf("str(%.*s)\n", (int)field->v_slice.len, field->v_slice.data);
+            break;
+        case SOL_OIC_REPR_TYPE_BYTE_STRING:
+            printf("bytestr() [not dumping]\n");
+            break;
+        case SOL_OIC_REPR_TYPE_HALF_FLOAT:
+            printf("hfloat(%p)\n", field->v_voidptr);
+            break;
+        case SOL_OIC_REPR_TYPE_FLOAT:
+            printf("float(%f)\n", field->v_float);
+            break;
+        case SOL_OIC_REPR_TYPE_DOUBLE:
+            printf("float(%g)\n", field->v_double);
+            break;
+        case SOL_OIC_REPR_TYPE_BOOLEAN:
+            printf("boolean(%s)\n", field->v_boolean ? "true" : "false");
+            break;
+        default:
+            printf("unknown(%d)\n", field->type);
+        }
+    }
+    printf("}\n\n");
 }
 
 static void
 found_resource(struct sol_oic_client *cli, struct sol_oic_resource *res, void *data)
 {
+    static const char digits[] = "0123456789abcdef";
     struct sol_str_slice *slice;
     uint16_t idx;
     char addr[SOL_INET_ADDR_STRLEN];
@@ -65,8 +103,26 @@ found_resource(struct sol_oic_client *cli, struct sol_oic_resource *res, void *d
         return;
     }
 
-    printf("Found resource: coap://%s%.*s <observable: %s>\n", addr,
-        SOL_STR_SLICE_PRINT(res->href), res->observable ? "yes" : "no");
+    printf("Found resource: coap://%s%.*s\n", addr,
+        SOL_STR_SLICE_PRINT(res->href));
+
+    printf("Flags:\n"
+        " - observable: %s\n"
+        " - active: %s\n"
+        " - slow: %s\n"
+        " - secure: %s\n",
+        res->observable ? "yes" : "no",
+        res->active ? "yes" : "no",
+        res->slow ? "yes" : "no",
+        res->secure ? "yes" : "no");
+
+    printf("Device ID: ");
+    for (idx = 0; idx < 16; idx++) {
+        unsigned int digit = res->device_id.data[idx];
+        putchar(digits[(digit >> 4) & 0x0f]);
+        putchar(digits[digit & 0x0f]);
+    }
+    putchar('\n');
 
     printf("Resource types:\n");
     SOL_VECTOR_FOREACH_IDX (&res->types, slice, idx)
@@ -77,7 +133,7 @@ found_resource(struct sol_oic_client *cli, struct sol_oic_resource *res, void *d
         printf("\t\t%.*s\n", SOL_STR_SLICE_PRINT(*slice));
 
     printf("Issuing GET %.*s on resource...\n", SOL_STR_SLICE_PRINT(res->href));
-    sol_oic_client_resource_request(cli, res, SOL_COAP_METHOD_GET, NULL, 0,
+    sol_oic_client_resource_request(cli, res, SOL_COAP_METHOD_GET, NULL,
         got_get_response, data);
 
     printf("\n");
@@ -86,7 +142,9 @@ found_resource(struct sol_oic_client *cli, struct sol_oic_resource *res, void *d
 int
 main(int argc, char *argv[])
 {
-    struct sol_oic_client client;
+    struct sol_oic_client client = {
+        .api_version = SOL_OIC_CLIENT_API_VERSION
+    };
     struct sol_network_link_addr cliaddr = { .family = AF_INET, .port = 5683 };
     const char *resource_type;
 

--- a/src/samples/coap/simple-server.c
+++ b/src/samples/coap/simple-server.c
@@ -215,7 +215,7 @@ static struct sol_coap_resource light = {
     .put = light_method_put,
     .iface = SOL_STR_SLICE_LITERAL("oc.mi.def"),
     .resource_type = SOL_STR_SLICE_LITERAL("core.light"),
-    .flags = SOL_COAP_FLAGS_WELL_KNOWN | SOL_COAP_FLAGS_OC_CORE,
+    .flags = SOL_COAP_FLAGS_WELL_KNOWN,
     .path = {
         SOL_STR_SLICE_LITERAL("a"),
         SOL_STR_SLICE_LITERAL("light"),

--- a/src/shared/sol-random.h
+++ b/src/shared/sol-random.h
@@ -64,6 +64,18 @@ sol_random_get_int32(struct sol_random *engine, int32_t *value)
 }
 
 static inline bool
+sol_random_get_int64(struct sol_random *engine, int64_t *value)
+{
+    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(value, sizeof(*value),
+        SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+    ssize_t r = sol_random_fill_buffer(engine, &buf, sizeof(*value));
+
+    sol_buffer_fini(&buf);
+
+    return r == (ssize_t)sizeof(*value);
+}
+
+static inline bool
 sol_random_get_double(struct sol_random *engine, double *value)
 {
     int32_t num, den;

--- a/src/thirdparty/README
+++ b/src/thirdparty/README
@@ -8,3 +8,10 @@ Thirdparty
       - Duktape is an embeddable Javascript engine, with focus on
         portabillity and compact footprint. This is used in order
         to create JS node types in flow.
+
+- TinyCBOR
+      - Repository: https://github.com/01org/tinycbor
+      - License: MIT - src/thirdparty/tinycbor/src/cbor.h
+      - CBOR is the "Concise Binary Object Representation", and is the
+        format used by OIC to encode network payload. TinyCBOR is a library
+        to encode and decode data in CBOR.

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -107,8 +107,9 @@ src_modulesdir := $(top_srcdir)src/modules/
 SCRIPTDIR := $(top_srcdir)data/scripts/
 
 # sub-modules and deps
+EXCLUDE_SUBDIRS := $(addprefix -not -path ,"$(top_srcdir)src/thirdparty/*")
 SUBDIRS := $(addprefix $(top_srcdir)src/lib/,common comms datatypes flow) $(top_srcdir)src/shared
-SUBDIRS := $(dir $(filter-out $(SUBDIRS),$(shell find $(top_srcdir)src/ -name 'Makefile')))
+SUBDIRS := $(dir $(filter-out $(SUBDIRS),$(shell find $(top_srcdir)src/ $(EXCLUDE_SUBDIRS) -name 'Makefile')))
 
 MAKEFILE_GEN := $(top_srcdir)Makefile.gen
 KCONFIG_GEN := $(top_srcdir)Kconfig.gen


### PR DESCRIPTION
CoAP does not handle OIC stuff anymore; its implementation of /oc/core is now gone.  This is handled by the OIC server like any other ordinary CoAP resource.    
    
OIC now requires TinyCBOR library (which this commit enables as a Git submodule).  All payloads have been converted from JSON to the current format as supported by IoTivity.    
    
All deprecated server resources have been removed; only /oic/res (for discovery) and /oic/d (for device information) remain.    
    
The server API has been also streamlined: now, one only pass a `sol_oic_resource_type` function to `sol_oic_server_add_resource()`, and the implementation does the rest (creating URIs, setting up for discovery, etc.).  This function returns a pointer to an opaque structure that can be used to unregister a resource and also to notify observers (which took a CoAP resource previously.)    
    
Since the encoding format changed from JSON to CBOR, the APIs to send and/or receive data changed.  This way, whoever consumes the OIC API does not need to encode/decode the payload, and TinyCBOR remains as an implementation detail.  Payload decoding is now performed within Soletta, and a vector of `sol_oic_repr_field` is passed to handlers as input, or received from them as output to be encoded and sent through the wire.  All formats supported by TinyCBOR are supported by this scheme.    

Deprecated functions and values required previously have been removed.    
    
The discovery process is now faster, since the device ID is now known without requiring another network hop to request from /oic/d.    
    
The samples and oicgen script have been updated as well.

This has been tested compatible with IoTivity as of ad4794090.