### PR TITLE
Http server v2

### DIFF
--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -192,6 +192,9 @@ sol_buffer_get_slice_at(const struct sol_buffer *buf, size_t pos)
     return SOL_STR_SLICE_STR(sol_buffer_at(buf,  pos), buf->used - pos);
 }
 
+/* Appends the 'c' into 'buf', reallocating if necessary. */
+int sol_buffer_append_char(struct sol_buffer *buf, const char c);
+
 /* Appends the 'slice' into 'buf', reallocating if necessary. */
 int sol_buffer_append_slice(struct sol_buffer *buf, const struct sol_str_slice slice);
 

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -342,3 +342,33 @@ sol_buffer_ensure_nul_byte(struct sol_buffer *buf)
 
     return 0;
 }
+
+SOL_API int
+sol_buffer_append_char(struct sol_buffer *buf, const char c)
+{
+    const size_t nul_size = nul_byte_size(buf);
+    char *p;
+    size_t new_size;
+    int err;
+
+    SOL_NULL_CHECK(buf, -EINVAL);
+
+    err = sol_util_size_add(buf->used, 1, &new_size);
+    if (err < 0)
+        return err;
+
+    /* Extra room for the ending NUL-byte. */
+    if (new_size >= SIZE_MAX - nul_size)
+        return -EOVERFLOW;
+    err = sol_buffer_ensure(buf, new_size + nul_size);
+    if (err < 0)
+        return err;
+
+    p = sol_buffer_at_end(buf);
+    *p = c;
+
+    if (nul_size)
+        *(++p) = '\0';
+    buf->used++;
+    return 0;
+}

--- a/src/modules/flow/http-server/http-server.c
+++ b/src/modules/flow/http-server/http-server.c
@@ -55,7 +55,6 @@
 #define DOUBLE_STRING_LEN 64
 
 struct http_data {
-    struct sol_flow_node *node;
     union {
         struct sol_irange i;
         struct sol_drange d;
@@ -66,12 +65,95 @@ struct http_data {
     char *path;
 };
 
+struct http_server_node_type {
+    struct sol_flow_node_type base;
+    int (*post_cb)(struct http_data *mdata, struct sol_flow_node *node,
+        struct sol_http_param_value *value);
+    int (*response_cb)(struct http_data *mdata, struct sol_buffer *content, bool json);
+    int (*process_cb)(struct http_data *mdata, const struct sol_flow_packet *packet);
+    void (*send_packet_cb)(struct http_data *mdata, struct sol_flow_node *node);
+};
+
 static struct sol_http_server *server = NULL;
 static int init_count = 0;
 
 static int
-start_server(struct http_data *http, const char *path,
-    int (*handler)(void *data, struct sol_http_request *request))
+common_response_cb(void *data, struct sol_http_request *request)
+{
+    int r = 0;
+    uint16_t idx;
+    bool send_json = false;
+    enum sol_http_method method;
+    struct sol_flow_node *node = data;
+    struct http_data *mdata = sol_flow_node_get_private_data(node);
+    const struct http_server_node_type *type;
+    struct sol_http_param_value *value;
+    struct sol_http_response response = {
+        .api_version = SOL_HTTP_RESPONSE_API_VERSION,
+        .content = SOL_BUFFER_INIT_EMPTY,
+        .param = SOL_HTTP_REQUEST_PARAM_INIT,
+        .response_code = SOL_HTTP_STATUS_OK
+    };
+
+    type = (const struct http_server_node_type *)
+        sol_flow_node_get_type(node);
+
+    method = sol_http_request_get_method(request);
+    response.url = sol_http_request_get_url(request);
+
+    SOL_HTTP_PARAM_FOREACH_IDX (sol_http_request_get_params(request), value, idx) {
+        switch (value->type) {
+        case SOL_HTTP_PARAM_POST_FIELD:
+            r = type->post_cb(mdata, node, value);
+            SOL_INT_CHECK_GOTO(r, < 0, end);
+
+            r = sol_http_server_set_last_modified(server, mdata->path, time(NULL));
+            SOL_INT_CHECK_GOTO(r, < 0, end);
+            break;
+        case SOL_HTTP_PARAM_HEADER:
+            if (streq(value->value.key_value.key, HTTP_HEADER_ACCEPT)) {
+                if (strstr(value->value.key_value.value, HTTP_HEADER_CONTENT_TYPE_JSON))
+                    send_json = true;
+            }
+            break;
+        default:
+            break;
+        }
+    }
+
+    if (send_json) {
+        r = sol_buffer_append_printf(&response.content, "{\"%s\":", mdata->path);
+        SOL_INT_CHECK_GOTO(r, < 0, end);
+    }
+
+    r = type->response_cb(mdata, &response.content, send_json);
+    SOL_INT_CHECK_GOTO(r, < 0, end);
+
+    if (send_json) {
+        r = sol_buffer_append_char(&response.content, '}');
+        SOL_INT_CHECK_GOTO(r, < 0, end);
+    }
+
+    r = sol_http_param_add(&response.param, SOL_HTTP_REQUEST_PARAM_HEADER(
+        HTTP_HEADER_CONTENT_TYPE, (send_json) ? HTTP_HEADER_CONTENT_TYPE_JSON : HTTP_HEADER_CONTENT_TYPE_TEXT));
+    SOL_INT_CHECK_GOTO(r, != true, end);
+
+    r = sol_http_server_send_response(request, &response);
+    SOL_INT_CHECK_GOTO(r, < 0, end);
+
+    if ((method == SOL_HTTP_METHOD_POST) && type->send_packet_cb)
+        type->send_packet_cb(mdata, node);
+
+end:
+    sol_buffer_fini(&response.content);
+    sol_http_param_free(&response.param);
+
+    return 0;
+}
+
+static int
+start_server(struct http_data *http, struct sol_flow_node *node,
+    const char *path)
 {
     int r;
 
@@ -81,11 +163,10 @@ start_server(struct http_data *http, const char *path,
     }
 
     init_count++;
-
     http->path = strdup(path);
     SOL_NULL_CHECK_GOTO(http->path, err);
 
-    r = sol_http_server_register_handler(server, http->path, handler, http);
+    r = sol_http_server_register_handler(server, http->path, common_response_cb, node);
     SOL_INT_CHECK_GOTO(r, < 0, err_handler);
 
     return 0;
@@ -113,100 +194,8 @@ stop_server(struct http_data *http)
     }
 }
 
-static int
-boolean_response_cb(void *data, struct sol_http_request *request)
-{
-    int r = 0;
-    uint16_t idx;
-    bool send_json = false;
-    enum sol_http_method method;
-    struct http_data *mdata = data;
-    char response_str[128];
-    struct sol_http_param_value *value;
-    struct sol_http_response response = {
-        .api_version = SOL_HTTP_RESPONSE_API_VERSION,
-        .content = SOL_BUFFER_INIT_EMPTY,
-        .param = SOL_HTTP_REQUEST_PARAM_INIT,
-        .response_code = SOL_HTTP_STATUS_OK
-    };
-
-    method = sol_http_request_get_method(request);
-    response.url = sol_http_request_get_url(request);
-
-    SOL_HTTP_PARAM_FOREACH_IDX (sol_http_request_get_params(request), value, idx) {
-        switch (value->type) {
-        case SOL_HTTP_PARAM_POST_FIELD:
-            if (streq(value->value.key_value.key, "value")) {
-                if (streq(value->value.key_value.value, "true"))
-                    mdata->value.b = true;
-                else if (streq(value->value.key_value.value, "false"))
-                    mdata->value.b = false;
-
-                r = sol_http_server_set_last_modified(server, mdata->path, time(NULL));
-                SOL_INT_CHECK_GOTO(r, < 0, end);
-            }
-            break;
-        case SOL_HTTP_PARAM_HEADER:
-            if (streq(value->value.key_value.key, HTTP_HEADER_ACCEPT)) {
-                if (strstr(value->value.key_value.value, HTTP_HEADER_CONTENT_TYPE_JSON))
-                    send_json = true;
-            }
-            break;
-        default:
-            break;
-        }
-    }
-
-    if (send_json) {
-        r = snprintf(response_str, sizeof(response_str), "{\"%s\": %s}", mdata->path,
-            mdata->value.b == true ? "true" : "false");
-    } else {
-        r = snprintf(response_str, sizeof(response_str), "%s", mdata->value.b == true ? "true" : "false");
-    }
-
-    SOL_INT_CHECK_GOTO(r, < 0, end);
-
-    r = sol_http_param_add(&response.param, SOL_HTTP_REQUEST_PARAM_HEADER(
-        HTTP_HEADER_CONTENT_TYPE, (send_json) ? HTTP_HEADER_CONTENT_TYPE_JSON : HTTP_HEADER_CONTENT_TYPE_TEXT));
-    SOL_INT_CHECK_GOTO(r, != true, end);
-
-    r = sol_buffer_set_slice(&response.content, sol_str_slice_from_str(response_str));
-    SOL_INT_CHECK_GOTO(r, < 0, end);
-
-    r = sol_http_server_send_response(request, &response);
-    SOL_INT_CHECK_GOTO(r, < 0, end);
-
-    if (method == SOL_HTTP_METHOD_POST) {
-        sol_flow_send_boolean_packet(mdata->node,
-            SOL_FLOW_NODE_TYPE_HTTP_SERVER_BOOLEAN__OUT__OUT,
-            mdata->value.b);
-    }
-
-end:
-    sol_buffer_fini(&response.content);
-    sol_http_param_free(&response.param);
-
-    return 0;
-}
-
-static int
-boolean_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id,
-    const struct sol_flow_packet *packet)
-{
-    struct http_data *mdata = data;
-    int r;
-
-    r = sol_flow_packet_get_boolean(packet, &mdata->value.b);
-    SOL_INT_CHECK(r, < 0, r);
-
-    r = sol_http_server_set_last_modified(server, mdata->path, time(NULL));
-    SOL_INT_CHECK(r, < 0, r);
-
-    return 0;
-}
-
 static void
-boolean_close(struct sol_flow_node *node, void *data)
+common_close(struct sol_flow_node *node, void *data)
 {
     struct http_data *mdata = data;
 
@@ -214,123 +203,129 @@ boolean_close(struct sol_flow_node *node, void *data)
 }
 
 static int
-boolean_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
+common_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
 {
     int r;
     struct http_data *mdata = data;
     struct sol_flow_node_type_http_server_boolean_options *opts =
         (struct sol_flow_node_type_http_server_boolean_options *)options;
 
-    r = start_server(mdata, opts->path, boolean_response_cb);
+    r = start_server(mdata, node, opts->path);
     SOL_INT_CHECK(r, < 0, r);
 
     mdata->value.b = opts->value;
-    mdata->node = node;
 
     return 0;
+}
+
+static int
+common_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id,
+    const struct sol_flow_packet *packet)
+{
+    struct http_data *mdata = data;
+    const struct http_server_node_type *type;
+    int r;
+
+    type = (const struct http_server_node_type *)
+        sol_flow_node_get_type(node);
+
+    r = type->process_cb(mdata, packet);
+    SOL_INT_CHECK(r, < 0, r);
+
+    r = sol_http_server_set_last_modified(server, mdata->path, time(NULL));
+    SOL_INT_CHECK(r, < 0, r);
+
+    return 0;
+}
+
+static int
+boolean_post_cb(struct http_data *mdata, struct sol_flow_node *node,
+    struct sol_http_param_value *value)
+{
+    if (streq(value->value.key_value.value, "true"))
+        mdata->value.b = true;
+    else if (streq(value->value.key_value.value, "false"))
+        mdata->value.b = false;
+    else
+        return -EINVAL;
+
+    sol_flow_send_boolean_packet(node,
+        SOL_FLOW_NODE_TYPE_HTTP_SERVER_BOOLEAN__OUT__OUT,
+        mdata->value.b);
+
+    return 0;
+}
+
+static int
+boolean_response_cb(struct http_data *mdata, struct sol_buffer *content, bool json)
+{
+    int r;
+
+    r = sol_buffer_append_printf(content, "%s", mdata->value.b == true ? "true" : "false");
+    SOL_INT_CHECK(r, < 0, r);
+
+    return 0;
+}
+
+static int
+boolean_process_cb(struct http_data *mdata, const struct sol_flow_packet *packet)
+{
+    return sol_flow_packet_get_boolean(packet, &mdata->value.b);
 }
 
 /* ------------------------------------- string ------------------------------------------- */
 
 static int
-string_response_cb(void *data, struct sol_http_request *request)
+string_response_cb(struct http_data *mdata, struct sol_buffer *content, bool json)
 {
     int r = 0;
-    uint16_t idx;
-    bool send_json = false;
-    enum sol_http_method method;
-    struct http_data *mdata = data;
-    char *response_str;
-    struct sol_http_param_value *value;
-    struct sol_http_response response = {
-        .api_version = SOL_HTTP_RESPONSE_API_VERSION,
-        .content = SOL_BUFFER_INIT_EMPTY,
-        .param = SOL_HTTP_REQUEST_PARAM_INIT,
-        .response_code = SOL_HTTP_STATUS_OK
-    };
 
-    method = sol_http_request_get_method(request);
-    response.url = sol_http_request_get_url(request);
-
-    SOL_HTTP_PARAM_FOREACH_IDX (sol_http_request_get_params(request), value, idx) {
-        switch (value->type) {
-        case SOL_HTTP_PARAM_POST_FIELD:
-            if (streq(value->value.key_value.key, "value")) {
-                free(mdata->value.s);
-                mdata->value.s = strdup(value->value.key_value.value);
-                if (!mdata->value.s) {
-                    r = -ENOMEM;
-                    SOL_WRN("Could not duplicate the string");
-                    goto end;
-                }
-
-                r = sol_http_server_set_last_modified(server, mdata->path, time(NULL));
-                SOL_INT_CHECK_GOTO(r, < 0, end);
-            }
-            break;
-        case SOL_HTTP_PARAM_HEADER:
-            if (streq(value->value.key_value.key, HTTP_HEADER_ACCEPT)) {
-                if (strstr(value->value.key_value.value, HTTP_HEADER_CONTENT_TYPE_JSON))
-                    send_json = true;
-            }
-            break;
-        default:
-            break;
-        }
-    }
-
-    if (send_json) {
-        char *escaped_str;
+    if (json) {
         size_t escaped_len = sol_json_calculate_escaped_string_len(mdata->value.s);
-        escaped_str = malloc(escaped_len);
-        if (!escaped_str) {
-            SOL_WRN("Could not allocate escaped string");
-            r = -ENOMEM;
-            goto end;
-        }
-        sol_json_escape_string(mdata->value.s, escaped_str, escaped_len);
-        r = asprintf(&response_str, "{\"%s\": \"%s\"}", mdata->path,
-            escaped_str);
-        free(escaped_str);
+        r = sol_buffer_ensure(content, content->used + escaped_len);
+        SOL_INT_CHECK(r, < 0, r);
+
+        r = sol_buffer_append_char(content, '\"');
+        SOL_INT_CHECK(r, < 0, r);
+
+        sol_json_escape_string(mdata->value.s, sol_buffer_at_end(content), escaped_len);
+        content->used += escaped_len - 1; /* remove \0 in the result */
+
+        r = sol_buffer_append_char(content, '\"');
+        SOL_INT_CHECK(r, < 0, r);
     } else {
-        r = asprintf(&response_str, "%s", mdata->value.s);
+        r = sol_buffer_append_printf(content, "%s", mdata->value.s);
     }
-    SOL_INT_CHECK_GOTO(r, < 0, end);
-
-    r = sol_http_param_add(&response.param, SOL_HTTP_REQUEST_PARAM_HEADER(
-        HTTP_HEADER_CONTENT_TYPE, (send_json) ? HTTP_HEADER_CONTENT_TYPE_JSON : HTTP_HEADER_CONTENT_TYPE_TEXT));
-    SOL_INT_CHECK_GOTO(r, != true, end_response);
-
-    r = sol_buffer_set_slice(&response.content, sol_str_slice_from_str(response_str));
-    SOL_INT_CHECK_GOTO(r, < 0, end_response);
-
-    r = sol_http_server_send_response(request, &response);
-    SOL_INT_CHECK_GOTO(r, < 0, end);
-
-    if (method == SOL_HTTP_METHOD_POST) {
-        sol_flow_send_string_packet(mdata->node, SOL_FLOW_NODE_TYPE_HTTP_SERVER_STRING__OUT__OUT, mdata->value.s);
-    }
-
-end_response:
-    free(response_str);
-end:
-    sol_buffer_fini(&response.content);
-    sol_http_param_free(&response.param);
 
     return r;
 }
 
 static int
-string_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+string_post_cb(struct http_data *mdata, struct sol_flow_node *node,
+    struct sol_http_param_value *value)
 {
-    struct http_data *mdata = data;
+    if (streq(value->value.key_value.key, "value")) {
+        int ret = sol_util_replace_str_if_changed(&mdata->value.s,
+            value->value.key_value.value);
+        SOL_INT_CHECK(ret, < 0, ret);
+    } else {
+        return -EINVAL;
+    }
+
+    sol_flow_send_string_packet(node,
+        SOL_FLOW_NODE_TYPE_HTTP_SERVER_STRING__OUT__OUT,
+        mdata->value.s);
+
+    return 0;
+}
+
+static int
+string_process_cb(struct http_data *mdata, const struct sol_flow_packet *packet)
+{
     const char *val;
     int r;
 
     r = sol_flow_packet_get_string(packet, &val);
-    SOL_INT_CHECK(r, < 0, r);
-
-    r = sol_http_server_set_last_modified(server, mdata->path, time(NULL));
     SOL_INT_CHECK(r, < 0, r);
 
     free(mdata->value.s);
@@ -360,10 +355,8 @@ string_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_o
     mdata->value.s = strdup(opts->value);
     SOL_NULL_CHECK(mdata->value.s, -ENOMEM);
 
-    r = start_server(mdata, opts->path, string_response_cb);
+    r = start_server(mdata, node, opts->path);
     SOL_INT_CHECK_GOTO(r, < 0, err);
-
-    mdata->node = node;
 
     return 0;
 
@@ -376,287 +369,132 @@ err:
 /* ----------------------------------- int ------------------------------------------- */
 
 static int
-int_response_cb(void *data, struct sol_http_request *request)
+int_post_cb(struct http_data *mdata, struct sol_flow_node *node,
+    struct sol_http_param_value *value)
 {
-    int r = 0;
-    uint16_t idx;
-    bool send_json = false, modified = false;
-    enum sol_http_method method;
-    struct http_data *mdata = data;
-    char *response_str;
-    struct sol_http_param_value *value;
-    struct sol_http_response response = {
-        .api_version = SOL_HTTP_RESPONSE_API_VERSION,
-        .content = SOL_BUFFER_INIT_EMPTY,
-        .param = SOL_HTTP_REQUEST_PARAM_INIT,
-        .response_code = SOL_HTTP_STATUS_OK
-    };
-
-    method = sol_http_request_get_method(request);
-    response.url = sol_http_request_get_url(request);
-
 #define STRTOL_(field_) \
     do { \
         errno = 0; \
-        modified = true; \
         mdata->value.i.field_ = strtol(value->value.key_value.value, NULL, 0); \
         if (errno != 0) { \
-            r = -errno; \
-            goto end; \
+            return -errno; \
         } \
     } while (0)
 
-    SOL_HTTP_PARAM_FOREACH_IDX (sol_http_request_get_params(request), value, idx) {
-        switch (value->type) {
-        case SOL_HTTP_PARAM_POST_FIELD:
-            if (streq(value->value.key_value.key, "value"))
-                STRTOL_(val);
-
-            else if (streq(value->value.key_value.key, "min"))
-                STRTOL_(min);
-
-            else if (streq(value->value.key_value.key, "max"))
-                STRTOL_(max);
-
-            else if (streq(value->value.key_value.key, "step"))
-                STRTOL_(step);
-            break;
-        case SOL_HTTP_PARAM_HEADER:
-            if (streq(value->value.key_value.key, HTTP_HEADER_ACCEPT)) {
-                if (strstr(value->value.key_value.value, HTTP_HEADER_CONTENT_TYPE_JSON))
-                    send_json = true;
-            }
-            break;
-        default:
-            break;
-        }
-    }
+    if (streq(value->value.key_value.key, "value"))
+        STRTOL_(val);
+    else if (streq(value->value.key_value.key, "min"))
+        STRTOL_(min);
+    else if (streq(value->value.key_value.key, "max"))
+        STRTOL_(max);
+    else if (streq(value->value.key_value.key, "step"))
+        STRTOL_(step);
+    else
+        return -EINVAL;
 #undef STRTOL_
 
-    if (modified) {
-        r = sol_http_server_set_last_modified(server, mdata->path, time(NULL));
-        SOL_INT_CHECK_GOTO(r, < 0, end);
-    }
+    return 0;
+}
 
-    if (send_json) {
-        r = asprintf(&response_str, "{\"%s\":{\"value\":%d,\"min\":%d,\"max\":%d,\"step\":%d}}",
-            mdata->path, mdata->value.i.val, mdata->value.i.min, mdata->value.i.max, mdata->value.i.step);
+static int
+int_response_cb(struct http_data *mdata, struct sol_buffer *content, bool json)
+{
+    int r;
+
+    if (json) {
+        r = sol_buffer_append_printf(content, "{\"value\":%d,\"min\":%d,\"max\":%d,\"step\":%d}",
+            mdata->value.i.val, mdata->value.i.min, mdata->value.i.max, mdata->value.i.step);
     } else {
-        r = asprintf(&response_str, "%d", mdata->value.i.val);
+        r = sol_buffer_append_printf(content, "%d", mdata->value.i.val);
     }
-    SOL_INT_CHECK_GOTO(r, < 0, end);
-
-    r = sol_http_param_add(&response.param, SOL_HTTP_REQUEST_PARAM_HEADER(
-        HTTP_HEADER_CONTENT_TYPE, (send_json) ? HTTP_HEADER_CONTENT_TYPE_JSON : HTTP_HEADER_CONTENT_TYPE_TEXT));
-    SOL_INT_CHECK_GOTO(r, != true, end_response);
-
-    r = sol_buffer_set_slice(&response.content, sol_str_slice_from_str(response_str));
-    SOL_INT_CHECK_GOTO(r, < 0, end_response);
-
-    if (method == SOL_HTTP_METHOD_POST) {
-        sol_flow_send_irange_packet(mdata->node, SOL_FLOW_NODE_TYPE_HTTP_SERVER_INT__OUT__OUT, &mdata->value.i);
-    }
-
-    r = sol_http_server_send_response(request, &response);
-    SOL_INT_CHECK_GOTO(r, < 0, end_response);
-
-end_response:
-    free(response_str);
-end:
-    sol_buffer_fini(&response.content);
-    sol_http_param_free(&response.param);
 
     return r;
 }
 
-static int
-int_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
-{
-    struct http_data *mdata = data;
-    int r;
-
-    r = sol_flow_packet_get_irange(packet, &mdata->value.i);
-    SOL_INT_CHECK(r, < 0, r);
-
-    r = sol_http_server_set_last_modified(server, mdata->path, time(NULL));
-    SOL_INT_CHECK(r, < 0, r);
-
-    return 0;
-}
-
 static void
-int_close(struct sol_flow_node *node, void *data)
+int_send_packet_cb(struct http_data *mdata, struct sol_flow_node *node)
 {
-    struct http_data *mdata = data;
-
-    stop_server(mdata);
+    sol_flow_send_irange_packet(node,
+        SOL_FLOW_NODE_TYPE_HTTP_SERVER_INT__OUT__OUT, &mdata->value.i);
 }
 
 static int
-int_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
+int_process_cb(struct http_data *mdata, const struct sol_flow_packet *packet)
 {
-    int r;
-    struct http_data *mdata = data;
-    struct sol_flow_node_type_http_server_int_options *opts =
-        (struct sol_flow_node_type_http_server_int_options *)options;
-
-    mdata->value.i = opts->value;
-    mdata->node = node;
-
-    r = start_server(mdata, opts->path, int_response_cb);
-    SOL_INT_CHECK(r, < 0, r);
-
-    return 0;
+    return sol_flow_packet_get_irange(packet, &mdata->value.i);
 }
 
 /* ------------------------------------------- float ------------------------------------------------- */
 
 static int
-float_response_cb(void *data, struct sol_http_request *request)
+float_post_cb(struct http_data *mdata, struct sol_flow_node *node,
+    struct sol_http_param_value *value)
 {
-    int r;
-    uint16_t idx;
-    enum sol_http_method method;
-    bool send_json = false, modified = false;
-    struct http_data *mdata = data;
-    char *response_str, val[DOUBLE_STRING_LEN], min[DOUBLE_STRING_LEN],
-        max[DOUBLE_STRING_LEN], step[DOUBLE_STRING_LEN];
-    struct sol_http_param_value *value;
-    struct sol_http_response response = {
-        .api_version = SOL_HTTP_RESPONSE_API_VERSION,
-        .content = SOL_BUFFER_INIT_EMPTY,
-        .param = SOL_HTTP_REQUEST_PARAM_INIT,
-        .response_code = SOL_HTTP_STATUS_OK
-    };
-
-    method = sol_http_request_get_method(request);
-    response.url = sol_http_request_get_url(request);
-
 #define STRTOD_(field_) \
     do { \
         errno = 0; \
-        modified = true; \
         mdata->value.d.field_ = sol_util_strtodn(value->value.key_value.value, NULL, \
             -1, false); \
         if ((fpclassify(mdata->value.d.field_) == FP_ZERO) && (errno != 0)) { \
-            r = -errno; \
-            goto end; \
+            return -errno; \
         } \
     } while (0)
 
-    SOL_HTTP_PARAM_FOREACH_IDX (sol_http_request_get_params(request), value, idx) {
-        switch (value->type) {
-        case SOL_HTTP_PARAM_POST_FIELD:
-            if (streq(value->value.key_value.key, "value"))
-                STRTOD_(val);
-
-            else if (streq(value->value.key_value.key, "min"))
-                STRTOD_(min);
-
-            else if (streq(value->value.key_value.key, "max"))
-                STRTOD_(max);
-
-            else if (streq(value->value.key_value.key, "step"))
-                STRTOD_(step);
-            break;
-        case SOL_HTTP_PARAM_HEADER:
-            if (streq(value->value.key_value.key, HTTP_HEADER_ACCEPT)) {
-                if (strstr(value->value.key_value.value, HTTP_HEADER_CONTENT_TYPE_JSON))
-                    send_json = true;
-            }
-            break;
-        default:
-            break;
-        }
-    }
+    if (streq(value->value.key_value.key, "value"))
+        STRTOD_(val);
+    else if (streq(value->value.key_value.key, "min"))
+        STRTOD_(min);
+    else if (streq(value->value.key_value.key, "max"))
+        STRTOD_(max);
+    else if (streq(value->value.key_value.key, "step"))
+        STRTOD_(step);
+    else
+        return -EINVAL;
 #undef STRTOD_
 
-    if (modified) {
-        r = sol_http_server_set_last_modified(server, mdata->path, time(NULL));
-        SOL_INT_CHECK_GOTO(r, < 0, end);
-    }
+    return 0;
+}
+
+static int
+float_response_cb(struct http_data *mdata, struct sol_buffer *content, bool json)
+{
+    int r;
+    char val[DOUBLE_STRING_LEN], min[DOUBLE_STRING_LEN],
+        max[DOUBLE_STRING_LEN], step[DOUBLE_STRING_LEN];
 
     r = sol_json_double_to_str(mdata->value.d.val, val, sizeof(val));
-    SOL_INT_CHECK_GOTO(r, < 0, end);
+    SOL_INT_CHECK(r, < 0, r);
 
     r = sol_json_double_to_str(mdata->value.d.min, min, sizeof(min));
-    SOL_INT_CHECK_GOTO(r, < 0, end);
+    SOL_INT_CHECK(r, < 0, r);
 
     r = sol_json_double_to_str(mdata->value.d.max, max, sizeof(max));
-    SOL_INT_CHECK_GOTO(r, < 0, end);
+    SOL_INT_CHECK(r, < 0, r);
 
     r = sol_json_double_to_str(mdata->value.d.step, step, sizeof(step));
-    SOL_INT_CHECK_GOTO(r, < 0, end);
+    SOL_INT_CHECK(r, < 0, r);
 
-    if (send_json) {
-        r = asprintf(&response_str, "{\"%s\":{\"value\":%s,\"min\":%s,\"max\":%s,\"step\":%s}}",
-            mdata->path, val, min, max, step);
+    if (json) {
+        r = sol_buffer_append_printf(content, "{\"value\":%s,\"min\":%s,\"max\":%s,\"step\":%s}",
+            val, min, max, step);
     } else {
-        r = asprintf(&response_str, "%s", val);
+        r = sol_buffer_append_printf(content, "%s", val);
     }
-    SOL_INT_CHECK_GOTO(r, < 0, end);
-
-    r = sol_http_param_add(&response.param, SOL_HTTP_REQUEST_PARAM_HEADER(
-        HTTP_HEADER_CONTENT_TYPE, (send_json) ? HTTP_HEADER_CONTENT_TYPE_JSON : HTTP_HEADER_CONTENT_TYPE_TEXT));
-    SOL_INT_CHECK_GOTO(r, != true, end_response);
-
-    r = sol_buffer_set_slice(&response.content, sol_str_slice_from_str(response_str));
-    SOL_INT_CHECK_GOTO(r, < 0, end_response);
-
-    if (method == SOL_HTTP_METHOD_POST) {
-        sol_flow_send_drange_packet(mdata->node, SOL_FLOW_NODE_TYPE_HTTP_SERVER_FLOAT__OUT__OUT, &mdata->value.d);
-    }
-
-    r = sol_http_server_send_response(request, &response);
-    SOL_INT_CHECK_GOTO(r, < 0, end_response);
-
-end_response:
-    free(response_str);
-end:
-    sol_buffer_fini(&response.content);
-    sol_http_param_free(&response.param);
 
     return r;
 }
 
-static int
-float_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
-{
-    struct http_data *mdata = data;
-    int r;
-
-    r = sol_flow_packet_get_drange(packet, &mdata->value.d);
-    SOL_INT_CHECK(r, < 0, r);
-
-    r = sol_http_server_set_last_modified(server, mdata->path, time(NULL));
-    SOL_INT_CHECK(r, < 0, r);
-
-    return 0;
-}
-
 static void
-float_close(struct sol_flow_node *node, void *data)
+float_send_packet_cb(struct http_data *mdata, struct sol_flow_node *node)
 {
-    struct http_data *mdata = data;
-
-    stop_server(mdata);
+    sol_flow_send_drange_packet(node,
+        SOL_FLOW_NODE_TYPE_HTTP_SERVER_FLOAT__OUT__OUT, &mdata->value.d);
 }
 
 static int
-float_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
+float_process_cb(struct http_data *mdata, const struct sol_flow_packet *packet)
 {
-    int r;
-    struct http_data *mdata = data;
-    struct sol_flow_node_type_http_server_float_options *opts =
-        (struct sol_flow_node_type_http_server_float_options *)options;
-
-    mdata->value.d = opts->value;
-    mdata->node = node;
-
-    r = start_server(mdata, opts->path, float_response_cb);
-    SOL_INT_CHECK(r, < 0, r);
-
-    return 0;
+    return sol_flow_packet_get_drange(packet, &mdata->value.d);
 }
 
 #include "http-server-gen.c"

--- a/src/modules/flow/http-server/http-server.c
+++ b/src/modules/flow/http-server/http-server.c
@@ -368,6 +368,7 @@ string_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_o
     return 0;
 
 err:
+    free(mdata->value.s);
     free(mdata->path);
     return -1;
 }

--- a/src/modules/flow/http-server/http-server.json
+++ b/src/modules/flow/http-server/http-server.json
@@ -11,8 +11,19 @@
       "category": "output/network",
       "description": "HTTP Server for boolean",
       "methods": {
-        "close": "boolean_close",
-        "open": "boolean_open"
+        "close": "common_close",
+        "open": "common_open"
+      },
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct http_server_node_type",
+        "extra_methods": {
+	  "response_cb": "boolean_response_cb",
+	  "post_cb": "boolean_post_cb",
+	  "process_cb": "boolean_process_cb"
+        }
       },
       "name": "http-server/boolean",
       "options": {
@@ -37,7 +48,7 @@
 	  "data_type": "boolean",
 	  "description": "The value that will be give on a GET",
           "methods": {
-            "process": "boolean_process"
+            "process": "common_process"
           },
           "name": "IN"
         }
@@ -58,6 +69,17 @@
       "methods": {
         "close": "string_close",
         "open": "string_open"
+      },
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct http_server_node_type",
+        "extra_methods": {
+	  "response_cb": "string_response_cb",
+	  "post_cb": "string_post_cb",
+	  "process_cb": "string_process_cb"
+        }
       },
       "name": "http-server/string",
       "options": {
@@ -82,7 +104,7 @@
 	  "data_type": "string",
 	  "description": "The value that will be give on a GET",
           "methods": {
-            "process": "string_process"
+            "process": "common_process"
           },
           "name": "IN"
         }
@@ -101,8 +123,20 @@
       "category": "output/network",
       "description": "HTTP Server for integer",
       "methods": {
-        "close": "int_close",
-        "open": "int_open"
+        "close": "common_close",
+        "open": "common_open"
+      },
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct http_server_node_type",
+        "extra_methods": {
+	  "response_cb": "int_response_cb",
+	  "post_cb": "int_post_cb",
+	  "process_cb": "int_process_cb",
+	  "send_packet_cb": "int_send_packet_cb"
+        }
       },
       "name": "http-server/int",
       "options": {
@@ -127,7 +161,7 @@
 	  "data_type": "int",
 	  "description": "The value that will be give on a GET",
           "methods": {
-            "process": "int_process"
+            "process": "common_process"
           },
           "name": "IN"
         }
@@ -146,8 +180,20 @@
       "category": "output/network",
       "description": "HTTP Server for float",
       "methods": {
-        "close": "float_close",
-        "open": "float_open"
+        "close": "common_close",
+        "open": "common_open"
+      },
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct http_server_node_type",
+        "extra_methods": {
+	  "response_cb": "float_response_cb",
+	  "post_cb": "float_post_cb",
+	  "process_cb": "float_process_cb",
+	  "send_packet_cb": "float_send_packet_cb"
+        }
       },
       "name": "http-server/float",
       "options": {
@@ -172,7 +218,7 @@
 	  "data_type": "float",
 	  "description": "The value that will be give on a GET",
           "methods": {
-            "process": "float_process"
+            "process": "common_process"
           },
           "name": "IN"
         }

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -329,3 +329,36 @@ err:
     sol_buffer_fini(&buf);
     return r;
 }
+
+SOL_API int
+sol_util_replace_str_if_changed(char **str, const char *new_str)
+{
+    if (!str)
+        return -EINVAL;
+
+    if (!new_str) {
+        if (*str)
+            free(*str);
+        *str = NULL;
+        return 0;
+    }
+
+    if (*str) {
+        size_t str_len = strlen(*str);
+        size_t new_str_len = strlen(new_str);
+
+        if (str_len == new_str_len && memcmp(*str, new_str, str_len) == 0) {
+            return 0;
+        } else if (str_len < new_str_len) {
+            char *tmp = realloc(*str, new_str_len + 1);
+            SOL_NULL_CHECK(tmp, -ENOMEM);
+            *str = tmp;
+        }
+        memcpy(*str, new_str, new_str_len + 1);
+    } else {
+        *str = strdup(new_str);
+        SOL_NULL_CHECK(*str, -ENOMEM);
+    }
+
+    return 0;
+}

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -371,3 +371,5 @@ sol_util_int32_clamp(int32_t start, int32_t end, int32_t value)
         return end;
     return value;
 }
+
+int sol_util_replace_str_if_changed(char **str, const char *new_str);


### PR DESCRIPTION
from v1:
 - Added function to replace a string only if the content changed
 - Added helper to append a char to a buffer
 - Manage the response content directly (sol-buffer) instead of create strings and then set them.
 - The virtual response_cb only set the value. Before it was setting the key (path) making harder to use it further on groups.