### PR TITLE
Fix undefined behavior in align_power2()

### DIFF
--- a/src/lib/common/include/sol-glib-integration.h
+++ b/src/lib/common/include/sol-glib-integration.h
@@ -47,6 +47,7 @@
 #include <sol-mainloop.h>
 #include <sol-log.h>
 #include <sol-vector.h>
+#include <sol-util.h>
 
 static gboolean
 _sol_glib_integration_gsource_prepare(GSource *source, gint *timeout)
@@ -252,18 +253,6 @@ _sol_glib_integration_source_release(struct _sol_glib_integration_source_data *m
     g_main_context_release(ctx);
 }
 
-static inline unsigned int
-_sol_glib_integration_align_power2(unsigned int u)
-{
-    unsigned int left_zeros;
-
-    if (u == 1)
-        return 1;
-    if ((left_zeros = __builtin_clz(u - 1)) < 1)
-        return 0;
-    return 1 << ((sizeof(u) * 8) - left_zeros);
-}
-
 static bool
 _sol_glib_integration_source_prepare(void *data)
 {
@@ -286,7 +275,7 @@ _sol_glib_integration_source_prepare(void *data)
 
         mdata->n_poll = g_main_context_query(ctx,
             mdata->max_prio, &mdata->timeout, mdata->fds, mdata->n_fds);
-        req_n_fds = _sol_glib_integration_align_power2(mdata->n_poll);
+        req_n_fds = align_power2_uint(mdata->n_poll);
 
         if (req_n_fds == mdata->n_fds)
             break;

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -77,7 +77,7 @@ sol_buffer_ensure(struct sol_buffer *buf, size_t min_size)
     if (buf->capacity >= min_size)
         return 0;
 
-    err = sol_buffer_resize(buf, align_power2(min_size + nul_byte_size(buf)));
+    err = sol_buffer_resize(buf, align_power2_size(min_size + nul_byte_size(buf)));
     if (err == -EPERM)
         return -ENOMEM;
     return err;

--- a/src/lib/datatypes/sol-vector.c
+++ b/src/lib/datatypes/sol-vector.c
@@ -56,8 +56,8 @@ sol_vector_grow(struct sol_vector *v, uint16_t amount)
         return -EOVERFLOW;
 
     new_len = v->len + amount;
-    old_cap = align_power2(v->len);
-    new_cap = align_power2(new_len);
+    old_cap = align_power2_short_uint(v->len);
+    new_cap = align_power2_short_uint(new_len);
 
     if (new_cap != old_cap) {
         void *data;
@@ -118,8 +118,8 @@ sol_vector_shrink(struct sol_vector *v)
         return;
     }
 
-    old_cap = align_power2(v->len + 1);
-    new_cap = align_power2(v->len);
+    old_cap = align_power2_short_uint(v->len + 1U);
+    new_cap = align_power2_short_uint(v->len);
     if (new_cap == old_cap)
         return;
 

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -193,18 +193,40 @@ char *sol_util_strerror(int errnum, char *buf, size_t buflen);
         sol_util_strerror((errnum), buf ## __COUNT__, sizeof(buf ## __COUNT__)); \
     })
 
-static inline unsigned int
-align_power2(unsigned int u)
-{
-    unsigned int left_zeros;
+/* Power of 2 alignment. */
+#define DEFINE_ALIGN_POWER2(name_, type_, max_, clz_fn_) \
+    static inline type_ \
+    name_(type_ u) \
+    { \
+        unsigned int left_zeros; \
+        if (u == 1) \
+            return 1; \
+        if ((left_zeros = clz_fn_(u - 1)) < 1) \
+            return 0; \
+        if (unlikely(left_zeros == 1)) \
+            return max_; \
+        return 1 << ((sizeof(u) * 8) - left_zeros); \
+    }
 
-    if (u == 1)
-        return 1;
-    if ((left_zeros = __builtin_clz(u - 1)) < 1)
-        return 0;
-    if (unlikely(left_zeros == 1))
-        return UINT_MAX;
-    return 1 << ((sizeof(u) * 8) - left_zeros);
+DEFINE_ALIGN_POWER2(align_power2_uint, unsigned int, UINT_MAX, __builtin_clz)
+#if SIZE_MAX == ULONG_MAX
+DEFINE_ALIGN_POWER2(align_power2_size, size_t, SIZE_MAX, __builtin_clzl)
+#elif SIZE_MAX == ULLONG_MAX
+DEFINE_ALIGN_POWER2(align_power2_size, size_t, SIZE_MAX, __builtin_clzll)
+#elif SIZE_MAX == UINT_MAX
+DEFINE_ALIGN_POWER2(align_power2_size, size_t, SIZE_MAX, __builtin_clz)
+#else
+#error Unsupported size_t size
+#endif
+
+#undef DEFINE_ALIGN_POWER2
+
+static inline int
+align_power2_short_uint(unsigned short u)
+{
+    unsigned int aligned = align_power2_uint(u);
+
+    return likely(aligned <= USHRT_MAX) ? aligned : USHRT_MAX;
 }
 
 /**

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -202,6 +202,8 @@ align_power2(unsigned int u)
         return 1;
     if ((left_zeros = __builtin_clz(u - 1)) < 1)
         return 0;
+    if (unlikely(left_zeros == 1))
+        return UINT_MAX;
     return 1 << ((sizeof(u) * 8) - left_zeros);
 }
 

--- a/src/test/test-util.c
+++ b/src/test/test-util.c
@@ -67,11 +67,12 @@ test_align_power2(void)
         { 15, 16 },
         { 16, 16 },
         { 17, 32 },
+        { ((1U << (sizeof(unsigned int) * 8U - 1U)) - 42U), UINT_MAX }
     };
 
     for (i = 0; i < ARRAY_SIZE(table); i++) {
         unsigned int actual;
-        actual = align_power2(table[i].input);
+        actual = align_power2_uint(table[i].input);
 
         if (actual != table[i].output) {
             fprintf(stderr, "Error calling align_power2(%u), got %u but expected %u\n",


### PR DESCRIPTION
If __builtin_clz() returns 1, the shift operation will try to shift by 31 bits, which is undefined behavior. Guard against that by returning UINT_MAX, which should be the next power of two.

In addition, create a bunch of align_power2() functions to work with integers of different sizes.  C11's _Generic() would be a better candidate but for some reason it's not available in the CI server.

These functions will each return the correct maximum value and uses the correct leading zero counting builtin for the type, and, in the case of unsigned shorts (often 16-bit), provide a function that clamps the results to USHRT_MAX.