### PR TITLE
flow/string-format: Also ensure that precision == 0 is valid in another case

### DIFF
--- a/src/modules/flow/converter/string-format.c
+++ b/src/modules/flow/converter/string-format.c
@@ -1289,7 +1289,7 @@ ensure_decimal_point(struct sol_buffer *buffer, int precision)
             /* We have a decimal point, but no following digit. Insert
                a zero after the decimal. */
             /* can't ever get here via double_to_string */
-            assert(precision == -1);
+            assert(precision == 0 || precision == -1);
             ++p;
             chars_to_insert = "0";
             insert_count = 1;


### PR DESCRIPTION
Do this not only in the case where there's an exponent.
