### PR TITLE
blob: Add helper to print string blobs

### DIFF
--- a/src/bin/sol-fbp-runner/inspector.c
+++ b/src/bin/sol-fbp-runner/inspector.c
@@ -182,13 +182,15 @@ inspector_show_packet(const struct sol_flow_packet *packet)
     } else if (type == SOL_FLOW_PACKET_TYPE_JSON_OBJECT) {
         struct sol_blob *v;
         if (sol_flow_packet_get_json_object(packet, &v) == 0) {
-            fprintf(stdout, "<%.*s>", (int)v->size, (char *)v->mem);
+            fprintf(stdout, "<%.*s>",
+                SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(v)));
             return;
         }
     } else if (type == SOL_FLOW_PACKET_TYPE_JSON_ARRAY) {
         struct sol_blob *v;
         if (sol_flow_packet_get_json_array(packet, &v) == 0) {
-            fprintf(stdout, "<%.*s>", (int)v->size, (char *)v->mem);
+            fprintf(stdout, "<%.*s>",
+                SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(v)));
             return;
         }
     } else if (type == SOL_FLOW_PACKET_TYPE_RGB) {

--- a/src/lib/datatypes/include/sol-str-slice.h
+++ b/src/lib/datatypes/include/sol-str-slice.h
@@ -37,6 +37,7 @@
 #include <string.h>
 
 #include <sol-macros.h>
+#include <sol-types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -106,6 +107,12 @@ static SOL_ATTR_NONNULL(1) inline struct sol_str_slice
 sol_str_slice_from_str(const char *s)
 {
     return SOL_STR_SLICE_STR(s, strlen(s));
+}
+
+static SOL_ATTR_NONNULL(1) inline struct sol_str_slice
+sol_str_slice_from_blob(const struct sol_blob *blob)
+{
+    return SOL_STR_SLICE_STR(blob->mem, blob->size);
 }
 
 int sol_str_slice_to_int(const struct sol_str_slice s, int *value);

--- a/src/modules/flow/console/console.c
+++ b/src/modules/flow/console/console.c
@@ -155,16 +155,16 @@ console_in_process(struct sol_flow_node *node, void *data, uint16_t port, uint16
         int r = sol_flow_packet_get_json_object(packet, &val);
         SOL_INT_CHECK(r, < 0, r);
 
-        console_output(mdata, "%.*s (JSON object)", (int)val->size,
-            (char *)val->mem);
+        console_output(mdata, "%.*s (JSON object)",
+            SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(val)));
     } else if (packet_type == SOL_FLOW_PACKET_TYPE_JSON_ARRAY) {
         struct sol_blob *val;
 
         int r = sol_flow_packet_get_json_array(packet, &val);
         SOL_INT_CHECK(r, < 0, r);
 
-        console_output(mdata, "%.*s (JSON array)", (int)val->size,
-            (char *)val->mem);
+        console_output(mdata, "%.*s (JSON array)",
+            SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(val)));
     } else if (packet_type == SOL_FLOW_PACKET_TYPE_ERROR) {
         int code;
         const char *msg;


### PR DESCRIPTION
Add a conversor from blob to str_slice to make it easier to print a string
blob using SOL_STR_SLICE_PRINT.

Note that creating a SOL_BLOB_PRINT macro is not a good approach because
not all blobs can be printed as strings. Making the conversion to
str_slice explicit may avoid errors

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>