### PR TITLE
Add extra nodes to handle JSON object and JSON array

### DIFF
--- a/src/lib/parsers/include/sol-json.h
+++ b/src/lib/parsers/include/sol-json.h
@@ -98,6 +98,14 @@ enum sol_json_loop_reason {
     for (end_reason_ = _sol_json_loop_helper_init(scanner_, token_, SOL_JSON_TYPE_ARRAY_START); \
         _sol_json_loop_helper_array(scanner_, token_, &end_reason_, element_type_);)
 
+#define SOL_JSON_SCANNER_ARRAY_LOOP_ALL_NEST(scanner_, token_, end_reason_) \
+    for (end_reason_ = SOL_JSON_LOOP_REASON_OK;  \
+        _sol_json_loop_helper_generic(scanner_, token_, SOL_JSON_TYPE_ARRAY_END, &end_reason_);)
+
+#define SOL_JSON_SCANNER_ARRAY_LOOP_ALL(scanner_, token_, end_reason_) \
+    for (end_reason_ = _sol_json_loop_helper_init(scanner_, token_, SOL_JSON_TYPE_ARRAY_START); \
+        _sol_json_loop_helper_generic(scanner_, token_, SOL_JSON_TYPE_ARRAY_END, &end_reason_);)
+
 #define SOL_JSON_SCANNER_OBJECT_LOOP_NEST(scanner_, token_, key_, value_, end_reason_) \
     for (end_reason_ = SOL_JSON_LOOP_REASON_OK; \
         _sol_json_loop_helper_object(scanner_, token_, key_, value_, &end_reason_);)

--- a/src/modules/flow/json/json.c
+++ b/src/modules/flow/json/json.c
@@ -72,17 +72,15 @@ json_object_get_key_close(struct sol_flow_node *node, void *data)
 }
 
 static struct sol_blob *
-create_sub_json_object(struct sol_blob *parent, struct sol_json_token *token)
+create_sub_json(struct sol_blob *parent, struct sol_json_scanner *scanner, struct sol_json_token *token, enum sol_json_type type)
 {
-    struct sol_json_scanner scanner;
     const char *mem;
 
     mem = token->start;
-    sol_json_scanner_init(&scanner, parent->mem, parent->size);
-    if (!sol_json_scanner_skip_over(&scanner, token))
+    if (!sol_json_scanner_skip_over(scanner, token))
         return NULL;
 
-    if (sol_json_token_get_type(token) != SOL_JSON_TYPE_OBJECT_END) {
+    if (sol_json_token_get_type(token) != type) {
         errno = EINVAL;
         return NULL;
     }
@@ -106,16 +104,91 @@ json_object_search_for_token(struct sol_json_scanner *scanner, const char *key, 
 }
 
 static int
+send_token_packet(struct sol_flow_node *node, struct sol_json_scanner *scanner, struct sol_blob *json, struct sol_json_token *token)
+{
+    enum sol_json_type type;
+    struct sol_blob *new_blob;
+    struct sol_irange value_int = SOL_IRANGE_INIT();
+    struct sol_drange value_float = SOL_DRANGE_INIT();
+    struct sol_str_slice slice;
+    int r;
+
+    type = sol_json_token_get_type(token);
+    switch (type) {
+    case SOL_JSON_TYPE_OBJECT_START:
+        new_blob = create_sub_json(json, scanner, token,
+            SOL_JSON_TYPE_OBJECT_END);
+        SOL_NULL_CHECK(new_blob, -errno);
+        r = sol_flow_send_json_object_packet(node,
+            SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__OBJECT,
+            new_blob);
+        sol_blob_unref(new_blob);
+        return r;
+    case SOL_JSON_TYPE_ARRAY_START:
+        if (sol_json_token_get_size(token) > 1) {
+            new_blob = sol_blob_new(SOL_BLOB_TYPE_NOFREE,
+                json, token->start, sol_json_token_get_size(token));
+            SOL_NULL_CHECK(new_blob, -errno);
+            r = sol_flow_send_json_array_packet(node,
+                SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__ARRAY, new_blob);
+            sol_blob_unref(new_blob);
+            return r;
+        }
+        new_blob = create_sub_json(json, scanner, token,
+            SOL_JSON_TYPE_ARRAY_END);
+        SOL_NULL_CHECK(new_blob, -errno);
+        r = sol_flow_send_json_array_packet(node,
+            SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__ARRAY,
+            new_blob);
+        sol_blob_unref(new_blob);
+        return r;
+    case SOL_JSON_TYPE_TRUE:
+        return sol_flow_send_boolean_packet(node,
+            SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__BOOLEAN,
+            true);
+    case SOL_JSON_TYPE_FALSE:
+        return sol_flow_send_boolean_packet(node,
+            SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__BOOLEAN,
+            false);
+    case SOL_JSON_TYPE_NULL:
+        return sol_flow_send_empty_packet(node,
+            SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__NULL);
+    case SOL_JSON_TYPE_STRING:
+        sol_json_token_remove_quotes(token);
+        slice = sol_json_token_to_slice(token);
+        return sol_flow_send_string_slice_packet(node,
+            SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__STRING,
+            slice);
+    case SOL_JSON_TYPE_NUMBER:
+        r = sol_json_token_get_double(token, &value_float.val);
+        SOL_INT_CHECK(r, < 0, r);
+        r = sol_flow_send_drange_packet(node,
+            SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__FLOAT,
+            &value_float);
+        SOL_INT_CHECK(r, < 0, r);
+
+        r = sol_json_token_get_int32(token, &value_int.val);
+        if (r == -EINVAL) /* Not an integer number */
+            return 0;
+        SOL_INT_CHECK(r, < 0, r);
+        return sol_flow_send_irange_packet(node,
+            SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__INT,
+            &value_int);
+
+    default:
+        slice = sol_json_token_to_slice(token);
+        return sol_flow_send_error_packet(node, EINVAL,
+            "JSON Object value %.*s is invalid",
+            SOL_STR_SLICE_PRINT(slice));
+    }
+}
+
+
+static int
 json_object_key_process(struct sol_flow_node *node, struct sol_json_object_key *mdata)
 {
     struct sol_json_scanner scanner;
     struct sol_json_token value;
-    enum sol_json_type type;
-    struct sol_irange value_int = SOL_IRANGE_INIT();
-    struct sol_drange value_float = SOL_DRANGE_INIT();
-    struct sol_str_slice slice;
-    struct sol_blob *new_blob;
-    int r;
 
     if (!mdata->key[0] || !mdata->json_object)
         return 0;
@@ -123,66 +196,8 @@ json_object_key_process(struct sol_flow_node *node, struct sol_json_object_key *
     sol_json_scanner_init(&scanner, mdata->json_object->mem,
         mdata->json_object->size);
 
-    if (json_object_search_for_token(&scanner, mdata->key, &value)) {
-        type = sol_json_token_get_type(&value);
-        switch (type) {
-        case SOL_JSON_TYPE_OBJECT_START:
-            new_blob = create_sub_json_object(mdata->json_object, &value);
-            SOL_NULL_CHECK(new_blob, -errno);
-            r = sol_flow_send_json_object_packet(node,
-                SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__OBJECT,
-                new_blob);
-            sol_blob_unref(new_blob);
-            return r;
-        case SOL_JSON_TYPE_ARRAY_START:
-            new_blob = sol_blob_new(SOL_BLOB_TYPE_NOFREE,
-                mdata->json_object, value.start,
-                sol_json_token_get_size(&value));
-            SOL_NULL_CHECK(new_blob, -errno);
-            r = sol_flow_send_json_array_packet(node,
-                SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__ARRAY,
-                new_blob);
-            sol_blob_unref(new_blob);
-            return r;
-        case SOL_JSON_TYPE_TRUE:
-            return sol_flow_send_boolean_packet(node,
-                SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__BOOLEAN,
-                true);
-        case SOL_JSON_TYPE_FALSE:
-            return sol_flow_send_boolean_packet(node,
-                SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__BOOLEAN,
-                false);
-        case SOL_JSON_TYPE_NULL:
-            return sol_flow_send_empty_packet(node,
-                SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__NULL);
-        case SOL_JSON_TYPE_STRING:
-            sol_json_token_remove_quotes(&value);
-            slice = sol_json_token_to_slice(&value);
-            return sol_flow_send_string_slice_packet(node,
-                SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__STRING,
-                slice);
-        case SOL_JSON_TYPE_NUMBER:
-            r = sol_json_token_get_double(&value, &value_float.val);
-            SOL_INT_CHECK(r, < 0, r);
-            r = sol_flow_send_drange_packet(node,
-                SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__FLOAT,
-                &value_float);
-            SOL_INT_CHECK(r, < 0, r);
-
-            r = sol_json_token_get_int32(&value, &value_int.val);
-            if (r == -EINVAL) /* Not an integer number */
-                return 0;
-            SOL_INT_CHECK(r, < 0, r);
-            return sol_flow_send_irange_packet(node,
-                SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__INT,
-                &value_int);
-        default:
-            slice = sol_json_token_to_slice(&value);
-            return sol_flow_send_error_packet(node, EINVAL,
-                "JSON Object value %.*s, pointed by key %s is invalid",
-                SOL_STR_SLICE_PRINT(slice), mdata->key);
-        }
-    }
+    if (json_object_search_for_token(&scanner, mdata->key, &value))
+        return send_token_packet(node, &scanner, mdata->json_object, &value);
 
     return sol_flow_send_error_packet(node, EINVAL,
         "JSON object doesn't contain key %s", mdata->key);
@@ -222,6 +237,221 @@ json_object_get_key_in_process(struct sol_flow_node *node, void *data, uint16_t 
     SOL_NULL_CHECK(mdata->json_object, -errno);
 
     return json_object_key_process(node, mdata);
+}
+
+static int
+json_object_length_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    int r;
+    struct sol_blob *in_value;
+    struct sol_json_scanner scanner;
+    enum sol_json_loop_reason reason;
+    struct sol_json_token token, key, value;
+    struct sol_irange len = { 0, 0, INT32_MAX, 1 };
+
+    r = sol_flow_packet_get_json_object(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    sol_json_scanner_init(&scanner, in_value->mem, in_value->size);
+    SOL_JSON_SCANNER_OBJECT_LOOP (&scanner, &token, &key, &value, reason)
+        len.val++;
+
+    return sol_flow_send_irange_packet(node,
+        SOL_FLOW_NODE_TYPE_JSON_OBJECT_LENGTH__OUT__OUT, &len);
+}
+
+static int
+json_object_get_all_keys_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    int r;
+    struct sol_blob *in_value;
+    struct sol_json_scanner scanner;
+    enum sol_json_loop_reason reason;
+    struct sol_json_token token, key, value;
+    struct sol_str_slice slice;
+    bool empty = true;
+
+    r = sol_flow_packet_get_json_object(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    sol_json_scanner_init(&scanner, in_value->mem, in_value->size);
+    SOL_JSON_SCANNER_OBJECT_LOOP (&scanner, &token, &key, &value, reason) {
+        sol_json_token_remove_quotes(&key);
+        slice = sol_json_token_to_slice(&key);
+        r = sol_flow_send_string_slice_packet(node,
+            SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_ALL_KEYS__OUT__OUT, slice);
+        SOL_INT_CHECK(r, < 0, r);
+        empty = false;
+    }
+
+    return sol_flow_send_boolean_packet(node,
+        SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_ALL_KEYS__OUT__EMPTY, empty);
+}
+
+struct sol_json_array_index {
+    struct sol_blob *json_array;
+    int32_t index;
+};
+
+
+static bool
+json_array_get_at_index(struct sol_json_scanner *scanner, struct sol_json_token *token, int32_t index, enum sol_json_loop_reason *reason)
+{
+    int32_t cur_index = 0;
+
+    SOL_JSON_SCANNER_ARRAY_LOOP_ALL(scanner, token, *reason) {
+        if (index == cur_index)
+            return true;
+
+        if (!sol_json_scanner_skip_over(scanner, token))
+            return -errno;
+        cur_index++;
+    }
+
+    return false;
+}
+
+static int
+json_array_get_index_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
+{
+    struct sol_json_array_index *mdata = data;
+    const struct sol_flow_node_type_json_array_get_at_index_options *opts;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_JSON_ARRAY_GET_AT_INDEX_OPTIONS_API_VERSION,
+        -EINVAL);
+    opts = (const struct sol_flow_node_type_json_array_get_at_index_options *)
+        options;
+
+    mdata->index = opts->index.val;
+
+    return 0;
+}
+
+static void
+json_array_get_index_close(struct sol_flow_node *node, void *data)
+{
+    struct sol_json_array_index *mdata = data;
+
+    if (mdata->json_array)
+        sol_blob_unref(mdata->json_array);
+}
+
+static int
+json_array_index_process(struct sol_flow_node *node, struct sol_json_array_index *mdata)
+{
+    struct sol_json_scanner scanner;
+    enum sol_json_loop_reason reason;
+    struct sol_json_token token;
+
+    if (mdata->index < 0 || !mdata->json_array)
+        return 0;
+
+    sol_json_scanner_init(&scanner, mdata->json_array->mem,
+        mdata->json_array->size);
+
+    if (json_array_get_at_index(&scanner, &token, mdata->index, &reason))
+        return send_token_packet(node, &scanner, mdata->json_array, &token);
+
+    if (reason == SOL_JSON_LOOP_REASON_INVALID)
+        return sol_flow_send_error_packet(node, EINVAL,
+            "Invalid JSON array (%.*s)", (int)mdata->json_array->size,
+            (char *)mdata->json_array->mem);
+
+    return sol_flow_send_error_packet(node, EINVAL,
+        "JSON array index out of bounds: %d", mdata->index);
+}
+
+static int
+json_array_get_index_index_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct sol_json_array_index *mdata = data;
+    int r;
+    struct sol_irange in_value;
+
+    r = sol_flow_packet_get_irange(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (in_value.val < 0)
+        return sol_flow_send_error_packet(node, EINVAL,
+            "Invalid negative JSON array index: %d", in_value.val);
+
+    mdata->index = in_value.val;
+    return json_array_index_process(node, mdata);
+}
+
+static int
+json_array_get_index_in_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct sol_json_array_index *mdata = data;
+    int r;
+    struct sol_blob *in_value;
+
+    r = sol_flow_packet_get_json_array(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (mdata->json_array)
+        sol_blob_unref(mdata->json_array);
+    mdata->json_array = sol_blob_ref(in_value);
+    SOL_NULL_CHECK(mdata->json_array, -errno);
+
+    return json_array_index_process(node, mdata);
+}
+
+static int
+json_array_length_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    int r;
+    struct sol_blob *in_value;
+    struct sol_json_scanner scanner;
+    enum sol_json_loop_reason reason;
+    struct sol_json_token token;
+    struct sol_irange len = { 0, 0, INT32_MAX, 1 };
+
+    r = sol_flow_packet_get_json_array(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    sol_json_scanner_init(&scanner, in_value->mem, in_value->size);
+    SOL_JSON_SCANNER_ARRAY_LOOP_ALL(&scanner, &token, reason) {
+        if (!sol_json_scanner_skip_over(&scanner, &token))
+            return -EINVAL;
+
+        if (len.val == INT32_MAX)
+            return -ERANGE;
+        len.val++;
+    }
+
+    return sol_flow_send_irange_packet(node,
+        SOL_FLOW_NODE_TYPE_JSON_ARRAY_LENGTH__OUT__OUT, &len);
+}
+
+static int
+json_array_get_all_elements_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    int r;
+    struct sol_blob *json_array;
+    struct sol_json_scanner scanner;
+    enum sol_json_loop_reason reason;
+    struct sol_json_token token;
+    bool empty = true;
+
+    r = sol_flow_packet_get_json_array(packet, &json_array);
+    SOL_INT_CHECK(r, < 0, r);
+
+    sol_json_scanner_init(&scanner, json_array->mem, json_array->size);
+    SOL_JSON_SCANNER_ARRAY_LOOP_ALL(&scanner, &token, reason) {
+        r = send_token_packet(node, &scanner, json_array, &token);
+        SOL_INT_CHECK(r, < 0, r);
+        empty = false;
+    }
+
+    if (reason == SOL_JSON_LOOP_REASON_INVALID)
+        return sol_flow_send_error_packet(node, EINVAL,
+            "Invalid JSON array (%.*s)", (int)json_array->size,
+            (char *)json_array->mem);
+
+    return sol_flow_send_boolean_packet(node,
+        SOL_FLOW_NODE_TYPE_JSON_ARRAY_GET_ALL_ELEMENTS__OUT__EMPTY, empty);
 }
 
 #include "json-gen.c"

--- a/src/modules/flow/json/json.json
+++ b/src/modules/flow/json/json.json
@@ -84,6 +84,220 @@
       ],
       "private_data_type": "sol_json_object_key",
       "url": "http://solettaproject.org/doc/latest/node_types/json/json-object-get-key.html"
+    },
+    {
+      "category": "json",
+      "description": "Get the number of children elements in a JSON object.",
+      "in_ports": [
+        {
+          "data_type": "json-object",
+          "description": "Port to receive the JSON object to count children.",
+          "methods": {
+            "process": "json_object_length_process"
+          },
+          "name": "IN",
+          "required": true
+        }
+      ],
+      "name": "json/object-length",
+      "out_ports": [
+        {
+          "data_type": "int",
+          "description": "The number of children from this JSON object",
+          "name": "OUT"
+        }
+      ],
+      "url": "http://solettaproject.org/doc/latest/node_types/json/json-object-length.html"
+    },
+    {
+      "category": "json",
+      "description": "Get all keys contained in this JSON object.",
+      "in_ports": [
+        {
+          "data_type": "json-object",
+          "description": "port to receive the JSON object.",
+          "methods": {
+            "process": "json_object_get_all_keys_process"
+          },
+          "name": "IN",
+          "required": true
+        }
+      ],
+      "name": "json/object-get-all-keys",
+      "out_ports": [
+        {
+          "data_type": "string",
+          "description": "Each key from the JSON object received in IN port. Multiple keys may be emitted for each JSON object",
+          "name": "OUT"
+        },
+        {
+          "data_type": "boolean",
+          "description": "Send true if object is empty, false otherwise.",
+          "name": "EMPTY"
+        }
+      ],
+      "url": "http://solettaproject.org/doc/latest/node_types/json/json-object-length.html"
+    },
+    {
+      "category": "json",
+      "description": "Receives a JSON array and send, to the appropriated port, the value of the child element pointed by index.",
+      "in_ports": [
+        {
+          "data_type": "json-array",
+          "description": "Port to receive the JSON array.",
+          "methods": {
+            "process": "json_array_get_index_in_process"
+          },
+          "name": "IN",
+          "required": true
+        },
+        {
+          "data_type": "int",
+          "description": "Receives an int packet to override the index set as option.",
+          "methods": {
+            "process": "json_array_get_index_index_process"
+          },
+          "name": "INDEX"
+        }
+      ],
+      "methods": {
+        "open": "json_array_get_index_open",
+        "close": "json_array_get_index_close"
+      },
+      "name": "json/array-get-at-index",
+      "options": {
+        "members": [
+          {
+            "data_type": "int",
+            "default": -1,
+            "description": "The index of the element to be sent to OUT port. If negative, no value will be sent before setting index using INDEX port",
+            "name": "index"
+          }
+        ],
+        "version": 1
+      },
+      "out_ports": [
+        {
+          "data_type": "int",
+          "description": "The integer value of a given index, if a number",
+          "name": "INT"
+        },
+        {
+          "data_type": "string",
+          "description": "The string value of a given index, if a string",
+          "name": "STRING"
+        },
+        {
+          "data_type": "boolean",
+          "description": "The boolean value of a given index, if a boolean",
+          "name": "BOOLEAN"
+        },
+        {
+          "data_type": "float",
+          "description": "The float value of a given index, if a number",
+          "name": "FLOAT"
+        },
+        {
+          "data_type": "json-object",
+          "description": "The JSON object of a given index, if a JSON object",
+          "name": "OBJECT"
+        },
+        {
+          "data_type": "json-array",
+          "description": "The JSON array of a given index, if a JSON array",
+          "name": "ARRAY"
+        },
+        {
+          "data_type": "empty",
+          "description": "An empty packet if value pointed by given index is null.",
+          "name": "NULL"
+        }
+      ],
+      "private_data_type": "sol_json_array_index",
+      "url": "http://solettaproject.org/doc/latest/node_types/json/json-array-get-at-index.html"
+    },
+    {
+      "category": "json",
+      "description": "Get the number of elements from JSON array.",
+      "in_ports": [
+        {
+          "data_type": "json-array",
+          "description": "Port to receive the JSON array to count elements.",
+          "methods": {
+            "process": "json_array_length_process"
+          },
+          "name": "IN",
+          "required": true
+        }
+      ],
+      "name": "json/array-length",
+      "out_ports": [
+        {
+          "data_type": "int",
+          "description": "The number of elements in this JSON array",
+          "name": "OUT"
+        }
+      ],
+      "url": "http://solettaproject.org/doc/latest/node_types/json/json-array-length.html"
+    },
+    {
+      "category": "json",
+      "description": "Get all elements contained in this JSON array.",
+      "in_ports": [
+        {
+          "data_type": "json-array",
+          "description": "port to receive the JSON array.",
+          "methods": {
+            "process": "json_array_get_all_elements_process"
+          },
+          "name": "IN",
+          "required": true
+        }
+      ],
+      "name": "json/array-get-all-elements",
+      "out_ports": [
+        {
+          "data_type": "int",
+          "description": "Each int value from number elements in the array. Multiple values may be emitted for each JSON array",
+          "name": "INT"
+        },
+        {
+          "data_type": "string",
+          "description": "Each string value from string elements in the array. Multiple values may be emitted for each JSON array",
+          "name": "STRING"
+        },
+        {
+          "data_type": "boolean",
+          "description": "Each boolean value from boolean elements in the array. Multiple values may be emitted for each JSON array",
+          "name": "BOOLEAN"
+        },
+        {
+          "data_type": "float",
+          "description": "Each float value from number elements in the array. Multiple values may be emitted for each JSON array",
+          "name": "FLOAT"
+        },
+        {
+          "data_type": "json-object",
+          "description": "Each JSON object value from JSON object elements in the array. Multiple values may be emitted for each JSON array",
+          "name": "OBJECT"
+        },
+        {
+          "data_type": "json-array",
+          "description": "Each JSON array value from JSON array elements in the array. Multiple values may be emitted for each JSON array",
+          "name": "ARRAY"
+        },
+        {
+          "data_type": "empty",
+          "description": "Empty packets for each null element in array. Multiple values may be emitted for each JSON array",
+          "name": "NULL"
+        },
+        {
+          "data_type": "boolean",
+          "description": "Send true if array is empty, false otherwise.",
+          "name": "EMPTY"
+        }
+      ],
+      "url": "http://solettaproject.org/doc/latest/node_types/json/json-array-get-all-elements.html"
     }
   ]
 }

--- a/src/test-fbp/json-array.fbp
+++ b/src/test-fbp/json-array.fbp
@@ -1,0 +1,121 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+json_array_str(constant/string:value="[0,1,2.1,\"str\",false,true,null,{\"inner\": 456},[1,2,3]]")
+json_array(converter/blob-to-json-array)
+
+int_validator(test/int-validator:sequence="0 1")
+float_validator(test/float-validator:sequence="0 1 2.1")
+string_validator(test/string-validator:sequence="str")
+bool_validator(test/boolean-validator:sequence="FT")
+null_validator(converter/empty-to-boolean:output_value=true)
+object_validator(test/int-validator:sequence="456")
+array_validator(test/blob-validator:expected="[1,2,3]")
+
+get_index_int0_val(json/array-get-at-index:index=0)
+get_index_int1_val(json/array-get-at-index:index=1)
+get_index_float_val(json/array-get-at-index:index=2)
+get_index_string_val(json/array-get-at-index:index=3)
+get_index_false_val(json/array-get-at-index:index=4)
+get_index_true_val(json/array-get-at-index:index=5)
+get_index_null_val(json/array-get-at-index:index=6)
+get_index_object_val(json/array-get-at-index:index=7)
+get_index_array_val(json/array-get-at-index:index=8)
+
+# Test node json/array-get-at-index
+json_array_str OUT -> IN _(converter/string-to-blob) OUT -> IN json_array
+json_array OUT -> IN get_index_int0_val
+json_array OUT -> IN get_index_int1_val
+json_array OUT -> IN get_index_float_val
+json_array OUT -> IN get_index_string_val
+json_array OUT -> IN get_index_false_val
+json_array OUT -> IN get_index_true_val
+json_array OUT -> IN get_index_null_val
+json_array OUT -> IN get_index_object_val
+json_array OUT -> IN get_index_array_val
+
+get_index_int0_val INT -> IN int_validator
+get_index_int0_val FLOAT -> IN float_validator
+get_index_int1_val INT -> IN int_validator
+get_index_int1_val FLOAT -> IN float_validator
+get_index_float_val FLOAT -> IN float_validator
+get_index_string_val STRING -> IN string_validator
+get_index_false_val BOOLEAN -> IN bool_validator
+get_index_true_val BOOLEAN -> IN bool_validator
+get_index_null_val NULL -> IN null_validator
+get_index_object_val OBJECT -> IN _(json/object-get-key:key="inner") INT -> IN object_validator
+get_index_array_val ARRAY -> IN _(converter/json-array-to-blob) OUT -> IN array_validator
+
+int_validator OUT -> RESULT int_result(test/result)
+float_validator OUT -> RESULT float_result(test/result)
+string_validator OUT -> RESULT string_result(test/result)
+bool_validator OUT -> RESULT bool_result(test/result)
+null_validator OUT -> RESULT null_result(test/result)
+object_validator OUT -> RESULT object_result(test/result)
+array_validator OUT -> RESULT array_result(test/result)
+
+# Test node json/array-length
+json_array OUT -> IN _(json/array-length) OUT -> IN array_length_validator(test/int-validator:sequence="9")
+array_length_validator OUT -> RESULT test_array_length(test/result)
+
+# Test node json/array-get-all-elements
+json_array_elements_str(constant/string:value="[0,1,{\"a\":123},2,3,null,[1,2,3],\"str1\",4,\"str2\",null,false,false,true,5.1,true,true,false,null]")
+json_array_elements(converter/blob-to-json-array)
+json_array_elements_str OUT -> IN _(converter/string-to-blob) OUT -> IN json_array_elements
+json_array_elements OUT -> IN json_array_all_elements(json/array-get-all-elements)
+
+int_validator_all(test/int-validator:sequence="0 1 2 3 4")
+float_validator_all(test/float-validator:sequence="0 1 2 3 4 5.1")
+string_validator_all(test/string-validator:sequence="str1|str2")
+bool_validator_all(test/boolean-validator:sequence="FFTTTF")
+null_validator_all(int/accumulator)
+object_validator_all(test/blob-validator:expected="{\"a\":123}")
+array_validator_all(test/blob-validator:expected="[1,2,3]")
+empty_validator_all(test/boolean-validator:sequence="FT")
+
+json_array_all_elements INT -> IN int_validator_all
+json_array_all_elements FLOAT -> IN float_validator_all
+json_array_all_elements STRING -> IN string_validator_all
+json_array_all_elements BOOLEAN -> IN bool_validator_all
+json_array_all_elements NULL -> INC null_validator_all
+json_array_all_elements OBJECT -> IN _(converter/json-object-to-blob) OUT -> IN object_validator_all
+json_array_all_elements ARRAY -> IN _(converter/json-array-to-blob) OUT -> IN array_validator_all
+json_array_all_elements EMPTY -> IN empty_validator_all
+
+_(constant/string:value="[]") OUT -> IN _(converter/string-to-blob) OUT -> IN _(converter/blob-to-json-array) OUT -> IN _(json/array-get-all-elements) EMPTY -> IN empty_validator_all
+
+int_validator_all OUT -> RESULT int_result_all(test/result)
+float_validator_all OUT -> RESULT float_result_all(test/result)
+string_validator_all OUT -> RESULT string_result_all(test/result)
+bool_validator_all OUT -> RESULT bool_result_all(test/result)
+null_validator_all OUT -> IN _(test/int-validator:sequence="0 1 2 3") OUT -> RESULT null_result_all(test/result)
+object_validator_all OUT -> RESULT object_result_all(test/result)
+array_validator_all OUT -> RESULT array_result_all(test/result)
+empty_validator_all OUT -> RESULT empty_result_all(test/result)

--- a/src/test-fbp/json-object-get.fbp
+++ b/src/test-fbp/json-object-get.fbp
@@ -48,6 +48,7 @@ get_key_null_val(json/object-get-key:key="null_val")
 get_key_object_val(json/object-get-key:key="object_val")
 get_key_array_val(json/object-get-key)
 
+# Test node json/object-get-key
 json_object_str OUT -> IN _(converter/string-to-blob) OUT -> IN json_object
 json_object OUT -> IN get_key_int_val
 json_object OUT -> IN get_key_float_val
@@ -76,3 +77,20 @@ bool_validator OUT -> RESULT bool_result(test/result)
 null_validator OUT -> RESULT null_result(test/result)
 object_validator OUT -> RESULT object_result(test/result)
 array_validator OUT -> RESULT array_result(test/result)
+
+# Test node json/object-length
+json_object OUT -> IN _(json/object-length) OUT -> IN object_length_validator(test/int-validator:sequence="8")
+object_length_validator OUT -> RESULT test_object_length(test/result)
+
+# Test node json/object-get-all-keys
+empty_str(constant/string:value="{}")
+empty_json_object(converter/blob-to-json-object)
+key_validator(test/string-validator:sequence="int_val|float_val|string_val|false_val|true_val|null_val|array_val|object_val")
+
+json_object OUT -> IN get_all_keys(json/object-get-all-keys)
+get_all_keys EMPTY -> IN _(boolean/not) OUT -> RESULT get_all_keys_empty_validator(test/result)
+get_all_keys OUT -> IN key_validator OUT -> RESULT get_all_keys_validator(test/result)
+
+empty_str OUT -> IN _(converter/string-to-blob) OUT -> IN empty_json_object
+empty_json_object OUT -> IN get_all_keys2(json/object-get-all-keys)
+get_all_keys2 EMPTY -> RESULT get_all_keys_empty_validator2(test/result)


### PR DESCRIPTION
Nodes added:
 - json/object-length: Get JSON object length
 - json/object-get-all-keys: Get all keys of a JSON object
 - json/array-get-at-index: Get a single element of a JSON array
 - json/array-length: Get the array length
 - json/array-get-all-elements: Send all elements from a JSON array to
   out PORTS

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>