### PR TITLE
oic: Various fixes when using flow based programming

### DIFF
--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -494,10 +494,10 @@ _sol_oic_resource_type_handle(
 
     code = handle_fn(cliaddr, res->callback.data, &input, &output);
     if (code == SOL_COAP_RSPCODE_CONTENT) {
+        sol_coap_add_option(response, SOL_COAP_OPTION_CONTENT_FORMAT, &format_cbor, sizeof(format_cbor));
+
         if (sol_oic_encode_cbor_repr(response, res->href, &output) != CborNoError)
             code = SOL_COAP_RSPCODE_INTERNAL_ERROR;
-        else
-            sol_coap_add_option(response, SOL_COAP_OPTION_CONTENT_FORMAT, &format_cbor, sizeof(format_cbor));
     }
 
 done:
@@ -685,10 +685,11 @@ sol_oic_notify_observers(struct sol_oic_server_resource *resource,
     pkt = sol_coap_packet_notification_new(oic_server.server, resource->coap);
     SOL_NULL_CHECK(pkt, false);
 
+    sol_coap_add_option(pkt, SOL_COAP_OPTION_CONTENT_FORMAT, &format_cbor, sizeof(format_cbor));
+
     if (sol_oic_encode_cbor_repr(pkt, resource->href, fields) != CborNoError) {
         sol_coap_header_set_code(pkt, SOL_COAP_RSPCODE_INTERNAL_ERROR);
     } else {
-        sol_coap_add_option(pkt, SOL_COAP_OPTION_CONTENT_FORMAT, &format_cbor, sizeof(format_cbor));
         sol_coap_header_set_code(pkt, SOL_COAP_RSPCODE_OK);
     }
 

--- a/src/samples/flow/oic/light-client.fbp
+++ b/src/samples/flow/oic/light-client.fbp
@@ -39,6 +39,7 @@
 # or save it as sol-flow.json
 
 timer(timer:interval=1000)
-light(Light)
+light(Light) FOUND -> ENABLED timer
+light FOUND -> IN _(console:prefix="Light found ")
 
 timer OUT -> IN toggle(boolean/toggle) OUT -> IN_STATE light


### PR DESCRIPTION
This commit fixes some problems that appeared during the update to the
newer version of the protocol, including some segmentation faults (due
to NULL pointer dereferencing), incorrect return values, CoAP encoding
errors, among other things.

It also updates the light-client.fbp example, illustrating the use of
the `FOUND` port to only enable the toggle timer if the light has been
found on the network.
