### PR TITLE
modules/int: fix division sigfpe

### DIFF
--- a/src/lib/common/sol-types.c
+++ b/src/lib/common/sol-types.c
@@ -174,11 +174,12 @@ sol_drange_equal(const struct sol_drange *var0, const struct sol_drange *var1)
     ((var1 > 0) && (var0 < INT32_MIN + var1))
 
 #define SOL_IRANGE_MULTIPLICATION_OVERFLOW(var0, var1) \
+    ((var0 == INT32_MAX) && (var1 == -1)) || \
     ((var0 > 0) && (var1 > 0) && (var0 > INT32_MAX / var1)) || \
     ((var0 < 0) && (var1 < 0) && (var0 < INT32_MAX / var1))
 
 #define SOL_IRANGE_MULTIPLICATION_UNDERFLOW(var0, var1) \
-    ((var0 > 0) && (var1 < 0) && (var0 > INT32_MIN / var1)) || \
+    ((var0 > 0) && (var1 < -1) && (var0 > INT32_MIN / var1)) || \
     ((var0 < 0) && (var1 > 0) && (var0 < INT32_MIN / var1))
 
 SOL_API int
@@ -237,6 +238,11 @@ sol_irange_division(const struct sol_irange *var0, const struct sol_irange *var1
     SOL_NULL_CHECK(var0, -EINVAL);
     SOL_NULL_CHECK(var1, -EINVAL);
     SOL_NULL_CHECK(result, -EINVAL);
+
+    if ((var0->val == INT32_MIN) && (var1->val == -1)) {
+        SOL_WRN("Division of most negative integer by -1");
+        return -EDOM;
+    }
 
     if (var1->val == 0) {
         SOL_WRN("Division by zero: %" PRId32 ", %" PRId32, var0->val, var1->val);

--- a/src/test-fbp/irange-arithmetic.fbp
+++ b/src/test-fbp/irange-arithmetic.fbp
@@ -48,26 +48,26 @@ sub OUT -> IN[0] equal_sub(int/equal)
 difference OUT -> IN[1] equal_sub
 equal_sub OUT -> RESULT r_sub(test/result)
 
-multiplicand(constant/int:value=37)
-multiplier(constant/int:value=5)
-product(constant/int:value=185)
+multiplicand(test/int-generator:sequence="0 1 2",interval=20)
+multiplier(test/int-generator:sequence="0 1 2 -1",interval=20)
+product(test/int-validator:sequence="0 0 1 2 4 -2")
 
 multiplicand OUT -> OPERAND[0] mul(int/multiplication)
 multiplier OUT -> OPERAND[1] mul
-mul OUT -> IN[0] equal_mul(int/equal)
-product OUT -> IN[1] equal_mul
-equal_mul OUT -> RESULT r_mul(test/result)
+mul OUT -> IN product OUT -> RESULT r_mul(test/result)
 
 dividend(constant/int:value=12)
 divisor(constant/int:value=3)
-quotient(constant/int:value=4)
+dividend2(constant/int:value=INT32_MIN)
+divisor2(constant/int:value=-1)
+quotient(test/int-validator:sequence="4 -715827882")
 remainder(constant/int:value=0)
 
 dividend OUT -> DIVIDEND div(int/division)
+dividend2 OUT -> DIVIDEND div
 divisor OUT -> DIVISOR div
-div OUT -> IN[0] equal_div(int/equal)
-quotient OUT -> IN[1] equal_div
-equal_div OUT -> RESULT r_div(test/result)
+divisor2 OUT -> DIVISOR div
+div OUT -> IN quotient OUT -> RESULT r_div(test/result)
 
 dividend OUT -> DIVIDEND mod(int/modulo)
 divisor OUT -> DIVISOR mod


### PR DESCRIPTION
The most negative integer by -1 may generate SIGFPE,
so it must be properly tested by division node type
and should be avoided on multiplication underflow test.

@lpereira , @anselmolsm , @ibriano ^

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>