### PR TITLE
Fix undefined behavior in align_power2() (V2)

### DIFF
--- a/src/lib/datatypes/sol-vector.c
+++ b/src/lib/datatypes/sol-vector.c
@@ -118,7 +118,7 @@ sol_vector_shrink(struct sol_vector *v)
         return;
     }
 
-    old_cap = align_power2(v->len + 1);
+    old_cap = align_power2(v->len + 1U);
     new_cap = align_power2(v->len);
     if (new_cap == old_cap)
         return;

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -193,19 +193,57 @@ char *sol_util_strerror(int errnum, char *buf, size_t buflen);
         sol_util_strerror((errnum), buf ## __COUNT__, sizeof(buf ## __COUNT__)); \
     })
 
-static inline unsigned int
-align_power2(unsigned int u)
-{
-    unsigned int left_zeros;
+/* Power of 2 alignment */
+#define DEFINE_ALIGN_POWER2(name_, type_, max_, clz_fn_) \
+    static inline type_ \
+    name_(type_ u) \
+    { \
+        unsigned int left_zeros; \
+        if (u <= 1) /* 0 is undefined for __builtin_clz() */ \
+            return u; \
+        left_zeros = clz_fn_(u - 1); \
+        if (unlikely(left_zeros <= 1)) \
+            return max_; \
+        return 1 << ((sizeof(u) * 8) - left_zeros); \
+    }
 
-    if (u == 1)
-        return 1;
-    if ((left_zeros = __builtin_clz(u - 1)) < 1)
-        return 0;
-    if (unlikely(left_zeros <= 1))
-        return UINT_MAX;
-    return 1 << ((sizeof(u) * 8) - left_zeros);
+DEFINE_ALIGN_POWER2(align_power2_uint, unsigned int, UINT_MAX, __builtin_clz)
+#if SIZE_MAX == ULONG_MAX
+DEFINE_ALIGN_POWER2(align_power2_size, size_t, SIZE_MAX, __builtin_clzl)
+#elif SIZE_MAX == ULLONG_MAX
+DEFINE_ALIGN_POWER2(align_power2_size, size_t, SIZE_MAX, __builtin_clzll)
+#elif SIZE_MAX == UINT_MAX
+DEFINE_ALIGN_POWER2(align_power2_size, size_t, SIZE_MAX, __builtin_clz)
+#else
+#error Unsupported size_t size
+#endif
+
+#undef DEFINE_ALIGN_POWER2
+
+static inline int
+align_power2_short_uint(unsigned short u)
+{
+    unsigned int aligned = align_power2_uint(u);
+
+    return likely(aligned <= USHRT_MAX) ? aligned : USHRT_MAX;
 }
+
+/* _Generic() from C11 would be better here, but it's not supported by
+ * the environment in Semaphore CI. */
+#define align_power2(u_) \
+    ({ \
+        typeof((u_) + 0)pow2__aligned; /* + 0 to remove const */ \
+        if (__builtin_types_compatible_p(typeof(u_), size_t)) { \
+            pow2__aligned = align_power2_size(u_); \
+        } else if (__builtin_types_compatible_p(typeof(u_), unsigned int)) { \
+            pow2__aligned = align_power2_uint(u_); \
+        } else if (__builtin_types_compatible_p(typeof(u_), short unsigned int)) { \
+            pow2__aligned = align_power2_short_uint(u_); \
+        } else { \
+            __builtin_unreachable(); \
+        } \
+        pow2__aligned; \
+    })
 
 /**
  * Return a list of the words in a given string slice, using a given

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -202,6 +202,8 @@ align_power2(unsigned int u)
         return 1;
     if ((left_zeros = __builtin_clz(u - 1)) < 1)
         return 0;
+    if (unlikely(left_zeros <= 1))
+        return UINT_MAX;
     return 1 << ((sizeof(u) * 8) - left_zeros);
 }
 


### PR DESCRIPTION
If left_zeros is 0, then don't shift by 32 bits, which is undefined behavior.  Return UINT_MAX as the value can't get larger than that. If left_zeros is 1, return UINT_MAX, as that's the next power-of-two
aligned value.

Also ensure align_power2() will work with types of sizes different than `unsigned int` (at the moment, uint16_t and size_t). Do this automatically using __builtin_types_compatible_p() as to not patch every call of this function.