### PR TITLE
sol_buffer: Fix append_printf function bug

### DIFF
--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -200,6 +200,8 @@ sol_buffer_insert_slice(struct sol_buffer *buf, size_t pos, const struct sol_str
     return 0;
 }
 
+/* Extra room for the ending NUL-byte, necessary even when the buffer has
+ * SOL_BUFFER_FLAGS_NO_NUL_BYTE because vsnprintf always write the '\0'. */
 SOL_API int
 sol_buffer_append_vprintf(struct sol_buffer *buf, const char *fmt, va_list args)
 {
@@ -233,11 +235,11 @@ sol_buffer_append_vprintf(struct sol_buffer *buf, const char *fmt, va_list args)
             goto end;
 
         /* Extra room for the ending NUL-byte. */
-        if (new_size >= SIZE_MAX - nul_byte_size(buf)) {
+        if (new_size >= SIZE_MAX - 1) {
             r = -EOVERFLOW;
             goto end;
         }
-        r = sol_buffer_ensure(buf, new_size + nul_byte_size(buf));
+        r = sol_buffer_ensure(buf, new_size + 1);
         if (r < 0)
             goto end;
 

--- a/src/test/test-buffer.c
+++ b/src/test/test-buffer.c
@@ -377,6 +377,16 @@ test_no_nul_byte(void)
     ASSERT_INT_NE(err, 0);
 
     sol_buffer_fini(&buf);
+
+    sol_buffer_init_flags(&buf, NULL, 0, SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+    err = sol_buffer_append_printf(&buf, "123");
+    ASSERT_INT_EQ(err, 0);
+    err = sol_buffer_append_printf(&buf, "4");
+    ASSERT_INT_EQ(err, 0);
+
+    ASSERT(sol_str_slice_eq(sol_buffer_get_slice(&buf),
+        SOL_STR_SLICE_STR("1234", 4)));
+    sol_buffer_fini(&buf);
 }
 
 TEST_MAIN();


### PR DESCRIPTION
Function sol_buffer_append_printf was not adding the last character to
the buffer if SOL_BUFFER_FLAGS_NO_NUL_BYTE was used and if this
character would be placed in the last available buffer position.

This was happening because printf function always place '\0' at the end
of the string being printed. So we need to allocate an extra byte even
if SOL_BUFFER_FLAGS_NO_NUL_BYTE is used.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>