### PR TITLE
board detection: Add rules for minnowboard max

### DIFF
--- a/data/jsons/board_detect.json
+++ b/data/jsons/board_detect.json
@@ -36,6 +36,28 @@
        "match": [ "SALT BAY" ]
       }
      ]
+    },
+    {
+     "name": "intel-minnow-max-linux_gt_3.19",
+     "validation": [
+      {
+       "file_path": "/sys/devices/virtual/dmi/id/bios_version",
+       "match": [ "^MNW2CRB1" ]
+      },
+      {
+       "file_path": "/proc/sys/kernel/osrelease",
+       "dont_match": [ "^[0-2][.]", "^3[.][0-9][.]", "^3[.][0-1][0-8]" ]
+      }
+     ]
+    },
+    {
+     "name": "intel-minnow-max",
+     "validation": [
+      {
+       "file_path": "/sys/devices/virtual/dmi/id/bios_version",
+       "match": [ "^MNW2CRB1" ]
+      }
+     ]
     }
   ]
 }


### PR DESCRIPTION
And have a distinction between minnowboards with kernel newer than 3.18,
when gpio numbering changed, so we can find a proper conffile
'automagically'.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>

btw I tryed to escape the '.' in an old fashion way but didn't work. That was the only way I found that passed my tests. Suggestions are welcome.