### PR TITLE
Base64

### DIFF
--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -221,6 +221,99 @@ int sol_buffer_set_slice_at(struct sol_buffer *buf, size_t pos, const struct sol
  */
 int sol_buffer_insert_slice(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice);
 
+
+// TODO: move this to some other file? where
+/**
+ * The default base 64 map to use. The last byte (position 64) is the
+ * padding character.
+ */
+extern const char SOL_BASE64_MAP[65];
+
+/**
+ * Insert the 'slice' into 'buf' at position 'pos' encoded as base64 using the given map.
+ *
+ * @param buf the already-initialized buffer to append the encoded
+ *        slice.
+ * @param pos the position in bytes from 0 up to @c buf->used. If pos
+ *        == buf->end, then the behavior is the same as
+ *        sol_buffer_append_as_base64().
+ * @param slice the byte string to encode, may contain null bytes
+ *        @c(\0), it will be encoded up the @c slice.len.
+ * @param base64_map the map to use, the default is available as
+ *        #SOL_BASE64_MAP. Note that the last char in the map (position 64)
+ *        is used as the padding char.
+ *
+ * @return 0 on success, -errno on failure.
+ *
+ * @see sol_buffer_append_as_base64()
+ * @see sol_buffer_insert_from_base64()
+ * @see sol_buffer_append_from_base64()
+ */
+int sol_buffer_insert_as_base64(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice, const char base64_map[static 65]);
+
+/**
+ * Append the 'slice' at the end of 'buf' encoded as base64 using the given map.
+ *
+ * See https://en.wikipedia.org/wiki/Base64
+ *
+ * @param buf the already-initialized buffer to append the encoded
+ *        slice.
+ * @param slice the byte string to encode, may contain null bytes
+ *        @c(\0), it will be encoded up the @c slice.len.
+ * @param base64_map the map to use, the default is available as
+ *        #SOL_BASE64_MAP. Note that the last char in the map (position 64)
+ *        is used as the padding char.
+ * @return 0 on success, -errno on failure.
+ *
+ * @see sol_buffer_insert_as_base64()
+ * @see sol_buffer_insert_from_base64()
+ * @see sol_buffer_append_from_base64()
+ */
+int sol_buffer_append_as_base64(struct sol_buffer *buf, const struct sol_str_slice slice, const char base64_map[static 65]);
+
+/**
+ * Insert the 'slice' into 'buf' at position 'pos' decoded from base64 using the given map.
+ *
+ * @param buf the already-initialized buffer to append the decoded
+ *        slice.
+ * @param pos the position in bytes from 0 up to @c buf->used. If pos
+ *        == buf->end, then the behavior is the same as
+ *        sol_buffer_append_from_base64().
+ * @param slice the byte string to decode, may contain null bytes
+ *        @c(\0), it will be decoded up the @c slice.len.
+ * @param base64_map the map to use, the default is available as
+ *        #SOL_BASE64_MAP. Note that the last char in the map (position 64)
+ *        is used as the padding char.
+ *
+ * @return 0 on success, -errno on failure.
+ *
+ * @see sol_buffer_insert_as_base64()
+ * @see sol_buffer_append_as_base64()
+ * @see sol_buffer_append_from_base64()
+ */
+int sol_buffer_insert_from_base64(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice, const char base64_map[static 65]);
+
+/**
+ * Append the 'slice' at the end of 'buf' decoded from base64 using the given map.
+ *
+ * See https://en.wikipedia.org/wiki/Base64
+ *
+ * @param buf the already-initialized buffer to append the decoded
+ *        slice.
+ * @param slice the byte string to decode, may contain null bytes
+ *        @c(\0), it will be decoded up the @c slice.len.
+ * @param base64_map the map to use, the default is available as
+ *        #SOL_BASE64_MAP. Note that the last char in the map (position 64)
+ *        is used as the padding char.
+ * @return 0 on success, -errno on failure.
+ *
+ * @see sol_buffer_insert_as_base64()
+ * @see sol_buffer_append_as_base64()
+ * @see sol_buffer_insert_from_base64()
+ */
+int sol_buffer_append_from_base64(struct sol_buffer *buf, const struct sol_str_slice slice, const char base64_map[static 65]);
+
+
 /* append the formatted string to buffer, including trailing \0 */
 int sol_buffer_append_vprintf(struct sol_buffer *buf, const char *fmt, va_list args);
 static inline int sol_buffer_append_printf(struct sol_buffer *buf, const char *fmt, ...) SOL_ATTR_PRINTF(2, 3);

--- a/src/modules/flow/string/string-common.c
+++ b/src/modules/flow/string/string-common.c
@@ -51,3 +51,226 @@ string_is_empty(struct sol_flow_node *node,
     return sol_flow_send_boolean_packet(node,
         SOL_FLOW_NODE_TYPE_STRING_IS_EMPTY__OUT__OUT, strlen(in_value) == 0);
 }
+
+int
+string_b64encode_string(struct sol_flow_node *node,
+    void *data,
+    uint16_t port,
+    uint16_t conn_id,
+    const struct sol_flow_packet *packet)
+{
+    struct string_b64_data *mdata = data;
+    const char *in_value;
+    char *output;
+    struct sol_buffer buf;
+    struct sol_str_slice slice;
+    int r;
+
+    r = sol_flow_packet_get_string(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    slice = sol_str_slice_from_str(in_value);
+
+    sol_buffer_init(&buf);
+    r = sol_buffer_append_as_base64(&buf, slice, mdata->base64_map);
+    SOL_INT_CHECK_GOTO(r, < 0, error);
+
+    output = sol_buffer_steal(&buf, NULL);
+    sol_buffer_fini(&buf);
+
+    return sol_flow_send_string_take_packet(node,
+        SOL_FLOW_NODE_TYPE_STRING_B64ENCODE__OUT__OUT, output);
+
+error:
+    sol_flow_send_error_packet(node, -r,
+        "Could not encode string '%s' to base64: %s",
+        in_value, sol_util_strerrora(-r));
+    sol_buffer_fini(&buf);
+    return r;
+}
+
+int
+string_b64encode_blob(struct sol_flow_node *node,
+    void *data,
+    uint16_t port,
+    uint16_t conn_id,
+    const struct sol_flow_packet *packet)
+{
+    struct string_b64_data *mdata = data;
+    struct sol_blob *in_value;
+    char *output;
+    struct sol_buffer buf;
+    struct sol_str_slice slice;
+    int r;
+
+    r = sol_flow_packet_get_blob(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    slice = sol_str_slice_from_blob(in_value);
+
+    sol_buffer_init(&buf);
+    r = sol_buffer_append_as_base64(&buf, slice, mdata->base64_map);
+    SOL_INT_CHECK_GOTO(r, < 0, error);
+
+    output = sol_buffer_steal(&buf, NULL);
+    sol_buffer_fini(&buf);
+
+    return sol_flow_send_string_take_packet(node,
+        SOL_FLOW_NODE_TYPE_STRING_B64ENCODE__OUT__OUT, output);
+
+error:
+    sol_flow_send_error_packet(node, -r,
+        "Could not encode blob mem=%p, size=%zd to base64: %s",
+        in_value->mem, in_value->size, sol_util_strerrora(-r));
+    sol_buffer_fini(&buf);
+    return r;
+}
+
+int
+string_b64decode(struct sol_flow_node *node,
+    void *data,
+    uint16_t port,
+    uint16_t conn_id,
+    const struct sol_flow_packet *packet)
+{
+    struct string_b64decode_data *mdata = data;
+    const char *in_value;
+    char *output;
+    struct sol_buffer buf;
+    struct sol_str_slice slice;
+    size_t outputlen;
+    int r;
+
+    if (mdata->string_conns == 0 && mdata->blob_conns == 0)
+        return 0;
+
+    r = sol_flow_packet_get_string(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    slice = sol_str_slice_from_str(in_value);
+
+    sol_buffer_init(&buf);
+    r = sol_buffer_append_from_base64(&buf, slice, mdata->base64_map);
+    SOL_INT_CHECK_GOTO(r, < 0, error);
+
+    output = sol_buffer_steal(&buf, &outputlen);
+    sol_buffer_fini(&buf);
+
+    if (mdata->string_conns > 0 && mdata->blob_conns == 0) {
+        return sol_flow_send_string_take_packet(node,
+            SOL_FLOW_NODE_TYPE_STRING_B64DECODE__OUT__STRING, output);
+    } else if (mdata->string_conns == 0 && mdata->blob_conns > 0) {
+        struct sol_blob *blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT,
+            NULL, output, outputlen);
+        SOL_NULL_CHECK_GOTO(blob, error_blob);
+        r = sol_flow_send_blob_packet(node,
+            SOL_FLOW_NODE_TYPE_STRING_B64DECODE__OUT__BLOB, blob);
+        sol_blob_unref(blob);
+        return r;
+    } else {
+        struct sol_blob *blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT,
+            NULL, output, outputlen);
+        int r2;
+        SOL_NULL_CHECK_GOTO(blob, error_blob);
+
+        r = sol_flow_send_string_packet(node,
+            SOL_FLOW_NODE_TYPE_STRING_B64DECODE__OUT__STRING, output);
+
+        r2 = sol_flow_send_blob_packet(node,
+            SOL_FLOW_NODE_TYPE_STRING_B64DECODE__OUT__BLOB, blob);
+        sol_blob_unref(blob);
+
+        return r || r2;
+    }
+
+error:
+    sol_flow_send_error_packet(node, -r,
+        "Could not decode string '%s' to base64: %s",
+        in_value, sol_util_strerrora(-r));
+    sol_buffer_fini(&buf);
+    return r;
+
+error_blob:
+    free(output);
+    return -ENOMEM;
+}
+
+int
+string_b64decode_port_connect(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id)
+{
+    struct string_b64decode_data *mdata = data;
+
+    if (port == SOL_FLOW_NODE_TYPE_STRING_B64DECODE__OUT__STRING)
+        mdata->string_conns++;
+    else if (port == SOL_FLOW_NODE_TYPE_STRING_B64DECODE__OUT__BLOB)
+        mdata->blob_conns++;
+    else
+        return -EINVAL;
+
+    return 0;
+}
+
+int
+string_b64decode_port_disconnect(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id)
+{
+    struct string_b64decode_data *mdata = data;
+
+    if (port == SOL_FLOW_NODE_TYPE_STRING_B64DECODE__OUT__STRING &&
+        mdata->string_conns > 0)
+        mdata->string_conns--;
+    else if (port == SOL_FLOW_NODE_TYPE_STRING_B64DECODE__OUT__BLOB &&
+        mdata->blob_conns > 0)
+        mdata->blob_conns--;
+    else
+        return -EINVAL;
+
+    return 0;
+}
+
+int
+string_b64_open(struct sol_flow_node *node,
+    void *data,
+    const struct sol_flow_node_options *options)
+{
+    struct string_b64_data *mdata = data;
+    const struct sol_flow_node_type_string_b64encode_options *opts;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK
+        (options, SOL_FLOW_NODE_TYPE_STRING_B64ENCODE_OPTIONS_API_VERSION, -EINVAL);
+    /* both b64encode and b64decode have the same options structure, however
+     * the generator emits different symbols. Let's pick one.
+     */
+    opts = (const struct sol_flow_node_type_string_b64encode_options *)options;
+
+    if (!opts->base64_map &&
+        (opts->base64_map[0] == '\0' ||
+        streq(opts->base64_map, SOL_BASE64_MAP)))
+        mdata->base64_map = SOL_BASE64_MAP;
+    else if (opts->base64_map) {
+        if (strlen(opts->base64_map) != 65) {
+            SOL_WRN("Invalid base64_map of length %zd, must be 65: %s. "
+                "Using default '%.65s'",
+                strlen(opts->base64_map), opts->base64_map, SOL_BASE64_MAP);
+            mdata->base64_map = SOL_BASE64_MAP;
+        } else {
+            mdata->base64_map = strdup(opts->base64_map);
+            if (!mdata->base64_map) {
+                SOL_WRN("Could not allocate memory for custom base64_map '%.65s'."
+                    "Using default '%.65s'",
+                    opts->base64_map, SOL_BASE64_MAP);
+                mdata->base64_map = SOL_BASE64_MAP;
+            }
+        }
+    }
+
+    return 0;
+}
+
+void
+string_b64_close(struct sol_flow_node *node, void *data)
+{
+    struct string_b64_data *mdata = data;
+
+    if (mdata->base64_map != SOL_BASE64_MAP)
+        free((char *)mdata->base64_map);
+}

--- a/src/modules/flow/string/string-common.h
+++ b/src/modules/flow/string/string-common.h
@@ -35,3 +35,24 @@
 #include "sol-flow.h"
 
 int string_is_empty(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet);
+
+struct string_b64_data {
+    const char *base64_map;
+};
+
+/* NOTE: string_b64decode_data is handled to functions such as open/close that will expect a
+ * string_b64_data, thus keep the same header (base64_map).
+ */
+struct string_b64decode_data {
+    const char *base64_map;
+    uint32_t string_conns;
+    uint32_t blob_conns;
+};
+
+int string_b64encode_string(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet);
+int string_b64encode_blob(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet);
+int string_b64decode(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet);
+int string_b64decode_port_connect(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id);
+int string_b64decode_port_disconnect(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id);
+int string_b64_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options);
+void string_b64_close(struct sol_flow_node *node, void *data);

--- a/src/modules/flow/string/string.json
+++ b/src/modules/flow/string/string.json
@@ -781,6 +781,105 @@
         }
       ],
       "url": "http://solettaproject.org/doc/latest/node_types/string/is-empty.html"
+    },
+    {
+      "category": "string",
+      "description": "Encode a string to Base64",
+      "in_ports": [
+        {
+          "data_type": "string",
+          "description": "Input string to be encoded to Base64. It will stop at the first null byte (\\0), for binary data use BLOB port.",
+          "methods": {
+            "process": "string_b64encode_string"
+          },
+          "name": "STRING"
+        },
+        {
+          "data_type": "blob",
+          "description": "Input blob to be encoded to Base64",
+          "methods": {
+            "process": "string_b64encode_blob"
+          },
+          "name": "BLOB"
+        }
+      ],
+      "methods": {
+        "open": "string_b64_open",
+        "close": "string_b64_close"
+      },
+      "name": "string/b64encode",
+      "options": {
+        "members": [
+          {
+            "data_type": "string",
+            "default": "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
+            "description": "If non-null must be a map with exactly 65 characters, the first 64 are the map for the 6-bits numbers and the last (position 64) is the padding if input string is not multiple of 3 bytes.",
+            "name": "base64_map"
+          }
+        ],
+        "version": 1
+      },
+      "out_ports": [
+        {
+          "data_type": "string",
+          "description": "The Base64 encoded string",
+          "name": "OUT"
+        }
+      ],
+      "private_data_type": "string_b64_data",
+      "url": "http://solettaproject.org/doc/latest/node_types/string/b64encode.html"
+    },
+    {
+      "category": "string",
+      "description": "Decode a string from Base64",
+      "in_ports": [
+        {
+          "data_type": "string",
+          "description": "Input Base64 string to be decoded",
+          "methods": {
+            "process": "string_b64decode"
+          },
+          "name": "IN"
+        }
+      ],
+      "methods": {
+        "open": "string_b64_open",
+        "close": "string_b64_close"
+      },
+      "name": "string/b64decode",
+      "options": {
+        "members": [
+          {
+            "data_type": "string",
+            "default": "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
+            "description": "If non-null must be a map with exactly 65 characters, the first 64 are the map for the 6-bits numbers and the last (position 64) is the padding if input string is not multiple of 3 bytes.",
+            "name": "base64_map"
+          }
+        ],
+        "version": 1
+      },
+      "out_ports": [
+        {
+          "data_type": "string",
+          "description": "The decoded Base64 as textual string. It will stop at the first null byte (\\0), for binary data use BLOB port.",
+          "name": "STRING",
+          "methods": {
+            "connect": "string_b64decode_port_connect",
+            "disconnect": "string_b64decode_port_disconnect"
+          }
+        },
+        {
+          "data_type": "blob",
+          "description": "The decoded Base64 as binary blob.",
+          "name": "BLOB",
+          "methods": {
+            "connect": "string_b64decode_port_connect",
+            "disconnect": "string_b64decode_port_disconnect"
+          }
+        }
+      ],
+      "private_data_type": "string_b64decode_data",
+      "url": "http://solettaproject.org/doc/latest/node_types/string/b64decode.html"
     }
   ]
 }

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -413,3 +413,77 @@ sol_util_int32_clamp(int32_t start, int32_t end, int32_t value)
 }
 
 int sol_util_replace_str_if_changed(char **str, const char *new_str);
+
+/**
+ * Encode the binary slice to base64 using the given map.
+ *
+ * https://en.wikipedia.org/wiki/Base64
+ *
+ * @note @b no trailing null '\0' is added!
+ *
+ * @note The char `=` is used as padding.
+ *
+ * @param buf a buffer of size @a buflen that is big enough to hold
+ *        the encoded string.
+ * @param buflen the number of bytes available in buffer. Must be
+ *        large enough to contain the encoded slice, that is:
+ *        (slice.len / 3 + 1) * 4
+ * @param slice the slice to encode, it may contain null-bytes (\0),
+ *        the whole size of the slice will be used (slice.len).
+ * @param base64_map the map to use. The last char is used as the
+ *        padding character if slice length is not multiple of 3 bytes.
+ *
+ * @return the number of bytes written or -errno if failed.
+ */
+ssize_t sol_util_base64_encode(void *buf, size_t buflen, const struct sol_str_slice slice, const char base64_map[static 65]);
+
+/**
+ * Decode the binary slice from base64 using the given map.
+ *
+ * https://en.wikipedia.org/wiki/Base64
+ *
+ * @note @b no trailing null '\0' is added!
+ *
+ * @param buf a buffer of size @a buflen that is big enough to hold
+ *        the decoded string.
+ * @param buflen the number of bytes available in buffer. Must be
+ *        large enough to contain the decoded slice, that is:
+ *        (slice.len / 4) * 3
+ * @param slice the slice to encode, it may contain null-bytes (\0),
+ *        the whole size of the slice will be used (slice.len).
+ * @param base64_map the map to use. The last char is used as the
+ *        padding character if slice length is not multiple of 3 bytes.
+ *
+ * @return the number of bytes written or -errno if failed.
+ */
+ssize_t sol_util_base64_decode(void *buf, size_t buflen, const struct sol_str_slice slice, const char base64_map[static 65]);
+
+static inline ssize_t
+sol_util_base64_calculate_encoded_len(const struct sol_str_slice slice, const char base64_map[static 65])
+{
+    ssize_t req_len = slice.len / 3;
+    int err;
+
+    if (slice.len % 3 != 0)
+        req_len++;
+    err = sol_util_ssize_mul(req_len, 4, &req_len);
+    if (err < 0)
+        return err;
+    return req_len;
+}
+
+static inline ssize_t
+sol_util_base64_calculate_decoded_len(const struct sol_str_slice slice, const char base64_map[static 65])
+{
+    size_t req_len = (slice.len / 4) * 3;
+    size_t i;
+
+    for (i = slice.len; i > 0; i--) {
+        if (slice.data[i - 1] != base64_map[64])
+            break;
+        req_len--;
+    }
+    if (req_len > SSIZE_MAX)
+        return -EOVERFLOW;
+    return req_len;
+}

--- a/src/test-fbp/string-b64decode.fbp
+++ b/src/test-fbp/string-b64decode.fbp
@@ -1,0 +1,38 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+hello_world(constant/string:value="Hello World")
+hello_world_as_b64(constant/string:value="SGVsbG8gV29ybGQ=")
+
+hello_world_as_b64 OUT -> IN b64dec(string/b64decode)
+
+b64dec STRING -> IN[0] hello_world_string_cmp(string/compare)
+hello_world OUT -> IN[1] hello_world_string_cmp
+hello_world_string_cmp EQUAL -> RESULT _(test/result)

--- a/src/test-fbp/string-b64encode.fbp
+++ b/src/test-fbp/string-b64encode.fbp
@@ -1,0 +1,49 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+hello_world(constant/string:value="Hello World")
+hello_world_as_b64_string(constant/string:value="SGVsbG8gV29ybGQ=")
+
+# blob will contain trailing null byte (\0), thus changes the encoded string
+hello_world_as_b64_blob(constant/string:value="SGVsbG8gV29ybGQA")
+
+hello_world OUT -> STRING b64enc_string(string/b64encode)
+
+b64enc_string OUT -> IN[0] hello_world_as_b64_string_cmp(string/compare)
+hello_world_as_b64_string OUT -> IN[1] hello_world_as_b64_string_cmp
+hello_world_as_b64_string_cmp EQUAL -> RESULT _(test/result)
+
+hello_world OUT -> IN _(converter/string-to-blob) OUT -> BLOB b64enc_blob(string/b64encode)
+
+b64enc_blob OUT -> IN[0] hello_world_as_b64_blob_cmp(string/compare)
+hello_world_as_b64_blob OUT -> IN[1] hello_world_as_b64_blob_cmp
+hello_world_as_b64_blob_cmp EQUAL -> RESULT _(test/result)
+
+

--- a/src/test/test-buffer.c
+++ b/src/test/test-buffer.c
@@ -379,4 +379,142 @@ test_no_nul_byte(void)
     sol_buffer_fini(&buf);
 }
 
+DEFINE_TEST(test_insert_as_base64);
+
+static void
+test_insert_as_base64(void)
+{
+    struct sol_buffer buf;
+    struct sol_str_slice slice;
+    const char to_encode[] = "This is a message that is multiple of 3 chars";
+    int err;
+
+#define B64_ENCODED "VGhpcyBpcyBhIG1lc3NhZ2UgdGhhdCBpcyBtdWx0aXBsZSBvZiAzIGNoYXJz"
+
+    sol_buffer_init(&buf);
+    slice = sol_str_slice_from_str("World");
+    err = sol_buffer_insert_slice(&buf, 0, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("World"));
+    ASSERT_STR_EQ(buf.data, "World");
+
+    slice = sol_str_slice_from_str("Hello");
+    err = sol_buffer_insert_slice(&buf, 0, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("HelloWorld"));
+    ASSERT_STR_EQ(buf.data, "HelloWorld");
+
+    slice = sol_str_slice_from_str(to_encode);
+    err = sol_buffer_insert_as_base64(&buf, strlen("Hello"), slice, SOL_BASE64_MAP);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("Hello" B64_ENCODED "World"));
+    ASSERT_STR_EQ(buf.data, "Hello" B64_ENCODED "World");
+
+    sol_buffer_fini(&buf);
+
+#undef B64_ENCODED
+}
+
+DEFINE_TEST(test_append_as_base64);
+
+static void
+test_append_as_base64(void)
+{
+    struct sol_buffer buf;
+    struct sol_str_slice slice;
+    const char to_encode[] = "This is a message that is multiple of 3 chars";
+    int err;
+
+#define B64_ENCODED "VGhpcyBpcyBhIG1lc3NhZ2UgdGhhdCBpcyBtdWx0aXBsZSBvZiAzIGNoYXJz"
+
+    sol_buffer_init(&buf);
+    slice = sol_str_slice_from_str("XYZ");
+    err = sol_buffer_append_slice(&buf, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("XYZ"));
+    ASSERT_STR_EQ(buf.data, "XYZ");
+
+    slice = sol_str_slice_from_str(to_encode);
+    err = sol_buffer_append_as_base64(&buf, slice, SOL_BASE64_MAP);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("XYZ" B64_ENCODED));
+    ASSERT_STR_EQ(buf.data, "XYZ" B64_ENCODED);
+
+    sol_buffer_fini(&buf);
+
+#undef B64_ENCODED
+}
+
+DEFINE_TEST(test_insert_from_base64);
+
+static void
+test_insert_from_base64(void)
+{
+    struct sol_buffer buf;
+    struct sol_str_slice slice;
+    const char to_decode[] = "VGhpcyBpcyBhIG1lc3NhZ2UgdGhhdCBpcyBtdWx0aXBsZSBvZiAzIGNoYXJz";
+    int err;
+
+#define B64_DECODED "This is a message that is multiple of 3 chars"
+
+    sol_buffer_init(&buf);
+    slice = sol_str_slice_from_str("World");
+    err = sol_buffer_insert_slice(&buf, 0, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("World"));
+    ASSERT_STR_EQ(buf.data, "World");
+
+    slice = sol_str_slice_from_str("Hello");
+    err = sol_buffer_insert_slice(&buf, 0, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("HelloWorld"));
+    ASSERT_STR_EQ(buf.data, "HelloWorld");
+
+    slice = sol_str_slice_from_str(to_decode);
+    err = sol_buffer_insert_from_base64(&buf, strlen("Hello"), slice, SOL_BASE64_MAP);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("Hello" B64_DECODED "World"));
+    ASSERT_STR_EQ(buf.data, "Hello" B64_DECODED "World");
+
+    slice = sol_str_slice_from_str("VGhpcy--"); /* broken base64 */
+    err = sol_buffer_insert_from_base64(&buf, strlen("Hello"), slice, SOL_BASE64_MAP);
+    ASSERT_INT_NE(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("Hello" B64_DECODED "World"));
+    ASSERT_STR_EQ(buf.data, "Hello" B64_DECODED "World");
+
+    sol_buffer_fini(&buf);
+
+#undef B64_DECODED
+}
+
+DEFINE_TEST(test_append_from_base64);
+
+static void
+test_append_from_base64(void)
+{
+    struct sol_buffer buf;
+    struct sol_str_slice slice;
+    const char to_decode[] = "VGhpcyBpcyBhIG1lc3NhZ2UgdGhhdCBpcyBtdWx0aXBsZSBvZiAzIGNoYXJz";
+    int err;
+
+#define B64_DECODED "This is a message that is multiple of 3 chars"
+
+    sol_buffer_init(&buf);
+    slice = sol_str_slice_from_str("XYZ");
+    err = sol_buffer_append_slice(&buf, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("XYZ"));
+    ASSERT_STR_EQ(buf.data, "XYZ");
+
+    slice = sol_str_slice_from_str(to_decode);
+    err = sol_buffer_append_from_base64(&buf, slice, SOL_BASE64_MAP);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("XYZ" B64_DECODED));
+    ASSERT_STR_EQ(buf.data, "XYZ" B64_DECODED);
+
+    sol_buffer_fini(&buf);
+
+#undef B64_DECODED
+}
+
 TEST_MAIN();

--- a/src/test/test-util.c
+++ b/src/test/test-util.c
@@ -301,5 +301,71 @@ test_strtodn(void)
     }
 }
 
+DEFINE_TEST(test_base64_encode);
+
+static void
+test_base64_encode(void)
+{
+    const char base64_map[65] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+    const char instr[] = "This is a message that is multiple of 3 chars";
+    const char *expectstrs[] = {
+        "VGhpcyBpcyBhIG1lc3NhZ2UgdGhhdCBpcyBtdWx0aXBsZSBvZiAzIGNoYXJz",
+        "VGhpcyBpcyBhIG1lc3NhZ2UgdGhhdCBpcyBtdWx0aXBsZSBvZiAzIGNoYXI=",
+        "VGhpcyBpcyBhIG1lc3NhZ2UgdGhhdCBpcyBtdWx0aXBsZSBvZiAzIGNoYQ==",
+        "VGhpcyBpcyBhIG1lc3NhZ2UgdGhhdCBpcyBtdWx0aXBsZSBvZiAzIGNo"
+    };
+    struct sol_str_slice slice;
+    char outstr[(sizeof(instr) / 3 + 1) * 4 + 1];
+    size_t r, i;
+
+    slice = sol_str_slice_from_str(instr);
+
+    for (i = 0; i < ARRAY_SIZE(expectstrs); i++) {
+        struct sol_str_slice exp = sol_str_slice_from_str(expectstrs[i]);
+
+        memset(outstr, 0xff, sizeof(outstr));
+        r = sol_util_base64_encode(outstr, sizeof(outstr), slice, base64_map);
+        ASSERT_INT_EQ(r, exp.len);
+        ASSERT_INT_EQ(outstr[r], (char)0xff);
+        outstr[r] = '\0';
+        ASSERT_STR_EQ(outstr, exp.data);
+
+        slice.len--;
+    }
+}
+
+DEFINE_TEST(test_base64_decode);
+
+static void
+test_base64_decode(void)
+{
+    const char base64_map[65] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+    char expstr[] = "This is a message that is multiple of 3 chars";
+    const char *instrs[] = {
+        "VGhpcyBpcyBhIG1lc3NhZ2UgdGhhdCBpcyBtdWx0aXBsZSBvZiAzIGNoYXJz",
+        "VGhpcyBpcyBhIG1lc3NhZ2UgdGhhdCBpcyBtdWx0aXBsZSBvZiAzIGNoYXI=",
+        "VGhpcyBpcyBhIG1lc3NhZ2UgdGhhdCBpcyBtdWx0aXBsZSBvZiAzIGNoYQ==",
+        "VGhpcyBpcyBhIG1lc3NhZ2UgdGhhdCBpcyBtdWx0aXBsZSBvZiAzIGNo"
+    };
+    struct sol_str_slice exp;
+    char outstr[sizeof(expstr)];
+    size_t r, i;
+
+    exp = sol_str_slice_from_str(expstr);
+
+    for (i = 0; i < ARRAY_SIZE(instrs); i++) {
+        struct sol_str_slice slice = sol_str_slice_from_str(instrs[i]);
+
+        memset(outstr, 0xff, sizeof(outstr));
+        r = sol_util_base64_decode(outstr, sizeof(outstr), slice, base64_map);
+        ASSERT_INT_EQ(r, exp.len);
+        ASSERT_INT_EQ(outstr[r], (char)0xff);
+        outstr[r] = '\0';
+        ASSERT_STR_EQ(outstr, exp.data);
+
+        exp.len--;
+        expstr[exp.len] = '\0';
+    }
+}
 
 TEST_MAIN();


### PR DESCRIPTION
Base64 allows encoding binary formats in printable form with "safe" chars (if a safe set of 65 are specified). It is often used in web contents.