### PR TITLE
Http uuid v2

### DIFF
--- a/src/modules/flow/http-client/http-client.c
+++ b/src/modules/flow/http-client/http-client.c
@@ -42,6 +42,7 @@
 #include "sol-http-client.h"
 #include "sol-json.h"
 #include "sol-mainloop.h"
+#include "sol-platform.h"
 #include "sol-util.h"
 #include "sol-vector.h"
 #include "sol_config.h"
@@ -51,6 +52,7 @@ struct http_data {
     struct sol_str_slice key;
     char *url;
     char *content_type;
+    bool machine_id;
     bool strict;
 };
 
@@ -59,6 +61,21 @@ struct http_client_node_type {
     int (*process_token)(struct sol_flow_node *node, struct sol_json_token *key, struct sol_json_token *value);
     int (*process_data)(struct sol_flow_node *node, struct sol_http_response *response);
 };
+
+static int
+machine_id_header_add(struct sol_http_param *params, char *id)
+{
+    int r;
+
+    r = sol_platform_get_machine_id(id);
+    SOL_INT_CHECK(r, < 0, r);
+
+    r = sol_http_param_add(params,
+        SOL_HTTP_REQUEST_PARAM_HEADER("X-Soletta-Machine-ID", id));
+    SOL_INT_CHECK(r, != true, -1);
+
+    return 0;
+}
 
 static void
 get_key(struct http_data *mdata)
@@ -99,6 +116,8 @@ common_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_o
 
     mdata->url = strdup(opts->url);
     SOL_NULL_CHECK(mdata->url, -ENOMEM);
+
+    mdata->machine_id = opts->machine_id;
 
     get_key(mdata);
     sol_ptr_vector_init(&mdata->pending_conns);
@@ -202,6 +221,7 @@ common_get_process(struct sol_flow_node *node, void *data, uint16_t port, uint16
     const struct sol_flow_packet *packet)
 {
     int r;
+    char id[33];
     struct sol_http_param params;
     struct http_data *mdata = data;
     struct sol_http_client_connection *connection;
@@ -212,8 +232,12 @@ common_get_process(struct sol_flow_node *node, void *data, uint16_t port, uint16
     if (!sol_http_param_add(&params,
         SOL_HTTP_REQUEST_PARAM_HEADER("Accept", "application/json"))) {
         SOL_WRN("Failed to set query params");
-        sol_http_param_free(&params);
-        return -ENOMEM;
+        goto err;
+    }
+
+    if (mdata->machine_id) {
+        r = machine_id_header_add(&params, id);
+        SOL_INT_CHECK_GOTO(r, < 0, err);
     }
 
     connection = sol_http_client_request(SOL_HTTP_METHOD_GET, mdata->url,
@@ -231,6 +255,10 @@ common_get_process(struct sol_flow_node *node, void *data, uint16_t port, uint16
     }
 
     return 0;
+
+err:
+    sol_http_param_free(&params);
+    return -ENOMEM;
 }
 
 static int
@@ -238,7 +266,7 @@ common_post_process(struct sol_flow_node *node, void *data, ...)
 {
     int r;
     va_list ap;
-    char *key, *value;
+    char *key, *value, id[33];
     struct sol_http_param params;
     struct http_data *mdata = data;
     struct sol_http_client_connection *connection;
@@ -249,6 +277,11 @@ common_post_process(struct sol_flow_node *node, void *data, ...)
         SOL_WRN("Could not add the header '%s:%s' into request to %s",
             "Accept", "application/json", mdata->url);
         goto err;
+    }
+
+    if (mdata->machine_id) {
+        r = machine_id_header_add(&params, id);
+        SOL_INT_CHECK_GOTO(r, < 0, err);
     }
 
     va_start(ap, data);
@@ -548,6 +581,7 @@ generic_open(struct sol_flow_node *node, void *data,
     }
 
     mdata->strict = opts->strict;
+    mdata->machine_id = opts->machine_id;
     sol_ptr_vector_init(&mdata->pending_conns);
     return 0;
 
@@ -651,14 +685,19 @@ generic_get_process(struct sol_flow_node *node, void *data, uint16_t port,
     struct http_data *mdata = data;
     struct sol_http_client_connection *conn;
     struct sol_http_param params;
+    char id[33];
     int r;
 
     sol_http_param_init(&params);
     if (mdata->content_type && !sol_http_param_add(&params,
         SOL_HTTP_REQUEST_PARAM_HEADER("Accept", mdata->content_type))) {
         SOL_ERR("Could not add the HTTP Accept's param");
-        sol_http_param_free(&params);
-        return -ENOMEM;
+        goto err;
+    }
+
+    if (mdata->machine_id) {
+        r = machine_id_header_add(&params, id);
+        SOL_INT_CHECK_GOTO(r, < 0, err);
     }
 
     conn = sol_http_client_request(SOL_HTTP_METHOD_GET, mdata->url, &params,
@@ -674,6 +713,10 @@ generic_get_process(struct sol_flow_node *node, void *data, uint16_t port,
     }
     SOL_DBG("Making request to: %s", mdata->url);
     return 0;
+
+err:
+    sol_http_param_free(&params);
+    return -ENOMEM;
 }
 
 #include "http-client-gen.c"

--- a/src/modules/flow/http-client/http-client.json
+++ b/src/modules/flow/http-client/http-client.json
@@ -21,19 +21,25 @@
         ],
         "data_type": "struct http_client_node_type",
         "extra_methods": {
-	  "process_token": "boolean_process_token",
-	  "process_data": "boolean_process_data"
+          "process_token": "boolean_process_token",
+          "process_data": "boolean_process_data"
         }
       },
       "options": {
-	"members": [
-	  {
-	    "data_type": "string",
-	    "description": "The url that will be used on request and posts",
-	    "name": "url"
-	  }
-	],
-	"version": 1
+        "members": [
+          {
+            "data_type": "string",
+            "description": "The url that will be used on request and posts",
+            "name": "url"
+          },
+          {
+            "data_type": "boolean",
+            "description": "If the machine_id should be set on every request made",
+            "name": "machine_id",
+            "default": false
+          }
+        ],
+        "version": 1
       },
       "in_ports": [
         {
@@ -85,19 +91,25 @@
         ],
         "data_type": "struct http_client_node_type",
         "extra_methods": {
-	  "process_token": "string_process_token",
-	  "process_data": "string_process_data"
+          "process_token": "string_process_token",
+          "process_data": "string_process_data"
         }
       },
       "options": {
-	"members": [
-	  {
-	    "data_type": "string",
-	    "description": "The url that will be used on request and posts",
-	    "name": "url"
-	  }
-	],
-	"version": 1
+        "members": [
+          {
+            "data_type": "string",
+            "description": "The url that will be used on request and posts",
+            "name": "url"
+          },
+          {
+            "data_type": "boolean",
+            "description": "If the machine_id should be set on every request made",
+            "name": "machine_id",
+            "default": false
+          }
+        ],
+        "version": 1
       },
       "in_ports": [
         {
@@ -149,19 +161,25 @@
         ],
         "data_type": "struct http_client_node_type",
         "extra_methods": {
-	  "process_token": "int_process_token",
-	  "process_data": "int_process_data"
+          "process_token": "int_process_token",
+          "process_data": "int_process_data"
         }
       },
       "options": {
-	"members": [
-	  {
-	    "data_type": "string",
-	    "description": "The url that will be used on request and posts",
-	    "name": "url"
-	  }
-	],
-	"version": 1
+        "members": [
+          {
+            "data_type": "string",
+            "description": "The url that will be used on request and posts",
+            "name": "url"
+          },
+          {
+            "data_type": "boolean",
+            "description": "If the machine_id should be set on every request made",
+            "name": "machine_id",
+            "default": false
+          }
+        ],
+        "version": 1
       },
       "in_ports": [
         {
@@ -213,19 +231,25 @@
         ],
         "data_type": "struct http_client_node_type",
         "extra_methods": {
-	  "process_token": "float_process_token",
-	  "process_data": "float_process_data"
+          "process_token": "float_process_token",
+          "process_data": "float_process_data"
         }
       },
       "options": {
-	"members": [
-	  {
-	    "data_type": "string",
-	    "description": "The url that will be used on request and posts",
-	    "name": "url"
-	  }
-	],
-	"version": 1
+        "members": [
+          {
+            "data_type": "string",
+            "description": "The url that will be used on request and posts",
+            "name": "url"
+          },
+          {
+            "data_type": "boolean",
+            "description": "If the machine_id should be set on every request made",
+            "name": "machine_id",
+            "default": false
+          }
+        ],
+        "version": 1
       },
       "in_ports": [
         {
@@ -289,6 +313,12 @@
             "default": null,
             "description": "The url to make a GET request",
             "name": "url"
+          },
+          {
+            "data_type": "boolean",
+            "description": "If the machine_id should be set on every request made",
+            "name": "machine_id",
+            "default": false
           },
           {
             "data_type": "boolean",
@@ -357,6 +387,12 @@
             "default": null,
             "description": "The url to make a GET request",
             "name": "url"
+          },
+          {
+            "data_type": "boolean",
+            "description": "If the machine_id should be set on every request made",
+            "name": "machine_id",
+            "default": false
           },
           {
             "data_type": "boolean",

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -47,6 +47,10 @@
 #include "sol-random.h"
 #include "sol-str-slice.h"
 
+struct sol_uuid {
+    uint8_t bytes[16];
+};
+
 #if defined(HAVE_NEWLOCALE) && defined(HAVE_STRTOD_L)
 static locale_t c_locale;
 static void

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -122,10 +122,6 @@ double sol_util_strtodn(const char *nptr, char **endptr, ssize_t len, bool use_l
 /* number of nanoseconds in a microsecond: 1,000,000,000 / 1,000,000 = 1,000 */
 #define NSEC_PER_USEC 1000ULL
 
-struct sol_uuid {
-    uint8_t bytes[16];
-};
-
 static inline int
 sol_util_int_compare(const int a, const int b)
 {


### PR DESCRIPTION
- from v1
  - Use machine_id instead of just using uuid
  - The header is only set on the cliend nodes and it's optional