### PR TITLE
test-str-slice: fix memory leak

### DIFF
--- a/src/test/test-str-slice.c
+++ b/src/test/test-str-slice.c
@@ -134,6 +134,7 @@ test_str_slice_to_string(void)
     for (i = 0; i < ARRAY_SIZE(input); i++) {
         char *s = sol_str_slice_to_string(input[i]);
         ASSERT(sol_str_slice_str_eq(input[i], s));
+        free(s);
     }
 }
 


### PR DESCRIPTION
sol_str_slice_to_string() will allocate a new string, this string must
be freed.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>