### PR TITLE
crypto/message-digest: add common infrastructure, improve non-threaded.

### DIFF
--- a/src/lib/crypto/Kconfig
+++ b/src/lib/crypto/Kconfig
@@ -1,6 +1,9 @@
 config CRYPTO_MESSAGE_DIGEST
 	bool
 
+config CRYPTO_MESSAGE_DIGEST_COMMON
+	bool
+
 choice
 	prompt "Message Digest (Hash)"
 	depends on FEATURE_CRYPTO_MESSAGE_DIGEST
@@ -30,6 +33,7 @@ config CRYPTO_MESSAGE_DIGEST_LINUX_KCAPI
 	bool "Linux Kernel Crypto API"
 	depends on LINUX && FEATURE_CRYPTO_MESSAGE_DIGEST
 	select CRYPTO_MESSAGE_DIGEST
+	select CRYPTO_MESSAGE_DIGEST_COMMON
 	help
             This implementation will use the Kernel-Userspace interface
             provided by Linux. Linux implementation are often very optimized
@@ -39,6 +43,7 @@ config CRYPTO_MESSAGE_DIGEST_OPENSSL
 	bool "OpenSSL"
 	depends on HAVE_OPENSSL && FEATURE_CRYPTO_MESSAGE_DIGEST
 	select CRYPTO_MESSAGE_DIGEST
+	select CRYPTO_MESSAGE_DIGEST_COMMON
 	help
             This implementation will use OpenSSL.
 

--- a/src/lib/crypto/Makefile
+++ b/src/lib/crypto/Makefile
@@ -3,6 +3,9 @@ obj-y += crypto.mod
 obj-crypto-y := \
     sol-crypto.o
 
+obj-crypto-$(CRYPTO_MESSAGE_DIGEST_COMMON) += \
+   sol-message-digest-common.o
+
 obj-crypto-$(CRYPTO_MESSAGE_DIGEST_LINUX_KCAPI) += \
    sol-message-digest-impl-linux-kcapi.o
 

--- a/src/lib/crypto/sol-message-digest-common.c
+++ b/src/lib/crypto/sol-message-digest-common.c
@@ -1,0 +1,711 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "sol-message-digest-common.h"
+
+SOL_LOG_INTERNAL_DECLARE(_sol_message_digest_common_log_domain, "message-digest");
+
+#include "sol-crypto.h"
+#include "sol-mainloop.h"
+#include "sol-util.h"
+#include "sol-vector.h"
+
+int
+sol_message_digest_common_init(void)
+{
+    SOL_LOG_INTERNAL_INIT_ONCE;
+
+    return 0;
+}
+
+void
+sol_message_digest_common_shutdown(void)
+{
+}
+
+#if defined(PTHREAD) && defined(WORKER_THREAD)
+#define MESSAGE_DIGEST_USE_THREAD
+#endif
+
+#if !defined(MESSAGE_DIGEST_USE_THREAD) && !defined(MESSAGE_DIGEST_MAX_FEED_BLOCK_SIZE)
+#define MESSAGE_DIGEST_MAX_FEED_BLOCK_SIZE 40960
+#endif
+
+
+#ifdef MESSAGE_DIGEST_USE_THREAD
+#include <pthread.h>
+#include "sol-worker-thread.h"
+#endif
+
+struct sol_message_digest_pending_feed {
+    struct sol_blob *blob;
+    size_t offset;
+    bool is_last;
+};
+
+#ifdef MESSAGE_DIGEST_USE_THREAD
+struct sol_message_digest_pending_dispatch {
+    struct sol_blob *blob;
+    bool is_digest;
+};
+#endif
+
+struct sol_message_digest {
+    void (*on_digest_ready)(void *data, struct sol_message_digest *handle, struct sol_blob *output);
+    void (*on_feed_done)(void *data, struct sol_message_digest *handle, struct sol_blob *input);
+    const void *data;
+    const struct sol_message_digest_common_ops *ops;
+#ifdef MESSAGE_DIGEST_USE_THREAD
+    struct sol_worker_thread *thread; /* current kcapi is not poll() friendly, it won't report IN/OUT, thus we use a thread */
+    struct sol_vector pending_dispatch;
+    int thread_pipe[2];
+    pthread_mutex_t lock;
+#else
+    struct sol_timeout *timer; /* current kcapi is not poll() friendly, it won't report IN/OUT, thus we use a timer to poll */
+#endif
+    struct sol_blob *digest;
+    struct sol_vector pending_feed;
+    size_t digest_offset;
+    size_t digest_size;
+    uint32_t refcnt;
+    bool deleted;
+};
+
+static void
+_sol_message_digest_lock(struct sol_message_digest *handle)
+{
+#ifdef MESSAGE_DIGEST_USE_THREAD
+    pthread_mutex_lock(&handle->lock);
+#endif
+}
+
+static void
+_sol_message_digest_unlock(struct sol_message_digest *handle)
+{
+#ifdef MESSAGE_DIGEST_USE_THREAD
+    pthread_mutex_unlock(&handle->lock);
+#endif
+}
+
+#ifdef MESSAGE_DIGEST_USE_THREAD
+static void
+_sol_message_digest_thread_send(struct sol_message_digest *handle, char cmd)
+{
+    while (write(handle->thread_pipe[1], &cmd, 1) != 1) {
+        if (errno != EAGAIN && errno != EINTR) {
+            SOL_WRN("handle %p couldn't send thread command %c: %s",
+                handle, cmd, sol_util_strerrora(errno));
+            return;
+        }
+    }
+}
+
+static char
+_sol_message_digest_thread_recv(struct sol_message_digest *handle)
+{
+    char cmd;
+
+    while (read(handle->thread_pipe[0], &cmd, 1) != 1) {
+        if (errno != EAGAIN && errno != EINTR) {
+            SOL_WRN("handle %p couldn't receive thread command: %s",
+                handle, sol_util_strerrora(errno));
+            return 0;
+        }
+    }
+
+    return cmd;
+}
+#endif
+
+static int
+_sol_message_digest_thread_init(struct sol_message_digest *handle)
+{
+#ifdef MESSAGE_DIGEST_USE_THREAD
+    int err;
+    if (pipe2(handle->thread_pipe, O_CLOEXEC) < 0)
+        return errno;
+
+    sol_vector_init(&handle->pending_dispatch,
+        sizeof(struct sol_message_digest_pending_dispatch));
+    err = pthread_mutex_init(&handle->lock, NULL);
+    if (err) {
+        close(handle->thread_pipe[0]);
+        close(handle->thread_pipe[1]);
+    }
+    return err;
+#else
+    return 0;
+#endif
+}
+
+static void
+_sol_message_digest_thread_fini(struct sol_message_digest *handle)
+{
+#ifdef MESSAGE_DIGEST_USE_THREAD
+    struct sol_message_digest_pending_dispatch *pd;
+    uint16_t i;
+
+    _sol_message_digest_thread_send(handle, 'c');
+    close(handle->thread_pipe[0]);
+    close(handle->thread_pipe[1]);
+
+    if (handle->thread)
+        sol_worker_thread_cancel(handle->thread);
+    pthread_mutex_destroy(&handle->lock);
+
+    SOL_VECTOR_FOREACH_IDX (&handle->pending_dispatch, pd, i) {
+        sol_blob_unref(pd->blob);
+    }
+    sol_vector_clear(&handle->pending_dispatch);
+#else
+    if (handle->timer)
+        sol_timeout_del(handle->timer);
+#endif
+}
+
+static void
+_sol_message_digest_thread_stop(struct sol_message_digest *handle)
+{
+#ifdef MESSAGE_DIGEST_USE_THREAD
+    _sol_message_digest_thread_send(handle, 'c');
+#endif
+}
+
+void *
+sol_message_digest_common_get_context(const struct sol_message_digest *handle)
+{
+    size_t padding = sizeof(struct sol_message_digest) % sizeof(void *);
+
+    if (padding > 0)
+        padding = sizeof(void *) - padding;
+
+    return (char *)handle + sizeof(struct sol_message_digest) + padding;
+}
+
+struct sol_message_digest *
+sol_message_digest_common_new(const struct sol_message_digest_common_new_params params)
+{
+    const struct sol_message_digest_config *config = params.config;
+    struct sol_message_digest *handle;
+    size_t padding;
+    int errno_bkp;
+
+    SOL_NULL_CHECK(params.ops, NULL);
+    SOL_NULL_CHECK(params.ops->feed, NULL);
+    SOL_NULL_CHECK(params.ops->read_digest, NULL);
+    SOL_NULL_CHECK(params.ops->cleanup, NULL);
+    SOL_INT_CHECK(params.digest_size, == 0, NULL);
+
+    padding = sizeof(struct sol_message_digest) % sizeof(void *);
+    if (padding > 0)
+        padding = sizeof(void *) - padding;
+
+    handle = calloc(1, sizeof(struct sol_message_digest) + padding + params.context_size);
+    SOL_NULL_CHECK(handle, NULL);
+
+    if (params.context_template) {
+        void *context = (char *)handle + sizeof(struct sol_message_digest) + padding;
+        memcpy(context, params.context_template, params.context_size);
+    }
+
+    handle->ops = params.ops;
+
+    handle->refcnt = 1;
+    handle->on_digest_ready = config->on_digest_ready;
+    handle->on_feed_done = config->on_feed_done;
+    handle->data = config->data;
+    sol_vector_init(&handle->pending_feed,
+        sizeof(struct sol_message_digest_pending_feed));
+
+    handle->digest_size = params.digest_size;
+
+    errno = _sol_message_digest_thread_init(handle);
+    if (errno)
+        goto error;
+
+    SOL_DBG("handle %p algorithm=\"%s\"", handle, config->algorithm);
+
+    errno = 0;
+    return handle;
+
+error:
+    errno_bkp = errno;
+    free(handle);
+    errno = errno_bkp;
+    return NULL;
+}
+
+static void
+_sol_message_digest_free(struct sol_message_digest *handle)
+{
+    struct sol_message_digest_pending_feed *pf;
+    uint16_t i;
+
+    SOL_DBG("free handle %p pending_feed=%hu, digest=%p",
+        handle, handle->pending_feed.len, handle->digest);
+
+    _sol_message_digest_thread_fini(handle);
+
+    SOL_VECTOR_FOREACH_IDX (&handle->pending_feed, pf, i) {
+        sol_blob_unref(pf->blob);
+    }
+    sol_vector_clear(&handle->pending_feed);
+
+    if (handle->digest)
+        sol_blob_unref(handle->digest);
+
+    handle->ops->cleanup(handle);
+
+    free(handle);
+}
+
+static inline void
+_sol_message_digest_unref(struct sol_message_digest *handle)
+{
+    handle->refcnt--;
+    if (handle->refcnt == 0)
+        _sol_message_digest_free(handle);
+}
+
+static inline void
+_sol_message_digest_ref(struct sol_message_digest *handle)
+{
+    handle->refcnt++;
+}
+
+SOL_API void
+sol_message_digest_del(struct sol_message_digest *handle)
+{
+    SOL_NULL_CHECK(handle);
+    SOL_EXP_CHECK(handle->deleted);
+    SOL_INT_CHECK(handle->refcnt, < 1);
+
+    handle->deleted = true;
+
+    _sol_message_digest_thread_stop(handle);
+
+    SOL_DBG("del handle %p refcnt=%" PRIu32
+        ", pending_feed=%hu, digest=%p",
+        handle, handle->refcnt,
+        handle->pending_feed.len, handle->digest);
+    _sol_message_digest_unref(handle);
+}
+
+static void
+_sol_message_digest_setup_receive_digest(struct sol_message_digest *handle)
+{
+    void *mem;
+
+    if (handle->digest) {
+        SOL_WRN("handle %p already have a digest to be received (%p).",
+            handle, handle->digest);
+        return;
+    }
+
+    mem = malloc(handle->digest_size);
+    SOL_NULL_CHECK(mem);
+
+    handle->digest = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL,
+        mem, handle->digest_size);
+    SOL_NULL_CHECK_GOTO(handle->digest, error);
+
+    SOL_DBG("handle %p to receive digest of %zd bytes at blob %p mem=%p",
+        handle, handle->digest_size,
+        handle->digest, handle->digest->mem);
+
+    return;
+
+error:
+    free(mem);
+}
+
+static void
+_sol_message_digest_report_feed_blob(struct sol_message_digest *handle, struct sol_blob *input)
+{
+#ifdef MESSAGE_DIGEST_USE_THREAD
+    struct sol_message_digest_pending_dispatch *pd;
+
+    _sol_message_digest_lock(handle);
+
+    pd = sol_vector_append(&handle->pending_dispatch);
+    SOL_NULL_CHECK_GOTO(pd, error);
+    pd->blob = input;
+    pd->is_digest = false;
+
+    _sol_message_digest_unlock(handle);
+    sol_worker_thread_feedback(handle->thread);
+    return;
+
+error:
+    _sol_message_digest_unlock(handle);
+    sol_blob_unref(input); /* this may cause problems if main thread changes blob refcnt */
+
+#else
+    _sol_message_digest_ref(handle);
+
+    if (handle->on_feed_done)
+        handle->on_feed_done((void *)handle->data, handle, input);
+
+    sol_blob_unref(input);
+    _sol_message_digest_unref(handle);
+#endif
+}
+
+static void
+_sol_message_digest_report_digest_ready(struct sol_message_digest *handle)
+{
+#ifdef MESSAGE_DIGEST_USE_THREAD
+    struct sol_message_digest_pending_dispatch *pd;
+
+    _sol_message_digest_lock(handle);
+
+    pd = sol_vector_append(&handle->pending_dispatch);
+    SOL_NULL_CHECK_GOTO(pd, end);
+    pd->blob = handle->digest;
+    pd->is_digest = true;
+
+    handle->digest = NULL;
+
+end:
+    _sol_message_digest_unlock(handle);
+    sol_worker_thread_feedback(handle->thread);
+
+#else
+    _sol_message_digest_ref(handle);
+
+    handle->on_digest_ready((void *)handle->data, handle, handle->digest);
+
+    sol_blob_unref(handle->digest);
+    handle->digest = NULL;
+
+    _sol_message_digest_unref(handle);
+#endif
+}
+
+static void
+_sol_message_digest_feed_blob(struct sol_message_digest *handle)
+{
+    struct sol_message_digest_pending_feed *pf;
+    struct sol_blob *input;
+    const uint8_t *mem;
+    bool is_last;
+    size_t offset, len;
+    ssize_t n;
+
+    _sol_message_digest_lock(handle);
+    pf = sol_vector_get(&handle->pending_feed, 0);
+    SOL_NULL_CHECK_GOTO(pf, error);
+
+    input = pf->blob;
+    mem = input->mem;
+    offset = pf->offset;
+    mem += offset;
+    len = input->size - offset;
+    is_last = pf->is_last;
+
+#ifdef MESSAGE_DIGEST_MAX_FEED_BLOCK_SIZE
+    if (len > MESSAGE_DIGEST_MAX_FEED_BLOCK_SIZE) {
+        len = MESSAGE_DIGEST_MAX_FEED_BLOCK_SIZE;
+        if (is_last)
+            is_last = false;
+    }
+#endif
+
+    _sol_message_digest_unlock(handle);
+
+    n = handle->ops->feed(handle, mem, len, is_last);
+    SOL_DBG("handle %p feed mem=%p (%zd bytes) (pending=%hu) is_last=%hhu:"
+        " %zd bytes",
+        handle, mem, len, handle->pending_feed.len, is_last, n);
+    if (n >= 0) {
+        if (offset + n < input->size) { /* not fully sent, need to try again later */
+            /* fetch first pending again as it's a sol_vector and
+             * calls to sol_message_digest_feed() may realloc() the vector,
+             * resulting in new pointer for the first element.
+             */
+            _sol_message_digest_lock(handle);
+            pf = sol_vector_get(&handle->pending_feed, 0);
+            SOL_NULL_CHECK_GOTO(pf, error);
+            pf->offset += n;
+            _sol_message_digest_unlock(handle);
+            return;
+        }
+
+        if (is_last)
+            _sol_message_digest_setup_receive_digest(handle);
+
+        _sol_message_digest_lock(handle);
+        sol_vector_del(&handle->pending_feed, 0);
+        _sol_message_digest_unlock(handle);
+
+        _sol_message_digest_report_feed_blob(handle, input);
+
+    } else {
+        errno = -n;
+        if (errno != EAGAIN && errno != EINTR) {
+            SOL_WRN("couldn't feed handle %p with %p of %zd bytes: %s",
+                handle, mem, len, sol_util_strerrora(errno));
+        }
+    }
+
+    return;
+
+error:
+    _sol_message_digest_unlock(handle);
+    SOL_WRN("no pending feed for handle %p", handle);
+}
+
+static void
+_sol_message_digest_receive_digest(struct sol_message_digest *handle)
+{
+    uint8_t *mem;
+    size_t len;
+    ssize_t n;
+
+    mem = handle->digest->mem;
+    mem += handle->digest_offset;
+    len = handle->digest->size - handle->digest_offset;
+
+    n = handle->ops->read_digest(handle, mem, len);
+    SOL_DBG("handle %p read digest mem=%p (%zd bytes): %zd bytes",
+        handle, mem, len, n);
+    if (n >= 0) {
+        handle->digest_offset += n;
+        if (handle->digest_offset < handle->digest->size) /* more to do... */
+            return;
+
+        _sol_message_digest_report_digest_ready(handle);
+
+    } else {
+        errno = -n;
+        if (errno != EAGAIN && errno != EINTR) {
+            SOL_WRN("couldn't recv digest handle %p with %p of %zd bytes: %s",
+                handle, mem, len, sol_util_strerrora(errno));
+        }
+    }
+}
+
+#ifdef MESSAGE_DIGEST_USE_THREAD
+
+static struct sol_blob *
+_sol_message_digest_peek_first_pending_blob(struct sol_message_digest *handle)
+{
+    struct sol_message_digest_pending_feed *pf;
+    struct sol_blob *blob = NULL;
+
+    _sol_message_digest_lock(handle);
+    if (handle->pending_feed.len) {
+        pf = sol_vector_get(&handle->pending_feed, 0);
+        if (pf)
+            blob = pf->blob;
+    }
+    _sol_message_digest_unlock(handle);
+
+    return blob;
+}
+
+static bool
+_sol_message_digest_thread_iterate(void *data)
+{
+    struct sol_message_digest *handle = data;
+    struct sol_blob *current = NULL;
+    char cmd;
+
+    cmd = _sol_message_digest_thread_recv(handle);
+    if (cmd == 'c' || cmd == 0)
+        return false;
+
+    current = _sol_message_digest_peek_first_pending_blob(handle);
+    while (current && !sol_worker_thread_cancel_check(handle->thread)) {
+        struct sol_blob *blob;
+
+        _sol_message_digest_feed_blob(handle);
+
+        blob = _sol_message_digest_peek_first_pending_blob(handle);
+        if (blob != current)
+            break;
+    }
+
+    while (handle->digest && !sol_worker_thread_cancel_check(handle->thread))
+        _sol_message_digest_receive_digest(handle);
+
+    return true;
+}
+
+static void
+_sol_message_digest_thread_finished(void *data)
+{
+    struct sol_message_digest *handle = data;
+
+    handle->thread = NULL;
+    _sol_message_digest_unref(handle);
+}
+
+static void
+_sol_message_digest_thread_feedback(void *data)
+{
+    struct sol_message_digest *handle = data;
+    struct sol_message_digest_pending_dispatch *pd;
+    struct sol_vector v;
+    uint16_t i;
+
+    _sol_message_digest_lock(handle);
+    v = handle->pending_dispatch;
+    sol_vector_init(&handle->pending_dispatch,
+        sizeof(struct sol_message_digest_pending_dispatch));
+    _sol_message_digest_unlock(handle);
+
+    _sol_message_digest_ref(handle);
+
+    SOL_VECTOR_FOREACH_IDX (&v, pd, i) {
+        if (!handle->deleted) {
+            if (pd->is_digest)
+                handle->on_digest_ready((void *)handle->data, handle, pd->blob);
+            else if (handle->on_feed_done)
+                handle->on_feed_done((void *)handle->data, handle, pd->blob);
+        }
+        sol_blob_unref(pd->blob);
+    }
+
+    _sol_message_digest_unref(handle);
+
+    sol_vector_clear(&v);
+}
+
+#else
+static bool
+_sol_message_digest_on_timer(void *data)
+{
+    struct sol_message_digest *handle = data;
+    bool ret;
+
+    SOL_DBG("handle %p pending=%hu, digest=%p",
+        handle, handle->pending_feed.len, handle->digest);
+
+    _sol_message_digest_ref(handle);
+
+    if (handle->pending_feed.len > 0)
+        _sol_message_digest_feed_blob(handle);
+
+    if (handle->digest)
+        _sol_message_digest_receive_digest(handle);
+
+    ret = (handle->pending_feed.len > 0 || handle->digest);
+    if (!ret)
+        handle->timer = NULL;
+
+    _sol_message_digest_unref(handle);
+    return ret;
+}
+#endif
+
+static int
+_sol_message_digest_thread_start(struct sol_message_digest *handle)
+{
+#ifdef MESSAGE_DIGEST_USE_THREAD
+    struct sol_worker_thread_spec spec = {
+        .api_version = SOL_WORKER_THREAD_SPEC_API_VERSION,
+        .data = handle,
+        .iterate = _sol_message_digest_thread_iterate,
+        .finished = _sol_message_digest_thread_finished,
+        .feedback = _sol_message_digest_thread_feedback
+    };
+
+    if (handle->thread)
+        goto end;
+
+    _sol_message_digest_ref(handle);
+    handle->thread = sol_worker_thread_new(&spec);
+    SOL_NULL_CHECK_GOTO(handle->thread, error);
+
+end:
+    _sol_message_digest_thread_send(handle, 'a');
+
+    return 0;
+
+error:
+    _sol_message_digest_unref(handle);
+    return -ENOMEM;
+
+#else
+    if (handle->timer)
+        return 0;
+
+    handle->timer = sol_timeout_add(0, _sol_message_digest_on_timer, handle);
+    SOL_NULL_CHECK(handle->timer, -ENOMEM);
+
+    return 0;
+#endif
+}
+
+SOL_API int
+sol_message_digest_feed(struct sol_message_digest *handle, struct sol_blob *input, bool is_last)
+{
+    struct sol_message_digest_pending_feed *pf;
+    int r;
+
+    SOL_NULL_CHECK(handle, -EINVAL);
+    SOL_EXP_CHECK(handle->deleted, -EINVAL);
+    SOL_INT_CHECK(handle->refcnt, < 1, -EINVAL);
+    SOL_NULL_CHECK(input, -EINVAL);
+
+    _sol_message_digest_lock(handle);
+    pf = sol_vector_append(&handle->pending_feed);
+    SOL_NULL_CHECK_GOTO(pf, error_append);
+
+    pf->blob = sol_blob_ref(input);
+    pf->offset = 0;
+    pf->is_last = is_last;
+
+    r = _sol_message_digest_thread_start(handle);
+    SOL_INT_CHECK_GOTO(r, < 0, error);
+
+    _sol_message_digest_unlock(handle);
+
+    SOL_DBG("handle %p blob=%p (%zd bytes), pending %hu",
+        handle, input, input->size, handle->pending_feed.len);
+
+    return 0;
+
+error:
+    sol_blob_unref(input);
+    sol_vector_del(&handle->pending_feed, handle->pending_feed.len - 1);
+
+error_append:
+    _sol_message_digest_unlock(handle);
+
+    return -ENOMEM;
+}

--- a/src/lib/crypto/sol-message-digest-common.c
+++ b/src/lib/crypto/sol-message-digest-common.c
@@ -101,6 +101,7 @@ struct sol_message_digest {
     size_t digest_offset;
     size_t digest_size;
     uint32_t refcnt;
+    bool finished;
     bool deleted;
 };
 
@@ -679,6 +680,7 @@ sol_message_digest_feed(struct sol_message_digest *handle, struct sol_blob *inpu
 
     SOL_NULL_CHECK(handle, -EINVAL);
     SOL_EXP_CHECK(handle->deleted, -EINVAL);
+    SOL_EXP_CHECK(handle->finished, -EINVAL);
     SOL_INT_CHECK(handle->refcnt, < 1, -EINVAL);
     SOL_NULL_CHECK(input, -EINVAL);
 
@@ -694,6 +696,9 @@ sol_message_digest_feed(struct sol_message_digest *handle, struct sol_blob *inpu
     SOL_INT_CHECK_GOTO(r, < 0, error);
 
     _sol_message_digest_unlock(handle);
+
+    if (is_last)
+        handle->finished = true;
 
     SOL_DBG("handle %p blob=%p (%zd bytes), pending %hu",
         handle, input, input->size, handle->pending_feed.len);

--- a/src/lib/crypto/sol-message-digest-common.h
+++ b/src/lib/crypto/sol-message-digest-common.h
@@ -1,0 +1,173 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define SOL_LOG_DOMAIN &_sol_message_digest_common_log_domain
+extern struct sol_log_domain _sol_message_digest_common_log_domain;
+#include "sol-log-internal.h"
+
+#include "sol-message-digest.h"
+
+int sol_message_digest_common_init(void);
+void sol_message_digest_common_shutdown(void);
+
+/**
+ * Operations to use with the common message digest implementation.
+ *
+ * @internal
+ */
+struct sol_message_digest_common_ops {
+    /* no api version as this struct is not exported */
+    /**
+     * Feed the algorithm with more data (@c mem of @c len bytes).
+     *
+     * This function is called from a thread if defined(PTHREAD) &&
+     * defined(WORKER_THREAD), and in such case care may be needed
+     * depending on the platform.
+     *
+     * It is guaranteed that the same handle is not called from
+     * different worker thread, both @c feed and @c read_digest are
+     * called from the same worker thread, while @c cleanup is called
+     * from the main thread once the worker thread is already
+     * finalized.
+     *
+     * If this function returns less then the requested amount of
+     * bytes (@c len), then it is called again with a new @c mem
+     * adapted (offset) to the remaining location and reduced @c len,
+     * so it would do partial feeds.
+     *
+     * @param handle the message digest handle feeding the algorithm.
+     * @param mem the pointer to memory to be feed.
+     * @param len the size in bytes of memory to be feed.
+     * @param is_last if this is the last chunk to be feed.
+     *
+     * @return number of bytes fed or -errno.
+     */
+    ssize_t (*feed)(struct sol_message_digest *handle, const void *mem, size_t len, bool is_last);
+    /**
+     * Read the digest from the message.
+     *
+     * This function is called from a thread if defined(PTHREAD) &&
+     * defined(WORKER_THREAD), and in such case care may be needed
+     * depending on the platform.
+     *
+     * It is guaranteed that the same handle is not called from
+     * different worker thread, both @c feed and @c read_digest are
+     * called from the same worker thread, while @c cleanup is called
+     * from the main thread once the worker thread is already
+     * finalized.
+     *
+     * If this function returns less then the requested amount of
+     * bytes (@c len), then it is called again with a new @c mem
+     * adapted (offset) to the remaining location and reduced @c len,
+     * so it would do partial reads. The initial call will always be
+     * enough to hold the whole digest as specified in @c digest_size;
+     *
+     * @param handle the message digest handle reading the hash.
+     * @param mem the pointer to memory to store the digest.
+     * @param len the size in bytes of memory to store the digest.
+     * @return number of bytes fed or -errno.
+     */
+    ssize_t (*read_digest)(struct sol_message_digest *handle, void *mem, size_t len);
+    /**
+     * Cleanup any remaining resources before the handle is deleted.
+     *
+     * This functions is called from the main thread.
+     */
+    void (*cleanup)(struct sol_message_digest *handle);
+};
+
+
+/**
+ * parameters to sol_message_digest_common_new(), used to avoid lots
+ * of parameters with similar types (size_t), that could be confusing
+ * and lead to mistakes.
+ *
+ * @internal
+ */
+struct sol_message_digest_common_new_params {
+    /* no api version as this struct is not exported */
+    /**
+     * The handle given to sol_message_digest_new().
+     *
+     * It must be sanitized before calling this function, this is
+     * considered safe since most users of this function will already
+     * need to check parameters such as algorithm before calling, thus
+     * it is not replicated in here.
+     */
+    const struct sol_message_digest_config *config;
+    /**
+     * The operations to feed and read the digest.
+     *
+     * @b NO copy is done, a reference is kept to it and thus it must
+     * be valid during the lifecycle of the handle (until @c cleanup()
+     * is called)
+     */
+    const struct sol_message_digest_common_ops *ops;
+    /**
+     * The algorithm specific context as a template, it will be copied
+     * using @c memcpy() @c context_size. No references to the given
+     * pointer are kept.
+     *
+     * If @c NULL, nothing is copied, but the memory is allocated
+     * anyway.
+     *
+     * The actual context may be retrieved with
+     * sol_message_digest_common_get_context().
+     */
+    const void *context_template;
+    /**
+     * Size in bytes of @c context_template, to copy with @c memcpy().
+     */
+    size_t context_size;
+    /**
+     * Size in bytes of the resulting digest.
+     */
+    size_t digest_size;
+};
+
+/**
+ * This function creates the base handle.
+ *
+ * If it fails, then @c params.ops->cleanup() is @b NOT called, one
+ * may need to do extra cleanups if needed.
+ *
+ * @param params the set of parameters is specified as a struct to
+ *        avoid mistakes. Se its documentation for each parameter
+ *        purpose and behavior.
+ *
+ * @param newly allocated handle or @c NULL on error, with errno set.
+ *
+ * @internal
+ */
+struct sol_message_digest *sol_message_digest_common_new(const struct sol_message_digest_common_new_params params);
+void *sol_message_digest_common_get_context(const struct sol_message_digest *handle);
+

--- a/src/lib/crypto/sol-message-digest-impl-linux-kcapi.c
+++ b/src/lib/crypto/sol-message-digest-impl-linux-kcapi.c
@@ -377,6 +377,8 @@ sol_message_digest_new(const struct sol_message_digest_config *config)
     handle = sol_message_digest_common_new(params);
     SOL_NULL_CHECK_GOTO(handle, error_handle);
 
+    close(bfd);
+
     return handle;
 
 error_handle:

--- a/src/lib/crypto/sol-message-digest-impl-openssl.c
+++ b/src/lib/crypto/sol-message-digest-impl-openssl.c
@@ -31,276 +31,137 @@
  */
 
 #include <errno.h>
-#include <unistd.h>
-#include <fcntl.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 
-#define SOL_LOG_DOMAIN &_log_domain
-#include "sol-log-internal.h"
-
-SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "message-digest");
-
+#include "sol-message-digest-common.h"
 #include "sol-crypto.h"
-#include "sol-mainloop.h"
-#include "sol-message-digest.h"
 #include "sol-util.h"
-#include "sol-vector.h"
 
 static bool did_openssl_load_digests = false;
 
 int
 sol_message_digest_init(void)
 {
-    SOL_LOG_INTERNAL_INIT_ONCE;
-
-    return 0;
+    return sol_message_digest_common_init();
 }
 
 void
 sol_message_digest_shutdown(void)
 {
+    sol_message_digest_common_shutdown();
 }
-
-#if defined(PTHREAD) && defined(WORKER_THREAD)
-#define MESSAGE_DIGEST_USE_THREAD
-#endif
-
-#ifdef MESSAGE_DIGEST_USE_THREAD
-#include <pthread.h>
-#include "sol-worker-thread.h"
-#endif
-
-struct sol_message_digest_pending_feed {
-    struct sol_blob *blob;
-    bool is_last;
-};
-
-#ifdef MESSAGE_DIGEST_USE_THREAD
-struct sol_message_digest_pending_dispatch {
-    struct sol_blob *blob;
-    bool is_digest;
-};
-#endif
-
-struct sol_message_digest_openssl_ops {
-    bool (*init)(struct sol_message_digest *handle, const EVP_MD *md, const struct sol_str_slice key);
-    bool (*update)(struct sol_message_digest *handle, struct sol_blob *input);
-    bool (*final)(struct sol_message_digest *handle, struct sol_blob *digest);
-    void (*cleanup)(struct sol_message_digest *handle);
-};
-
-struct sol_message_digest {
-    void (*on_digest_ready)(void *data, struct sol_message_digest *handle, struct sol_blob *output);
-    void (*on_feed_done)(void *data, struct sol_message_digest *handle, struct sol_blob *input);
-    const void *data;
-#ifdef MESSAGE_DIGEST_USE_THREAD
-    struct sol_worker_thread *thread; /* current kcapi is not poll() friendly, it won't report IN/OUT, thus we use a thread */
-    struct sol_vector pending_dispatch;
-    int thread_pipe[2];
-    pthread_mutex_t lock;
-#else
-    struct sol_timeout *timer; /* current kcapi is not poll() friendly, it won't report IN/OUT, thus we use a timer to poll */
-#endif
-    struct sol_vector pending_feed;
-    struct sol_blob *digest;
-    size_t digest_size;
-    uint32_t refcnt;
-    union {
-        EVP_MD_CTX evp;
-        HMAC_CTX hmac;
-    } ctx;
-    struct sol_message_digest_openssl_ops ops;
-    bool deleted;
-};
-
-static void
-_sol_message_digest_lock(struct sol_message_digest *handle)
-{
-#ifdef MESSAGE_DIGEST_USE_THREAD
-    pthread_mutex_lock(&handle->lock);
-#endif
-}
-
-static void
-_sol_message_digest_unlock(struct sol_message_digest *handle)
-{
-#ifdef MESSAGE_DIGEST_USE_THREAD
-    pthread_mutex_unlock(&handle->lock);
-#endif
-}
-
-#ifdef MESSAGE_DIGEST_USE_THREAD
-static void
-_sol_message_digest_thread_send(struct sol_message_digest *handle, char cmd)
-{
-    while (write(handle->thread_pipe[1], &cmd, 1) != 1) {
-        if (errno != EAGAIN && errno != EINTR) {
-            SOL_WRN("handle %p couldn't send thread command %c: %s",
-                handle, cmd, sol_util_strerrora(errno));
-            return;
-        }
-    }
-}
-
-static char
-_sol_message_digest_thread_recv(struct sol_message_digest *handle)
-{
-    char cmd;
-
-    while (read(handle->thread_pipe[0], &cmd, 1) != 1) {
-        if (errno != EAGAIN && errno != EINTR) {
-            SOL_WRN("handle %p couldn't receive thread command: %s",
-                handle, sol_util_strerrora(errno));
-            return 0;
-        }
-    }
-
-    return cmd;
-}
-#endif
 
 static int
-_sol_message_digest_thread_init(struct sol_message_digest *handle)
-{
-#ifdef MESSAGE_DIGEST_USE_THREAD
-    if (pipe2(handle->thread_pipe, O_CLOEXEC) < 0)
-        return errno;
-
-    sol_vector_init(&handle->pending_dispatch,
-        sizeof(struct sol_message_digest_pending_dispatch));
-    errno = pthread_mutex_init(&handle->lock, NULL);
-    if (errno) {
-        close(handle->thread_pipe[0]);
-        close(handle->thread_pipe[1]);
-    }
-    return errno;
-#else
-    return 0;
-#endif
-}
-
-static void
-_sol_message_digest_thread_fini(struct sol_message_digest *handle)
-{
-#ifdef MESSAGE_DIGEST_USE_THREAD
-    struct sol_message_digest_pending_dispatch *pd;
-    uint16_t i;
-
-    _sol_message_digest_thread_send(handle, 'c');
-    close(handle->thread_pipe[0]);
-    close(handle->thread_pipe[1]);
-
-    if (handle->thread)
-        sol_worker_thread_cancel(handle->thread);
-    pthread_mutex_destroy(&handle->lock);
-
-    SOL_VECTOR_FOREACH_IDX (&handle->pending_dispatch, pd, i) {
-        sol_blob_unref(pd->blob);
-    }
-    sol_vector_clear(&handle->pending_dispatch);
-#else
-    if (handle->timer)
-        sol_timeout_del(handle->timer);
-#endif
-}
-
-static void
-_sol_message_digest_thread_stop(struct sol_message_digest *handle)
-{
-#ifdef MESSAGE_DIGEST_USE_THREAD
-    _sol_message_digest_thread_send(handle, 'c');
-#endif
-}
-
-static bool
 _sol_message_digest_evp_init(struct sol_message_digest *handle, const EVP_MD *md, const struct sol_str_slice key)
 {
-    return !!EVP_DigestInit(&handle->ctx.evp, md);
+    EVP_MD_CTX *ctx = sol_message_digest_common_get_context(handle);
+
+    if (EVP_DigestInit(ctx, md))
+        return 0;
+
+    return -EINVAL;
 }
 
 static void
 _sol_message_digest_evp_cleanup(struct sol_message_digest *handle)
 {
-    EVP_MD_CTX_cleanup(&handle->ctx.evp);
+    EVP_MD_CTX *ctx = sol_message_digest_common_get_context(handle);
+
+    EVP_MD_CTX_cleanup(ctx);
 }
 
-static bool
-_sol_message_digest_evp_update(struct sol_message_digest *handle, struct sol_blob *input)
+static ssize_t
+_sol_message_digest_evp_feed(struct sol_message_digest *handle, const void *mem, size_t len, bool is_last)
 {
-    return !!EVP_DigestUpdate(&handle->ctx.evp, input->mem, input->size);
+    EVP_MD_CTX *ctx = sol_message_digest_common_get_context(handle);
+
+    if (EVP_DigestUpdate(ctx, mem, len))
+        return len;
+
+    return -EIO;
 }
 
-static bool
-_sol_message_digest_evp_final(struct sol_message_digest *handle, struct sol_blob *digest)
+static ssize_t
+_sol_message_digest_evp_read_digest(struct sol_message_digest *handle, void *mem, size_t len)
 {
-    unsigned int len = digest->size;
+    EVP_MD_CTX *ctx = sol_message_digest_common_get_context(handle);
+    unsigned int rlen = len;
 
-    if (EVP_DigestFinal_ex(&handle->ctx.evp, digest->mem, &len)) {
-        if (len != digest->size) {
-            SOL_WRN("Wanted %zd digest bytes, got %u", digest->size, len);
-            digest->size = len;
-        }
-        return true;
+    if (EVP_DigestFinal_ex(ctx, mem, &rlen)) {
+        if (rlen != len)
+            SOL_WRN("Wanted %zd digest bytes, got %u", len, rlen);
+        return rlen;
     }
-    return false;
+
+    return -EIO;
 }
 
-static const struct sol_message_digest_openssl_ops _sol_message_digest_openssl_ops_evp = {
-    .init = _sol_message_digest_evp_init,
-    .cleanup = _sol_message_digest_evp_cleanup,
-    .update = _sol_message_digest_evp_update,
-    .final = _sol_message_digest_evp_final
+static const struct sol_message_digest_common_ops _sol_message_digest_evp_ops = {
+    .feed = _sol_message_digest_evp_feed,
+    .read_digest = _sol_message_digest_evp_read_digest,
+    .cleanup = _sol_message_digest_evp_cleanup
 };
 
-static bool
+static int
 _sol_message_digest_hmac_init(struct sol_message_digest *handle, const EVP_MD *md, const struct sol_str_slice key)
 {
-    return !!HMAC_Init(&handle->ctx.hmac, key.data, key.len, md);
+    HMAC_CTX *ctx = sol_message_digest_common_get_context(handle);
+
+    if (HMAC_Init(ctx, key.data, key.len, md))
+        return 0;
+
+    return -EINVAL;
 }
 
 static void
 _sol_message_digest_hmac_cleanup(struct sol_message_digest *handle)
 {
-    HMAC_CTX_cleanup(&handle->ctx.hmac);
+    HMAC_CTX *ctx = sol_message_digest_common_get_context(handle);
+
+    HMAC_CTX_cleanup(ctx);
 }
 
-static bool
-_sol_message_digest_hmac_update(struct sol_message_digest *handle, struct sol_blob *input)
+static ssize_t
+_sol_message_digest_hmac_feed(struct sol_message_digest *handle, const void *mem, size_t len, bool is_last)
 {
-    return !!HMAC_Update(&handle->ctx.hmac, input->mem, input->size);
+    HMAC_CTX *ctx = sol_message_digest_common_get_context(handle);
+
+    if (HMAC_Update(ctx, mem, len))
+        return len;
+
+    return -EIO;
 }
 
-static bool
-_sol_message_digest_hmac_final(struct sol_message_digest *handle, struct sol_blob *digest)
+static ssize_t
+_sol_message_digest_hmac_read_digest(struct sol_message_digest *handle, void *mem, size_t len)
 {
-    unsigned int len = digest->size;
+    HMAC_CTX *ctx = sol_message_digest_common_get_context(handle);
+    unsigned int rlen = len;
 
-    if (HMAC_Final(&handle->ctx.hmac, digest->mem, &len)) {
-        if (len != digest->size) {
-            SOL_WRN("Wanted %zd digest bytes, got %u", digest->size, len);
-            digest->size = len;
-        }
-        return true;
+    if (HMAC_Final(ctx, mem, &rlen)) {
+        if (rlen != len)
+            SOL_WRN("Wanted %zd digest bytes, got %u", len, rlen);
+        return rlen;
     }
-    return false;
+
+    return -EIO;
 }
 
-static const struct sol_message_digest_openssl_ops _sol_message_digest_openssl_ops_hmac = {
-    .init = _sol_message_digest_hmac_init,
-    .cleanup = _sol_message_digest_hmac_cleanup,
-    .update = _sol_message_digest_hmac_update,
-    .final = _sol_message_digest_hmac_final
+static const struct sol_message_digest_common_ops _sol_message_digest_hmac_ops = {
+    .feed = _sol_message_digest_hmac_feed,
+    .read_digest = _sol_message_digest_hmac_read_digest,
+    .cleanup = _sol_message_digest_hmac_cleanup
 };
 
 SOL_API struct sol_message_digest *
 sol_message_digest_new(const struct sol_message_digest_config *config)
 {
-    const struct sol_message_digest_openssl_ops *ops = NULL;
+    int (*init_fn)(struct sol_message_digest *, const EVP_MD *, const struct sol_str_slice);
+    struct sol_message_digest_common_new_params params;
     const EVP_MD *md;
     struct sol_message_digest *handle;
     int errno_bkp;
-    bool r;
 
     errno = EINVAL;
     SOL_NULL_CHECK(config, NULL);
@@ -319,9 +180,15 @@ sol_message_digest_new(const struct sol_message_digest_config *config)
         did_openssl_load_digests = true;
     }
 
+    params.config = config;
+    params.ops = NULL;
+    params.context_template = NULL;
+
     md = EVP_get_digestbyname(config->algorithm);
     if (md) {
-        ops = &_sol_message_digest_openssl_ops_evp;
+        init_fn = _sol_message_digest_evp_init;
+        params.ops = &_sol_message_digest_evp_ops;
+        params.context_size = sizeof(EVP_MD_CTX);
         SOL_DBG("using evp, md=%p, algorithm=\"%s\"", md, config->algorithm);
     } else if (streqn(config->algorithm, "hmac(", strlen("hmac("))) {
         const char *p = config->algorithm + strlen("hmac(");
@@ -334,447 +201,32 @@ sol_message_digest_new(const struct sol_message_digest_config *config)
                     mdname, config->algorithm);
                 return NULL;
             }
-            ops = &_sol_message_digest_openssl_ops_hmac;
+            init_fn = _sol_message_digest_hmac_init;
+            params.ops = &_sol_message_digest_hmac_ops;
+            params.context_size = sizeof(HMAC_CTX);
             SOL_DBG("using hmac, md=%p, algorithm=\"%s\"", md, mdname);
         }
     }
 
-    if (!ops) {
+    if (!params.ops) {
         SOL_WRN("failed to get digest algorithm \"%s\".", config->algorithm);
         return NULL;
     }
 
-    handle = calloc(1, sizeof(struct sol_message_digest));
+    params.digest_size = EVP_MD_size(md);
+
+    handle = sol_message_digest_common_new(params);
     SOL_NULL_CHECK(handle, NULL);
 
-    handle->ops = *ops;
-    r = handle->ops.init(handle, md, config->key);
-    SOL_EXP_CHECK_GOTO(!r, error_init);
-
-    handle->refcnt = 1;
-    handle->on_digest_ready = config->on_digest_ready;
-    handle->on_feed_done = config->on_feed_done;
-    handle->data = config->data;
-    sol_vector_init(&handle->pending_feed,
-        sizeof(struct sol_message_digest_pending_feed));
-
-    handle->digest_size = EVP_MD_size(md);
-
-    errno = _sol_message_digest_thread_init(handle);
+    errno = init_fn(handle, md, config->key);
     if (errno)
-        goto error_thread_init;
+        goto error;
 
-    SOL_DBG("handle %p algorithm=\"%s\"",
-        handle, config->algorithm);
-
-    errno = 0;
     return handle;
 
-error_thread_init:
-    handle->ops.cleanup(handle);
-
-error_init:
+error:
     errno_bkp = errno;
-    free(handle);
+    sol_message_digest_del(handle);
     errno = errno_bkp;
     return NULL;
-}
-
-static void
-_sol_message_digest_free(struct sol_message_digest *handle)
-{
-    struct sol_message_digest_pending_feed *pf;
-    uint16_t i;
-
-    SOL_DBG("free handle %p pending_feed=%hu, digest=%p",
-        handle, handle->pending_feed.len, handle->digest);
-
-    _sol_message_digest_thread_fini(handle);
-
-    SOL_VECTOR_FOREACH_IDX (&handle->pending_feed, pf, i) {
-        sol_blob_unref(pf->blob);
-    }
-    sol_vector_clear(&handle->pending_feed);
-
-    if (handle->digest)
-        sol_blob_unref(handle->digest);
-
-    handle->ops.cleanup(handle);
-
-    free(handle);
-}
-
-static inline void
-_sol_message_digest_unref(struct sol_message_digest *handle)
-{
-    handle->refcnt--;
-    if (handle->refcnt == 0)
-        _sol_message_digest_free(handle);
-}
-
-static inline void
-_sol_message_digest_ref(struct sol_message_digest *handle)
-{
-    handle->refcnt++;
-}
-
-SOL_API void
-sol_message_digest_del(struct sol_message_digest *handle)
-{
-    SOL_NULL_CHECK(handle);
-    SOL_EXP_CHECK(handle->deleted);
-    SOL_INT_CHECK(handle->refcnt, < 1);
-
-    handle->deleted = true;
-
-    _sol_message_digest_thread_stop(handle);
-
-    SOL_DBG("del handle %p refcnt=%" PRIu32
-        ", pending_feed=%hu, digest=%p",
-        handle, handle->refcnt,
-        handle->pending_feed.len, handle->digest);
-    _sol_message_digest_unref(handle);
-}
-
-static void
-_sol_message_digest_setup_receive_digest(struct sol_message_digest *handle)
-{
-    void *mem;
-
-    if (handle->digest) {
-        SOL_WRN("handle %p already have a digest to be received (%p).",
-            handle, handle->digest);
-        return;
-    }
-
-    mem = malloc(handle->digest_size);
-    SOL_NULL_CHECK(mem);
-
-    handle->digest = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL,
-        mem, handle->digest_size);
-    SOL_NULL_CHECK_GOTO(handle->digest, error);
-
-    SOL_DBG("handle %p to receive digest of %zd bytes at blob %p mem=%p",
-        handle, handle->digest_size,
-        handle->digest, handle->digest->mem);
-
-    return;
-
-error:
-    free(mem);
-}
-
-static void
-_sol_message_digest_report_feed_blob(struct sol_message_digest *handle, struct sol_blob *input)
-{
-#ifdef MESSAGE_DIGEST_USE_THREAD
-    struct sol_message_digest_pending_dispatch *pd;
-
-    _sol_message_digest_lock(handle);
-
-    pd = sol_vector_append(&handle->pending_dispatch);
-    SOL_NULL_CHECK_GOTO(pd, error);
-    pd->blob = input;
-    pd->is_digest = false;
-
-    _sol_message_digest_unlock(handle);
-    sol_worker_thread_feedback(handle->thread);
-    return;
-
-error:
-    _sol_message_digest_unlock(handle);
-    sol_blob_unref(input); /* this may cause problems if main thread changes blob refcnt */
-
-#else
-    _sol_message_digest_ref(handle);
-
-    if (handle->on_feed_done)
-        handle->on_feed_done((void *)handle->data, handle, input);
-
-    sol_blob_unref(input);
-    _sol_message_digest_unref(handle);
-#endif
-}
-
-static void
-_sol_message_digest_report_digest_ready(struct sol_message_digest *handle)
-{
-#ifdef MESSAGE_DIGEST_USE_THREAD
-    struct sol_message_digest_pending_dispatch *pd;
-
-    _sol_message_digest_lock(handle);
-
-    pd = sol_vector_append(&handle->pending_dispatch);
-    SOL_NULL_CHECK_GOTO(pd, end);
-    pd->blob = handle->digest;
-    pd->is_digest = true;
-
-    handle->digest = NULL;
-
-end:
-    _sol_message_digest_unlock(handle);
-    sol_worker_thread_feedback(handle->thread);
-
-#else
-    _sol_message_digest_ref(handle);
-
-    handle->on_digest_ready((void *)handle->data, handle, handle->digest);
-
-    sol_blob_unref(handle->digest);
-    handle->digest = NULL;
-
-    _sol_message_digest_unref(handle);
-#endif
-}
-
-static void
-_sol_message_digest_feed_blob(struct sol_message_digest *handle)
-{
-    struct sol_message_digest_pending_feed *pf;
-    struct sol_blob *input;
-    bool is_last;
-    bool r;
-
-    _sol_message_digest_lock(handle);
-    pf = sol_vector_get(&handle->pending_feed, 0);
-    SOL_NULL_CHECK_GOTO(pf, error);
-
-    input = pf->blob;
-    is_last = pf->is_last;
-
-    _sol_message_digest_unlock(handle);
-
-    r = handle->ops.update(handle, input);
-    SOL_DBG("handle %p feed mem=%p of %zd bytes: %hhu",
-        handle, input->mem, input->size, r);
-
-    if (!r) {
-        SOL_WRN("could not feed openssl with %p of %zd bytes",
-            input->mem, input->size);
-        return;
-    }
-
-    if (is_last)
-        _sol_message_digest_setup_receive_digest(handle);
-
-    _sol_message_digest_lock(handle);
-    sol_vector_del(&handle->pending_feed, 0);
-    _sol_message_digest_unlock(handle);
-
-    _sol_message_digest_report_feed_blob(handle, input);
-
-    return;
-
-error:
-    _sol_message_digest_unlock(handle);
-    SOL_WRN("no pending feed for handle %p", handle);
-}
-
-static void
-_sol_message_digest_receive_digest(struct sol_message_digest *handle)
-{
-    bool r;
-
-    r = handle->ops.final(handle, handle->digest);
-    SOL_DBG("handle %p digest mem=%p of %zd bytes: %hhu",
-        handle, handle->digest->mem, handle->digest->size, r);
-
-    if (!r) {
-        SOL_WRN("could not digest to %p of %zd bytes",
-            handle->digest->mem, handle->digest->size);
-        return;
-    }
-
-    _sol_message_digest_report_digest_ready(handle);
-}
-
-#ifdef MESSAGE_DIGEST_USE_THREAD
-
-static struct sol_blob *
-_sol_message_digest_peek_first_pending_blob(struct sol_message_digest *handle)
-{
-    struct sol_message_digest_pending_feed *pf;
-    struct sol_blob *blob = NULL;
-
-    _sol_message_digest_lock(handle);
-    if (handle->pending_feed.len) {
-        pf = sol_vector_get(&handle->pending_feed, 0);
-        if (pf)
-            blob = pf->blob;
-    }
-    _sol_message_digest_unlock(handle);
-
-    return blob;
-}
-
-static bool
-_sol_message_digest_thread_iterate(void *data)
-{
-    struct sol_message_digest *handle = data;
-    struct sol_blob *current = NULL;
-    char cmd;
-
-    cmd = _sol_message_digest_thread_recv(handle);
-    if (cmd == 'c' || cmd == 0)
-        return false;
-
-    current = _sol_message_digest_peek_first_pending_blob(handle);
-    while (current && !sol_worker_thread_cancel_check(handle->thread)) {
-        struct sol_blob *blob;
-
-        _sol_message_digest_feed_blob(handle);
-
-        blob = _sol_message_digest_peek_first_pending_blob(handle);
-        if (blob != current)
-            break;
-    }
-
-    while (handle->digest && !sol_worker_thread_cancel_check(handle->thread))
-        _sol_message_digest_receive_digest(handle);
-
-    return true;
-}
-
-static void
-_sol_message_digest_thread_finished(void *data)
-{
-    struct sol_message_digest *handle = data;
-
-    handle->thread = NULL;
-    _sol_message_digest_unref(handle);
-}
-
-static void
-_sol_message_digest_thread_feedback(void *data)
-{
-    struct sol_message_digest *handle = data;
-    struct sol_message_digest_pending_dispatch *pd;
-    struct sol_vector v;
-    uint16_t i;
-
-    _sol_message_digest_lock(handle);
-    v = handle->pending_dispatch;
-    sol_vector_init(&handle->pending_dispatch,
-        sizeof(struct sol_message_digest_pending_dispatch));
-    _sol_message_digest_unlock(handle);
-
-    _sol_message_digest_ref(handle);
-
-    SOL_VECTOR_FOREACH_IDX (&v, pd, i) {
-        if (!handle->deleted) {
-            if (pd->is_digest)
-                handle->on_digest_ready((void *)handle->data, handle, pd->blob);
-            else if (handle->on_feed_done)
-                handle->on_feed_done((void *)handle->data, handle, pd->blob);
-        }
-        sol_blob_unref(pd->blob);
-    }
-
-    _sol_message_digest_unref(handle);
-
-    sol_vector_clear(&v);
-}
-
-#else
-static bool
-_sol_message_digest_on_timer(void *data)
-{
-    struct sol_message_digest *handle = data;
-    bool ret;
-
-    SOL_DBG("handle %p pending=%hu, digest=%p",
-        handle, handle->pending_feed.len, handle->digest);
-
-    _sol_message_digest_ref(handle);
-
-    if (handle->pending_feed.len > 0)
-        _sol_message_digest_feed_blob(handle);
-
-    if (handle->digest)
-        _sol_message_digest_receive_digest(handle);
-
-    ret = (handle->pending_feed.len > 0 || handle->digest);
-    if (!ret)
-        handle->timer = NULL;
-
-    _sol_message_digest_unref(handle);
-    return ret;
-}
-#endif
-
-static int
-_sol_message_digest_thread_start(struct sol_message_digest *handle)
-{
-#ifdef MESSAGE_DIGEST_USE_THREAD
-    struct sol_worker_thread_spec spec = {
-        .api_version = SOL_WORKER_THREAD_SPEC_API_VERSION,
-        .data = handle,
-        .iterate = _sol_message_digest_thread_iterate,
-        .finished = _sol_message_digest_thread_finished,
-        .feedback = _sol_message_digest_thread_feedback
-    };
-
-    if (handle->thread)
-        goto end;
-
-    _sol_message_digest_ref(handle);
-    handle->thread = sol_worker_thread_new(&spec);
-    SOL_NULL_CHECK_GOTO(handle->thread, error);
-
-end:
-    _sol_message_digest_thread_send(handle, 'a');
-
-    return 0;
-
-error:
-    _sol_message_digest_unref(handle);
-    return -ENOMEM;
-
-#else
-    if (handle->timer)
-        return 0;
-
-    handle->timer = sol_timeout_add(0, _sol_message_digest_on_timer, handle);
-    SOL_NULL_CHECK(handle->timer, -ENOMEM);
-
-    return 0;
-#endif
-}
-
-SOL_API int
-sol_message_digest_feed(struct sol_message_digest *handle, struct sol_blob *input, bool is_last)
-{
-    struct sol_message_digest_pending_feed *pf;
-    int r;
-
-    SOL_NULL_CHECK(handle, -EINVAL);
-    SOL_EXP_CHECK(handle->deleted, -EINVAL);
-    SOL_INT_CHECK(handle->refcnt, < 1, -EINVAL);
-    SOL_NULL_CHECK(input, -EINVAL);
-
-    _sol_message_digest_lock(handle);
-    pf = sol_vector_append(&handle->pending_feed);
-    SOL_NULL_CHECK_GOTO(pf, error_append);
-
-    pf->blob = sol_blob_ref(input);
-    pf->is_last = is_last;
-
-    r = _sol_message_digest_thread_start(handle);
-    SOL_INT_CHECK_GOTO(r, < 0, error);
-
-    _sol_message_digest_unlock(handle);
-
-    SOL_DBG("handle %p blob=%p (%zd bytes), pending %hu",
-        handle, input, input->size, handle->pending_feed.len);
-
-    return 0;
-
-error:
-    sol_blob_unref(input);
-    sol_vector_del(&handle->pending_feed, handle->pending_feed.len - 1);
-
-error_append:
-    _sol_message_digest_unlock(handle);
-
-    return -ENOMEM;
 }

--- a/src/test/Kconfig
+++ b/src/test/Kconfig
@@ -96,3 +96,7 @@ config TEST_UTIL
 config TEST_COMPOSED_TYPE
       bool "composed-type"
       default y
+
+config TEST_MESSAGE_DIGEST
+      bool "crypto message-digest"
+      default y

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -68,3 +68,6 @@ test-test-util-$(TEST_UTIL) := test.c test-util.c
 
 test-$(TEST_COMPOSED_TYPE) += test-composed-type
 test-test-composed-type-$(TEST_COMPOSED_TYPE) := test.c test-composed-type.c
+
+test-$(TEST_MESSAGE_DIGEST) += test-message-digest
+test-test-message-digest-$(TEST_MESSAGE_DIGEST) := test.c test-message-digest.c

--- a/src/test/test-message-digest.c
+++ b/src/test/test-message-digest.c
@@ -1,0 +1,405 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sol-mainloop.h"
+#include "sol-message-digest.h"
+#include "sol-buffer.h"
+
+#include "test.h"
+
+static char big_blob_of_zeros[40960];
+static uint8_t big_blob_of_chars[40960];
+
+static void
+init_big_blobs(void)
+{
+    uint8_t v = 0, *itr, *end;
+
+    memset(big_blob_of_zeros, 0, sizeof(big_blob_of_zeros));
+
+    itr = big_blob_of_chars;
+    end = itr + sizeof(big_blob_of_chars);
+    for (; itr < end; itr++, v++)
+        *itr = v;
+}
+
+struct md_test {
+    const char *algorithm;
+    struct sol_str_slice key;
+    const void *mem;
+    size_t len;
+    const char *hex_digest;
+#define MD_TEST(a, k, m, h) { a, k, m, sizeof(m), h }
+#define MD_TEST_END { NULL, SOL_STR_SLICE_EMPTY, 0, NULL }
+};
+
+static uint32_t pending;
+
+static void
+on_digest_ready_simple(void *data, struct sol_message_digest *handle, struct sol_blob *digest)
+{
+    const struct md_test *t = data;
+    struct sol_buffer buf = SOL_BUFFER_INIT_EMPTY;
+    const char *hex_digest;
+    int r;
+
+    r = sol_buffer_append_as_base16(&buf, sol_str_slice_from_blob(digest), false);
+    ASSERT_INT_EQ(r, 0);
+
+    hex_digest = buf.data;
+    ASSERT_STR_EQ(t->hex_digest, hex_digest);
+
+    sol_buffer_fini(&buf);
+    sol_message_digest_del(handle);
+
+    pending--;
+    if (pending == 0)
+        sol_quit();
+}
+
+static bool
+on_timeout_do_single(void *data)
+{
+    const struct md_test *itr = data;
+
+    for (; itr->mem != NULL; itr++) {
+        struct sol_message_digest_config cfg = {
+            .api_version = SOL_MESSAGE_DIGEST_CONFIG_API_VERSION,
+            .algorithm = itr->algorithm,
+            .key = itr->key,
+            .on_digest_ready = on_digest_ready_simple,
+            .on_feed_done = NULL,
+            .data = itr
+        };
+        struct sol_message_digest *md;
+        struct sol_blob *blob;
+        int r;
+
+        blob = sol_blob_new(SOL_BLOB_TYPE_NOFREE, NULL, itr->mem, itr->len);
+        ASSERT(blob != NULL);
+
+        md = sol_message_digest_new(&cfg);
+        ASSERT(md != NULL);
+
+        r = sol_message_digest_feed(md, blob, true);
+        ASSERT_INT_EQ(r, 0);
+
+        sol_blob_unref(blob);
+
+        pending++;
+    }
+
+    return false;
+}
+
+#define CHUNK_SIZE 64
+struct chunked_ctx {
+    const struct md_test *t;
+    struct sol_message_digest *md;
+    size_t offset;
+};
+
+static bool
+on_timeout_do_chunked_internal(void *data)
+{
+    struct chunked_ctx *ctx = data;
+    uint8_t i;
+
+    if (ctx->offset >= ctx->t->len)
+        return false;
+
+    /* feed 3 blobs from within the same main loop iteration, then
+     * wait to be completed and send more.
+     */
+    for (i = 0; i < 3; i++) {
+        struct sol_blob *blob;
+        bool is_final = false;
+        size_t len = CHUNK_SIZE;
+        const void *mem;
+        int r;
+
+        if (ctx->offset + CHUNK_SIZE >= ctx->t->len) {
+            is_final = true;
+            len = ctx->t->len - ctx->offset;
+        }
+
+        mem = (char *)ctx->t->mem + ctx->offset;
+        blob = sol_blob_new(SOL_BLOB_TYPE_NOFREE, NULL, mem, len);
+        ASSERT(blob != NULL);
+
+        ctx->offset += len;
+
+        r = sol_message_digest_feed(ctx->md, blob, is_final);
+        ASSERT_INT_EQ(r, 0);
+
+        sol_blob_unref(blob);
+
+        if (is_final)
+            break;
+    }
+
+    /* keep calling this function (will call from different main loop
+     * iteration (10ms timer) and possibly before on_feed_done.
+     */
+    return ctx->offset < ctx->t->len;
+}
+
+static void
+on_feed_done_chunked(void *data, struct sol_message_digest *handle, struct sol_blob *input)
+{
+    /* feed more after we're done with our previous data */
+    on_timeout_do_chunked_internal(data);
+}
+
+static void
+on_digest_ready_chunked(void *data, struct sol_message_digest *handle, struct sol_blob *digest)
+{
+    struct chunked_ctx *ctx = data;
+
+    on_digest_ready_simple((void *)ctx->t, handle, digest);
+    free(ctx);
+}
+
+static bool
+on_timeout_do_chunked(void *data)
+{
+    const struct md_test *itr = data;
+
+    for (; itr->mem != NULL; itr++) {
+        struct chunked_ctx *ctx;
+        struct sol_message_digest_config cfg = {
+            .api_version = SOL_MESSAGE_DIGEST_CONFIG_API_VERSION,
+            .algorithm = itr->algorithm,
+            .key = itr->key,
+            .on_digest_ready = on_digest_ready_chunked,
+            .on_feed_done = on_feed_done_chunked,
+        };
+
+        ctx = malloc(sizeof(*ctx));
+        ASSERT(ctx != NULL);
+        ctx->t = itr;
+        ctx->offset = 0;
+        cfg.data = ctx;
+
+        ctx->md = sol_message_digest_new(&cfg);
+        ASSERT(ctx->md != NULL);
+
+        sol_timeout_add(10, on_timeout_do_chunked_internal, ctx);
+
+        pending++;
+    }
+
+    return false;
+}
+
+DEFINE_TEST(test_md5_single);
+
+static void
+test_md5_single(void)
+{
+    /* note: mem includes string trailing null byte */
+    static const struct md_test md5_single_test[] = {
+        MD_TEST("md5", SOL_STR_SLICE_EMPTY, "test", "e2a3e68d23ce348b8f68b3079de3d4c9"),
+        MD_TEST("md5", SOL_STR_SLICE_EMPTY, "long line of text bla bla bla more text here yada yada", "18511ce4f220de4744390ca3ae72873f"),
+        MD_TEST("md5", SOL_STR_SLICE_EMPTY, big_blob_of_zeros, "ab893875d697a3145af5eed5309bee26"),
+        MD_TEST("md5", SOL_STR_SLICE_EMPTY, big_blob_of_chars, "9a36eacb09f8e98e103e9ee897f8e31c"),
+        MD_TEST_END
+    };
+
+    init_big_blobs();
+
+    sol_timeout_add(0, on_timeout_do_single, md5_single_test);
+    sol_run();
+}
+
+DEFINE_TEST(test_sha512_single);
+
+static void
+test_sha512_single(void)
+{
+    /* note: mem includes string trailing null byte */
+    static const struct md_test sha512_single_test[] = {
+        MD_TEST("sha512", SOL_STR_SLICE_EMPTY, "test", "d55ced17163bf5386f2cd9ff21d6fd7fe576a915065c24744d09cfae4ec84ee1ef6ef11bfbc5acce3639bab725b50a1fe2c204f8c820d6d7db0df0ecbc49c5ca"),
+        MD_TEST("sha512", SOL_STR_SLICE_EMPTY, "long line of text bla bla bla more text here yada yada", "33e8b361e2f1b1d015e3f661b72633c411b2b0f7bc253373875c570af92d79af38eac9f98f44af7fa32e46050d029200b7d33e7a76c3bc425aa74759fb97308a"),
+        MD_TEST("sha512", SOL_STR_SLICE_EMPTY, big_blob_of_zeros, "6b65c0a1956ce18df2d271205f53274d2905c803d059a0801bf8331ccaa28a1d4842d3585dd9c2b01502a4be6664bde2e965b15fcfec981e85eed37c595cd6bc"),
+        MD_TEST("sha512", SOL_STR_SLICE_EMPTY, big_blob_of_chars, "b8f8002d7512d979e65ae4244c6c86a13cfd9978f0c2d642f110e4377b87eb3168325f582acfb0974d1578b8a152798363446354e2750b14289dbb3f2e325e88"),
+        MD_TEST_END
+    };
+
+    init_big_blobs();
+
+    sol_timeout_add(0, on_timeout_do_single, sha512_single_test);
+    sol_run();
+}
+
+DEFINE_TEST(test_multiple_single);
+
+static void
+test_multiple_single(void)
+{
+    /* note: mem includes string trailing null byte */
+    static const struct md_test multiple_single_test[] = {
+        MD_TEST("md5", SOL_STR_SLICE_EMPTY, "test", "e2a3e68d23ce348b8f68b3079de3d4c9"),
+        MD_TEST("sha512", SOL_STR_SLICE_EMPTY, big_blob_of_chars, "b8f8002d7512d979e65ae4244c6c86a13cfd9978f0c2d642f110e4377b87eb3168325f582acfb0974d1578b8a152798363446354e2750b14289dbb3f2e325e88"),
+        MD_TEST("md5", SOL_STR_SLICE_EMPTY, "long line of text bla bla bla more text here yada yada", "18511ce4f220de4744390ca3ae72873f"),
+        MD_TEST("sha512", SOL_STR_SLICE_EMPTY, "long line of text bla bla bla more text here yada yada", "33e8b361e2f1b1d015e3f661b72633c411b2b0f7bc253373875c570af92d79af38eac9f98f44af7fa32e46050d029200b7d33e7a76c3bc425aa74759fb97308a"),
+        MD_TEST("md5", SOL_STR_SLICE_EMPTY, big_blob_of_zeros, "ab893875d697a3145af5eed5309bee26"),
+        MD_TEST("sha512", SOL_STR_SLICE_EMPTY, "test", "d55ced17163bf5386f2cd9ff21d6fd7fe576a915065c24744d09cfae4ec84ee1ef6ef11bfbc5acce3639bab725b50a1fe2c204f8c820d6d7db0df0ecbc49c5ca"),
+        MD_TEST("md5", SOL_STR_SLICE_EMPTY, big_blob_of_chars, "9a36eacb09f8e98e103e9ee897f8e31c"),
+        MD_TEST("sha512", SOL_STR_SLICE_EMPTY, big_blob_of_zeros, "6b65c0a1956ce18df2d271205f53274d2905c803d059a0801bf8331ccaa28a1d4842d3585dd9c2b01502a4be6664bde2e965b15fcfec981e85eed37c595cd6bc"),
+        MD_TEST_END
+    };
+
+    init_big_blobs();
+
+    sol_timeout_add(0, on_timeout_do_single, multiple_single_test);
+    sol_run();
+}
+
+
+DEFINE_TEST(test_md5_chunked);
+
+static void
+test_md5_chunked(void)
+{
+    /* note: mem includes string trailing null byte */
+    static const struct md_test md5_chunked_test[] = {
+        MD_TEST("md5", SOL_STR_SLICE_EMPTY, "test", "e2a3e68d23ce348b8f68b3079de3d4c9"),
+        MD_TEST("md5", SOL_STR_SLICE_EMPTY, "long line of text bla bla bla more text here yada yada", "18511ce4f220de4744390ca3ae72873f"),
+        MD_TEST("md5", SOL_STR_SLICE_EMPTY, big_blob_of_zeros, "ab893875d697a3145af5eed5309bee26"),
+        MD_TEST("md5", SOL_STR_SLICE_EMPTY, big_blob_of_chars, "9a36eacb09f8e98e103e9ee897f8e31c"),
+        MD_TEST_END
+    };
+
+    init_big_blobs();
+
+    sol_timeout_add(0, on_timeout_do_chunked, md5_chunked_test);
+    sol_run();
+}
+
+DEFINE_TEST(test_sha512_chunked);
+
+static void
+test_sha512_chunked(void)
+{
+    /* note: mem includes string trailing null byte */
+    static const struct md_test sha512_chunked_test[] = {
+        MD_TEST("sha512", SOL_STR_SLICE_EMPTY, "test", "d55ced17163bf5386f2cd9ff21d6fd7fe576a915065c24744d09cfae4ec84ee1ef6ef11bfbc5acce3639bab725b50a1fe2c204f8c820d6d7db0df0ecbc49c5ca"),
+        MD_TEST("sha512", SOL_STR_SLICE_EMPTY, "long line of text bla bla bla more text here yada yada", "33e8b361e2f1b1d015e3f661b72633c411b2b0f7bc253373875c570af92d79af38eac9f98f44af7fa32e46050d029200b7d33e7a76c3bc425aa74759fb97308a"),
+        MD_TEST("sha512", SOL_STR_SLICE_EMPTY, big_blob_of_zeros, "6b65c0a1956ce18df2d271205f53274d2905c803d059a0801bf8331ccaa28a1d4842d3585dd9c2b01502a4be6664bde2e965b15fcfec981e85eed37c595cd6bc"),
+        MD_TEST("sha512", SOL_STR_SLICE_EMPTY, big_blob_of_chars, "b8f8002d7512d979e65ae4244c6c86a13cfd9978f0c2d642f110e4377b87eb3168325f582acfb0974d1578b8a152798363446354e2750b14289dbb3f2e325e88"),
+        MD_TEST_END
+    };
+
+    init_big_blobs();
+
+    sol_timeout_add(0, on_timeout_do_chunked, sha512_chunked_test);
+    sol_run();
+}
+
+DEFINE_TEST(test_multiple_chunked);
+
+static void
+test_multiple_chunked(void)
+{
+    /* note: mem includes string trailing null byte */
+    static const struct md_test multiple_chunked_test[] = {
+        MD_TEST("md5", SOL_STR_SLICE_EMPTY, "test", "e2a3e68d23ce348b8f68b3079de3d4c9"),
+        MD_TEST("sha512", SOL_STR_SLICE_EMPTY, big_blob_of_chars, "b8f8002d7512d979e65ae4244c6c86a13cfd9978f0c2d642f110e4377b87eb3168325f582acfb0974d1578b8a152798363446354e2750b14289dbb3f2e325e88"),
+        MD_TEST("md5", SOL_STR_SLICE_EMPTY, "long line of text bla bla bla more text here yada yada", "18511ce4f220de4744390ca3ae72873f"),
+        MD_TEST("sha512", SOL_STR_SLICE_EMPTY, "long line of text bla bla bla more text here yada yada", "33e8b361e2f1b1d015e3f661b72633c411b2b0f7bc253373875c570af92d79af38eac9f98f44af7fa32e46050d029200b7d33e7a76c3bc425aa74759fb97308a"),
+        MD_TEST("md5", SOL_STR_SLICE_EMPTY, big_blob_of_zeros, "ab893875d697a3145af5eed5309bee26"),
+        MD_TEST("sha512", SOL_STR_SLICE_EMPTY, "test", "d55ced17163bf5386f2cd9ff21d6fd7fe576a915065c24744d09cfae4ec84ee1ef6ef11bfbc5acce3639bab725b50a1fe2c204f8c820d6d7db0df0ecbc49c5ca"),
+        MD_TEST("md5", SOL_STR_SLICE_EMPTY, big_blob_of_chars, "9a36eacb09f8e98e103e9ee897f8e31c"),
+        MD_TEST("sha512", SOL_STR_SLICE_EMPTY, big_blob_of_zeros, "6b65c0a1956ce18df2d271205f53274d2905c803d059a0801bf8331ccaa28a1d4842d3585dd9c2b01502a4be6664bde2e965b15fcfec981e85eed37c595cd6bc"),
+        MD_TEST_END
+    };
+
+    init_big_blobs();
+
+    sol_timeout_add(0, on_timeout_do_chunked, multiple_chunked_test);
+    sol_run();
+}
+
+DEFINE_TEST(test_feed_after_last);
+
+static void
+on_digest_ready_feed_after_last(void *data, struct sol_message_digest *handle, struct sol_blob *digest)
+{
+    struct sol_blob *blob;
+    static char mem[] = "x";
+    int r;
+
+    blob = sol_blob_new(SOL_BLOB_TYPE_NOFREE, NULL, mem, sizeof(mem));
+    ASSERT(blob != NULL);
+
+    r = sol_message_digest_feed(handle, blob, true);
+    ASSERT_INT_EQ(r, -EINVAL);
+
+    sol_blob_unref(blob);
+    sol_quit();
+}
+
+static bool
+on_timeout_feed_after_last(void *data)
+{
+    struct sol_message_digest_config cfg = {
+        .api_version = SOL_MESSAGE_DIGEST_CONFIG_API_VERSION,
+        .algorithm = "md5",
+        .on_digest_ready = on_digest_ready_feed_after_last,
+    };
+    struct sol_message_digest *md;
+    struct sol_blob *blob;
+    static char mem[] = "x";
+    int r;
+
+    blob = sol_blob_new(SOL_BLOB_TYPE_NOFREE, NULL, mem, sizeof(mem));
+    ASSERT(blob != NULL);
+
+    md = sol_message_digest_new(&cfg);
+    ASSERT(md != NULL);
+
+    r = sol_message_digest_feed(md, blob, true);
+    ASSERT_INT_EQ(r, 0);
+
+    sol_blob_unref(blob);
+    return false;
+}
+
+static void
+test_feed_after_last(void)
+{
+    sol_timeout_add(0, on_timeout_feed_after_last, NULL);
+    sol_run();
+}
+
+TEST_MAIN();


### PR DESCRIPTION
this moves the common bits from linux-kcapi and openssl to a single
file, allows that cumbersome core to be shared with other
implementations.

it also introduces a maximum limit per feed if not using threads, this
way we avoid locking the main loop for too long.

Signed-off-by: Gustavo Sverzut Barbieri gustavo.barbieri@intel.com