### PR TITLE
Board detect

### DIFF
--- a/data/jsons/board_detect.json
+++ b/data/jsons/board_detect.json
@@ -38,7 +38,7 @@
      ]
     },
     {
-     "name": "intel-minnow-max-linux_gt_3.19",
+     "name": "intel-minnow-max-linux_gt_3_19",
      "validation": [
       {
        "file_path": "/sys/devices/virtual/dmi/id/bios_version",

--- a/data/jsons/board_detect.json
+++ b/data/jsons/board_detect.json
@@ -58,6 +58,15 @@
        "match": [ "^MNW2CRB1" ]
       }
      ]
+    },
+    {
+     "name": "broadcom-bcm2708",
+     "validation": [
+      {
+       "file_path": "/proc/cpuinfo",
+       "match": [ "BCM2708" ]
+      }
+     ]
     }
   ]
 }


### PR DESCRIPTION
Fix minnow name because I f**k up and applied k-s suggested name without test <because had lost the minnow to someone else already>.

Add detection to "raspberry pi", actually it's processor. I couldn't find a way to detect that the processor was actually on a raspberry board.