### PR TITLE
Add nodes to extract data from JSON using JSON path

### DIFF
--- a/src/modules/flow/json/json.c
+++ b/src/modules/flow/json/json.c
@@ -42,7 +42,13 @@
 struct sol_json_object_key {
     struct sol_blob *json_object;
     char *key;
+    int (*process)(struct sol_flow_node *node,
+        struct sol_json_object_key *mdata);
 };
+
+static int json_object_key_process(struct sol_flow_node *node, struct sol_json_object_key *mdata);
+static int json_object_path_process(struct sol_flow_node *node, struct sol_json_object_key *mdata);
+static bool json_array_get_at_index(struct sol_json_scanner *scanner, struct sol_json_token *token, int32_t i, enum sol_json_loop_reason *reason);
 
 static int
 json_object_get_key_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
@@ -56,7 +62,27 @@ json_object_get_key_open(struct sol_flow_node *node, void *data, const struct so
     opts = (const struct sol_flow_node_type_json_object_get_key_options *)
         options;
 
+    mdata->process = json_object_key_process;
     mdata->key = strdup(opts->key);
+    SOL_NULL_CHECK(mdata->key, -ENOMEM);
+
+    return 0;
+}
+
+static int
+json_object_get_path_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
+{
+    struct sol_json_object_key *mdata = data;
+    const struct sol_flow_node_type_json_object_get_path_options *opts;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_PATH_OPTIONS_API_VERSION,
+        -EINVAL);
+    opts = (const struct sol_flow_node_type_json_object_get_path_options *)
+        options;
+
+    mdata->process = json_object_path_process;
+    mdata->key = strdup(opts->path);
     SOL_NULL_CHECK(mdata->key, -ENOMEM);
 
     return 0;
@@ -77,6 +103,10 @@ create_sub_json(struct sol_blob *parent, struct sol_json_scanner *scanner, struc
 {
     const char *mem;
 
+    if (sol_json_mem_get_type(token->end - 1) == type)
+        return sol_blob_new(SOL_BLOB_TYPE_NOFREE, parent, token->start,
+            token->end - token->start);
+
     mem = token->start;
     if (!sol_json_scanner_skip_over(scanner, token))
         return NULL;
@@ -90,15 +120,72 @@ create_sub_json(struct sol_blob *parent, struct sol_json_scanner *scanner, struc
 }
 
 static bool
-json_object_search_for_token(struct sol_json_scanner *scanner, const char *key, struct sol_json_token *value)
+_get_next_slice(const struct sol_str_slice path, struct sol_str_slice *slice)
 {
-    struct sol_json_token token, token_key;
-    enum sol_json_loop_reason reason;
-    unsigned int len;
+    const char *p, *p2, *end;
 
-    len = strlen(key);
-    SOL_JSON_SCANNER_OBJECT_LOOP (scanner, &token, &token_key, value, reason)
-        if (sol_json_token_str_eq(&token_key, key, len))
+    if (!path.len)
+        return false;
+
+    end = path.data + path.len;
+    //Root element
+    if (!slice->len) {
+        if (path.data[0] != '$')
+            return false;
+        slice->data = path.data + 1;
+    } else
+        slice->data += slice->len;
+
+    if (slice->data >= end) {
+        slice->len = 0;
+        return true;
+    }
+    if (*slice->data == '[') {
+        if (*(slice->data + 1) == '\'') {
+            for (p = slice->data + 2; p < end; p++) {
+                p = memchr(p, '\'', end - p);
+                if (!p)
+                    return false;
+                if (*(p - 1) != '\\')
+                    break;
+            }
+            if (p < end && *(p + 1) == ']') {
+                slice->len = p - slice->data + 2;
+                return true;
+            }
+        } else {
+            p = memchr(slice->data + 1, ']', end - (slice->data + 1));
+            if (p && p != slice->data + 1) {
+                slice->len = p - slice->data + 1;
+                return true;
+            }
+        }
+    } else if (*slice->data == '.') {
+        p = memchr(slice->data + 1, '.', end - (slice->data + 1));
+        p2 = memchr(slice->data + 1, '[', end - (slice->data + 1));
+        if (!p && !p2)
+            p = end;
+        else if (!p || (p2 && p2 < p))
+            p = p2;
+
+        if (p != slice->data + 1) {
+            slice->data++;
+            slice->len = p - slice->data;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool
+json_object_search_for_token(struct sol_json_scanner *scanner, const struct sol_str_slice key_slice, struct sol_json_token *value)
+{
+    struct sol_json_token token, key;
+    enum sol_json_loop_reason reason;
+
+    SOL_JSON_SCANNER_OBJECT_LOOP_NEST (scanner, &token, &key, value, reason)
+        if (sol_json_token_str_eq(&key, key_slice.data, key_slice.len))
             return true;
 
     return false;
@@ -186,12 +273,77 @@ error:
         SOL_STR_SLICE_PRINT(slice));
 }
 
-
 static int
 json_object_key_process(struct sol_flow_node *node, struct sol_json_object_key *mdata)
 {
+    struct sol_json_token value, token;
     struct sol_json_scanner scanner;
-    struct sol_json_token value;
+
+    if (!mdata->key[0] || !mdata->json_object)
+        return 0;
+
+    sol_json_scanner_init(&scanner, mdata->json_object->mem,
+        mdata->json_object->size);
+    if (_sol_json_loop_helper_init(&scanner, &token,
+        SOL_JSON_TYPE_OBJECT_START) != SOL_JSON_LOOP_REASON_OK)
+        return false;
+
+    if (json_object_search_for_token(&scanner,
+        sol_str_slice_from_str(mdata->key), &value))
+        return send_token_packet(node, &scanner, mdata->json_object, &value);
+
+    return sol_flow_send_error_packet(node, EINVAL,
+        "JSON object doesn't contain key %s", mdata->key);
+}
+
+static int
+_get_brackets_index(const struct sol_str_slice slice, struct sol_str_slice *current, bool *allocated)
+{
+    const char *end, *p, *p2;
+    char *dest = NULL, *last;
+
+    end = slice.data + slice.len;
+    for (p = slice.data + 2; p < end; p = p2 + 1) {
+        p2 = memchr(p, '\'', end - p);
+        if (!p2 || p2 == end - 2)
+            break;
+        if (!dest) {
+            dest = malloc(slice.len - 5);
+            SOL_NULL_CHECK(dest, -ENOMEM);
+            last = dest;
+        }
+        memcpy(last, p, p2 - p);
+        last = last + (p2 - p);
+        *(last - 1) = '\'';
+    }
+
+    if (!dest) {
+        *allocated = false;
+        *current = SOL_STR_SLICE_STR(slice.data + 2, slice.len - 4);
+        return 0;
+    }
+
+    memcpy(last, p, p2 - p);
+    last = last + (p2 - p);
+    *allocated = true;
+    *current = SOL_STR_SLICE_STR(dest, last - dest);
+    return 0;
+}
+
+static int
+json_object_path_process(struct sol_flow_node *node, struct sol_json_object_key *mdata)
+{
+    enum sol_json_type type;
+    struct sol_str_slice key_slice = SOL_STR_SLICE_EMPTY;
+    struct sol_str_slice current_key;
+    struct sol_json_token value, token;
+    struct sol_json_scanner scanner;
+    struct sol_str_slice path;
+    enum sol_json_loop_reason reason;
+    char *endptr;
+    long int index_val;
+    bool ret, allocated;
+    int r;
 
     if (!mdata->key[0] || !mdata->json_object)
         return 0;
@@ -199,12 +351,82 @@ json_object_key_process(struct sol_flow_node *node, struct sol_json_object_key *
     sol_json_scanner_init(&scanner, mdata->json_object->mem,
         mdata->json_object->size);
 
-    if (json_object_search_for_token(&scanner, mdata->key, &value))
-        return send_token_packet(node, &scanner, mdata->json_object, &value);
+    path = sol_str_slice_from_str(mdata->key);
+    if (!_get_next_slice(path, &key_slice))
+        goto error;
 
+    if (key_slice.len == 0) {
+        type = sol_json_mem_get_type(scanner.current);
+        if (type == SOL_JSON_TYPE_OBJECT_START)
+            return sol_flow_send_json_object_packet(node,
+                SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_PATH__OUT__OBJECT,
+                mdata->json_object);
+        else
+            return sol_flow_send_json_array_packet(node,
+                SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_PATH__OUT__ARRAY,
+                mdata->json_object);
+    }
+
+    while (key_slice.len > 0) {
+        switch (sol_json_mem_get_type(scanner.current)) {
+        case SOL_JSON_TYPE_OBJECT_START:
+            if (_sol_json_loop_helper_init(&scanner, &token,
+                SOL_JSON_TYPE_OBJECT_START) != SOL_JSON_LOOP_REASON_OK)
+                goto error;
+
+            if (*key_slice.data == '[') {
+                if (key_slice.len < 4 || *(key_slice.data + 1) != '\'')
+                    goto error;
+                r = _get_brackets_index(key_slice, &current_key, &allocated);
+                SOL_INT_CHECK(r, < 0, r);
+            } else {
+                current_key = key_slice;
+                allocated = false;
+            }
+
+            ret = json_object_search_for_token(&scanner, current_key, &value);
+            if (allocated)
+                free((void *)current_key.data);
+
+            if (ret) {
+                if (!_get_next_slice(path, &key_slice))
+                    goto error;
+                scanner.current = value.start;
+                continue;
+            }
+            break;
+        case SOL_JSON_TYPE_ARRAY_START:
+            if (_sol_json_loop_helper_init(&scanner, &token,
+                SOL_JSON_TYPE_ARRAY_START) != SOL_JSON_LOOP_REASON_OK)
+                goto error;
+
+            if (*key_slice.data != '[' || *(key_slice.data + 1) == '\'')
+                goto error;
+            errno = 0;
+            index_val = strtol(key_slice.data + 1, &endptr, 10);
+            if (endptr != key_slice.data + key_slice.len - 1 ||
+                index_val < 0 || errno > 0)
+                goto error;
+
+            if (json_array_get_at_index(&scanner, &value, index_val, &reason)) {
+                if (!_get_next_slice(path, &key_slice))
+                    goto error;
+                scanner.current = value.start;
+                continue;
+            }
+
+            break;
+        default:
+            goto error;
+        }
+
+        goto error;
+    }
+    return send_token_packet(node, &scanner, mdata->json_object, &value);
+
+error:
     return sol_flow_send_error_packet(node, EINVAL,
-        "JSON object doesn't contain key %s", mdata->key);
-    return 0;
+        "JSON element doesn't contain path %s", mdata->key);
 }
 
 static int
@@ -221,7 +443,25 @@ json_object_get_key_key_process(struct sol_flow_node *node, void *data, uint16_t
     mdata->key = strdup(in_value);
     SOL_NULL_CHECK(mdata->key, -ENOMEM);
 
-    return json_object_key_process(node, mdata);
+    return mdata->process(node, mdata);
+}
+
+static int
+json_array_get_path_in_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct sol_json_object_key *mdata = data;
+    int r;
+    struct sol_blob *in_value;
+
+    r = sol_flow_packet_get_json_array(packet, &in_value);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (mdata->json_object)
+        sol_blob_unref(mdata->json_object);
+    mdata->json_object = sol_blob_ref(in_value);
+    SOL_NULL_CHECK(mdata->json_object, -errno);
+
+    return mdata->process(node, mdata);
 }
 
 static int
@@ -239,7 +479,7 @@ json_object_get_key_in_process(struct sol_flow_node *node, void *data, uint16_t 
     mdata->json_object = sol_blob_ref(in_value);
     SOL_NULL_CHECK(mdata->json_object, -errno);
 
-    return json_object_key_process(node, mdata);
+    return mdata->process(node, mdata);
 }
 
 static int
@@ -309,7 +549,7 @@ json_array_get_at_index(struct sol_json_scanner *scanner, struct sol_json_token 
 {
     int32_t cur_index = 0;
 
-    SOL_JSON_SCANNER_ARRAY_LOOP_ALL(scanner, token, *reason) {
+    SOL_JSON_SCANNER_ARRAY_LOOP_ALL_NEST(scanner, token, *reason) {
         if (i == cur_index)
             return true;
 
@@ -359,17 +599,20 @@ json_array_index_process(struct sol_flow_node *node, struct sol_json_array_index
 
     sol_json_scanner_init(&scanner, mdata->json_array->mem,
         mdata->json_array->size);
+    if (_sol_json_loop_helper_init(&scanner, &token,
+        SOL_JSON_TYPE_ARRAY_START) != SOL_JSON_LOOP_REASON_OK)
+        goto invalid_array;
 
     if (json_array_get_at_index(&scanner, &token, mdata->index, &reason))
         return send_token_packet(node, &scanner, mdata->json_array, &token);
 
-    if (reason == SOL_JSON_LOOP_REASON_INVALID)
+    if (reason != SOL_JSON_LOOP_REASON_INVALID)
         return sol_flow_send_error_packet(node, EINVAL,
-            "Invalid JSON array (%.*s)", (int)mdata->json_array->size,
-            (char *)mdata->json_array->mem);
-
+            "JSON array index out of bounds: %" PRId32, mdata->index);
+invalid_array:
     return sol_flow_send_error_packet(node, EINVAL,
-        "JSON array index out of bounds: %" PRId32, mdata->index);
+        "Invalid JSON array (%.*s)", (int)mdata->json_array->size,
+        (char *)mdata->json_array->mem);
 }
 
 static int

--- a/src/modules/flow/json/json.json
+++ b/src/modules/flow/json/json.json
@@ -87,6 +87,162 @@
     },
     {
       "category": "json",
+      "description": "Receives a JSON object and send, to the appropriated port, the value of the child element pointed by path.",
+      "in_ports": [
+        {
+          "data_type": "json-object",
+          "description": "Port to receive the JSON object where path will be located.",
+          "methods": {
+            "process": "json_object_get_key_in_process"
+          },
+          "name": "IN",
+          "required": true
+        },
+        {
+          "data_type": "string",
+          "description": "Receives a string packet to override the path set as option.",
+          "methods": {
+            "process": "json_object_get_key_key_process"
+          },
+          "name": "PATH"
+        }
+      ],
+      "methods": {
+        "open": "json_object_get_path_open",
+        "close": "json_object_get_key_close"
+      },
+      "name": "json/object-get-path",
+      "options": {
+        "members": [
+          {
+            "data_type": "string",
+            "default": "",
+            "description": "The path of the JSON object child to access.",
+            "name": "path"
+          }
+        ],
+        "version": 1
+      },
+      "out_ports": [
+        {
+          "data_type": "int",
+          "description": "The integer value of a given path, if a number",
+          "name": "INT"
+        },
+        {
+          "data_type": "string",
+          "description": "The string value of a given path, if a string",
+          "name": "STRING"
+        },
+        {
+          "data_type": "boolean",
+          "description": "The boolean value of a given path, if a boolean",
+          "name": "BOOLEAN"
+        },
+        {
+          "data_type": "float",
+          "description": "The float value of a given path, if a number",
+          "name": "FLOAT"
+        },
+        {
+          "data_type": "json-object",
+          "description": "The JSON object of a given path, if a JSON object",
+          "name": "OBJECT"
+        },
+        {
+          "data_type": "json-array",
+          "description": "The JSON array of a given path, if a JSON array",
+          "name": "ARRAY"
+        },
+        {
+          "data_type": "empty",
+          "description": "An empty packet if value pointed by given path is null.",
+          "name": "NULL"
+        }
+      ],
+      "private_data_type": "sol_json_object_key",
+      "url": "http://solettaproject.org/doc/latest/node_types/json/json-object-get-path.html"
+    },
+    {
+      "category": "json",
+      "description": "Receives a JSON array and send, to the appropriated port, the value of the child element pointed by path.",
+      "in_ports": [
+        {
+          "data_type": "json-array",
+          "description": "Port to receive the JSON array where path will be located.",
+          "methods": {
+            "process": "json_array_get_path_in_process"
+          },
+          "name": "IN",
+          "required": true
+        },
+        {
+          "data_type": "string",
+          "description": "Receives a string packet to override the path set as option.",
+          "methods": {
+            "process": "json_object_get_key_key_process"
+          },
+          "name": "PATH"
+        }
+      ],
+      "methods": {
+        "open": "json_object_get_path_open",
+        "close": "json_object_get_key_close"
+      },
+      "name": "json/array-get-path",
+      "options": {
+        "members": [
+          {
+            "data_type": "string",
+            "default": "",
+            "description": "The path of the JSON array child to access.",
+            "name": "path"
+          }
+        ],
+        "version": 1
+      },
+      "out_ports": [
+        {
+          "data_type": "int",
+          "description": "The integer value of a given path, if a number",
+          "name": "INT"
+        },
+        {
+          "data_type": "string",
+          "description": "The string value of a given path, if a string",
+          "name": "STRING"
+        },
+        {
+          "data_type": "boolean",
+          "description": "The boolean value of a given path, if a boolean",
+          "name": "BOOLEAN"
+        },
+        {
+          "data_type": "float",
+          "description": "The float value of a given path, if a number",
+          "name": "FLOAT"
+        },
+        {
+          "data_type": "json-object",
+          "description": "The JSON object of a given path, if a JSON object",
+          "name": "OBJECT"
+        },
+        {
+          "data_type": "json-array",
+          "description": "The JSON array of a given path, if a JSON array",
+          "name": "ARRAY"
+        },
+        {
+          "data_type": "empty",
+          "description": "An empty packet if value pointed by given path is null.",
+          "name": "NULL"
+        }
+      ],
+      "private_data_type": "sol_json_object_key",
+      "url": "http://solettaproject.org/doc/latest/node_types/json/json-array-get-path.html"
+    },
+    {
+      "category": "json",
       "description": "Get the number of children elements in a JSON object.",
       "in_ports": [
         {

--- a/src/test-fbp/json-object-get.fbp
+++ b/src/test-fbp/json-object-get.fbp
@@ -36,8 +36,9 @@ float_validator(test/float-validator:sequence="123 1.23")
 string_validator(test/string-validator:sequence="hello")
 bool_validator(test/boolean-validator:sequence="FT")
 null_validator(converter/empty-to-boolean:output_value=true)
-object_validator(test/int-validator:sequence="456")
+object_validator_int(test/int-validator:sequence="456")
 array_validator(test/blob-validator:expected="[1,2,3]")
+object_validator(test/blob-validator:expected="{\"inner_int\": 456}")
 
 get_key_int_val(json/object-get-key:key="int_val")
 get_key_float_val(json/object-get-key:key="float_val")
@@ -66,7 +67,8 @@ get_key_string_val STRING -> IN string_validator
 get_key_false_val BOOLEAN -> IN bool_validator
 get_key_true_val BOOLEAN -> IN bool_validator
 get_key_null_val NULL -> IN null_validator
-get_key_object_val OBJECT -> IN _(json/object-get-key:key="inner_int") INT -> IN object_validator
+get_key_object_val OBJECT -> IN _(json/object-get-key:key="inner_int") INT -> IN object_validator_int
+get_key_object_val OBJECT -> IN _(converter/json-object-to-blob) OUT -> IN object_validator
 get_key_array_val ARRAY -> IN _(converter/json-array-to-blob) OUT -> IN array_validator
 _(constant/string:value="array_val") OUT -> KEY get_key_array_val
 
@@ -75,8 +77,9 @@ float_validator OUT -> RESULT float_result(test/result)
 string_validator OUT -> RESULT string_result(test/result)
 bool_validator OUT -> RESULT bool_result(test/result)
 null_validator OUT -> RESULT null_result(test/result)
-object_validator OUT -> RESULT object_result(test/result)
+object_validator OUT -> RESULT object_int_result(test/result)
 array_validator OUT -> RESULT array_result(test/result)
+object_validator OUT -> RESULT object_result(test/result)
 
 # Test node json/object-length
 json_object OUT -> IN _(json/object-length) OUT -> IN object_length_validator(test/int-validator:sequence="8")

--- a/src/test-fbp/json-path.fbp
+++ b/src/test-fbp/json-path.fbp
@@ -1,0 +1,80 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+## TEST-SKIP-COMPILE Due to path resolution to test-blob-data.txt we're disabling this test until we get it right
+
+reader(file/reader:path="json-path.txt")
+json_array(converter/blob-to-json-array)
+json_object(json/array-get-at-index:index=0)
+
+int_validator(test/int-validator:sequence="0 1 2 3 4 5 6 7 8 9")
+int_validator2(test/int-validator:sequence="10 11 12 13 14 15")
+
+reader OUT -> IN json_array
+json_array OUT -> IN json_object
+
+json_array OUT -> IN _(json/array-get-path:path="$[0].data1.array[0]") INT -> IN int_validator
+json_array OUT -> IN _(json/array-get-path:path="$[0]['data1'].array[1]") INT -> IN int_validator
+json_array OUT -> IN _(json/array-get-path:path="$[0]['data1']['array'][2]") INT -> IN int_validator
+json_array OUT -> IN _(json/array-get-path:path="$[0].data1['array'][3]") INT -> IN int_validator
+json_object OBJECT -> IN _(json/object-get-path:path="$.data1['array'][4]") INT -> IN int_validator
+json_object OBJECT -> IN _(json/object-get-path:path="$['data1'].array[5]") INT -> IN int_validator
+json_object OBJECT -> IN _(json/object-get-path:path="$.data1.array[6]") INT -> IN int_validator
+json_object OBJECT -> IN _(json/object-get-path:path="$['data1']['array'][7]") INT -> IN int_validator
+
+json_array OUT -> IN _(json/array-get-path:path="$") ARRAY -> IN _(json/array-get-path:path="$[0].data1['array'][8]") INT -> IN int_validator
+json_object OBJECT -> IN _(json/object-get-path:path="$") OBJECT -> IN _(json/object-get-path:path="$['data1']['array'][9]") INT -> IN int_validator
+
+json_array OUT -> IN _(json/array-get-path:path="$[0].my data's info\\nwith\\tescapes[0]") INT -> IN int_validator2
+json_array OUT -> IN _(json/array-get-path:path="$[0]['my data\\'s info\\nwith\\tescapes'][1]") INT -> IN int_validator2
+json_array OUT -> IN _(json/array-get-path:path="$[0]['my.data']") INT -> IN int_validator2
+
+json_array OUT -> IN array_get_path(json/array-get-path) INT -> IN int_validator2
+_(constant/string:value="$[0]['']") OUT -> PATH array_get_path
+
+json_array OUT -> IN _(json/array-get-path:path="$[0]['data1'].array2[0].data[0].data[0]") INT -> IN int_validator2
+json_object OBJECT -> IN _(json/object-get-path:path="$['data1'].array2[0].data[0].data[1]") INT -> IN int_validator2
+
+int_validator OUT -> RESULT int_result(test/result)
+int_validator2 OUT -> RESULT int_result2(test/result)
+
+#Errors
+json_object OBJECT -> IN _(json/object-get-path:path="invalid_path") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS error1(test/result)
+json_array OUT -> IN _(json/array-get-path:path="invalid_path") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS error2(test/result)
+
+json_array OUT -> IN _(json/array-get-path:path="$[1]") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS array_out_of_bounds(test/result)
+json_array OUT -> IN _(json/array-get-path:path="$[-1]") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS array_out_of_bounds2(test/result)
+
+json_object OBJECT -> IN _(json/object-get-path:path="$.invalid") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS error3(test/result)
+json_object OBJECT -> IN _(json/object-get-path:path="$['invalid']") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS error4(test/result)
+json_object OBJECT -> IN _(json/object-get-path:path="$[''']") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS error5(test/result)
+json_object OBJECT -> IN _(json/object-get-path:path="$['invalid'quote']") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS error6(test/result)
+json_object OBJECT -> IN _(json/object-get-path:path="$[']") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS error7(test/result)
+json_object OBJECT -> IN _(json/object-get-path:path="$[invalid_index]") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS error8(test/result)

--- a/src/test-fbp/json-path.txt
+++ b/src/test-fbp/json-path.txt
@@ -1,0 +1,10 @@
+[{
+    "data1": {
+        "array": [0,1,2,3,4,5,6,7,8,9],
+        "array2": [{"data": [{"data": [14, 15]}]}],
+        "": 8
+    },
+    "my data's info\nwith\tescapes": [10,11],
+    "my.data": 12,
+    "": 13
+}]


### PR DESCRIPTION
To extract data from complex JSON objects and JSON arrays, we need to
create multiple json/object-get-key and json/array-get-index to find the
desired elements.

Nodes json/object-get-path and json/array-get-path were created to
extract inner data from JSON elements using a single path that points to
the specific desired element.

JSON path follows specification from http://goessner.net/articles/JsonPath/,
but multiple elements extraction was not implemented

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>