### PR TITLE
JSON unescape of unicode chars to utf-8 was incorrect

### DIFF
--- a/src/lib/parsers/sol-json.c
+++ b/src/lib/parsers/sol-json.c
@@ -690,6 +690,24 @@ sol_json_serialize_boolean(struct sol_buffer *buffer, bool val)
     return 0;
 }
 
+static int
+_hex_decode(const char *p, uint8_t *val)
+{
+    int16_t n;
+    char hexdigits[3], *endptr;
+
+    hexdigits[2] = '\0';
+    memcpy(hexdigits, p, 2);
+    errno = 0;
+    n = strtoul(hexdigits, &endptr, 16);
+    SOL_INT_CHECK(errno, > 0, -errno);
+    if (n < 0 || n > UINT8_MAX || endptr != hexdigits + 2)
+        return -EINVAL;
+
+    *val = n;
+    return 0;
+}
+
 SOL_API int
 sol_json_token_get_unescaped_string(const struct sol_json_token *token, struct sol_buffer *buffer)
 {
@@ -745,27 +763,46 @@ sol_json_token_get_unescaped_string(const struct sol_json_token *token, struct s
                 break;
             case 'u':
                 if (p + 4 < token->end - 1) {
-                    char hexdigits[3], *endptr;
-                    uint16_t n;
-                    hexdigits[2] = '\0';
+                    uint8_t n1, n2, b;
 
-                    //Add first unicode byte
-                    memcpy(hexdigits, p + 3, 2);
-                    errno = 0;
-                    n = strtoul(hexdigits, &endptr, 16);
-                    SOL_INT_CHECK(errno, > 0, -errno);
-                    if (n > 0) {
-                        r = sol_buffer_append_char(buffer, (char)n);
+                    r = _hex_decode(p + 1, &n1);
+                    SOL_INT_CHECK(r, < 0, r);
+                    r = _hex_decode(p + 3, &n2);
+                    SOL_INT_CHECK(r, < 0, r);
+
+                    if (n1 >= 0x08) {
+                        //Three bytes
+                        b = 0xe0;
+                        b |= (n1 & 0xF0) >> 4;
+                        r = sol_buffer_append_char(buffer, b);
+                        SOL_INT_CHECK(r, < 0, r);
+
+                        b = 0x80;
+                        b |= (n1 & 0x0F) << 2;
+                        b |= (n2 & 0xc0) >> 6;
+                        r = sol_buffer_append_char(buffer, b);
+                        SOL_INT_CHECK(r, < 0, r);
+
+                        b = 0x80;
+                        b |= (n2 & 0x3F);
+                        r = sol_buffer_append_char(buffer, b);
+                        SOL_INT_CHECK(r, < 0, r);
+                    } else if (!n1 && n2 < 0x80) {
+                        //Just one byte
+                        r = sol_buffer_append_char(buffer, n2);
+                        SOL_INT_CHECK(r, < 0, r);
+                    } else {
+                        //Two bytes
+                        b = 0xc0;
+                        b |= (n1 & 0x7) << 2;
+                        b |= ((0xc0 & n2) >> 6);
+                        r = sol_buffer_append_char(buffer, b);
+                        SOL_INT_CHECK(r, < 0, r);
+
+                        b = 0x80 | (n2 & 0x3f);
+                        r = sol_buffer_append_char(buffer, b);
                         SOL_INT_CHECK(r, < 0, r);
                     }
-
-                    //Add second unicode byte
-                    memcpy(hexdigits, p + 1, 2);
-                    errno = 0;
-                    n = strtoul(hexdigits, &endptr, 16);
-                    SOL_INT_CHECK(errno, > 0, -errno);
-                    r = sol_buffer_append_char(buffer, (char)n);
-                    SOL_INT_CHECK(r, < 0, r);
 
                     start += 4;
                     p += 4;

--- a/src/test-fbp/json-escaping.fbp
+++ b/src/test-fbp/json-escaping.fbp
@@ -1,0 +1,44 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#json_object_str(constant/string:value="{\"val1\": \"teste\t\\t\n\\n de \\\\ \\\"escaping\\\" \\ua9c3 \"}")
+json_object_str(constant/string:value="{\"escape\": \"escape: \\\\\\/\\\"\\b\\r\\n\\f\\t\", \"unicode\": \"\\u0055\\u006E\\u0069\\u0063\\u006f\\u0064\\u0065\\u0020\\u00c0\\u00CA\\u00CD\\u00f6\\u00FA\\u010e\\u01e7\\u0275\\u0722\\u0788\\u085E\\u0936\\u0f4c\\u2764\\u264e\\u2600\\u2691\\u20ac\\u266b\"}")
+json_object(converter/blob-to-json-object)
+
+string_validator(test/string-validator:sequence="escape: \\/\"\b\r\n\f\t|Unicode ÀÊÍöúĎǧɵܢވ࡞शཌ❤♎☀⚑€♫")
+
+# Test node json/object-get-key
+json_object_str OUT -> IN _(converter/string-to-blob) OUT -> IN json_object
+json_object OUT -> IN _(json/object-get-key:key="escape") STRING -> IN string_validator
+json_object OUT -> IN _(json/object-get-key:key="unicode") STRING -> IN string_validator
+string_validator OUT -> RESULT string_result(test/result)
+
+json_object_error(constant/string:value="{\"x\": \"a\\u123x\"}")
+json_object_error OUT -> IN _(converter/string-to-blob) OUT -> IN _(converter/blob-to-json-object) OUT -> IN _(json/object-get-key:key="x") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS invalid_json_array_test(test/result)


### PR DESCRIPTION
The implementation of sol_json_token_get_unescaped_string was converting
unicode number to utf-8 in an incorrect way. The conversion is a bit
more complex than what was implemented.

This patch fixes this issue and also adds a test to check unicode
conversions

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>