### PR TITLE
Async

### DIFF
--- a/src/lib/io/include/sol-efivarfs-storage.h
+++ b/src/lib/io/include/sol-efivarfs-storage.h
@@ -36,114 +36,161 @@
 #include <stdint.h>
 
 #include "sol-buffer.h"
+#include "sol-log.h"
 #include "sol-types.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int sol_efivars_write_raw(const char *name, const struct sol_buffer *buffer);
+int sol_efivars_write_raw(const char *name, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data);
 int sol_efivars_read_raw(const char *name, struct sol_buffer *buffer);
 
-#define CREATE_BUFFER(_val, _empty) \
+#define CREATE_BUFFER(_val) \
     struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val, \
-    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED); \
-    buf.used = (_empty) ? 0 : sizeof(*(_val));
+    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+
+#define CREATE_BLOB(_val) \
+    struct sol_blob *blob; \
+    size_t _s = sizeof(*_val); \
+    void *v = malloc(_s); \
+    SOL_NULL_CHECK(v, -EINVAL); \
+    memcpy(v, _val, _s); \
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, v, _s); \
+    SOL_NULL_CHECK(blob, -EINVAL);
 
 static inline int
 sol_efivars_read_uint8(const char *name, uint8_t *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-sol_efivars_write_uint8(const char *name, uint8_t value)
+sol_efivars_write_uint8(const char *name, uint8_t value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_efivars_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_efivars_read_bool(const char *name, bool *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-sol_efivars_write_bool(const char *name, bool value)
+sol_efivars_write_bool(const char *name, bool value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_efivars_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_efivars_read_int32(const char *name, int32_t *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-sol_efivars_write_int32(const char *name, int32_t value)
+sol_efivars_write_int32(const char *name, int32_t value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_efivars_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_efivars_read_irange(const char *name, struct sol_irange *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-sol_efivars_write_irange(const char *name, struct sol_irange *value)
+sol_efivars_write_irange(const char *name, struct sol_irange *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(value, false);
+    int r;
 
-    return sol_efivars_write_raw(name, &buf);
+    CREATE_BLOB(value);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_efivars_read_drange(const char *name, struct sol_drange *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-sol_efivars_write_drange(const char *name, struct sol_drange *value)
+sol_efivars_write_drange(const char *name, struct sol_drange *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(value, false);
+    int r;
 
-    return sol_efivars_write_raw(name, &buf);
+    CREATE_BLOB(value);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_efivars_read_double(const char *name, double *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-sol_efivars_write_double(const char *name, double value)
+sol_efivars_write_double(const char *name, double value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_efivars_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
@@ -164,17 +211,32 @@ sol_efivars_read_string(const char *name, char **value)
 }
 
 static inline int
-sol_efivars_write_string(const char *name, const char *value)
+sol_efivars_write_string(const char *name, const char *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS((void *)value, strlen(value),
-        SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
+    int r;
+    struct sol_blob *blob;
+    char *string;
 
-    buf.used = buf.capacity;
+    string = strdup(value);
+    SOL_NULL_CHECK(string, -ENOMEM);
 
-    return sol_efivars_write_raw(name, &buf);
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, string, strlen(value));
+    SOL_NULL_CHECK(blob, -ENOMEM);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
+/**
+ * @}
+ */
+
 #undef CREATE_BUFFER
+
+#undef CREATE_BLOB
 
 #ifdef __cplusplus
 }

--- a/src/lib/io/include/sol-fs-storage.h
+++ b/src/lib/io/include/sol-fs-storage.h
@@ -36,114 +36,161 @@
 #include <stdint.h>
 
 #include "sol-buffer.h"
+#include "sol-log.h"
 #include "sol-types.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int sol_fs_write_raw(const char *name, const struct sol_buffer *buffer);
+int sol_fs_write_raw(const char *name, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data);
 int sol_fs_read_raw(const char *name, struct sol_buffer *buffer);
 
-#define CREATE_BUFFER(_val, _empty) \
+#define CREATE_BUFFER(_val) \
     struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val, \
-    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED); \
-    buf.used = (_empty) ? 0 : sizeof(*(_val));
+    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+
+#define CREATE_BLOB(_val) \
+    struct sol_blob *blob; \
+    size_t _s = sizeof(*_val); \
+    void *v = malloc(_s); \
+    SOL_NULL_CHECK(v, -EINVAL); \
+    memcpy(v, _val, _s); \
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, v, _s); \
+    SOL_NULL_CHECK(blob, -EINVAL);
 
 static inline int
 sol_fs_read_uint8(const char *name, uint8_t *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-sol_fs_write_uint8(const char *name, uint8_t value)
+sol_fs_write_uint8(const char *name, uint8_t value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_fs_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_fs_read_bool(const char *name, bool *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-sol_fs_write_bool(const char *name, bool value)
+sol_fs_write_bool(const char *name, bool value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_fs_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_fs_read_int32(const char *name, int32_t *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-sol_fs_write_int32(const char *name, int32_t value)
+sol_fs_write_int32(const char *name, int32_t value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_fs_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_fs_read_irange(const char *name, struct sol_irange *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-sol_fs_write_irange(const char *name, struct sol_irange *value)
+sol_fs_write_irange(const char *name, struct sol_irange *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(value, false);
+    int r;
 
-    return sol_fs_write_raw(name, &buf);
+    CREATE_BLOB(value);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_fs_read_drange(const char *name, struct sol_drange *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-sol_fs_write_drange(const char *name, struct sol_drange *value)
+sol_fs_write_drange(const char *name, struct sol_drange *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(value, false);
+    int r;
 
-    return sol_fs_write_raw(name, &buf);
+    CREATE_BLOB(value);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_fs_read_double(const char *name, double *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-sol_fs_write_double(const char *name, double value)
+sol_fs_write_double(const char *name, double value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_fs_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
@@ -164,17 +211,32 @@ sol_fs_read_string(const char *name, char **value)
 }
 
 static inline int
-sol_fs_write_string(const char *name, const char *value)
+sol_fs_write_string(const char *name, const char *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS((void *)value, strlen(value),
-        SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
+    int r;
+    struct sol_blob *blob;
+    char *string;
 
-    buf.used = buf.capacity;
+    string = strdup(value);
+    SOL_NULL_CHECK(string, -ENOMEM);
 
-    return sol_fs_write_raw(name, &buf);
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, string, strlen(value));
+    SOL_NULL_CHECK(blob, -ENOMEM);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
+/**
+ * @}
+ */
+
 #undef CREATE_BUFFER
+
+#undef CREATE_BLOB
 
 #ifdef __cplusplus
 }

--- a/src/lib/io/include/sol-memmap-storage.h
+++ b/src/lib/io/include/sol-memmap-storage.h
@@ -103,11 +103,13 @@ struct sol_memmap_entry {
  * @param name name of property. must be present in one of maps previoulsy
  * added via @c sol_memmap_add_map (if present in more than one,
  * behaviour is undefined)
- * @param buffer buffer that will be written, according to its entry on map.
+ * @param blob blob that will be written, according to its entry on map.
  *
  * return 0 on success, a negative number on failure
  */
-int sol_memmap_write_raw(const char *name, const struct sol_buffer *buffer);
+int sol_memmap_write_raw(const char *name, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data);
 
 /**
  * Read storage contents to buffer.
@@ -143,105 +145,149 @@ int sol_memmap_add_map(const struct sol_memmap_map *map);
  */
 int sol_memmap_remove_map(const struct sol_memmap_map *map);
 
-#define CREATE_BUFFER(_val, _empty) \
+#define CREATE_BUFFER(_val) \
     struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val, \
-    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE); \
-    buf.used = (_empty) ? 0 : sizeof(*(_val));
+    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+
+#define CREATE_BLOB(_val) \
+    struct sol_blob *blob; \
+    size_t _s = sizeof(*_val); \
+    void *v = malloc(_s); \
+    SOL_NULL_CHECK(v, -EINVAL); \
+    memcpy(v, _val, _s); \
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, v, _s); \
+    SOL_NULL_CHECK(blob, -EINVAL);
 
 static inline int
 sol_memmap_read_uint8(const char *name, uint8_t *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_memmap_read_raw(name, &buf);
 }
 
 static inline int
-sol_memmap_write_uint8(const char *name, uint8_t value)
+sol_memmap_write_uint8(const char *name, uint8_t value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_memmap_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_memmap_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_memmap_read_bool(const char *name, bool *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_memmap_read_raw(name, &buf);
 }
 
 static inline int
-sol_memmap_write_bool(const char *name, bool value)
+sol_memmap_write_bool(const char *name, bool value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_memmap_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_memmap_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_memmap_read_int32(const char *name, int32_t *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_memmap_read_raw(name, &buf);
 }
 
 static inline int
-sol_memmap_write_int32(const char *name, int32_t value)
+sol_memmap_write_int32(const char *name, int32_t value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_memmap_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_memmap_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_memmap_read_irange(const char *name, struct sol_irange *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_memmap_read_raw(name, &buf);
 }
 
 static inline int
-sol_memmap_write_irange(const char *name, struct sol_irange *value)
+sol_memmap_write_irange(const char *name, struct sol_irange *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(value, false);
+    int r;
 
-    return sol_memmap_write_raw(name, &buf);
+    CREATE_BLOB(value);
+
+    r = sol_memmap_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_memmap_read_drange(const char *name, struct sol_drange *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_memmap_read_raw(name, &buf);
 }
 
 static inline int
-sol_memmap_write_drange(const char *name, struct sol_drange *value)
+sol_memmap_write_drange(const char *name, struct sol_drange *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(value, false);
+    int r;
 
-    return sol_memmap_write_raw(name, &buf);
+    CREATE_BLOB(value);
+
+    r = sol_memmap_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_memmap_read_double(const char *name, double *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_memmap_read_raw(name, &buf);
 }
 
 static inline int
-sol_memmap_write_double(const char *name, double value)
+sol_memmap_write_double(const char *name, double value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_memmap_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_memmap_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
@@ -262,14 +308,23 @@ sol_memmap_read_string(const char *name, char **value)
 }
 
 static inline int
-sol_memmap_write_string(const char *name, const char *value)
+sol_memmap_write_string(const char *name, const char *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS((void *)value, strlen(value),
-        SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
+    int r;
+    struct sol_blob *blob;
+    char *string;
 
-    buf.used = buf.capacity;
+    string = strdup(value);
+    SOL_NULL_CHECK(string, -ENOMEM);
 
-    return sol_memmap_write_raw(name, &buf);
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, string, strlen(value) + 1);
+    SOL_NULL_CHECK(blob, -ENOMEM);
+
+    r = sol_memmap_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 /**
@@ -277,6 +332,8 @@ sol_memmap_write_string(const char *name, const char *value)
  */
 
 #undef CREATE_BUFFER
+
+#undef CREATE_BLOB
 
 #ifdef __cplusplus
 }

--- a/src/lib/io/sol-efivarfs-storage.c
+++ b/src/lib/io/sol-efivarfs-storage.c
@@ -41,12 +41,21 @@
 
 #include "sol-buffer.h"
 #include "sol-log.h"
+#include "sol-mainloop.h"
 #include "sol-util.h"
 #include "sol-util-file.h"
 
 #define SOLETTA_EFIVARS_GUID "076027a8-c791-41d7-940f-3d465869f821"
 #define EFIVARFS_VAR_DIR "/sys/firmware/efi/efivars/"
 #define EFIVARFS_VAR_PATH EFIVARFS_VAR_DIR "%s-" SOLETTA_EFIVARS_GUID
+
+struct cb_data {
+    char *name;
+    struct sol_blob *blob;
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status);
+    const void *data;
+    int status;
+};
 
 static const int EFIVARS_DEFAULT_ATTR = 0x7;
 
@@ -62,27 +71,71 @@ check_realpath(const char *path)
     return false;
 }
 
-SOL_API int
-sol_efivars_write_raw(const char *name, const struct sol_buffer *buffer)
+static bool
+write_cb(void *data)
 {
-    FILE *file;
+    struct cb_data *cb_data = data;
+
+    cb_data->cb((void *)cb_data->data, cb_data->name, cb_data->blob, cb_data->status);
+    sol_blob_unref(cb_data->blob);
+
+    free(cb_data->name);
+    free(cb_data);
+
+    return false;
+}
+
+SOL_API int
+sol_efivars_write_raw(const char *name, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
+{
+    FILE *file = NULL;
     char path[PATH_MAX];
     int r;
+    struct cb_data *cb_data = NULL;
 
     SOL_NULL_CHECK(name, -EINVAL);
-    SOL_NULL_CHECK(buffer, -EINVAL);
+    SOL_NULL_CHECK(blob, -EINVAL);
+
+    if (cb) {
+        cb_data = calloc(1, sizeof(struct cb_data));
+        SOL_NULL_CHECK(cb_data, -ENOMEM);
+
+        cb_data->blob = sol_blob_ref(blob);
+        if (!cb_data->blob) {
+            free(cb_data);
+            return -ENOMEM;
+        }
+
+        cb_data->blob = blob;
+        cb_data->data = data;
+        cb_data->cb = cb;
+        cb_data->name = strdup(name);
+        if (!cb_data->name) {
+            sol_blob_unref(blob);
+            free(cb_data);
+            return -ENOMEM;
+        }
+    }
 
     r = snprintf(path, sizeof(path), EFIVARFS_VAR_PATH, name);
     if (r < 0 || r >= PATH_MAX) {
         SOL_WRN("Could not create path for efivars persistence file [%s]", path);
-        return -EINVAL;
+        goto path_error;
     }
+
+    /* From this point on, we return success even on failure, and report
+     * failure on cb, if any. So we have a uniform behaviour among storage
+     * api */
 
     file = fopen(path, "w+e");
     if (!file) {
         SOL_WRN("Could not open persistence file [%s]", path);
-        return -errno;
+        r = -errno;
+        goto end;
     }
+
     if (!check_realpath(path)) {
         /* At this point, a file on an invalid location may have been created.
          * Should we care about it? Is there a 'realpath()' that doesn't need
@@ -99,15 +152,29 @@ sol_efivars_write_raw(const char *name, const struct sol_buffer *buffer)
         goto end;
     }
 
-    fwrite(buffer->data, buffer->used, 1, file);
+    fwrite(blob->mem, blob->size, 1, file);
 
 end:
-    if (fclose(file)) {
+    if (file && fclose(file)) {
         SOL_WRN("Could not close persistence file [%s]", path);
-        return -errno;
+        r = -errno;
     }
 
-    return r;
+    if (cb) {
+        cb_data->status = r;
+        sol_timeout_add(0, write_cb, cb_data);
+    }
+
+    return 0;
+
+path_error:
+    if (cb_data) {
+        sol_blob_unref(blob);
+        free(cb_data->name);
+        free(cb_data);
+    }
+
+    return -ENOMEM;
 }
 
 SOL_API int

--- a/src/lib/io/sol-fs-storage.c
+++ b/src/lib/io/sol-fs-storage.c
@@ -41,33 +41,91 @@
 
 #include "sol-buffer.h"
 #include "sol-log.h"
+#include "sol-mainloop.h"
 #include "sol-util.h"
 #include "sol-util-file.h"
 
-SOL_API int
-sol_fs_write_raw(const char *name, const struct sol_buffer *buffer)
+struct cb_data {
+    char *name;
+    struct sol_blob *blob;
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status);
+    const void *data;
+    int status;
+};
+
+static bool
+write_cb(void *data)
 {
-    FILE *file;
-    int ret = 0;
+    struct cb_data *cb_data = data;
+
+    cb_data->cb((void *)cb_data->data, cb_data->name, cb_data->blob, cb_data->status);
+    sol_blob_unref(cb_data->blob);
+
+    free(cb_data->name);
+    free(cb_data);
+
+    return false;
+}
+
+SOL_API int
+sol_fs_write_raw(const char *name, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
+{
+    FILE *file = NULL;
+    struct cb_data *cb_data;
+    int ret = 0, status = 0;
 
     SOL_NULL_CHECK(name, -EINVAL);
-    SOL_NULL_CHECK(buffer, -EINVAL);
+    SOL_NULL_CHECK(blob, -EINVAL);
+
+    if (cb) {
+        cb_data = calloc(1, sizeof(struct cb_data));
+        SOL_NULL_CHECK(cb_data, -ENOMEM);
+
+        cb_data->blob = sol_blob_ref(blob);
+        if (!cb_data->blob) {
+            free(cb_data);
+            return -ENOMEM;
+        }
+
+        cb_data->blob = blob;
+        cb_data->data = data;
+        cb_data->cb = cb;
+        cb_data->name = strdup(name);
+        if (!cb_data->name) {
+            sol_blob_unref(blob);
+            free(cb_data);
+            return -ENOMEM;
+        }
+    }
+
+    /* From this point on, we return success even on failure, and report
+     * failure on cb, if any. So we have a uniform behaviour among storage
+     * api */
 
     file = fopen(name, "w+e");
     if (!file) {
         SOL_WRN("Could not open persistence file [%s]", name);
-        return -errno;
+        status = -errno;
+        goto end;
     }
 
-    fwrite(buffer->data, buffer->used, 1, file);
+    fwrite(blob->mem, blob->size, 1, file);
     if (ferror(file)) {
         SOL_WRN("Could not write to persistence file [%s]", name);
-        ret = -EIO;
+        status = -EIO;
     }
 
-    if (fclose(file)) {
+end:
+    if (file && fclose(file)) {
         SOL_WRN("Could not close persistence file [%s]", name);
-        return -errno;
+        status = -errno;
+    }
+
+    if (cb) {
+        cb_data->status = status;
+        sol_timeout_add(0, write_cb, cb_data);
     }
 
     return ret;

--- a/src/lib/io/sol-memmap-storage.c
+++ b/src/lib/io/sol-memmap-storage.c
@@ -118,7 +118,7 @@ sol_memmap_read_raw_do(const char *path, const struct sol_memmap_entry *entry, u
     if (lseek(fd, entry->offset, SEEK_SET) < 0)
         goto error;
 
-    if (sol_util_fill_buffer(fd, buffer, entry->size) < 0)
+    if ((ret = sol_util_fill_buffer(fd, buffer, entry->size)) < 0)
         goto error;
 
     if (mask) {
@@ -139,7 +139,8 @@ sol_memmap_read_raw_do(const char *path, const struct sol_memmap_entry *entry, u
     return 0;
 
 error:
-    ret = -errno;
+    if (!ret)
+        ret = -errno;
     close(fd);
 
     return ret;

--- a/src/test/.gitignore
+++ b/src/test/.gitignore
@@ -19,6 +19,7 @@
 /test-mainloop-linux
 /test-monitors
 /test-parser
+/test-persistence-memmap
 /test-scanner
 /test-str-slice
 /test-str-split

--- a/src/test/Kconfig
+++ b/src/test/Kconfig
@@ -100,3 +100,8 @@ config TEST_COMPOSED_TYPE
 config TEST_MESSAGE_DIGEST
       bool "crypto message-digest"
       default y
+
+config TEST_PERSISTENCE_MEMMAP
+	bool "Memmap persistence API"
+	depends on USE_MEMMAP
+	default y

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -71,3 +71,6 @@ test-test-composed-type-$(TEST_COMPOSED_TYPE) := test.c test-composed-type.c
 
 test-$(TEST_MESSAGE_DIGEST) += test-message-digest
 test-test-message-digest-$(TEST_MESSAGE_DIGEST) := test.c test-message-digest.c
+
+test-$(TEST_PERSISTENCE_MEMMAP) += test-persistence-memmap
+test-test-persistence-memmap-$(TEST_PERSISTENCE_MEMMAP) := test.c test-persistence-memmap.c

--- a/src/test/test-persistence-memmap.c
+++ b/src/test/test-persistence-memmap.c
@@ -1,0 +1,368 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sol-mainloop.h"
+#include "sol-memmap-storage.h"
+
+#include "test.h"
+
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry0, 2, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry1, 3, 1, 0, 1);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry2, 3, 4, 1, 30);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry3, 0, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry4, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry5, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry6, 0, 10, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry7, 0, 32, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry8, 0, 8, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry9, 0, 32, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry10, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry11, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry12, 0, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry13, 0, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry14, 0, 10, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry15, 0, 32, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry16, 0, 32, 0, 0);
+
+static const struct sol_str_table_ptr _memmap0_entries[] = {
+    SOL_STR_TABLE_PTR_ITEM("_version", &map0_entry0),
+    SOL_STR_TABLE_PTR_ITEM("boolean", &map0_entry1),
+    SOL_STR_TABLE_PTR_ITEM("int_only_val", &map0_entry2),
+    SOL_STR_TABLE_PTR_ITEM("byte", &map0_entry3),
+    SOL_STR_TABLE_PTR_ITEM("int", &map0_entry4),
+    SOL_STR_TABLE_PTR_ITEM("irange", &map0_entry5),
+    SOL_STR_TABLE_PTR_ITEM("string", &map0_entry6),
+    SOL_STR_TABLE_PTR_ITEM("double", &map0_entry7),
+    SOL_STR_TABLE_PTR_ITEM("double_only_val", &map0_entry8),
+    SOL_STR_TABLE_PTR_ITEM("drange", &map0_entry9),
+    SOL_STR_TABLE_PTR_ITEM("int_def", &map0_entry10),
+    SOL_STR_TABLE_PTR_ITEM("irange_def", &map0_entry11),
+    SOL_STR_TABLE_PTR_ITEM("byte_def", &map0_entry12),
+    SOL_STR_TABLE_PTR_ITEM("boolean_def", &map0_entry13),
+    SOL_STR_TABLE_PTR_ITEM("string_def", &map0_entry14),
+    SOL_STR_TABLE_PTR_ITEM("double_def", &map0_entry15),
+    SOL_STR_TABLE_PTR_ITEM("drange_def", &map0_entry16),
+    { }
+};
+
+static const struct sol_memmap_map _memmap0 = {
+    .version = 1,
+    .path = "memmap-test.bin",
+    .entries = _memmap0_entries
+};
+
+static struct sol_irange irange_not_delayed = {
+    .val = -23,
+    .min = -1000,
+    .max = 1000,
+    .step = 1
+};
+
+static struct sol_drange drange_not_delayed = {
+    .val = -2.3,
+    .min = -100.0,
+    .max = 100.0,
+    .step = 0.1
+};
+
+static struct sol_irange irange_delayed = {
+    .val = -33,
+    .min = -10000,
+    .max = 10000,
+    .step = 3
+};
+
+static struct sol_drange drange_delayed = {
+    .val = -9.8,
+    .min = -1000.0,
+    .max = 1000.0,
+    .step = 0.2
+};
+
+static void
+write_cb(void *data, const char *name, struct sol_blob *blob, int status)
+{
+    ASSERT_INT_EQ(status, 0);
+}
+
+static void
+write_cancelled_cb(void *data, const char *name, struct sol_blob *blob, int status)
+{
+    ASSERT_INT_EQ(status, -ECANCELED);
+}
+
+static void
+write_one(void)
+{
+    int r;
+
+    r = sol_memmap_write_bool("boolean", true, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_uint8("byte", 78, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_int32("int_only_val", 7804, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_irange("irange", &irange_not_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_drange("drange", &drange_not_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_double("double_only_val", 97.36, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_string("string", "gama delta", write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+}
+
+static void
+read_one(void)
+{
+    int r, i;
+    struct sol_irange irange;
+    struct sol_drange drange;
+    double d;
+    bool b;
+    uint8_t u;
+    char *string;
+
+    r = sol_memmap_read_bool("boolean", &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(b);
+
+    r = sol_memmap_read_uint8("byte", &u);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(u, 78);
+
+    r = sol_memmap_read_int32("int_only_val", &i);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(i, 7804);
+
+    r = sol_memmap_read_irange("irange", &irange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_irange_equal(&irange, &irange_not_delayed));
+
+    r = sol_memmap_read_drange("drange", &drange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_equal(&drange, &drange_not_delayed));
+
+    r = sol_memmap_read_double("double_only_val", &d);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_val_equal(d, 97.36));
+
+    r = sol_memmap_read_string("string", &string);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_STR_EQ(string, "gama delta");
+    free(string);
+}
+
+static void
+write_two(void)
+{
+    int r;
+
+    r = sol_memmap_write_bool("boolean", false, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_uint8("byte", 88, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_int32("int_only_val", 7814, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_irange("irange", &irange_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_drange("drange", &drange_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_double("double_only_val", 107.36, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_string("string", "alfa beta", write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+}
+
+static void
+read_two(void)
+{
+    int r, i;
+    struct sol_irange irange;
+    struct sol_drange drange;
+    double d;
+    bool b;
+    uint8_t u;
+    char *string;
+
+    r = sol_memmap_read_bool("boolean", &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(!b);
+
+    r = sol_memmap_read_uint8("byte", &u);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(u, 88);
+
+    r = sol_memmap_read_int32("int_only_val", &i);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(i, 7814);
+
+    r = sol_memmap_read_irange("irange", &irange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_irange_equal(&irange, &irange_delayed));
+
+    r = sol_memmap_read_drange("drange", &drange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_equal(&drange, &drange_delayed));
+
+    r = sol_memmap_read_double("double_only_val", &d);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_val_equal(d, 107.36));
+
+    r = sol_memmap_read_string("string", &string);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_STR_EQ(string, "alfa beta");
+    free(string);
+}
+
+static bool
+read_two_after(void *data)
+{
+    read_two();
+
+    return false;
+}
+
+static void
+write_one_cancelled(void)
+{
+    int r;
+
+    sol_memmap_add_map(&_memmap0);
+
+    r = sol_memmap_write_bool("boolean", true, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_uint8("byte", 78, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_int32("int_only_val", 7804, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_irange("irange", &irange_not_delayed, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_drange("drange", &drange_not_delayed, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_double("double_only_val", 97.36, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_string("string", "gama delta", write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+}
+
+static bool
+write_two_timeout(void *data)
+{
+    write_two();
+    read_two();
+
+    return false;
+}
+
+static bool
+read_one_after_mainloop(void *data)
+{
+    read_one();
+
+    return false;
+}
+
+static bool
+write_cancelled_timeout(void *data)
+{
+    write_one_cancelled();
+    read_one(); /* write_one_cancelled writes same values as write_one */
+
+    write_two(); /* reuse second part of test */
+    read_two();
+
+    sol_quit();
+
+    return false;
+}
+
+static bool
+perform_tests(void *data)
+{
+    char command[128];
+    int n;
+
+    sol_memmap_add_map(&_memmap0);
+
+    n = snprintf(command, sizeof(command), "truncate -s0 %s && truncate -s128 %s",
+        _memmap0.path, _memmap0.path);
+    ASSERT(n > 0 && (size_t)n < sizeof(command));
+
+    n = system(command);
+    ASSERT(!n);
+
+    write_one();
+    read_one(); /* This one should happen before actually writing data */
+    sol_idle_add(read_one_after_mainloop, NULL); /* This one should be after a main loop */
+    sol_timeout_add(50, write_two_timeout, NULL); /* This, much after */
+    sol_timeout_add(1000, read_two_after, NULL); /* Even later */
+
+    sol_timeout_add(2000, write_cancelled_timeout, NULL);
+
+    return false;
+}
+
+int
+main(int argc, char *argv[])
+{
+    int err;
+
+    err = sol_init();
+    ASSERT(!err);
+
+    sol_idle_add(perform_tests, NULL);
+
+    sol_run();
+
+    sol_shutdown();
+
+    return 0;
+}


### PR DESCRIPTION
First try at making persistence APIs async. Although memory map, file system and efivars were changed in a uniform fashion, only memory map actually does async writing - but all of them return the real result of writing on a callback.
Tests were also added, memap only now - although `make check-valgrind` failed here in a way I couldn't understand, no leaks, but an assert failure o.O.
@barbieri there's no `delayed`. All operations are async, so I couldn't find use for it. Reasoning is that we will only have async option when writing via i2c, so I kept things uniform. Comments/objections?