### PR TITLE
Make composed types API similar to API for other packet types

### DIFF
--- a/data/scripts/sol-flow-node-type-stub-gen.py
+++ b/data/scripts/sol-flow-node-type-stub-gen.py
@@ -337,7 +337,7 @@ send_%(name)s_packet(struct sol_flow_node *src, uint16_t src_port
 static int
 send_%s_packet(struct sol_flow_node *src, uint16_t src_port, %s)
 {
-   struct sol_flow_packet **children, *composed_packet;
+   struct sol_flow_packet **children;
    const struct sol_flow_packet_type *p_type;
    uint16_t len, i;
    int r;
@@ -348,11 +348,8 @@ send_%s_packet(struct sol_flow_node *src, uint16_t src_port, %s)
    children = alloca(len * sizeof(struct sol_flow_packet *));
    memset(children, 0, len * sizeof(struct sol_flow_packet *));
 
-   %s
-   composed_packet = sol_flow_packet_new(p_type, children);
-   SOL_NULL_CHECK_GOTO(composed_packet, exit);
-
-   r = sol_flow_send_packet(src, src_port, composed_packet);
+%s
+   r = sol_flow_send_composed_packet(src, src_port, p_type, children);
 exit:
    for (i = 0; i < len; i++) {
         if (children[i] == NULL && r == 0) {
@@ -526,18 +523,15 @@ static int
     p_type = sol_flow_packet_get_type(packet);
     if (p_type != %s_get_composed_%s_packet_type())
        return -EINVAL;
-    r = sol_flow_packet_get_composed_members_len(p_type, &len);
+
+    r = sol_flow_packet_get_composed_members(packet, &packets, &len);
     SOL_INT_CHECK(r, < 0, r);
     SOL_INT_CHECK(len, < %d, -EINVAL);
-    packets = malloc(len * sizeof(struct sol_flow_packet *));
-    SOL_NULL_CHECK(packets, -ENOMEM);
-    r = sol_flow_packet_get(packet, &packets);
-    SOL_INT_CHECK_GOTO(r, < 0, err_exit);
 """ % (data["name_c"], get_composed_types_with_underscore(single_type), len(types_list)))
             for i, type in enumerate(types_list):
                 outfile.write("""
     r = %s;
-    SOL_INT_CHECK_GOTO(r, < 0, err_exit);""" % (data_type_to_packet_getter(type).replace(")", (("_%d)" % (i)))).replace("(packet", "(packets[%d]" % (i))))
+    SOL_INT_CHECK(r, < 0, r);""" % (data_type_to_packet_getter(type).replace(")", (("_%d)" % (i)))).replace("(packet", "(packets[%d]" % (i))))
         elif single_type:
             outfile.write("""
     int r;
@@ -553,14 +547,8 @@ static int
     /* TODO: implement process method */
 
     return 0;
+}
 """)
-        if single_type and is_composed(single_type):
-            outfile.write("""
-err_exit:
-    free(packets);
-    return r;""")
-        outfile.write("""
-}\n""")
 
 def generate_stub(stub_file, inputs_list, prefix, is_module, namespace):
     data = []

--- a/data/scripts/sol-flow-node-type-stub-gen.py
+++ b/data/scripts/sol-flow-node-type-stub-gen.py
@@ -528,15 +528,16 @@ static int
        return -EINVAL;
     r = sol_flow_packet_get_composed_members_len(p_type, &len);
     SOL_INT_CHECK(r, < 0, r);
+    SOL_INT_CHECK(len, < %d, -EINVAL);
     packets = malloc(len * sizeof(struct sol_flow_packet *));
     SOL_NULL_CHECK(packets, -ENOMEM);
     r = sol_flow_packet_get(packet, &packets);
     SOL_INT_CHECK_GOTO(r, < 0, err_exit);
-""" % (data["name_c"], get_composed_types_with_underscore(single_type)))
+""" % (data["name_c"], get_composed_types_with_underscore(single_type), len(types_list)))
             for i, type in enumerate(types_list):
                 outfile.write("""
     r = %s;
-    SOL_INT_CHECK_GOTO(r, < 0, err_exit);""" % (data_type_to_packet_getter(type).replace(")", (("_%d" % (i)))) + ")" ))
+    SOL_INT_CHECK_GOTO(r, < 0, err_exit);""" % (data_type_to_packet_getter(type).replace(")", (("_%d)" % (i)))).replace("(packet", "(packets[%d]" % (i))))
         elif single_type:
             outfile.write("""
     int r;

--- a/src/bin/sol-fbp-runner/inspector.c
+++ b/src/bin/sol-fbp-runner/inspector.c
@@ -241,20 +241,19 @@ static void
 inspector_show_packet(const struct sol_flow_packet *packet)
 {
     const struct sol_flow_packet_type *type = sol_flow_packet_get_type(packet);
+    int r;
 
     if (sol_flow_packet_is_composed_type(type)) {
         uint16_t len, i;
         struct sol_flow_packet **packets;
 
-        sol_flow_packet_get_composed_members_len(type, &len);
-        packets = malloc(len * sizeof(struct sol_flow_packet *));
-        SOL_NULL_CHECK(packets);
-        sol_flow_packet_get(packet, packets);
+        r = sol_flow_packet_get_composed_members(packet, &packets, &len);
+        SOL_INT_CHECK(r, < 0);
+
         fprintf(stdout, "<COMPOSED-PACKET {");
         for (i = 0; i < len; i++)
             inspector_show_packet_value(packets[i]);
         fprintf(stdout, "}>");
-        free(packets);
     } else
         inspector_show_packet_value(packet);
 }

--- a/src/lib/flow/include/sol-flow-packet.h
+++ b/src/lib/flow/include/sol-flow-packet.h
@@ -159,6 +159,7 @@ int sol_flow_packet_get_timestamp(const struct sol_flow_packet *packet, struct t
 const struct sol_flow_packet_type *sol_flow_packet_type_composed_new(const struct sol_flow_packet_type **types);
 bool sol_flow_packet_is_composed_type(const struct sol_flow_packet_type *type);
 int sol_flow_packet_get_composed_members_len(const struct sol_flow_packet_type *type, uint16_t *len);
+int sol_flow_packet_get_composed_members(const struct sol_flow_packet *packet, struct sol_flow_packet ***value, uint16_t *len);
 struct sol_flow_packet *sol_flow_packet_dup(const struct sol_flow_packet *packet);
 /**
  * @}

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -192,6 +192,8 @@ int sol_flow_send_string_slice_packet(struct sol_flow_node *src, uint16_t src_po
 
 int sol_flow_send_string_take_packet(struct sol_flow_node *src, uint16_t src_port, char *value);
 
+int sol_flow_send_composed_packet(struct sol_flow_node *src, uint16_t src_port, const struct sol_flow_packet_type *composed_type, struct sol_flow_packet **children);
+
 /**
  * Get a node's type.
  *

--- a/src/lib/flow/sol-flow-packet.c
+++ b/src/lib/flow/sol-flow-packet.c
@@ -410,6 +410,23 @@ error:
     return NULL;
 }
 
+SOL_API int
+sol_flow_packet_get_composed_members(const struct sol_flow_packet *packet, struct sol_flow_packet ***value, uint16_t *len)
+{
+    SOL_NULL_CHECK(packet, -EINVAL);
+    SOL_NULL_CHECK(packet->type, -EINVAL);
+
+    if (!sol_flow_packet_is_composed_type(packet->type)) {
+        SOL_WRN("Not a composed packet type. Type name:%s", packet->type->name);
+        return -EINVAL;
+    }
+
+    if (len)
+        *len = ((const struct sol_flow_packet_composed_type *)packet->type)->members_len;
+
+    return sol_flow_packet_get(packet, value);
+}
+
 static int
 blob_packet_init(const struct sol_flow_packet_type *packet_type, void *mem, const void *input)
 {
@@ -787,13 +804,19 @@ sol_flow_packet_get_error(const struct sol_flow_packet *packet, int *code, const
 static int
 composed_type_init(const struct sol_flow_packet_type *packet_type, void *mem, const void *input)
 {
-    const struct sol_flow_packet **in = (void *)input;
-    struct sol_flow_packet **array = mem;
+    const struct sol_flow_packet_composed_type *composed_type;
+    const struct sol_flow_packet ***in = (void *)input;
+    struct sol_flow_packet ***composed = mem;
+    struct sol_flow_packet **array;
     uint16_t i, last;
 
-    for (i = 0; i < packet_type->data_size / sizeof(struct sol_flow_packet *);
-        i++) {
-        array[i] = sol_flow_packet_dup(in[i]);
+    composed_type = (struct sol_flow_packet_composed_type *)packet_type;
+    *composed = malloc(sizeof(struct sol_flow_packet *) *
+        composed_type->members_len);
+    SOL_NULL_CHECK(*composed, -ENOMEM);
+    array = *composed;
+    for (i = 0; i < composed_type->members_len; i++) {
+        array[i] = sol_flow_packet_dup((*in)[i]);
         SOL_NULL_CHECK_GOTO(array[i], err_exit);
     }
 
@@ -804,18 +827,21 @@ err_exit:
     last = i;
     for (i = 0; i < last; i++)
         sol_flow_packet_del(array[i]);
+    free(*composed);
     return -ENOMEM;
 }
 
 static void
 composed_type_dispose(const struct sol_flow_packet_type *packet_type, void *mem)
 {
-    struct sol_flow_packet **array = mem;
+    const struct sol_flow_packet_composed_type *composed_type;
+    struct sol_flow_packet **composed = *((struct sol_flow_packet ***)mem);
     uint16_t i;
 
-    for (i = 0; i < packet_type->data_size / sizeof(struct sol_flow_packet *);
-        i++)
-        sol_flow_packet_del(array[i]);
+    composed_type = (struct sol_flow_packet_composed_type *)packet_type;
+    for (i = 0; i < composed_type->members_len; i++)
+        sol_flow_packet_del(composed[i]);
+    free(composed);
 }
 
 SOL_API const struct sol_flow_packet_type *
@@ -861,7 +887,7 @@ sol_flow_packet_type_composed_new(const struct sol_flow_packet_type **types)
 
     ctype->self.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION;
     ctype->self.name = sol_buffer_steal(&buf, NULL);
-    ctype->self.data_size = types_len * sizeof(struct sol_flow_packet *);
+    ctype->self.data_size = sizeof(struct sol_flow_packet **);
     ctype->self.init = composed_type_init;
     ctype->self.dispose = composed_type_dispose;
 
@@ -910,7 +936,7 @@ sol_flow_packet_get_composed_members_len(const struct sol_flow_packet_type *type
         return -EINVAL;
     }
 
-    *len = type->data_size / sizeof(struct sol_flow_packet *);
+    *len = ((const struct sol_flow_packet_composed_type *)type)->members_len;
     return 0;
 }
 

--- a/src/lib/flow/sol-flow.c
+++ b/src/lib/flow/sol-flow.c
@@ -377,6 +377,17 @@ sol_flow_send_string_slice_packet(struct sol_flow_node *src, uint16_t src_port, 
     SOL_FLOW_SEND_PACKET(string_slice);
 }
 
+SOL_API int
+sol_flow_send_composed_packet(struct sol_flow_node *src, uint16_t src_port, const struct sol_flow_packet_type *composed_type, struct sol_flow_packet **children)
+{
+    struct sol_flow_packet *out_packet;
+
+    out_packet = sol_flow_packet_new(composed_type, &children);
+    SOL_NULL_CHECK(out_packet, -ENOMEM);
+
+    return sol_flow_send_packet(src, src_port, out_packet);
+}
+
 #undef SOL_FLOW_SEND_PACKET
 
 SOL_API int

--- a/src/modules/flow/console/console.c
+++ b/src/modules/flow/console/console.c
@@ -194,10 +194,9 @@ console_in_process(struct sol_flow_node *node, void *data, uint16_t port, uint16
         uint16_t len, i;
         struct sol_flow_packet **packets;
 
-        sol_flow_packet_get_composed_members_len(packet_type, &len);
-        packets = malloc(len * sizeof(struct sol_flow_packet *));
-        SOL_NULL_CHECK(packets, -ENOMEM);
-        sol_flow_packet_get(packet, packets);
+        r = sol_flow_packet_get_composed_members(packet, &packets, &len);
+        SOL_INT_CHECK(r, < 0, r);
+
         console_output(mdata, mdata->prefix, NULL, 0, "Composed packet {");
         for (i = 0; i < len; i++) {
             char sep = ',';
@@ -207,7 +206,6 @@ console_in_process(struct sol_flow_node *node, void *data, uint16_t port, uint16
             SOL_INT_CHECK(r, < 0, r);
         }
         console_output(mdata, NULL, mdata->suffix, '\n',  "} (%s)", packet_type->name);
-        free(packets);
     } else {
         r = print_packet_content(packet, node, mdata, mdata->prefix, mdata->suffix,  '\n');
         SOL_INT_CHECK(r, < 0, r);


### PR DESCRIPTION
API for sending or receiving a composed type was different than other
packet types. User needed to allocate memory manually to get composed
members data and do some checks that are not necessary for other
packets. This patch tries to make a bit easier to work with packet
types.

Receiving packets changed from:

r = sol_flow_packet_get_composed_members_len(
        sol_flow_packet_get_type(packet), &len);
SOL_INT_CHECK(r, < 0, r);
packets = malloc(len * sizeof(struct sol_flow_packet *));
SOL_NULL_CHECK(packets, -ENOMEM);
r = sol_flow_packet_get(packet, &packets);
SOL_INT_CHECK_GOTO(r, < 0, err_exit);
...
err_exit:
free(packets);
return r;

to:

r = sol_flow_packet_get_composed_members(packet, &children, &len);
SOL_INT_CHECK(r, < 0, r);

Sending packets changed from:

struct sol_flow_packet *composed = sol_flow_packet_new(type, children);
SOL_NULL_CHECK(composed, -ENOMEM);
return sol_flow_send_packet(node, 0, composed);

to:

return sol_flow_send_composed_packet(node, 0, type, children);

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>