### PR TITLE
parser: fix parsing of large integers on i686 systems.

### DIFF
--- a/src/lib/flow/sol-flow-node-options.c
+++ b/src/lib/flow/sol-flow-node-options.c
@@ -51,7 +51,7 @@ get_member_memory(const struct sol_flow_node_options_member_description *member,
     return (uint8_t *)opts + member->offset;
 }
 
-#define STRTOL_DECIMAL(_ptr, _endptr) strtol(_ptr, _endptr, 0)
+#define STRTOL_DECIMAL(_ptr, _endptr) strtoll(_ptr, _endptr, 0)
 
 #define ASSIGN_LINEAR_VALUES(_parse_func, \
         _max_val, _max_str, _max_str_len,          \


### PR DESCRIPTION
Our integer packets are set in int32_t for size, but parsing them
involved an intermediary strtol(), which could overflow on our inputs on
32 bit systems. By moving the strtoll() we stay safe on both 64/32-bit
systems.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>