### PR TITLE
run-fbp-tests: use same path for fbps on runner and compiled tests

### DIFF
--- a/src/test-fbp/file-reader.fbp
+++ b/src/test-fbp/file-reader.fbp
@@ -28,8 +28,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-## TEST-SKIP-COMPILE Due to path resolution to test-blob-data.txt we're disabling this test until we get it right
-
 reader(file/reader)
 blob_validator(test/blob-validator:expected="test validator data")
 file(constant/string:value="test-blob-data.txt") OUT -> PATH reader

--- a/src/test-fbp/file-writer.fbp
+++ b/src/test-fbp/file-writer.fbp
@@ -28,8 +28,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-## TEST-SKIP-COMPILE Due to path resolution to file-writer-test.txt we're disabling this test until we get it right
-
 file_writer(file/writer)
 
 path(constant/string:value="file-writer-test.txt") OUT -> PATH file_writer

--- a/tools/run-fbp-tests
+++ b/tools/run-fbp-tests
@@ -248,7 +248,7 @@ def run_tests(args):
         else:
             exe = os.path.join(args.compiled_dir, path["file"].replace(".fbp", ""))
             cmd = cmd_prefix + [exe]
-            test_cwd = "./"
+            test_cwd = path["dir"]
 
         result = ""
         if curr.precondition:


### PR DESCRIPTION
Otherwise tests trying to read files will work on runner but
fail in compiled form.

Required to make test on pr #917 work without skipping

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>