### PR TITLE
Change string/concatenate to support mulitple inputs

### DIFF
--- a/src/modules/flow/string/string-ascii.c
+++ b/src/modules/flow/string/string-ascii.c
@@ -51,8 +51,11 @@ struct string_data {
 };
 
 struct string_concatenate_data {
-    struct string_data base;
+    uint32_t n;
+    char *string[32];
     char *separator;
+    uint32_t var_initialized;
+    uint32_t var_connected;
 };
 
 struct string_compare_data {
@@ -73,15 +76,17 @@ static void
 string_concatenate_close(struct sol_flow_node *node, void *data)
 {
     struct string_concatenate_data *mdata = data;
+    uint8_t i;
 
-    string_close(node, data);
+    for (i = 0; i < 32; i++)
+        free(mdata->string[i]);
     free(mdata->separator);
 }
 
-static bool
+static int
 get_string_by_port(const struct sol_flow_packet *packet,
     uint16_t port,
-    struct string_data *mdata)
+    char **string)
 {
     const char *in_value;
     int r;
@@ -89,17 +94,14 @@ get_string_by_port(const struct sol_flow_packet *packet,
     r = sol_flow_packet_get_string(packet, &in_value);
     SOL_INT_CHECK(r, < 0, r);
 
-    if (mdata->string[port] && !strcmp(mdata->string[port], in_value))
-        return false;
+    if (string[port] && !strcmp(string[port], in_value))
+        return 0;
 
-    free(mdata->string[port]);
+    free(string[port]);
 
-    mdata->string[port] = strdup(in_value);
-    if (!mdata->string[port])
-        return false;
-
-    if (!mdata->string[0] || !mdata->string[1])
-        return false;
+    string[port] = strdup(in_value);
+    if (!string[port])
+        return -ENOMEM;
 
     return true;
 }
@@ -122,9 +124,9 @@ string_concatenate_open(struct sol_flow_node *node,
         SOL_WRN("Option 'chars' (%" PRId32 ") must be a positive "
             "amount of chars to be copied or zero if whole strings "
             "should be concatenated. Considering zero.", opts->chars.val);
-        mdata->base.n = 0;
+        mdata->n = 0;
     } else
-        mdata->base.n = opts->chars.val;
+        mdata->n = opts->chars.val;
 
     if (opts->separator) {
         mdata->separator = strdup(opts->separator);
@@ -138,6 +140,39 @@ string_concatenate_open(struct sol_flow_node *node,
 }
 
 static int
+string_concat_connect(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id)
+{
+    struct string_concatenate_data *mdata = data;
+
+    mdata->var_connected |= 1u << port;
+    return 0;
+}
+
+static size_t
+string_list_len(char **string, int32_t var_initialized, size_t sep_len, size_t len_limit)
+{
+    size_t len;
+    uint8_t i;
+    int r;
+
+    for (i = 0; i < 32; i++) {
+        if (!(var_initialized & (1u << i)))
+            continue;
+
+        r = sol_util_size_add(len, sep_len, &len);
+        SOL_INT_CHECK(r, < 0, r);
+
+        r = sol_util_size_add(len, strlen(string[i]), &len);
+        SOL_INT_CHECK(r, < 0, r);
+    }
+
+    if (len_limit && len_limit < len)
+        return len_limit;
+
+    return len;
+}
+
+static int
 string_concat(struct sol_flow_node *node,
     void *data,
     uint16_t port,
@@ -146,27 +181,45 @@ string_concat(struct sol_flow_node *node,
 {
     struct string_concatenate_data *mdata = data;
     char *dest;
-    int r, len;
+    int r;
+    uint8_t i, count = 0;
+    size_t len = 0, sep_len = 0;
 
-    if (!get_string_by_port(packet, port, &mdata->base))
+    r = get_string_by_port(packet, port, mdata->string);
+    SOL_INT_CHECK(r, < 0, r);
+
+    mdata->var_initialized |= 1u << port;
+    if (mdata->var_initialized != mdata->var_connected)
         return 0;
 
-    len = strlen(mdata->base.string[0]) + strlen(mdata->base.string[1]) + 1;
+    //calculate final length
     if (mdata->separator)
-        len += strlen(mdata->separator);
+        sep_len = strlen(mdata->separator);
+    len = string_list_len(mdata->string, mdata->var_initialized, sep_len,
+        mdata->n);
 
-    dest = calloc(len, sizeof(*dest));
+    if (len > SIZE_MAX - 1)
+        return -EOVERFLOW;
+    dest = calloc(len + 1, sizeof(*dest));
     SOL_NULL_CHECK(dest, -ENOMEM);
 
-    dest = strcpy(dest, mdata->base.string[0]);
+    for (i = 0; i < 32; i++) {
+        if (!(mdata->var_initialized & (1u << i)))
+            continue;
 
-    if (mdata->separator)
-        dest = strcat(dest, mdata->separator);
+        if (count && mdata->separator) {
+            dest = strncat(dest, mdata->separator, len);
+            r = sol_util_size_sub(len, sep_len, &len);
+            if (r < 0)
+                break;
+        }
 
-    if (!mdata->base.n)
-        dest = strcat(dest, mdata->base.string[1]);
-    else
-        dest = strncat(dest, mdata->base.string[1], mdata->base.n);
+        dest = strncat(dest, mdata->string[i], len);
+        r = sol_util_size_sub(len, strlen(mdata->string[i]), &len);
+        if (r < 0)
+            break;
+        count++;
+    }
 
     r = sol_flow_send_string_take_packet(node,
         SOL_FLOW_NODE_TYPE_STRING_CONCATENATE__OUT__OUT,
@@ -213,8 +266,11 @@ string_compare(struct sol_flow_node *node,
     uint32_t result;
     int r;
 
-    if (!get_string_by_port(packet, port, &mdata->base))
-        return 0;
+    r = get_string_by_port(packet, port, mdata->base.string);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (!mdata->base.string[0] || !mdata->base.string[1])
+        return false;
 
     if (mdata->base.n) {
         if (mdata->ignore_case)

--- a/src/modules/flow/string/string-ascii.c
+++ b/src/modules/flow/string/string-ascii.c
@@ -118,13 +118,13 @@ string_concatenate_open(struct sol_flow_node *node,
 
     opts = (const struct sol_flow_node_type_string_concatenate_options *)options;
 
-    if (opts->bytes.val < 0) {
-        SOL_WRN("Option 'bytes' (%" PRId32 ") must be a positive "
-            "amount of bytes to be copied or zero if whole strings "
-            "should be concatenated. Considering zero.", opts->bytes.val);
+    if (opts->chars.val < 0) {
+        SOL_WRN("Option 'chars' (%" PRId32 ") must be a positive "
+            "amount of chars to be copied or zero if whole strings "
+            "should be concatenated. Considering zero.", opts->chars.val);
         mdata->base.n = 0;
     } else
-        mdata->base.n = opts->bytes.val;
+        mdata->base.n = opts->chars.val;
 
     if (opts->separator) {
         mdata->separator = strdup(opts->separator);
@@ -189,13 +189,13 @@ string_compare_open(struct sol_flow_node *node,
 
     opts = (const struct sol_flow_node_type_string_compare_options *)options;
 
-    if (opts->bytes.val < 0) {
-        SOL_WRN("Option 'bytes' (%" PRId32 ") must be a positive "
-            "amount of bytes to be compared or zero if whole strings "
-            "should be compared. Considering zero.", opts->bytes.val);
+    if (opts->chars.val < 0) {
+        SOL_WRN("Option 'chars' (%" PRId32 ") must be a positive "
+            "amount of chars to be compared or zero if whole strings "
+            "should be compared. Considering zero.", opts->chars.val);
         mdata->base.n = 0;
     } else
-        mdata->base.n = opts->bytes.val;
+        mdata->base.n = opts->chars.val;
 
     mdata->ignore_case = opts->ignore_case;
 

--- a/src/modules/flow/string/string-icu.c
+++ b/src/modules/flow/string/string-icu.c
@@ -192,13 +192,13 @@ string_concatenate_open(struct sol_flow_node *node,
 
     opts = (const struct sol_flow_node_type_string_concatenate_options *)options;
 
-    if (opts->bytes.val < 0) {
-        SOL_WRN("Option 'bytes' (%" PRId32 ") must be a positive "
-            "amount of bytes to be copied or zero if whole strings "
-            "should be concatenated. Considering zero.", opts->bytes.val);
+    if (opts->chars.val < 0) {
+        SOL_WRN("Option 'chars' (%" PRId32 ") must be a positive "
+            "amount of chars to be copied or zero if whole strings "
+            "should be concatenated. Considering zero.", opts->chars.val);
         mdata->base.n = 0;
     } else
-        mdata->base.n = opts->bytes.val;
+        mdata->base.n = opts->chars.val;
 
     if (opts->separator) {
         UErrorCode err;
@@ -273,13 +273,13 @@ string_compare_open(struct sol_flow_node *node,
 
     opts = (const struct sol_flow_node_type_string_compare_options *)options;
 
-    if (opts->bytes.val < 0) {
-        SOL_WRN("Option 'bytes' (%" PRId32 ") must be a positive "
-            "amount of bytes to be compared or zero if whole strings "
-            "should be compared. Considering zero.", opts->bytes.val);
+    if (opts->chars.val < 0) {
+        SOL_WRN("Option 'chars' (%" PRId32 ") must be a positive "
+            "amount of chars to be compared or zero if whole strings "
+            "should be compared. Considering zero.", opts->chars.val);
         mdata->base.n = 0;
     } else
-        mdata->base.n = opts->bytes.val;
+        mdata->base.n = opts->chars.val;
 
     mdata->ignore_case = opts->ignore_case;
 

--- a/src/modules/flow/string/string.json
+++ b/src/modules/flow/string/string.json
@@ -30,8 +30,8 @@
           {
             "data_type": "int",
             "default": 0,
-            "description": "Amount of bytes to be compared between strings. If zero, the whole strings will be compared.",
-            "name": "bytes"
+            "description": "Amount of chars to be compared between strings. If zero, the whole strings will be compared.",
+            "name": "chars"
           },
           {
             "data_type": "boolean",
@@ -79,8 +79,8 @@
           {
             "data_type": "int",
             "default": 0,
-            "description": "Amount of bytes to be copied from string received on IN[1]. If zero, the whole string will be concatenated to the string received on IN[0]",
-            "name": "bytes"
+            "description": "Amount of chars to be copied to destination string. If zero, no chars limit will be defined.",
+            "name": "chars"
           },
           {
             "data_type": "string",

--- a/src/modules/flow/string/string.json
+++ b/src/modules/flow/string/string.json
@@ -59,15 +59,16 @@
     },
     {
       "category": "string",
-      "description": "Concatenate two strings",
+      "description": "Concatenate strings",
       "in_ports": [
         {
           "data_type": "string",
-          "description": "Two strings to be concatenated. Indexed from 0 to 1.",
+          "description": "Strings to be concatenated. Indexed from 0 to 31.",
           "methods": {
+            "connect": "string_concat_connect",
             "process": "string_concat"
           },
-          "name": "IN[2]"
+          "name": "IN[32]"
         }
       ],
       "methods": {
@@ -85,7 +86,7 @@
           {
             "data_type": "string",
             "default": null,
-            "description": "Separator string to be used between the two concatenated strings. It's set to null by default (no separator).",
+            "description": "Separator string to be used between the concatenated strings. It's set to null by default (no separator).",
             "name": "separator"
           }
         ],
@@ -95,7 +96,7 @@
       "out_ports": [
         {
           "data_type": "string",
-          "description": "String IN[0] concatenated to string IN[1].",
+          "description": "Strings received on pors IN[0] to IN[31] concatenated.",
           "name": "OUT"
         }
       ],

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -335,6 +335,20 @@ sol_util_size_add(const size_t a, const size_t b, size_t *out)
 }
 
 static inline int
+sol_util_size_sub(const size_t a, const size_t b, size_t *out)
+{
+#ifdef HAVE_BUILTIN_SUB_OVERFLOW
+    if (__builtin_sub_overflow(a, b, out))
+        return -EOVERFLOW;
+#else
+    if (b > a)
+        return -EOVERFLOW;
+    *out = a - b;
+#endif
+    return 0;
+}
+
+static inline int
 sol_util_uint64_mul(const uint64_t a, const uint64_t b, uint64_t *out)
 {
 #ifdef HAVE_BUILTIN_MUL_OVERFLOW

--- a/src/test-fbp/string-compare.fbp
+++ b/src/test-fbp/string-compare.fbp
@@ -55,7 +55,7 @@ not_cmp_great OUT -> RESULT greater_and_full_are_not_equal(test/result)
 cmp_great OUT -> IN[0] cmp_greater_than_zero(int/greater)
 zero OUT -> IN[1] cmp_greater_than_zero OUT -> RESULT greater_and_full_gives_greater_than_zero(test/result)
 
-lesser_string OUT -> IN[0] cmp_bytes(string/compare:bytes=5)
+lesser_string OUT -> IN[0] cmp_bytes(string/compare:chars=5)
 full_string OUT -> IN[1] cmp_bytes EQUAL -> RESULT comparing_n_bytes_equal(test/result)
 cmp_bytes OUT -> IN[0] cmp_bytes_is_zero(int/equal)
 zero OUT -> IN[1] cmp_bytes_is_zero OUT -> RESULT comparing_n_bytes_gives_zero(test/result)

--- a/src/test-fbp/string-concat.fbp
+++ b/src/test-fbp/string-concat.fbp
@@ -30,13 +30,22 @@
 
 hello(constant/string:value="Hello")
 world(constant/string:value=" World")
+end(constant/string:value="!!!")
 
 hello OUT -> IN[0] concat(string/concatenate)
 world OUT -> IN[1] concat
 hello_world(constant/string:value="Hello World") OUT -> IN[0] concat_cmp(string/compare)
 concat OUT -> IN[1] concat_cmp EQUAL -> RESULT concat_entire_strings(test/result)
+concat OUT -> IN _(console)
 
-hello OUT -> IN[0] concat_n(string/concatenate:chars=2)
+hello OUT -> IN[0] concat_n(string/concatenate:chars=7)
 world OUT -> IN[1] concat_n
+end OUT -> IN[2] concat_n
 hello_w(constant/string:value="Hello W") OUT -> IN[0] concat_n_cmp(string/compare)
 concat_n OUT -> IN[1] concat_n_cmp EQUAL -> RESULT concat_some_bytes(test/result)
+
+hello OUT -> IN[0] concat_3(string/concatenate)
+world OUT -> IN[1] concat_3
+end OUT -> IN[2] concat_3
+hello_world_3(constant/string:value="Hello World!!!") OUT -> IN[0] concat3_cmp(string/compare)
+concat_3 OUT -> IN[1] concat3_cmp EQUAL -> RESULT concat3_entire_strings(test/result)

--- a/src/test-fbp/string-concat.fbp
+++ b/src/test-fbp/string-concat.fbp
@@ -36,7 +36,7 @@ world OUT -> IN[1] concat
 hello_world(constant/string:value="Hello World") OUT -> IN[0] concat_cmp(string/compare)
 concat OUT -> IN[1] concat_cmp EQUAL -> RESULT concat_entire_strings(test/result)
 
-hello OUT -> IN[0] concat_n(string/concatenate:bytes=2)
+hello OUT -> IN[0] concat_n(string/concatenate:chars=2)
 world OUT -> IN[1] concat_n
 hello_w(constant/string:value="Hello W") OUT -> IN[0] concat_n_cmp(string/compare)
 concat_n OUT -> IN[1] concat_n_cmp EQUAL -> RESULT concat_some_bytes(test/result)

--- a/src/test-fbp/string-icu-compare.fbp
+++ b/src/test-fbp/string-icu-compare.fbp
@@ -55,7 +55,7 @@ not_cmp_great OUT -> RESULT greater_and_full_are_not_equal(test/result)
 cmp_great OUT -> IN[0] cmp_greater_than_zero(int/greater)
 zero OUT -> IN[1] cmp_greater_than_zero OUT -> RESULT greater_and_full_gives_greater_than_zero(test/result)
 
-lesser_string OUT -> IN[0] cmp_bytes(string/compare:bytes=5)
+lesser_string OUT -> IN[0] cmp_bytes(string/compare:chars=5)
 full_string OUT -> IN[1] cmp_bytes EQUAL -> RESULT comparing_n_bytes_equal(test/result)
 cmp_bytes OUT -> IN[0] cmp_bytes_is_zero(int/equal)
 zero OUT -> IN[1] cmp_bytes_is_zero OUT -> RESULT comparing_n_bytes_gives_zero(test/result)

--- a/src/test-fbp/string-icu-concat.fbp
+++ b/src/test-fbp/string-icu-concat.fbp
@@ -36,7 +36,7 @@ world OUT -> IN[1] concat
 hello_world(constant/string:value="Ħěĺļō Ɯőŗŀď") OUT -> IN[0] concat_cmp(string/compare)
 concat OUT -> IN[1] concat_cmp EQUAL -> RESULT concat_entire_strings(test/result)
 
-hello OUT -> IN[0] concat_n(string/concatenate:bytes=2)
+hello OUT -> IN[0] concat_n(string/concatenate:chars=2)
 world OUT -> IN[1] concat_n
 hello_w(constant/string:value="Ħěĺļō Ɯ") OUT -> IN[0] concat_n_cmp(string/compare)
 concat_n OUT -> IN[1] concat_n_cmp EQUAL -> RESULT concat_some_bytes(test/result)

--- a/src/test-fbp/string-icu-concat.fbp
+++ b/src/test-fbp/string-icu-concat.fbp
@@ -30,13 +30,21 @@
 
 hello(constant/string:value="Ħěĺļō")
 world(constant/string:value=" Ɯőŗŀď")
+end(constant/string:value="♫♫♫")
 
 hello OUT -> IN[0] concat(string/concatenate)
 world OUT -> IN[1] concat
 hello_world(constant/string:value="Ħěĺļō Ɯőŗŀď") OUT -> IN[0] concat_cmp(string/compare)
 concat OUT -> IN[1] concat_cmp EQUAL -> RESULT concat_entire_strings(test/result)
 
-hello OUT -> IN[0] concat_n(string/concatenate:chars=2)
+hello OUT -> IN[0] concat_n(string/concatenate:chars=7)
 world OUT -> IN[1] concat_n
+end OUT -> IN[2] concat_n
 hello_w(constant/string:value="Ħěĺļō Ɯ") OUT -> IN[0] concat_n_cmp(string/compare)
 concat_n OUT -> IN[1] concat_n_cmp EQUAL -> RESULT concat_some_bytes(test/result)
+
+hello OUT -> IN[0] concat_3(string/concatenate)
+world OUT -> IN[1] concat_3
+end OUT -> IN[2] concat_3
+hello_world_3(constant/string:value="Ħěĺļō Ɯőŗŀď♫♫♫") OUT -> IN[0] concat_3_cmp(string/compare)
+concat_3 OUT -> IN[1] concat_3_cmp EQUAL -> RESULT concat_3_entire_strings(test/result)


### PR DESCRIPTION
String concatenate was only concatenating 2 strings. Now we are able to
concatenate up to 32 strings using a single node. The approach taken is
the same approach from int opeartions that have multiple inputs

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>