### PR TITLE
flow: only consider named descriptions

### DIFF
--- a/src/lib/flow/sol-flow-node-options.c
+++ b/src/lib/flow/sol-flow-node-options.c
@@ -869,7 +869,7 @@ sol_flow_node_named_options_init_from_strv(
             if (sol_str_slice_str_eq(SOL_STR_SLICE_STR(key, key_len), mdesc->name))
                 break;
         }
-        if (!mdesc) {
+        if (!mdesc || !mdesc->name) {
             r = -EINVAL;
             SOL_DBG("Unknown option: \"%s\"", *entry);
             goto end;


### PR DESCRIPTION
It was a condition to stop but when checking if it failed
to find descriptions it was checking only for a not null
mdesc pointer.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>