### PR TITLE
modules/converter: add string-to-json-[array|object]

### DIFF
--- a/src/modules/flow/converter/converter.json
+++ b/src/modules/flow/converter/converter.json
@@ -2204,6 +2204,60 @@
         }
       ],
       "url": "http://solettaproject.org/doc/latest/node_types/converter/json-array-to-blob.html"
+    },
+    {
+      "category": "converter",
+      "description": "Receives a string packet, validates it and converts it to a JSON object.",
+      "in_ports": [
+        {
+          "data_type": "string",
+          "description": "Where to receive the string value to be converted.",
+          "methods": {
+            "process": "string_to_json_object_convert"
+          },
+          "name": "IN"
+        }
+      ],
+      "methods": {
+        "open": "string_to_json_open"
+      },
+      "name": "converter/string-to-json-object",
+      "out_ports": [
+        {
+          "data_type": "json-object",
+          "description": "Packet with JSON object converted from string received on port IN.",
+          "name": "OUT"
+        }
+      ],
+      "private_data_type": "sol_converter_string_blob",
+      "url": "http://solettaproject.org/doc/latest/node_types/converter/string-to-json-object.html"
+    },
+    {
+      "category": "converter",
+      "description": "Receives a string packet, validates it and converts it to a JSON array.",
+      "in_ports": [
+        {
+          "data_type": "string",
+          "description": "Where to receive the string value to be converted.",
+          "methods": {
+            "process": "string_to_json_array_convert"
+          },
+          "name": "IN"
+        }
+      ],
+      "methods": {
+        "open": "string_to_json_open"
+      },
+      "name": "converter/string-to-json-array",
+      "out_ports": [
+        {
+          "data_type": "json-array",
+          "description": "Packet with JSON array converted from string received on port IN.",
+          "name": "OUT"
+        }
+      ],
+      "private_data_type": "sol_converter_string_blob",
+      "url": "http://solettaproject.org/doc/latest/node_types/converter/string-to-json-array.html"
     }
   ]
 }

--- a/src/test-fbp/json-array.fbp
+++ b/src/test-fbp/json-array.fbp
@@ -29,7 +29,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 json_array_str(constant/string:value="[0,1,2.1,\"str\",false,true,null,{\"inner\": 456},[1,2,3]]")
-json_array(converter/blob-to-json-array)
+json_array(converter/string-to-json-array)
 
 int_validator(test/int-validator:sequence="0 1")
 float_validator(test/float-validator:sequence="0 1 2.1")
@@ -50,7 +50,7 @@ get_index_object_val(json/array-get-at-index:index=7)
 get_index_array_val(json/array-get-at-index:index=8)
 
 # Test node json/array-get-at-index
-json_array_str OUT -> IN _(converter/string-to-blob) OUT -> IN json_array
+json_array_str OUT -> IN json_array
 json_array OUT -> IN get_index_int0_val
 json_array OUT -> IN get_index_int1_val
 json_array OUT -> IN get_index_float_val
@@ -87,8 +87,8 @@ array_length_validator OUT -> RESULT test_array_length(test/result)
 
 # Test node json/array-get-all-elements
 json_array_elements_str(constant/string:value="[0,1,{\"a\":123},2,3,null,[1,2,3],\"str1\",4,\"str2\",null,false,false,true,5.1,true,true,false,null]")
-json_array_elements(converter/blob-to-json-array)
-json_array_elements_str OUT -> IN _(converter/string-to-blob) OUT -> IN json_array_elements
+json_array_elements(converter/string-to-json-array)
+json_array_elements_str OUT -> IN json_array_elements
 json_array_elements OUT -> IN json_array_all_elements(json/array-get-all-elements)
 
 int_validator_all(test/int-validator:sequence="0 1 2 3 4")
@@ -109,7 +109,7 @@ json_array_all_elements OBJECT -> IN _(converter/json-object-to-blob) OUT -> IN 
 json_array_all_elements ARRAY -> IN _(converter/json-array-to-blob) OUT -> IN array_validator_all
 json_array_all_elements EMPTY -> IN empty_validator_all
 
-_(constant/string:value="[]") OUT -> IN _(converter/string-to-blob) OUT -> IN _(converter/blob-to-json-array) OUT -> IN _(json/array-get-all-elements) EMPTY -> IN empty_validator_all
+_(constant/string:value="[]") OUT -> IN _(converter/string-to-json-array) OUT -> IN _(json/array-get-all-elements) EMPTY -> IN empty_validator_all
 
 int_validator_all OUT -> RESULT int_result_all(test/result)
 float_validator_all OUT -> RESULT float_result_all(test/result)

--- a/src/test-fbp/json-escaping.fbp
+++ b/src/test-fbp/json-escaping.fbp
@@ -29,12 +29,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 json_object_str(constant/string:value="{\"escape\": \"escape: \\\\\\/\\\"\\b\\r\\n\\f\\t\", \"unicode\": \"\\u0055\\u006E\\u0069\\u0063\\u006f\\u0064\\u0065\\u0020\\u00c0\\u00CA\\u00CD\\u00f6\\u00FA\\u010e\\u01e7\\u0275\\u0722\\u0788\\u085E\\u0936\\u0f4c\\u2764\\u264e\\u2600\\u2691\\u20ac\\u266b\"}")
-json_object(converter/blob-to-json-object)
+json_object(converter/string-to-json-object)
 
 string_validator(test/string-validator:sequence="escape: \\/\"\b\r\n\f\t|Unicode ÀÊÍöúĎǧɵܢވ࡞शཌ❤♎☀⚑€♫")
 
 # Test node json/object-get-key
-json_object_str OUT -> IN _(converter/string-to-blob) OUT -> IN json_object
+json_object_str OUT -> IN json_object
 json_object OUT -> IN _(json/object-get-key:key="escape") STRING -> IN string_validator
 json_object OUT -> IN _(json/object-get-key:key="unicode") STRING -> IN string_validator
 string_validator OUT -> RESULT string_result(test/result)

--- a/src/test-fbp/json-object-get.fbp
+++ b/src/test-fbp/json-object-get.fbp
@@ -29,7 +29,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 json_object_str(constant/string:value="{\"int_val\": 123, \"float_val\": 1.23 \"string_val\" : \"hello\" \"false_val\": false, \"true_val\": true, \"null_val\": null, \"array_val\":[1,2,3], \"object_val\": {\"inner_int\": 456}}")
-json_object(converter/blob-to-json-object)
+json_object(converter/string-to-json-object)
 
 int_validator(test/int-validator:sequence="123")
 float_validator(test/float-validator:sequence="123 1.23")
@@ -49,7 +49,7 @@ get_key_object_val(json/object-get-key:key="object_val")
 get_key_array_val(json/object-get-key)
 
 # Test node json/object-get-key
-json_object_str OUT -> IN _(converter/string-to-blob) OUT -> IN json_object
+json_object_str OUT -> IN json_object
 json_object OUT -> IN get_key_int_val
 json_object OUT -> IN get_key_float_val
 json_object OUT -> IN get_key_string_val
@@ -84,13 +84,13 @@ object_length_validator OUT -> RESULT test_object_length(test/result)
 
 # Test node json/object-get-all-keys
 empty_str(constant/string:value="{}")
-empty_json_object(converter/blob-to-json-object)
+empty_json_object(converter/string-to-json-object)
 key_validator(test/string-validator:sequence="int_val|float_val|string_val|false_val|true_val|null_val|array_val|object_val")
 
 json_object OUT -> IN get_all_keys(json/object-get-all-keys)
 get_all_keys EMPTY -> IN _(boolean/not) OUT -> RESULT get_all_keys_empty_validator(test/result)
 get_all_keys OUT -> IN key_validator OUT -> RESULT get_all_keys_validator(test/result)
 
-empty_str OUT -> IN _(converter/string-to-blob) OUT -> IN empty_json_object
+empty_str OUT -> IN empty_json_object
 empty_json_object OUT -> IN get_all_keys2(json/object-get-all-keys)
 get_all_keys2 EMPTY -> RESULT get_all_keys_empty_validator2(test/result)


### PR DESCRIPTION
It seems to be useful since all our tests need to
convert from string to blob and then blob to json.

I've let some usages of string-to-blob -> blob-to-json-*
just to make sure this converters are tested as well.

@otaviobp could you please take a look on this PR?

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>