### PR TITLE
Add nodes to extract data from JSON using JSON path - v3

### DIFF
--- a/src/modules/flow/converter/converter.c
+++ b/src/modules/flow/converter/converter.c
@@ -2127,13 +2127,27 @@ timestamp_error:
     return 0;
 }
 
-static bool
+static struct sol_blob *
 json_validate(struct sol_blob *blob, enum sol_json_type type)
 {
     struct sol_json_scanner scanner;
+    char *p;
+    size_t size;
+
+    p = (char *)blob->mem + blob->size - 1;
+    while (isspace(*p) && p >= (char *)blob->mem)
+        p--;
+    size = p - (char *)blob->mem + 1;
+    if (size == 0)
+        return NULL;
+
+    if (size < blob->size)
+        blob = sol_blob_new(SOL_BLOB_TYPE_NOFREE, blob, blob->mem, size);
 
     sol_json_scanner_init(&scanner, blob->mem, blob->size);
-    return sol_json_is_valid_type(&scanner, type);
+    if (sol_json_is_valid_type(&scanner, type))
+        return blob;
+    return NULL;
 }
 
 static int
@@ -2145,7 +2159,8 @@ blob_to_json_object_process(struct sol_flow_node *node, void *data, uint16_t por
     ret = sol_flow_packet_get_blob(packet, &blob);
     SOL_INT_CHECK(ret, < 0, -EINVAL);
 
-    if (!json_validate(blob, SOL_JSON_TYPE_OBJECT_START))
+    blob = json_validate(blob, SOL_JSON_TYPE_OBJECT_START);
+    if (!blob)
         return sol_flow_send_error_packet(node, EINVAL,
             "Blob isn't a valid JSON Object");
 
@@ -2177,7 +2192,8 @@ blob_to_json_array_process(struct sol_flow_node *node, void *data, uint16_t port
     ret = sol_flow_packet_get_blob(packet, &blob);
     SOL_INT_CHECK(ret, < 0, -EINVAL);
 
-    if (!json_validate(blob, SOL_JSON_TYPE_ARRAY_START))
+    blob = json_validate(blob, SOL_JSON_TYPE_ARRAY_START);
+    if (!blob)
         return sol_flow_send_error_packet(node, EINVAL,
             "Blob isn't a valid JSON Array");
 

--- a/src/modules/flow/json/json.c
+++ b/src/modules/flow/json/json.c
@@ -39,15 +39,22 @@
 #include <sol-buffer.h>
 #include <errno.h>
 
-struct sol_json_object_key {
-    struct sol_blob *json_object;
+struct sol_json_node_data {
+    struct sol_blob *json_element;
     char *key;
 };
 
+struct json_node_type {
+    struct sol_flow_node_type base;
+    int (*process)(struct sol_flow_node *node,
+        struct sol_json_node_data *mdata);
+    int (*get_packet_data)(const struct sol_flow_packet *packet, struct sol_blob **value);
+};
+
 static int
-json_object_get_key_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
+json_node_key_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
 {
-    struct sol_json_object_key *mdata = data;
+    struct sol_json_node_data *mdata = data;
     const struct sol_flow_node_type_json_object_get_key_options *opts;
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
@@ -63,12 +70,12 @@ json_object_get_key_open(struct sol_flow_node *node, void *data, const struct so
 }
 
 static void
-json_object_get_key_close(struct sol_flow_node *node, void *data)
+json_node_close(struct sol_flow_node *node, void *data)
 {
-    struct sol_json_object_key *mdata = data;
+    struct sol_json_node_data *mdata = data;
 
-    if (mdata->json_object)
-        sol_blob_unref(mdata->json_object);
+    if (mdata->json_element)
+        sol_blob_unref(mdata->json_element);
     free(mdata->key);
 }
 
@@ -76,6 +83,10 @@ static struct sol_blob *
 create_sub_json(struct sol_blob *parent, struct sol_json_scanner *scanner, struct sol_json_token *token, enum sol_json_type type)
 {
     const char *mem;
+
+    if (sol_json_mem_get_type(token->end - 1) == type)
+        return sol_blob_new(SOL_BLOB_TYPE_NOFREE, parent, token->start,
+            token->end - token->start);
 
     mem = token->start;
     if (!sol_json_scanner_skip_over(scanner, token))
@@ -89,16 +100,128 @@ create_sub_json(struct sol_blob *parent, struct sol_json_scanner *scanner, struc
     return sol_blob_new(SOL_BLOB_TYPE_NOFREE, parent, mem, token->end - mem);
 }
 
-static bool
-json_object_search_for_token(struct sol_json_scanner *scanner, const char *key, struct sol_json_token *value)
-{
-    struct sol_json_token token, token_key;
-    enum sol_json_loop_reason reason;
-    unsigned int len;
+struct json_path_scanner {
+    const char *path;
+    const char *end;
+    const char *current;
+};
 
-    len = strlen(key);
-    SOL_JSON_SCANNER_OBJECT_LOOP (scanner, &token, &token_key, value, reason)
-        if (sol_json_token_str_eq(&token_key, key, len))
+static void
+json_path_scanner_init(struct json_path_scanner *scanner, struct sol_str_slice path)
+{
+    scanner->path = path.data;
+    scanner->end = path.data + path.len;
+    scanner->current = path.data;
+}
+
+static bool
+json_path_parse_key_in_brackets(struct json_path_scanner *scanner, struct sol_str_slice *slice)
+{
+    const char *p;
+
+    p = scanner->current + 1;
+
+    //index is a string
+    if (*p == '\'') {
+        //Look for first unescaped '
+        for (p = p + 1; p < scanner->end; p++) {
+            p = memchr(p, '\'', scanner->end - p);
+            if (!p)
+                return false;
+            if (*(p - 1) != '\\') //is not escaped
+                break;
+        }
+        p++;
+        if (p >= scanner->end || *p != ']')
+            return false;
+    } else if (*p != ']') { //index is is not empty and is suppose to be a num
+        p++;
+        p = memchr(p, ']', scanner->end - p);
+        if (!p)
+            return false;
+
+    } else
+        return false;
+
+    p++;
+    *slice = SOL_STR_SLICE_STR(scanner->current, p - scanner->current);
+    scanner->current += slice->len;
+    return true;
+}
+
+static inline const char *
+get_lowest_not_null_pointer(const char *p, const char *p2)
+{
+    if (p && (!p2 || p < p2))
+        return p;
+
+    return p2;
+}
+
+static bool
+json_path_parse_key_after_dot(struct json_path_scanner *scanner, struct sol_str_slice *slice)
+{
+    const char *start, *first_dot, *first_bracket_start, *end;
+
+    start = scanner->current + 1;
+    first_dot = memchr(start, '.', scanner->end - start);
+    first_bracket_start = memchr(start, '[', scanner->end - start);
+
+    end = get_lowest_not_null_pointer(first_dot, first_bracket_start);
+    if (end == NULL)
+        end = scanner->end;
+
+    if (end == start)
+        return false;
+
+    *slice = SOL_STR_SLICE_STR(start, end - start);
+    scanner->current = start + slice->len;
+    return true;
+}
+
+static bool
+json_path_get_next_slice(struct json_path_scanner *scanner, struct sol_str_slice *slice, enum sol_json_loop_reason *end_reason)
+{
+    if (scanner->path == scanner->end) {
+        *end_reason = SOL_JSON_LOOP_REASON_INVALID;
+        return false;
+    }
+
+    //Root element
+    if (scanner->current == scanner->path) {
+        if (scanner->path[0] != '$') {
+            *end_reason = SOL_JSON_LOOP_REASON_INVALID;
+            return false;
+        }
+        scanner->current = scanner->path + 1;
+    }
+
+    if (scanner->current >= scanner->end) {
+        slice->data = scanner->end;
+        slice->len = 0;
+        return false;
+    }
+
+    if (*scanner->current == '[') {
+        if (json_path_parse_key_in_brackets(scanner, slice))
+            return true;
+    } else if (*scanner->current == '.') {
+        if (json_path_parse_key_after_dot(scanner, slice))
+            return true;
+    }
+
+    *end_reason = SOL_JSON_LOOP_REASON_INVALID;
+    return false;
+}
+
+static bool
+json_object_search_for_token(struct sol_json_scanner *scanner, const struct sol_str_slice key_slice, struct sol_json_token *value)
+{
+    struct sol_json_token token, key;
+    enum sol_json_loop_reason reason;
+
+    SOL_JSON_SCANNER_OBJECT_LOOP_NEST (scanner, &token, &key, value, reason)
+        if (sol_json_token_str_eq(&key, key_slice.data, key_slice.len))
             return true;
 
     return false;
@@ -109,8 +232,7 @@ send_token_packet(struct sol_flow_node *node, struct sol_json_scanner *scanner, 
 {
     enum sol_json_type type;
     struct sol_blob *new_blob;
-    struct sol_irange value_int = SOL_IRANGE_INIT();
-    struct sol_drange value_float = SOL_DRANGE_INIT();
+    double value_float;
     struct sol_str_slice slice;
     char *str;
     int r;
@@ -161,20 +283,17 @@ send_token_packet(struct sol_flow_node *node, struct sol_json_scanner *scanner, 
         return sol_flow_send_string_take_packet(node,
             SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__STRING, str);
     case SOL_JSON_TYPE_NUMBER:
-        r = sol_json_token_get_double(token, &value_float.val);
+        r = sol_json_token_get_double(token, &value_float);
         SOL_INT_CHECK(r, < 0, r);
-        r = sol_flow_send_drange_packet(node,
+        r = sol_flow_send_drange_value_packet(node,
             SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__FLOAT,
-            &value_float);
+            value_float);
         SOL_INT_CHECK(r, < 0, r);
 
-        r = sol_json_token_get_int32(token, &value_int.val);
-        if (r == -EINVAL) /* Not an integer number */
-            return 0;
-        SOL_INT_CHECK(r, < 0, r);
-        return sol_flow_send_irange_packet(node,
-            SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__INT,
-            &value_int);
+        if (value_float < INT32_MAX && value_float > INT32_MIN)
+            return sol_flow_send_irange_value_packet(node,
+                SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_KEY__OUT__INT,
+                value_float);
     default:
         break;
     }
@@ -186,34 +305,203 @@ error:
         SOL_STR_SLICE_PRINT(slice));
 }
 
-
 static int
-json_object_key_process(struct sol_flow_node *node, struct sol_json_object_key *mdata)
+json_object_key_process(struct sol_flow_node *node, struct sol_json_node_data *mdata)
 {
+    struct sol_json_token value, token;
     struct sol_json_scanner scanner;
-    struct sol_json_token value;
 
-    if (!mdata->key[0] || !mdata->json_object)
+    if (!mdata->key[0] || !mdata->json_element)
         return 0;
 
-    sol_json_scanner_init(&scanner, mdata->json_object->mem,
-        mdata->json_object->size);
+    sol_json_scanner_init(&scanner, mdata->json_element->mem,
+        mdata->json_element->size);
+    if (_sol_json_loop_helper_init(&scanner, &token,
+        SOL_JSON_TYPE_OBJECT_START) != SOL_JSON_LOOP_REASON_OK)
+        return false;
 
-    if (json_object_search_for_token(&scanner, mdata->key, &value))
-        return send_token_packet(node, &scanner, mdata->json_object, &value);
+    if (json_object_search_for_token(&scanner,
+        sol_str_slice_from_str(mdata->key), &value))
+        return send_token_packet(node, &scanner, mdata->json_element, &value);
 
     return sol_flow_send_error_packet(node, EINVAL,
         "JSON object doesn't contain key %s", mdata->key);
+}
+
+/*
+ * If index is between [' and '] we need to unescape the ' char and to remove
+ * the [' and '] separator.
+ */
+static int
+json_path_parse_object_key(const struct sol_str_slice slice, struct sol_buffer *buffer)
+{
+    const char *end, *p, *p2;
+    struct sol_str_slice key;
+    int r;
+
+    if (slice.data[0] != '[') {
+        sol_buffer_init_flags(buffer, (char *)slice.data, slice.len,
+            SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+        buffer->used = buffer->capacity;
+        return 0;
+    }
+
+    //remove [' and ']
+    key = SOL_STR_SLICE_STR(slice.data + 2, slice.len - 4);
+
+    //unescape '\'' if necessary
+    sol_buffer_init_flags(buffer, NULL, 0, SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+    end = key.data + key.len;
+    for (p = key.data; p < end; p = p2 + 1) {
+        p2 = memchr(p, '\'', end - p);
+        if (!p2)
+            break;
+
+        //Append string preceding '
+        r = sol_buffer_append_slice(buffer, SOL_STR_SLICE_STR(p, p2 - p - 1));
+        SOL_INT_CHECK(r, < 0, r);
+        r = sol_buffer_append_char(buffer, '\'');
+        SOL_INT_CHECK(r, < 0, r);
+    }
+
+    if (!buffer->data) {
+        sol_buffer_init_flags(buffer, (char *)key.data, key.len,
+            SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+        buffer->used = buffer->capacity;
+        return 0;
+    }
+
+    //Append the string leftover
+    r = sol_buffer_append_slice(buffer, SOL_STR_SLICE_STR(p, end - p));
+    SOL_INT_CHECK(r, < 0, r);
     return 0;
 }
 
-static int
-json_object_get_key_key_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+static bool
+json_array_get_at_index(struct sol_json_scanner *scanner, struct sol_json_token *token, int32_t i, enum sol_json_loop_reason *reason)
 {
-    struct sol_json_object_key *mdata = data;
+    int32_t cur_index = 0;
+
+    SOL_JSON_SCANNER_ARRAY_LOOP_ALL_NEST(scanner, token, *reason) {
+        if (i == cur_index)
+            return true;
+
+        if (!sol_json_scanner_skip_over(scanner, token))
+            return false;
+        cur_index++;
+    }
+
+    return false;
+}
+
+static inline bool
+json_path_is_array_key(struct sol_str_slice slice)
+{
+    return slice.data[0] == '[' &&  //is between brackets or
+           slice.data[1] != '\''; //index is not a string
+}
+
+#define JSON_PATH_FOREACH(scanner, key, end_reason) \
+    for (end_reason = SOL_JSON_LOOP_REASON_OK; \
+        json_path_get_next_slice(&scanner, &key_slice, &end_reason);)
+
+static int
+json_object_path_process(struct sol_flow_node *node, struct sol_json_node_data *mdata)
+{
+    enum sol_json_type type;
+    struct sol_str_slice key_slice = SOL_STR_SLICE_EMPTY;
+    struct sol_buffer current_key;
+    struct sol_json_token value, token;
+    struct sol_json_scanner json_scanner;
+    struct json_path_scanner path_scanner;
+    enum sol_json_loop_reason array_reason, reason;
+    char *endptr;
+    long int index_val;
+    bool found;
+    int r;
+
+    if (!mdata->key[0] || !mdata->json_element)
+        return 0;
+
+    sol_json_scanner_init(&json_scanner, mdata->json_element->mem,
+        mdata->json_element->size);
+    json_path_scanner_init(&path_scanner, sol_str_slice_from_str(mdata->key));
+
+    JSON_PATH_FOREACH(path_scanner, key_slice, reason) {
+        type = sol_json_mem_get_type(json_scanner.current);
+        if (_sol_json_loop_helper_init(&json_scanner, &token, type) !=
+            SOL_JSON_LOOP_REASON_OK)
+            goto error;
+
+        switch (type) {
+        case SOL_JSON_TYPE_OBJECT_START:
+            if (json_path_is_array_key(key_slice))
+                goto error;
+
+            r = json_path_parse_object_key(key_slice, &current_key);
+            SOL_INT_CHECK(r, < 0, r);
+
+            found = json_object_search_for_token(&json_scanner,
+                sol_buffer_get_slice(&current_key), &value);
+            sol_buffer_fini(&current_key);
+            if (!found)
+                goto error;
+            break;
+        case SOL_JSON_TYPE_ARRAY_START:
+            if (!json_path_is_array_key(key_slice))
+                goto error;
+
+            errno = 0;
+            index_val = strtol(key_slice.data + 1, &endptr, 10);
+            if (endptr != key_slice.data + key_slice.len - 1 ||
+                index_val < 0 || errno > 0)
+                goto error;
+
+            if (!json_array_get_at_index(&json_scanner, &value, index_val,
+                &array_reason))
+                goto error;
+            break;
+        default:
+            goto error;
+        }
+
+        json_scanner.current = value.start;
+    }
+    if (reason != SOL_JSON_LOOP_REASON_OK)
+        goto error;
+
+    //If path is root
+    if (json_scanner.current == mdata->json_element->mem) {
+        //TODO: use send_token_packet
+        type = sol_json_mem_get_type(json_scanner.current);
+        if (type == SOL_JSON_TYPE_OBJECT_START)
+            return sol_flow_send_json_object_packet(node,
+                SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_PATH__OUT__OBJECT,
+                mdata->json_element);
+        else
+            return sol_flow_send_json_array_packet(node,
+                SOL_FLOW_NODE_TYPE_JSON_OBJECT_GET_PATH__OUT__ARRAY,
+                mdata->json_element);
+    }
+
+    return send_token_packet(node, &json_scanner, mdata->json_element, &value);
+
+error:
+    return sol_flow_send_error_packet(node, EINVAL,
+        "JSON element doesn't contain path %s", mdata->key);
+}
+
+#undef JSON_PATH_FOREACH
+
+static int
+json_node_get_key_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct sol_json_node_data *mdata = data;
+    struct json_node_type *type;
     int r;
     const char *in_value;
 
+    type = (struct json_node_type *)sol_flow_node_get_type(node);
     r = sol_flow_packet_get_string(packet, &in_value);
     SOL_INT_CHECK(r, < 0, r);
 
@@ -221,25 +509,27 @@ json_object_get_key_key_process(struct sol_flow_node *node, void *data, uint16_t
     mdata->key = strdup(in_value);
     SOL_NULL_CHECK(mdata->key, -ENOMEM);
 
-    return json_object_key_process(node, mdata);
+    return type->process(node, mdata);
 }
 
 static int
-json_object_get_key_in_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+json_node_in_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
 {
-    struct sol_json_object_key *mdata = data;
+    struct json_node_type *type;
+    struct sol_json_node_data *mdata = data;
     int r;
     struct sol_blob *in_value;
 
-    r = sol_flow_packet_get_json_object(packet, &in_value);
+    type = (struct json_node_type *)sol_flow_node_get_type(node);
+    r = type->get_packet_data(packet, &in_value);
     SOL_INT_CHECK(r, < 0, r);
 
-    if (mdata->json_object)
-        sol_blob_unref(mdata->json_object);
-    mdata->json_object = sol_blob_ref(in_value);
-    SOL_NULL_CHECK(mdata->json_object, -errno);
+    if (mdata->json_element)
+        sol_blob_unref(mdata->json_element);
+    mdata->json_element = sol_blob_ref(in_value);
+    SOL_NULL_CHECK(mdata->json_element, -errno);
 
-    return json_object_key_process(node, mdata);
+    return type->process(node, mdata);
 }
 
 static int
@@ -303,24 +593,6 @@ struct sol_json_array_index {
     int32_t index;
 };
 
-
-static bool
-json_array_get_at_index(struct sol_json_scanner *scanner, struct sol_json_token *token, int32_t i, enum sol_json_loop_reason *reason)
-{
-    int32_t cur_index = 0;
-
-    SOL_JSON_SCANNER_ARRAY_LOOP_ALL(scanner, token, *reason) {
-        if (i == cur_index)
-            return true;
-
-        if (!sol_json_scanner_skip_over(scanner, token))
-            return -errno;
-        cur_index++;
-    }
-
-    return false;
-}
-
 static int
 json_array_get_index_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
 {
@@ -359,17 +631,20 @@ json_array_index_process(struct sol_flow_node *node, struct sol_json_array_index
 
     sol_json_scanner_init(&scanner, mdata->json_array->mem,
         mdata->json_array->size);
+    if (_sol_json_loop_helper_init(&scanner, &token,
+        SOL_JSON_TYPE_ARRAY_START) != SOL_JSON_LOOP_REASON_OK)
+        goto invalid_array;
 
     if (json_array_get_at_index(&scanner, &token, mdata->index, &reason))
         return send_token_packet(node, &scanner, mdata->json_array, &token);
 
-    if (reason == SOL_JSON_LOOP_REASON_INVALID)
+    if (reason != SOL_JSON_LOOP_REASON_INVALID)
         return sol_flow_send_error_packet(node, EINVAL,
-            "Invalid JSON array (%.*s)", (int)mdata->json_array->size,
-            (char *)mdata->json_array->mem);
-
+            "JSON array index out of bounds: %" PRId32, mdata->index);
+invalid_array:
     return sol_flow_send_error_packet(node, EINVAL,
-        "JSON array index out of bounds: %" PRId32, mdata->index);
+        "Invalid JSON array (%.*s)", (int)mdata->json_array->size,
+        (char *)mdata->json_array->mem);
 }
 
 static int

--- a/src/modules/flow/json/json.json
+++ b/src/modules/flow/json/json.json
@@ -15,7 +15,7 @@
           "data_type": "json-object",
           "description": "Port to receive the JSON object where key will be located.",
           "methods": {
-            "process": "json_object_get_key_in_process"
+            "process": "json_node_in_process"
           },
           "name": "IN",
           "required": true
@@ -24,16 +24,26 @@
           "data_type": "string",
           "description": "Receives a string packet to override the key set as option.",
           "methods": {
-            "process": "json_object_get_key_key_process"
+            "process": "json_node_get_key_process"
           },
           "name": "KEY"
         }
       ],
       "methods": {
-        "open": "json_object_get_key_open",
-        "close": "json_object_get_key_close"
+        "open": "json_node_key_open",
+        "close": "json_node_close"
       },
       "name": "json/object-get-key",
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct json_node_type",
+        "extra_methods": {
+          "process": "json_object_key_process",
+          "get_packet_data": "sol_flow_packet_get_json_object"
+        }
+      },
       "options": {
         "members": [
           {
@@ -82,8 +92,184 @@
           "name": "NULL"
         }
       ],
-      "private_data_type": "sol_json_object_key",
+      "private_data_type": "sol_json_node_data",
       "url": "http://solettaproject.org/doc/latest/node_types/json/json-object-get-key.html"
+    },
+    {
+      "category": "json",
+      "description": "Receives a JSON object and send, to the appropriated port, the value of the child element pointed by path. Path needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+      "in_ports": [
+        {
+          "data_type": "json-object",
+          "description": "Port to receive the JSON object where path will be located.",
+          "methods": {
+            "process": "json_node_in_process"
+          },
+          "name": "IN",
+          "required": true
+        },
+        {
+          "data_type": "string",
+          "description": "Receives a string packet to override the path set as option. Path needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+          "methods": {
+            "process": "json_node_get_key_process"
+          },
+          "name": "PATH"
+        }
+      ],
+      "methods": {
+        "open": "json_node_key_open",
+        "close": "json_node_close"
+      },
+      "name": "json/object-get-path",
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct json_node_type",
+        "extra_methods": {
+          "process": "json_object_path_process",
+          "get_packet_data": "sol_flow_packet_get_json_object"
+        }
+      },
+      "options": {
+        "members": [
+          {
+            "data_type": "string",
+            "default": "",
+            "description": "The path of the JSON object child to access. Path needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+            "name": "path"
+          }
+        ],
+        "version": 1
+      },
+      "out_ports": [
+        {
+          "data_type": "int",
+          "description": "The integer value of a given path, if a number",
+          "name": "INT"
+        },
+        {
+          "data_type": "string",
+          "description": "The string value of a given path, if a string",
+          "name": "STRING"
+        },
+        {
+          "data_type": "boolean",
+          "description": "The boolean value of a given path, if a boolean",
+          "name": "BOOLEAN"
+        },
+        {
+          "data_type": "float",
+          "description": "The float value of a given path, if a number",
+          "name": "FLOAT"
+        },
+        {
+          "data_type": "json-object",
+          "description": "The JSON object of a given path, if a JSON object",
+          "name": "OBJECT"
+        },
+        {
+          "data_type": "json-array",
+          "description": "The JSON array of a given path, if a JSON array",
+          "name": "ARRAY"
+        },
+        {
+          "data_type": "empty",
+          "description": "An empty packet if value pointed by given path is null.",
+          "name": "NULL"
+        }
+      ],
+      "private_data_type": "sol_json_node_data",
+      "url": "http://solettaproject.org/doc/latest/node_types/json/json-object-get-path.html"
+    },
+    {
+      "category": "json",
+      "description": "Receives a JSON array and send, to the appropriated port, the value of the child element pointed by path. Path needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+      "in_ports": [
+        {
+          "data_type": "json-array",
+          "description": "Port to receive the JSON array where path will be located.",
+          "methods": {
+            "process": "json_node_in_process"
+          },
+          "name": "IN",
+          "required": true
+        },
+        {
+          "data_type": "string",
+          "description": "Receives a string packet to override the path set as option. Path needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+          "methods": {
+            "process": "json_node_get_key_process"
+          },
+          "name": "PATH"
+        }
+      ],
+      "methods": {
+        "open": "json_node_key_open",
+        "close": "json_node_close"
+      },
+      "name": "json/array-get-path",
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct json_node_type",
+        "extra_methods": {
+          "process": "json_object_path_process",
+          "get_packet_data": "sol_flow_packet_get_json_array"
+        }
+      },
+      "options": {
+        "members": [
+          {
+            "data_type": "string",
+            "default": "",
+            "description": "The path of the JSON array child to access. Path needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+            "name": "path"
+          }
+        ],
+        "version": 1
+      },
+      "out_ports": [
+        {
+          "data_type": "int",
+          "description": "The integer value of a given path, if a number",
+          "name": "INT"
+        },
+        {
+          "data_type": "string",
+          "description": "The string value of a given path, if a string",
+          "name": "STRING"
+        },
+        {
+          "data_type": "boolean",
+          "description": "The boolean value of a given path, if a boolean",
+          "name": "BOOLEAN"
+        },
+        {
+          "data_type": "float",
+          "description": "The float value of a given path, if a number",
+          "name": "FLOAT"
+        },
+        {
+          "data_type": "json-object",
+          "description": "The JSON object of a given path, if a JSON object",
+          "name": "OBJECT"
+        },
+        {
+          "data_type": "json-array",
+          "description": "The JSON array of a given path, if a JSON array",
+          "name": "ARRAY"
+        },
+        {
+          "data_type": "empty",
+          "description": "An empty packet if value pointed by given path is null.",
+          "name": "NULL"
+        }
+      ],
+      "private_data_type": "sol_json_node_data",
+      "url": "http://solettaproject.org/doc/latest/node_types/json/json-array-get-path.html"
     },
     {
       "category": "json",

--- a/src/test-fbp/json-array.fbp
+++ b/src/test-fbp/json-array.fbp
@@ -31,7 +31,7 @@
 json_array_str(constant/string:value="[0,1,2.1,\"str\",false,true,null,{\"inner\": 456},[1,2,3]]")
 json_array(converter/blob-to-json-array)
 
-int_validator(test/int-validator:sequence="0 1")
+int_validator(test/int-validator:sequence="0 1 2")
 float_validator(test/float-validator:sequence="0 1 2.1")
 string_validator(test/string-validator:sequence="str")
 bool_validator(test/boolean-validator:sequence="FT")
@@ -65,6 +65,7 @@ get_index_int0_val INT -> IN int_validator
 get_index_int0_val FLOAT -> IN float_validator
 get_index_int1_val INT -> IN int_validator
 get_index_int1_val FLOAT -> IN float_validator
+get_index_float_val INT -> IN int_validator
 get_index_float_val FLOAT -> IN float_validator
 get_index_string_val STRING -> IN string_validator
 get_index_false_val BOOLEAN -> IN bool_validator

--- a/src/test-fbp/json-object-get.fbp
+++ b/src/test-fbp/json-object-get.fbp
@@ -31,7 +31,7 @@
 json_object_str(constant/string:value="{\"int_val\": 123, \"float_val\": 1.23 \"string_val\" : \"hello\" \"false_val\": false, \"true_val\": true, \"null_val\": null, \"array_val\":[1,2,3], \"object_val\": {\"inner_int\": 456}}")
 json_object(converter/blob-to-json-object)
 
-int_validator(test/int-validator:sequence="123")
+int_validator(test/int-validator:sequence="123 1")
 float_validator(test/float-validator:sequence="123 1.23")
 string_validator(test/string-validator:sequence="hello")
 bool_validator(test/boolean-validator:sequence="FT")
@@ -62,6 +62,7 @@ json_object OUT -> IN get_key_array_val
 
 get_key_int_val INT -> IN int_validator
 get_key_int_val FLOAT -> IN float_validator
+get_key_float_val INT -> IN int_validator
 get_key_float_val FLOAT -> IN float_validator
 get_key_string_val STRING -> IN string_validator
 get_key_false_val BOOLEAN -> IN bool_validator

--- a/src/test-fbp/json-object-get.fbp
+++ b/src/test-fbp/json-object-get.fbp
@@ -36,8 +36,9 @@ float_validator(test/float-validator:sequence="123 1.23")
 string_validator(test/string-validator:sequence="hello")
 bool_validator(test/boolean-validator:sequence="FT")
 null_validator(converter/empty-to-boolean:output_value=true)
-object_validator(test/int-validator:sequence="456")
+object_validator_int(test/int-validator:sequence="456")
 array_validator(test/blob-validator:expected="[1,2,3]")
+object_validator(test/blob-validator:expected="{\"inner_int\": 456}")
 
 get_key_int_val(json/object-get-key:key="int_val")
 get_key_float_val(json/object-get-key:key="float_val")
@@ -66,7 +67,8 @@ get_key_string_val STRING -> IN string_validator
 get_key_false_val BOOLEAN -> IN bool_validator
 get_key_true_val BOOLEAN -> IN bool_validator
 get_key_null_val NULL -> IN null_validator
-get_key_object_val OBJECT -> IN _(json/object-get-key:key="inner_int") INT -> IN object_validator
+get_key_object_val OBJECT -> IN _(json/object-get-key:key="inner_int") INT -> IN object_validator_int
+get_key_object_val OBJECT -> IN _(converter/json-object-to-blob) OUT -> IN object_validator
 get_key_array_val ARRAY -> IN _(converter/json-array-to-blob) OUT -> IN array_validator
 _(constant/string:value="array_val") OUT -> KEY get_key_array_val
 
@@ -75,8 +77,9 @@ float_validator OUT -> RESULT float_result(test/result)
 string_validator OUT -> RESULT string_result(test/result)
 bool_validator OUT -> RESULT bool_result(test/result)
 null_validator OUT -> RESULT null_result(test/result)
-object_validator OUT -> RESULT object_result(test/result)
+object_validator_int OUT -> RESULT object_int_result(test/result)
 array_validator OUT -> RESULT array_result(test/result)
+object_validator OUT -> RESULT object_result(test/result)
 
 # Test node json/object-length
 json_object OUT -> IN _(json/object-length) OUT -> IN object_length_validator(test/int-validator:sequence="8")

--- a/src/test-fbp/json-path.fbp
+++ b/src/test-fbp/json-path.fbp
@@ -1,0 +1,78 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+reader(file/reader:path="json-path.txt")
+json_array(converter/blob-to-json-array)
+json_object(json/array-get-at-index:index=0)
+
+int_validator(test/int-validator:sequence="0 1 2 3 4 5 6 7 8 9")
+int_validator2(test/int-validator:sequence="10 11 12 13 14 15")
+
+reader OUT -> IN json_array
+json_array OUT -> IN json_object
+
+json_array OUT -> IN _(json/array-get-path:path="$[0].data1.array[0]") INT -> IN int_validator
+json_array OUT -> IN _(json/array-get-path:path="$[0]['data1'].array[1]") INT -> IN int_validator
+json_array OUT -> IN _(json/array-get-path:path="$[0]['data1']['array'][2]") INT -> IN int_validator
+json_array OUT -> IN _(json/array-get-path:path="$[0].data1['array'][3]") INT -> IN int_validator
+json_object OBJECT -> IN _(json/object-get-path:path="$.data1['array'][4]") INT -> IN int_validator
+json_object OBJECT -> IN _(json/object-get-path:path="$['data1'].array[5]") INT -> IN int_validator
+json_object OBJECT -> IN _(json/object-get-path:path="$.data1.array[6]") INT -> IN int_validator
+json_object OBJECT -> IN _(json/object-get-path:path="$['data1']['array'][7]") INT -> IN int_validator
+
+json_array OUT -> IN _(json/array-get-path:path="$") ARRAY -> IN _(json/array-get-path:path="$[0].data1['array'][8]") INT -> IN int_validator
+json_object OBJECT -> IN _(json/object-get-path:path="$") OBJECT -> IN _(json/object-get-path:path="$['data1']['array'][9]") INT -> IN int_validator
+
+json_array OUT -> IN _(json/array-get-path:path="$[0].my data's info\\nwith\\tescapes[0]") INT -> IN int_validator2
+json_array OUT -> IN _(json/array-get-path:path="$[0]['my data\\'s info\\nwith\\tescapes'][1]") INT -> IN int_validator2
+json_array OUT -> IN _(json/array-get-path:path="$[0]['my.data']") INT -> IN int_validator2
+
+json_array OUT -> IN array_get_path(json/array-get-path) INT -> IN int_validator2
+_(constant/string:value="$[0]['']") OUT -> PATH array_get_path
+
+json_array OUT -> IN _(json/array-get-path:path="$[0]['data1'].array2[0].data[0].data[0]") INT -> IN int_validator2
+json_object OBJECT -> IN _(json/object-get-path:path="$['data1'].array2[0].data[0].data[1]") INT -> IN int_validator2
+
+int_validator OUT -> RESULT int_result(test/result)
+int_validator2 OUT -> RESULT int_result2(test/result)
+
+#Errors
+json_object OBJECT -> IN _(json/object-get-path:path="invalid_path") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS error1(test/result)
+json_array OUT -> IN _(json/array-get-path:path="invalid_path") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS error2(test/result)
+
+json_array OUT -> IN _(json/array-get-path:path="$[1]") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS array_out_of_bounds(test/result)
+json_array OUT -> IN _(json/array-get-path:path="$[-1]") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS array_out_of_bounds2(test/result)
+
+json_object OBJECT -> IN _(json/object-get-path:path="$.invalid") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS error3(test/result)
+json_object OBJECT -> IN _(json/object-get-path:path="$['invalid']") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS error4(test/result)
+json_object OBJECT -> IN _(json/object-get-path:path="$[''']") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS error5(test/result)
+json_object OBJECT -> IN _(json/object-get-path:path="$['invalid'quote']") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS error6(test/result)
+json_object OBJECT -> IN _(json/object-get-path:path="$[']") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS error7(test/result)
+json_object OBJECT -> IN _(json/object-get-path:path="$[invalid_index]") ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS error8(test/result)

--- a/src/test-fbp/json-path.txt
+++ b/src/test-fbp/json-path.txt
@@ -1,0 +1,10 @@
+[{
+    "data1": {
+        "array": [0,1,2,3,4,5,6,7,8,9],
+        "array2": [{"data": [{"data": [14, 15]}]}],
+        "": 8
+    },
+    "my data's info\nwith\tescapes": [10,11],
+    "my.data": 12,
+    "": 13
+}]


### PR DESCRIPTION
Chagelog from v2:
  skip removed from code generation 
  INT ports receives truncated float values
  path documented in json.json
  extra_methods used to reduce duplicated methods

Replaces #917