### PR TITLE
Add nodes to create JSON objects and JSON arrays - v3

### DIFF
--- a/data/schemas/node-type-genspec.schema
+++ b/data/schemas/node-type-genspec.schema
@@ -56,7 +56,7 @@
         },
         {
           "type": "string",
-          "pattern": "^composed:([a-zA-Z]*?)((,[a-zA-Z]+)+)$"
+          "pattern": "^composed:([\\-a-zA-Z]*?)((,[\\-a-zA-Z]+)+)$"
         }
       ]
     },

--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -303,7 +303,7 @@ def is_composed(typename):
     return typename.startswith("composed:")
 
 def get_composed_types_with_underscore(types):
-    return types[len("composed:"):].replace(",", "_")
+    return types[len("composed:"):].replace(",", "_").replace("-", "_")
 
 def port_name_and_size(orig_name):
     m = re.match(r"([A-Z0-9_]+)(?:\[([0-9]+)\])?", orig_name)
@@ -460,7 +460,7 @@ def generate_header_tail(outfile, data):
 
 def generate_composed_type_get_signature(outfile, composed_type, prefix):
     types = composed_type[len("composed:"):]
-    types_with_underscore = types.replace(",", "_")
+    types_with_underscore = types.replace(",", "_").replace("-", "_")
     sig = "%s_get_composed_%s_packet_type(void)" % (prefix, types_with_underscore)
     if sig in composed_types_signatures:
         return

--- a/src/lib/flow/sol-flow-composed.c
+++ b/src/lib/flow/sol-flow-composed.c
@@ -44,6 +44,7 @@
 #include "sol-types.h"
 #include "sol-flow-composed.h"
 #include "sol-log.h"
+#include "sol-str-table.h"
 
 #define DELIM ("|")
 #define INPUT_PORT_NAME ("IN")
@@ -172,33 +173,24 @@ get_packet_type(const struct sol_str_slice type)
 static const char *
 get_packet_type_as_string(const struct sol_str_slice type)
 {
-    if (sol_str_slice_str_eq(type, "int"))
-        return "SOL_FLOW_PACKET_TYPE_IRANGE";
-    if (sol_str_slice_str_eq(type, "float"))
-        return "SOL_FLOW_PACKET_TYPE_DRANGE";
-    if (sol_str_slice_str_eq(type, "string"))
-        return "SOL_FLOW_PACKET_TYPE_STRING";
-    if (sol_str_slice_str_eq(type, "boolean"))
-        return "SOL_FLOW_PACKET_TYPE_BOOLEAN";
-    if (sol_str_slice_str_eq(type, "byte"))
-        return "SOL_FLOW_PACKET_TYPE_BYTE";
-    if (sol_str_slice_str_eq(type, "blob"))
-        return "SOL_FLOW_PACKET_TYPE_BLOB";
-    if (sol_str_slice_str_eq(type, "rgb"))
-        return "SOL_FLOW_PACKET_TYPE_RGB";
-    if (sol_str_slice_str_eq(type, "location"))
-        return "SOL_FLOW_PACKET_TYPE_LOCATION";
-    if (sol_str_slice_str_eq(type, "timestamp"))
-        return "SOL_FLOW_PACKET_TYPE_TIMESTAMP";
-    if (sol_str_slice_str_eq(type, "direction-vector"))
-        return "SOL_FLOW_PACKET_TYPE_DIRECTION_VECTOR";
-    if (sol_str_slice_str_eq(type, "error"))
-        return "SOL_FLOW_PACKET_TYPE_ERROR";
-    if (sol_str_slice_str_eq(type, "json-object"))
-        return "SOL_FLOW_PACKET_TYPE_JSON_OBJECT";
-    if (sol_str_slice_str_eq(type, "json-array"))
-        return "SOL_FLOW_PACKET_TYPE_JSON_ARRAY";
-    return NULL;
+    static const struct sol_str_table_ptr map[] = {
+        SOL_STR_TABLE_PTR_ITEM("int", "SOL_FLOW_PACKET_TYPE_IRANGE"),
+        SOL_STR_TABLE_PTR_ITEM("float", "SOL_FLOW_PACKET_TYPE_DRANGE"),
+        SOL_STR_TABLE_PTR_ITEM("string", "SOL_FLOW_PACKET_TYPE_STRING"),
+        SOL_STR_TABLE_PTR_ITEM("boolean", "SOL_FLOW_PACKET_TYPE_BOOLEAN"),
+        SOL_STR_TABLE_PTR_ITEM("byte", "SOL_FLOW_PACKET_TYPE_BYTE"),
+        SOL_STR_TABLE_PTR_ITEM("blob", "SOL_FLOW_PACKET_TYPE_BLOB"),
+        SOL_STR_TABLE_PTR_ITEM("rgb", "SOL_FLOW_PACKET_TYPE_RGB"),
+        SOL_STR_TABLE_PTR_ITEM("location", "SOL_FLOW_PACKET_TYPE_LOCATION"),
+        SOL_STR_TABLE_PTR_ITEM("timestamp", "SOL_FLOW_PACKET_TYPE_TIMESTAMP"),
+        SOL_STR_TABLE_PTR_ITEM("direction-vector",
+            "SOL_FLOW_PACKET_TYPE_DIRECTION_VECTOR"),
+        SOL_STR_TABLE_PTR_ITEM("error", "SOL_FLOW_PACKET_TYPE_ERROR"),
+        SOL_STR_TABLE_PTR_ITEM("json-object", "SOL_FLOW_PACKET_TYPE_JSON_OBJECT"),
+        SOL_STR_TABLE_PTR_ITEM("json-array", "SOL_FLOW_PACKET_TYPE_JSON_ARRAY"),
+    };
+
+    return sol_str_table_ptr_lookup_fallback(map, type, NULL);
 }
 
 static int

--- a/src/lib/flow/sol-flow-packet.c
+++ b/src/lib/flow/sol-flow-packet.c
@@ -227,7 +227,7 @@ packet_empty_get_constant(const struct sol_flow_packet_type *packet_type, const 
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_EMPTY = {
     .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
-    .name = "Empty",
+    .name = "empty",
     .get = packet_empty_get,
     .get_constant = packet_empty_get_constant,
 };
@@ -265,7 +265,7 @@ packet_boolean_get_constant(const struct sol_flow_packet_type *packet_type, cons
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_BOOLEAN = {
     .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
-    .name = "Boolean",
+    .name = "boolean",
     .data_size = sizeof(bool),
     .get_constant = packet_boolean_get_constant,
 };
@@ -286,7 +286,7 @@ sol_flow_packet_get_boolean(const struct sol_flow_packet *packet, bool *boolean)
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_IRANGE = {
     .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
-    .name = "IRange",
+    .name = "int",
     .data_size = sizeof(struct sol_irange),
 };
 
@@ -353,7 +353,7 @@ string_packet_dispose(const struct sol_flow_packet_type *packet_type, void *mem)
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_STRING = {
     .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
-    .name = "String",
+    .name = "string",
     .data_size = sizeof(char *),
     .init = string_packet_init,
     .dispose = string_packet_dispose,
@@ -453,7 +453,7 @@ blob_packet_dispose(const struct sol_flow_packet_type *packet_type, void *mem)
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_BLOB = {
     .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
-    .name = "Blob",
+    .name = "blob",
     .data_size = sizeof(struct sol_blob *),
     .init = blob_packet_init,
     .dispose = blob_packet_dispose,
@@ -477,7 +477,7 @@ sol_flow_packet_get_blob(const struct sol_flow_packet *packet, struct sol_blob *
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_JSON_OBJECT  = {
     .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
-    .name = "JSON-Object",
+    .name = "json-object",
     .data_size = sizeof(struct sol_blob *),
     .init = blob_packet_init,
     .dispose = blob_packet_dispose,
@@ -501,7 +501,7 @@ sol_flow_packet_get_json_object(const struct sol_flow_packet *packet, struct sol
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_JSON_ARRAY  = {
     .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
-    .name = "JSON-array",
+    .name = "json-array",
     .data_size = sizeof(struct sol_blob *),
     .init = blob_packet_init,
     .dispose = blob_packet_dispose,
@@ -525,7 +525,7 @@ sol_flow_packet_get_json_array(const struct sol_flow_packet *packet, struct sol_
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_DRANGE = {
     .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
-    .name = "DRange",
+    .name = "float",
     .data_size = sizeof(struct sol_drange),
 };
 
@@ -571,7 +571,7 @@ sol_flow_packet_get_drange_value(const struct sol_flow_packet *packet, double *v
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_BYTE = {
     .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
-    .name = "Byte",
+    .name = "byte",
     .data_size = sizeof(unsigned char),
 };
 SOL_API const struct sol_flow_packet_type *SOL_FLOW_PACKET_TYPE_BYTE = &_SOL_FLOW_PACKET_TYPE_BYTE;
@@ -591,7 +591,7 @@ sol_flow_packet_get_byte(const struct sol_flow_packet *packet, unsigned char *by
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_RGB = {
     .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
-    .name = "RGB",
+    .name = "rgb",
     .data_size = sizeof(struct sol_rgb),
 };
 SOL_API const struct sol_flow_packet_type *SOL_FLOW_PACKET_TYPE_RGB = &_SOL_FLOW_PACKET_TYPE_RGB;
@@ -643,7 +643,7 @@ sol_flow_packet_get_rgb_components(const struct sol_flow_packet *packet, uint32_
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_DIRECTION_VECTOR = {
     .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
-    .name = "DIRECTION_VECTOR",
+    .name = "direction-vector",
     .data_size = sizeof(struct sol_direction_vector),
 };
 SOL_API const struct sol_flow_packet_type *SOL_FLOW_PACKET_TYPE_DIRECTION_VECTOR = &_SOL_FLOW_PACKET_TYPE_DIRECTION_VECTOR;
@@ -694,7 +694,7 @@ sol_flow_packet_get_direction_vector_components(const struct sol_flow_packet *pa
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_LOCATION = {
     .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
-    .name = "LOCATION",
+    .name = "location",
     .data_size = sizeof(struct sol_location),
 };
 SOL_API const struct sol_flow_packet_type *SOL_FLOW_PACKET_TYPE_LOCATION = &_SOL_FLOW_PACKET_TYPE_LOCATION;
@@ -714,7 +714,7 @@ sol_flow_packet_get_location(const struct sol_flow_packet *packet, struct sol_lo
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_TIMESTAMP = {
     .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
-    .name = "TIMESTAMP",
+    .name = "timestamp",
     .data_size = sizeof(struct timespec),
 };
 SOL_API const struct sol_flow_packet_type *SOL_FLOW_PACKET_TYPE_TIMESTAMP = &_SOL_FLOW_PACKET_TYPE_TIMESTAMP;
@@ -734,7 +734,7 @@ sol_flow_packet_get_timestamp(const struct sol_flow_packet *packet, struct times
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_ANY = {
     .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
-    .name = "Any",
+    .name = "any",
     .data_size = sizeof(void *)
 };
 SOL_API const struct sol_flow_packet_type *SOL_FLOW_PACKET_TYPE_ANY = &_SOL_FLOW_PACKET_TYPE_ANY;
@@ -766,7 +766,7 @@ error_packet_init(const struct sol_flow_packet_type *packet_type, void *mem, con
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_ERROR = {
     .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
-    .name = "Error",
+    .name = "error",
     .data_size = sizeof(struct error_data),
     .init = error_packet_init,
     .dispose = error_packet_dispose,

--- a/src/lib/flow/sol-flow-packet.c
+++ b/src/lib/flow/sol-flow-packet.c
@@ -851,6 +851,7 @@ sol_flow_packet_type_composed_new(const struct sol_flow_packet_type **types)
     uint16_t i, types_len, members_bytes;
     int r;
     struct sol_buffer buf;
+    const char *type_name;
 
     SOL_NULL_CHECK(types, NULL);
 
@@ -875,13 +876,15 @@ sol_flow_packet_type_composed_new(const struct sol_flow_packet_type **types)
 
     sol_buffer_init(&buf);
 
-    r = sol_buffer_append_slice(&buf, sol_str_slice_from_str("COMPOSED-TYPE:"));
+    r = sol_buffer_append_slice(&buf, sol_str_slice_from_str("composed:"));
     SOL_INT_CHECK_GOTO(r, < 0, err_buf);
     for (i = 0; i < types_len; i++) {
+        type_name = types[i]->name;
+        SOL_NULL_CHECK_GOTO(type_name, err_buf);
         if (i == types_len - 1)
-            r = sol_buffer_append_printf(&buf, "%s", types[i]->name);
+            r = sol_buffer_append_printf(&buf, "%s", type_name);
         else
-            r = sol_buffer_append_printf(&buf, "%s,", types[i]->name);
+            r = sol_buffer_append_printf(&buf, "%s,", type_name);
         SOL_INT_CHECK_GOTO(r, < 0, err_buf);
     }
 

--- a/src/lib/parsers/include/sol-json.h
+++ b/src/lib/parsers/include/sol-json.h
@@ -442,6 +442,14 @@ int sol_json_serialize_int64(struct sol_buffer *buffer, int64_t val) SOL_ATTR_NO
 int sol_json_serialize_uint64(struct sol_buffer *buffer, uint64_t val) SOL_ATTR_NONNULL(1);
 int sol_json_serialize_boolean(struct sol_buffer *buffer, bool val) SOL_ATTR_NONNULL(1);
 
+static inline int
+sol_json_serialize_null(struct sol_buffer *buffer)
+{
+    static const struct sol_str_slice null = SOL_STR_SLICE_LITERAL("null");
+
+    return sol_buffer_append_slice(buffer, null);
+}
+
 /**
  *  Get in a sol_buffer the string value of informed token. If token type is
  *  a JSON string, quotes are removed and string is unescaped. If not

--- a/src/modules/flow/json/json.c
+++ b/src/modules/flow/json/json.c
@@ -464,4 +464,370 @@ json_array_get_all_elements_process(struct sol_flow_node *node, void *data, uint
         SOL_FLOW_NODE_TYPE_JSON_ARRAY_GET_ALL_ELEMENTS__OUT__EMPTY, empty);
 }
 
+enum json_element_type {
+    JSON_TYPE_INT = 0,
+    JSON_TYPE_STRING,
+    JSON_TYPE_BOOLEAN,
+    JSON_TYPE_FLOAT,
+    JSON_TYPE_ARRAY,
+    JSON_TYPE_OBJECT,
+    JSON_TYPE_ARRAY_BLOB,
+    JSON_TYPE_OBJECT_BLOB,
+    JSON_TYPE_NULL,
+};
+
+struct json_node_create_type {
+    struct sol_flow_node_type base;
+    int (*send_json_packet) (struct sol_flow_node *src, uint16_t src_port, const struct sol_blob *value);
+};
+
+struct json_element {
+    enum json_element_type type;
+    union {
+        int32_t int_value;
+        char *str;
+        bool bool_value;
+        double float_value;
+        struct sol_vector children;
+        struct sol_blob *blob;
+    };
+};
+
+struct json_key_element {
+    char *key;
+    struct json_element element;
+};
+
+static void
+json_element_clear(struct json_element *element)
+{
+    struct json_element *var;
+    struct json_key_element *key_element;
+    uint16_t i;
+
+    switch (element->type) {
+    case JSON_TYPE_STRING:
+        free(element->str);
+        break;
+    case JSON_TYPE_OBJECT:
+        SOL_VECTOR_FOREACH_IDX (&element->children, key_element, i) {
+            free(key_element->key);
+            json_element_clear(&key_element->element);
+        }
+        sol_vector_clear(&element->children);
+        break;
+    case JSON_TYPE_ARRAY:
+        SOL_VECTOR_FOREACH_IDX (&element->children, var, i)
+            json_element_clear(var);
+        sol_vector_clear(&element->children);
+        break;
+    case JSON_TYPE_ARRAY_BLOB:
+    case JSON_TYPE_OBJECT_BLOB:
+        sol_blob_unref(element->blob);
+        break;
+    default:
+        break;
+    }
+}
+
+static int
+json_array_create_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
+{
+    struct json_element *mdata = data;
+
+    mdata->type = JSON_TYPE_ARRAY;
+    sol_vector_init(&mdata->children, sizeof(struct json_element));
+
+    return 0;
+}
+
+static int
+json_object_create_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
+{
+    struct json_element *mdata = data;
+
+    mdata->type = JSON_TYPE_OBJECT;
+    sol_vector_init(&mdata->children, sizeof(struct json_key_element));
+
+    return 0;
+}
+
+static void
+json_create_close(struct sol_flow_node *node, void *data)
+{
+    struct json_element *mdata = data;
+
+    json_element_clear(mdata);
+}
+
+static int
+json_array_create_count(struct sol_flow_node *node, struct json_element *mdata)
+{
+    struct sol_irange count = SOL_IRANGE_INIT();
+
+    count.val = mdata->children.len;
+    return sol_flow_send_irange_packet(node,
+        SOL_FLOW_NODE_TYPE_JSON_CREATE_ARRAY__OUT__COUNT,
+        &count);
+}
+
+static int
+json_node_fill_element(const struct sol_flow_packet *packet, uint16_t port, struct json_element *element)
+{
+    int r;
+    double dval;
+    int32_t ival;
+    struct sol_blob *blob;
+    const char *str;
+
+    switch (port) {
+    case SOL_FLOW_NODE_TYPE_JSON_CREATE_OBJECT__IN__INT:
+        element->type = JSON_TYPE_INT;
+        r = sol_flow_packet_get_irange_value(packet, &ival);
+        SOL_INT_CHECK(r, < 0, r);
+        element->int_value = ival;
+        break;
+    case SOL_FLOW_NODE_TYPE_JSON_CREATE_OBJECT__IN__FLOAT:
+        element->type = JSON_TYPE_FLOAT;
+        r = sol_flow_packet_get_drange_value(packet, &dval);
+        SOL_INT_CHECK(r, < 0, r);
+        element->float_value = dval;
+        break;
+    case SOL_FLOW_NODE_TYPE_JSON_CREATE_OBJECT__IN__BOOLEAN:
+        element->type = JSON_TYPE_BOOLEAN;
+        r = sol_flow_packet_get_boolean(packet, &element->bool_value);
+        SOL_INT_CHECK(r, < 0, r);
+        break;
+    case SOL_FLOW_NODE_TYPE_JSON_CREATE_OBJECT__IN__STRING:
+        element->type = JSON_TYPE_STRING;
+        r = sol_flow_packet_get_string(packet, &str);
+        SOL_INT_CHECK(r, < 0, r);
+        element->str = strdup(str);
+        SOL_NULL_CHECK(element->str, -ENOMEM);
+        break;
+    case SOL_FLOW_NODE_TYPE_JSON_CREATE_OBJECT__IN__ARRAY:
+        element->type = JSON_TYPE_ARRAY_BLOB;
+        r = sol_flow_packet_get_json_array(packet, &blob);
+        SOL_INT_CHECK(r, < 0, r);
+        element->blob = sol_blob_ref(blob);
+        SOL_NULL_CHECK(element->blob, -ENOMEM);
+        break;
+    case SOL_FLOW_NODE_TYPE_JSON_CREATE_OBJECT__IN__OBJECT:
+        element->type = JSON_TYPE_OBJECT_BLOB;
+        r = sol_flow_packet_get_json_object(packet, &blob);
+        SOL_INT_CHECK(r, < 0, r);
+        element->blob = sol_blob_ref(blob);
+        SOL_NULL_CHECK(element->blob, -ENOMEM);
+        break;
+    case SOL_FLOW_NODE_TYPE_JSON_CREATE_OBJECT__IN__NULL:
+        element->type = JSON_TYPE_NULL;
+        break;
+    default:
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+static int
+json_array_in_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct json_element *new, *mdata = data;
+    int r;
+
+    new = sol_vector_append(&mdata->children);
+    SOL_NULL_CHECK(new, -errno);
+
+    r = json_node_fill_element(packet, port, new);
+    SOL_INT_CHECK_GOTO(r, < 0, error);
+
+    return json_array_create_count(node, mdata);
+
+error:
+    sol_vector_del(&mdata->children, mdata->children.len - 1);
+    return r;
+}
+
+static int
+json_serialize_blob(struct sol_buffer *buffer, struct sol_blob *blob)
+{
+    int r;
+    char *p;
+
+    if (!blob->size)
+        return 0;
+
+    r = sol_buffer_append_slice(buffer, sol_str_slice_from_blob(blob));
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (buffer->used == 0)
+        return 0;
+
+    p = sol_buffer_at(buffer, buffer->used - 1);
+    if (p && *p == '\0')
+        buffer->used--;
+    return 0;
+}
+
+static int json_serialize(struct sol_buffer *buffer, struct json_element *element);
+
+static int
+json_serialize_key_element(struct sol_buffer *buffer, struct json_key_element *key_element)
+{
+    int r;
+
+    r = sol_json_serialize_string(buffer, key_element->key);
+    SOL_INT_CHECK(r, < 0, r);
+    r = sol_buffer_append_char(buffer, ':');
+    SOL_INT_CHECK(r, < 0, r);
+
+    return json_serialize(buffer, &key_element->element);
+}
+
+static int
+json_serialize(struct sol_buffer *buffer, struct json_element *element)
+{
+    struct json_element *var;
+    struct json_key_element *key_element;
+    uint16_t i;
+    int r;
+
+    switch (element->type) {
+    case JSON_TYPE_OBJECT:
+        r = sol_buffer_append_char(buffer, '{');
+        SOL_INT_CHECK(r, < 0, r);
+
+        SOL_VECTOR_FOREACH_IDX (&element->children, key_element, i) {
+            if (i > 0)
+                r = sol_buffer_append_char(buffer, ',');
+            r = json_serialize_key_element(buffer, key_element);
+            SOL_INT_CHECK(r, < 0, r);
+        }
+        return sol_buffer_append_char(buffer, '}');
+    case JSON_TYPE_ARRAY:
+        r = sol_buffer_append_char(buffer, '[');
+        SOL_INT_CHECK(r, < 0, r);
+
+        SOL_VECTOR_FOREACH_IDX (&element->children, var, i) {
+            if (i > 0)
+                r = sol_buffer_append_char(buffer, ',');
+            r = json_serialize(buffer, var);
+            SOL_INT_CHECK(r, < 0, r);
+        }
+        return sol_buffer_append_char(buffer, ']');
+    case JSON_TYPE_NULL:
+        return sol_json_serialize_null(buffer);
+    case JSON_TYPE_INT:
+        return sol_json_serialize_int32(buffer, element->int_value);
+    case JSON_TYPE_FLOAT:
+        return sol_json_serialize_double(buffer, element->float_value);
+    case JSON_TYPE_BOOLEAN:
+        return sol_json_serialize_int32(buffer, element->bool_value);
+    case JSON_TYPE_STRING:
+        return sol_json_serialize_string(buffer, element->str);
+    case JSON_TYPE_ARRAY_BLOB:
+    case JSON_TYPE_OBJECT_BLOB:
+        return json_serialize_blob(buffer, element->blob);
+    }
+
+    return -EINVAL;
+}
+
+static int
+json_object_in_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct json_key_element *new;
+    struct json_element *mdata = data;
+    const char *key;
+    uint16_t len;
+    struct sol_flow_packet **packets;
+    int r;
+
+    r = sol_flow_packet_get_composed_members(packet, &packets, &len);
+    SOL_INT_CHECK(r, < 0, r);
+    SOL_INT_CHECK(len, < 2, -EINVAL);
+
+    r = sol_flow_packet_get_string(packets[0], &key);
+    SOL_INT_CHECK(r, < 0, r);
+
+    new = sol_vector_append(&mdata->children);
+    SOL_NULL_CHECK(new, -errno);
+
+    r = json_node_fill_element(packets[1], port, &new->element);
+    SOL_INT_CHECK_GOTO(r, < 0, error);
+
+    new->key = strdup(key);
+    SOL_NULL_CHECK_GOTO(new->key, str_error);
+    return 0;
+
+str_error:
+    r = -ENOMEM;
+error:
+    sol_vector_del(&mdata->children, mdata->children.len - 1);
+    return r;
+}
+
+static int
+json_object_null_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct json_key_element *new;
+    struct json_element *mdata = data;
+    const char *key;
+    int r;
+
+    r = sol_flow_packet_get_string(packet, &key);
+    SOL_INT_CHECK(r, < 0, r);
+
+    new = sol_vector_append(&mdata->children);
+    SOL_NULL_CHECK(new, -errno);
+
+    new->element.type = JSON_TYPE_NULL;
+    new->key = strdup(key);
+    SOL_NULL_CHECK_GOTO(new->key, error);
+    return 0;
+
+error:
+    sol_vector_del(&mdata->children, mdata->children.len - 1);
+    return -ENOMEM;
+}
+
+static int
+json_node_create_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct json_node_create_type *type;
+    struct sol_buffer buffer = SOL_BUFFER_INIT_EMPTY;
+    struct sol_blob *blob;
+    char *str;
+    size_t size;
+    int r;
+    struct json_element *mdata = data;
+
+    r = json_serialize(&buffer, mdata);
+    if (r < 0) {
+        sol_buffer_fini(&buffer);
+        return r;
+    }
+
+    str = sol_buffer_steal(&buffer, &size);
+    SOL_NULL_CHECK(str, -ENOMEM);
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, str, size);
+    SOL_NULL_CHECK(blob, -errno);
+
+    type = (struct json_node_create_type *)sol_flow_node_get_type(node);
+    r = type->send_json_packet(node,
+        SOL_FLOW_NODE_TYPE_JSON_CREATE_OBJECT__OUT__OUT, blob);
+    sol_blob_unref(blob);
+    return r;
+}
+
+static int
+json_clear_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct json_element *mdata = data;
+
+    json_element_clear(mdata);
+
+    return 0;
+}
+
 #include "json-gen.c"

--- a/src/modules/flow/json/json.json
+++ b/src/modules/flow/json/json.json
@@ -298,6 +298,213 @@
         }
       ],
       "url": "http://solettaproject.org/doc/latest/node_types/json/json-array-get-all-elements.html"
+    },
+    {
+     "category": "json",
+      "description": "Create a JSON array using data from input ports. JSON array is only created and sent to OUT port when CREATE port is triggered.",
+      "in_ports": [
+        {
+          "data_type": "int",
+          "description": "A integer number to append as last element",
+          "methods": {
+            "process": "json_array_in_process"
+          },
+          "name": "INT"
+        },
+        {
+          "data_type": "string",
+          "description": "A string to append as last element",
+          "methods": {
+            "process": "json_array_in_process"
+          },
+          "name": "STRING"
+        },
+        {
+          "data_type": "boolean",
+          "description": "A boolean value to append as last element",
+          "methods": {
+            "process": "json_array_in_process"
+          },
+          "name": "BOOLEAN"
+        },
+        {
+          "data_type": "float",
+          "description": "A float number to append as last element",
+          "methods": {
+            "process": "json_array_in_process"
+          },
+          "name": "FLOAT"
+        },
+        {
+          "data_type": "json-object",
+          "description": "A JSON object to append as last element",
+          "methods": {
+            "process": "json_array_in_process"
+          },
+          "name": "OBJECT"
+        },
+        {
+          "data_type": "json-array",
+          "description": "A JSON array to append as last element",
+          "methods": {
+            "process": "json_array_in_process"
+          },
+          "name": "ARRAY"
+        },
+        {
+          "data_type": "any",
+          "description": "A null element will be appended each time a packet is received in this port",
+          "methods": {
+            "process": "json_array_in_process"
+          },
+          "name": "NULL"
+        },
+        {
+          "data_type": "any",
+          "description": "Clear the JSON array.",
+          "methods": {
+            "process": "json_clear_process"
+          },
+          "name": "CLEAR"
+        },
+        {
+          "data_type": "any",
+          "description": "Create a JSON array with data received in input ports and send it to OUT port.",
+          "methods": {
+            "process": "json_node_create_process"
+          },
+          "name": "CREATE"
+        }
+      ],
+      "methods": {
+        "open": "json_array_create_open",
+        "close": "json_create_close"
+      },
+      "name": "json/create-array",
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct json_node_create_type",
+        "extra_methods": {
+          "send_json_packet": "sol_flow_send_json_array_packet"
+        }
+      },
+      "out_ports": [
+        {
+          "data_type": "json-array",
+          "description": "A JSON array created and sent by CREATE trigger.",
+          "name": "OUT"
+        },
+        {
+          "data_type": "int",
+          "description": "Number of elements added to this array so far.",
+          "name": "COUNT"
+        }
+      ],
+      "private_data_type": "json_element",
+      "url": "http://solettaproject.org/doc/latest/node_types/json/json-create-array.html"
+    },
+    {
+      "category": "json",
+      "description": "Create a JSON object using data from input ports. JSON object is only created and sent to OUT port when CREATE port is triggered.",
+      "in_ports": [
+        {
+          "data_type": "composed:string,int",
+          "description": "A string with the key and the int number value",
+          "methods": {
+            "process": "json_object_in_process"
+          },
+          "name": "INT"
+        },
+        {
+          "data_type": "composed:string,string",
+          "description": "A string with the key and the string value",
+          "methods": {
+            "process": "json_object_in_process"
+          },
+          "name": "STRING"
+        },
+        {
+          "data_type": "composed:string,boolean",
+          "description": "A string with the key and the boolean value",
+          "methods": {
+            "process": "json_object_in_process"
+          },
+          "name": "BOOLEAN"
+        },
+        {
+          "data_type": "composed:string,float",
+          "description": "A string with the key and the float number value",
+          "methods": {
+            "process": "json_object_in_process"
+          },
+          "name": "FLOAT"
+        },
+        {
+          "data_type": "composed:string,json-object",
+          "description": "A string with the key and the JSON array value",
+          "methods": {
+            "process": "json_object_in_process"
+          },
+          "name": "OBJECT"
+        },
+        {
+          "data_type": "composed:string,json-array",
+          "description": "A string with the key and the JSON object value",
+          "methods": {
+            "process": "json_object_in_process"
+          },
+          "name": "ARRAY"
+        },
+        {
+          "data_type": "string",
+          "description": "A string with the key of null value",
+          "methods": {
+            "process": "json_object_null_process"
+          },
+          "name": "NULL"
+        },
+        {
+          "data_type": "any",
+          "description": "Clear the JSON object",
+          "methods": {
+            "process": "json_clear_process"
+          },
+          "name": "CLEAR"
+        },
+        {
+          "data_type": "any",
+          "description": "Create a JSON object with data received in input ports and send it to OUT port.",
+          "methods": {
+            "process": "json_node_create_process"
+          },
+          "name": "CREATE"
+        }
+      ],
+      "methods": {
+        "open": "json_object_create_open",
+        "close": "json_create_close"
+      },
+      "name": "json/create-object",
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct json_node_create_type",
+        "extra_methods": {
+          "send_json_packet": "sol_flow_send_json_object_packet"
+        }
+      },
+      "out_ports": [
+        {
+          "data_type": "json-object",
+          "description": "A JSON object created and sent by CREATE trigger.",
+          "name": "OUT"
+        }
+      ],
+      "private_data_type": "json_element",
+      "url": "http://solettaproject.org/doc/latest/node_types/json/json-create-object.html"
     }
   ]
 }

--- a/src/test-fbp/json-create.fbp
+++ b/src/test-fbp/json-create.fbp
@@ -1,0 +1,90 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+DECLARE=int_pair:composed-new:KEY(string)|VALUE(int)
+DECLARE=float_pair:composed-new:KEY(string)|VALUE(float)
+DECLARE=boolean_pair:composed-new:KEY(string)|VALUE(boolean)
+DECLARE=string_pair:composed-new:KEY(string)|VALUE(string)
+DECLARE=json_array_pair:composed-new:KEY(string)|VALUE(json-array)
+DECLARE=json_object_pair:composed-new:KEY(string)|VALUE(json-object)
+
+
+json_object_str(constant/string:value="{\"index\":3}")
+json_array_str(constant/string:value="[1,2,3]")
+json_object(converter/string-to-json-object)
+json_array(converter/string-to-json-array)
+json_object_str OUT -> IN json_object
+json_array_str OUT -> IN json_array
+
+validator_json_object(test/blob-validator:expected="{\"null_value\":null,\"int_value\":892,\"boolean_value\":1,\"float_value\":1.23,\"string_value\":\"str\",\"json_object_value\":{\"index\":3},\"json_array_value\":[1,2,3]}")
+validator_json_array(test/blob-validator:expected="[null,892,1,1.23,\"str\",{\"index\":3},[1,2,3]]")
+create_obj(json/create-object)
+create_array(json/create-array)
+
+null_const(constant/string:value="null_value") OUT -> NULL create_obj
+null_const OUT -> NULL create_array
+
+int_val(int_pair) OUT -> INT create_obj
+_(constant/string:value="int_value") OUT -> KEY int_val
+int_const(constant/int:value=892) OUT -> VALUE int_val
+int_const OUT -> INT create_array
+
+boolean_val(boolean_pair) OUT -> BOOLEAN create_obj
+_(constant/string:value="boolean_value") OUT -> KEY boolean_val
+boolean_const(constant/boolean:value=true) OUT -> VALUE boolean_val
+boolean_const OUT -> BOOLEAN create_array
+
+float_val(float_pair) OUT -> FLOAT create_obj
+_(constant/string:value="float_value") OUT -> KEY float_val
+float_const(constant/float:value=1.23) OUT -> VALUE float_val
+float_const OUT -> FLOAT create_array
+
+string_val(string_pair) OUT -> STRING create_obj
+_(constant/string:value="string_value") OUT -> KEY string_val
+str_const(constant/string:value="str") OUT -> VALUE string_val
+str_const OUT -> STRING create_array
+
+json_object_val(json_object_pair) OUT -> OBJECT create_obj
+_(constant/string:value="json_object_value") OUT -> KEY json_object_val
+json_object OUT -> VALUE json_object_val
+json_object OUT -> OBJECT create_array
+
+json_array_val(json_array_pair) OUT -> ARRAY create_obj
+_(constant/string:value="json_array_value") OUT -> KEY json_array_val
+json_array OUT -> VALUE json_array_val
+json_array OUT -> ARRAY create_array
+
+json_array_val OUT -> CREATE create_obj
+json_array_val OUT -> CREATE create_array
+
+create_obj OUT -> IN _(converter/json-object-to-blob) OUT -> IN validator_json_object
+create_array OUT -> IN _(converter/json-array-to-blob) OUT -> IN validator_json_array
+validator_json_object OUT -> RESULT json_object_test(test/result)
+validator_json_array OUT -> RESULT json_array_test(test/result)


### PR DESCRIPTION
Changelog from v2:
 - Add commit changing type names of packets and using it in the commit that fixes composed bug
 - s/FLUSH/CLEAR port name
 - Improve CREATE port documentation
 - Use single pulse instead of timer in test. Also using new converter/string-to-json-*
 - Check strdup returns
 - Reorganizing functions and using extra_methods to reduce the number of duplicated functions