### PR TITLE
schemas: allow usage of special values for int / float when just val

### DIFF
--- a/data/schemas/node-type-genspec.schema
+++ b/data/schemas/node-type-genspec.schema
@@ -39,11 +39,33 @@
     },
 
     "data_type": {
-      "enum": [ "boolean", "int", "byte", "string", "float", "rgb", "direction-vector", "error", "location", "timestamp", "blob", "json-object", "json-array"]
+      "enum": [
+        "blob",
+        "boolean",
+        "byte",
+        "direction-vector",
+        "error",
+        "float",
+        "int",
+        "json-object",
+        "json-array",
+        "location",
+        "rgb",
+        "string",
+        "timestamp"
+      ]
     },
 
     "option_data_type": {
-      "enum": [ "boolean", "int", "byte", "string", "float", "rgb", "direction-vector"]
+      "enum": [
+        "boolean",
+        "byte",
+        "direction-vector",
+        "float",
+        "int",
+        "rgb",
+        "string"
+      ]
     },
 
     "port_data_type": {
@@ -293,13 +315,13 @@
         {
           "oneOf": [
             { "$ref": "#/definitions/options_members_boolean" },
-            { "$ref": "#/definitions/options_members_int" },
-            { "$ref": "#/definitions/options_members_float" },
-            { "$ref": "#/definitions/options_members_string" },
             { "$ref": "#/definitions/options_members_byte" },
-            { "$ref": "#/definitions/options_members_rgb" },
+            { "$ref": "#/definitions/options_members_custom" },
             { "$ref": "#/definitions/options_members_direction_vector" },
-            { "$ref": "#/definitions/options_members_custom" }
+            { "$ref": "#/definitions/options_members_float" },
+            { "$ref": "#/definitions/options_members_int" },
+            { "$ref": "#/definitions/options_members_rgb" },
+            { "$ref": "#/definitions/options_members_string" }
           ]
         }
       ]

--- a/data/schemas/node-type-genspec.schema
+++ b/data/schemas/node-type-genspec.schema
@@ -201,7 +201,7 @@
         "data_type": { "enum": [ "int" ] },
         "default": {
           "oneOf": [
-            { "type": "integer" },
+            { "$ref": "#/definitions/int_or_limit" },
             {
               "type": "object",
               "properties": {
@@ -222,7 +222,7 @@
         "data_type": { "enum": [ "float" ] },
         "default": {
           "oneOf": [
-            { "type": "number" },
+            { "$ref": "#/definitions/float_or_limit" },
             {
               "type": "object",
               "properties": {


### PR DESCRIPTION
Allow to have something like:
"options": {
    "something_float": DBL_MAX
}

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>