### PR TITLE
modules/test: use "int" for time interval option

### DIFF
--- a/src/modules/flow/test/test.json
+++ b/src/modules/flow/test/test.json
@@ -287,7 +287,7 @@
             "name": "sequence"
           },
           {
-            "data_type": "float",
+            "data_type": "int",
             "default": 0,
             "description": "Interval between packets, in miliseconds.",
             "name": "interval"


### PR DESCRIPTION
Instead of "float", since it converts it to int later
to create timers anyway.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>