### PR TITLE
Fix warning when building message-digest sample

### DIFF
--- a/src/samples/crypto/message-digest.c
+++ b/src/samples/crypto/message-digest.c
@@ -98,7 +98,7 @@ print_time(const struct feed_ctx *ctx, size_t amount, const char *prefix)
         r_unit = "b";
     }
 
-    printf("%s chunk{#%zd, %zdb] %0.1f%s done in %0.3fseconds: %0.1f%s/s\n",
+    printf("%s chunk{#%" PRIu32 ", %zdb] %0.1f%s done in %0.3fseconds: %0.1f%s/s\n",
         prefix, ctx->idx, ctx->chunk_size, size, s_unit, seconds, rate, r_unit);
 }
 


### PR DESCRIPTION
Printf format for signed value was used with an unsigned variable

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>