### PR TITLE
flow: use options 'float' + 'drange_spec'

### DIFF
--- a/data/schemas/node-type-genspec.schema
+++ b/data/schemas/node-type-genspec.schema
@@ -62,6 +62,7 @@
         "byte",
         "direction-vector",
         "drange",
+        "float",
         "int",
         "rgb",
         "string"
@@ -238,6 +239,13 @@
       }
     },
 
+    "options_members_float": {
+      "properties": {
+        "data_type": { "enum": [ "float" ] },
+        "default": { "$ref": "#/definitions/float_or_limit" }
+      }
+    },
+
     "options_members_rgb": {
       "properties": {
         "data_type": { "enum": [ "rgb" ] },
@@ -319,6 +327,7 @@
             { "$ref": "#/definitions/options_members_custom" },
             { "$ref": "#/definitions/options_members_direction_vector" },
             { "$ref": "#/definitions/options_members_drange" },
+            { "$ref": "#/definitions/options_members_float" },
             { "$ref": "#/definitions/options_members_int" },
             { "$ref": "#/definitions/options_members_rgb" },
             { "$ref": "#/definitions/options_members_string" }

--- a/data/schemas/node-type-genspec.schema
+++ b/data/schemas/node-type-genspec.schema
@@ -61,7 +61,7 @@
         "boolean",
         "byte",
         "direction-vector",
-        "float",
+        "drange",
         "int",
         "rgb",
         "string"
@@ -217,9 +217,9 @@
       }
     },
 
-    "options_members_float": {
+    "options_members_drange": {
       "properties": {
-        "data_type": { "enum": [ "float" ] },
+        "data_type": { "enum": [ "drange" ] },
         "default": {
           "oneOf": [
             { "$ref": "#/definitions/float_or_limit" },
@@ -318,7 +318,7 @@
             { "$ref": "#/definitions/options_members_byte" },
             { "$ref": "#/definitions/options_members_custom" },
             { "$ref": "#/definitions/options_members_direction_vector" },
-            { "$ref": "#/definitions/options_members_float" },
+            { "$ref": "#/definitions/options_members_drange" },
             { "$ref": "#/definitions/options_members_int" },
             { "$ref": "#/definitions/options_members_rgb" },
             { "$ref": "#/definitions/options_members_string" }

--- a/data/schemas/node-type-genspec.schema
+++ b/data/schemas/node-type-genspec.schema
@@ -62,6 +62,7 @@
         "byte",
         "direction-vector",
         "drange",
+        "drange-spec",
         "float",
         "int",
         "rgb",
@@ -239,6 +240,25 @@
       }
     },
 
+    "options_members_drange_spec": {
+      "properties": {
+        "data_type": { "enum": [ "drange-spec" ] },
+        "default": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "min": { "$ref": "#/definitions/float_or_limit" },
+                "max": { "$ref": "#/definitions/float_or_limit" },
+                "step": { "$ref": "#/definitions/float_or_limit" }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
+
     "options_members_float": {
       "properties": {
         "data_type": { "enum": [ "float" ] },
@@ -327,6 +347,7 @@
             { "$ref": "#/definitions/options_members_custom" },
             { "$ref": "#/definitions/options_members_direction_vector" },
             { "$ref": "#/definitions/options_members_drange" },
+            { "$ref": "#/definitions/options_members_drange_spec" },
             { "$ref": "#/definitions/options_members_float" },
             { "$ref": "#/definitions/options_members_int" },
             { "$ref": "#/definitions/options_members_rgb" },

--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -253,7 +253,7 @@ data_type_to_c_map = {
     "boolean": "bool",
     "byte": "unsigned char",
     "int": "struct sol_irange",
-    "float": "struct sol_drange",
+    "drange": "struct sol_drange",
     "rgb": "struct sol_rgb",
     "direction-vector": "struct sol_direction_vector",
     "string": "const char *",
@@ -267,7 +267,7 @@ data_type_to_default_member_map = {
     "boolean": "b",
     "byte": "byte",
     "int": "i",
-    "float": "f",
+    "drange": "drange",
     "string": "s",
     "rgb": "rgb",
     "direction-vector": "direction_vector",
@@ -275,6 +275,9 @@ data_type_to_default_member_map = {
 composed_types_signatures = {}
 
 def data_type_to_default_member(typename):
+    if (typename in ["drange"]):
+        sys.stderr.write("Warning: using deprecated option type \"%s\"\n" %
+                         typename)
     return data_type_to_default_member_map.get(typename, "ptr")
 
 data_type_to_packet_type_map = {
@@ -347,7 +350,7 @@ def expand_value(value, data_type):
         value.setdefault("step", 1)
         value.setdefault("min", "INT32_MIN")
         value.setdefault("max", "INT32_MAX")
-    elif data_type == "float":
+    elif data_type == "drange":
         if isinstance(value, (float, int)):
             value = {"val": float(value)}
         value.setdefault("val", 0.0)
@@ -368,7 +371,7 @@ def value_to_c(value, data_type):
         return str_to_c_or_null(value)
     elif data_type == "boolean":
         return bool_to_c(value)
-    elif data_type in ("rgb", "direction-vector", "int", "float"):
+    elif data_type in ("rgb", "direction-vector", "int", "drange"):
         return json_to_c_struct(value)
     else:
         return "%s" % (value)
@@ -399,7 +402,7 @@ def uses_float(data):
                 return header
     elif "options" in data and "members" in data["options"]:
         for o in data["options"]["members"]:
-            if o["data_type"] == "float" or o["data_type"] == "direction-vector":
+            if o["data_type"] == "drange" or o["data_type"] == "direction-vector":
                 return "#include <float.h>\n"
     return ""
 

--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -253,6 +253,7 @@ data_type_to_c_map = {
     "boolean": "bool",
     "byte": "unsigned char",
     "drange": "struct sol_drange",
+    "drange-spec": "struct sol_drange_spec",
     "float": "double",
     "int": "struct sol_irange",
     "rgb": "struct sol_rgb",
@@ -268,6 +269,7 @@ data_type_to_default_member_map = {
     "boolean": "b",
     "byte": "byte",
     "drange": "drange",
+    "drange-spec": "drange_spec",
     "float": "f",
     "int": "i",
     "string": "s",
@@ -359,6 +361,10 @@ def expand_value(value, data_type):
         value.setdefault("step", "DBL_MIN")
         value.setdefault("min", "-DBL_MAX")
         value.setdefault("max", "DBL_MAX")
+    elif data_type == "drange-spec":
+        value.setdefault("step", "DBL_MIN")
+        value.setdefault("min", "-DBL_MAX")
+        value.setdefault("max", "DBL_MAX")
 
     return value
 
@@ -373,7 +379,7 @@ def value_to_c(value, data_type):
         return str_to_c_or_null(value)
     elif data_type == "boolean":
         return bool_to_c(value)
-    elif data_type in ("rgb", "direction-vector", "int", "drange"):
+    elif data_type in ("rgb", "direction-vector", "int", "drange", "drange-spec"):
         return json_to_c_struct(value)
     else:
         return "%s" % (value)
@@ -404,7 +410,7 @@ def uses_float(data):
                 return header
     elif "options" in data and "members" in data["options"]:
         for o in data["options"]["members"]:
-            if o["data_type"] in ["direction-vector", "drange", "float"]:
+            if o["data_type"] in ["direction-vector", "drange", "drange-spec", "float"]:
                 return "#include <float.h>\n"
     return ""
 

--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -252,8 +252,9 @@ def c_clean(string):
 data_type_to_c_map = {
     "boolean": "bool",
     "byte": "unsigned char",
-    "int": "struct sol_irange",
     "drange": "struct sol_drange",
+    "float": "double",
+    "int": "struct sol_irange",
     "rgb": "struct sol_rgb",
     "direction-vector": "struct sol_direction_vector",
     "string": "const char *",
@@ -266,8 +267,9 @@ def data_type_to_c(typename):
 data_type_to_default_member_map = {
     "boolean": "b",
     "byte": "byte",
-    "int": "i",
     "drange": "drange",
+    "float": "f",
+    "int": "i",
     "string": "s",
     "rgb": "rgb",
     "direction-vector": "direction_vector",
@@ -402,7 +404,7 @@ def uses_float(data):
                 return header
     elif "options" in data and "members" in data["options"]:
         for o in data["options"]["members"]:
-            if o["data_type"] == "drange" or o["data_type"] == "direction-vector":
+            if o["data_type"] in ["direction-vector", "drange", "float"]:
                 return "#include <float.h>\n"
     return ""
 

--- a/data/scripts/sol-flow-node-type-stub-gen.py
+++ b/data/scripts/sol-flow-node-type-stub-gen.py
@@ -555,8 +555,8 @@ def generate_stub(stub_file, inputs_list, prefix, is_module, namespace):
     base_names = []
     methods = []
     # blacklist our types that are often used
-    structs = ['sol_drange', 'sol_irange', 'sol_rgb', 'sol_direction_vector',
-               'sol_location']
+    structs = ['sol_drange', 'sol_drange_spec' 'sol_irange',
+               'sol_rgb', 'sol_direction_vector', 'sol_location']
     packets = []
 
     try:

--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -496,7 +496,7 @@ handle_option(const struct sol_fbp_meta *meta, struct option_description *o,
             irange_default_values, sizeof(irange_default_values) /
             sizeof(irange_default_values[0]),
             handle_irange_drange_suboption, has_default_option);
-    } else if (streq(o->data_type, "float")) {
+    } else if (streq(o->data_type, "drange")) {
         r = true;
         dispatch_handle_suboptions(meta, fbp_file, (const char *)buf.data,
             drange_default_values, sizeof(drange_default_values) /
@@ -1003,7 +1003,7 @@ get_type_data_by_name(const char *type)
 {
     if (streq(type, "int"))
         return "struct sol_irange";
-    if (streq(type, "float"))
+    if (streq(type, "drange"))
         return "struct sol_drange";
     if (streq(type, "string"))
         return "const char *";

--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -99,6 +99,9 @@ static const struct sol_type_default_value drange_default_values[] = {
     { "val", "0" }, { "min", "-DBL_MAX" }, { "max", "DBL_MAX" },
     { "step", "DBL_MIN" }
 };
+static const struct sol_type_default_value drange_spec_default_values[] = {
+    { "min", "-DBL_MAX" }, { "max", "DBL_MAX" }, { "step", "DBL_MIN" }
+};
 static const struct sol_type_default_value direction_vector_default_values[] = {
     { "x", "0" }, { "y", "0" }, { "z", "0" }, { "min", "-DBL_MAX" },
     { "max", "DBL_MAX" }
@@ -501,6 +504,12 @@ handle_option(const struct sol_fbp_meta *meta, struct option_description *o,
         dispatch_handle_suboptions(meta, fbp_file, (const char *)buf.data,
             drange_default_values, sizeof(drange_default_values) /
             sizeof(drange_default_values[0]),
+            handle_irange_drange_suboption, has_default_option);
+    } else if (streq(o->data_type, "drange-spec")) {
+        r = true;
+        dispatch_handle_suboptions(meta, fbp_file, (const char *)buf.data,
+            drange_spec_default_values, sizeof(drange_spec_default_values) /
+            sizeof(drange_spec_default_values[0]),
             handle_irange_drange_suboption, has_default_option);
     } else if (streq(o->data_type, "rgb")) {
         r = true;
@@ -1005,6 +1014,8 @@ get_type_data_by_name(const char *type)
         return "struct sol_irange";
     if (streq(type, "drange"))
         return "struct sol_drange";
+    if (streq(type, "drange-spec"))
+        return "struct sol_drange_spec";
     if (streq(type, "string"))
         return "const char *";
     if (streq(type, "rgb"))

--- a/src/bin/sol-fbp-generator/type-store.c
+++ b/src/bin/sol-fbp-generator/type-store.c
@@ -572,7 +572,7 @@ parse_default_value(struct option_description *o)
      * scanner state. */
     sol_json_scanner_init_from_token(&value_scanner, &o->default_value.token);
 
-    if (streq(o->data_type, "int") || streq(o->data_type, "float")) {
+    if (streq(o->data_type, "int") || streq(o->data_type, "drange")) {
         o->default_value_type = OPTION_VALUE_TYPE_RANGE;
         return parse_range_default_value(&value_scanner, o);
     }

--- a/src/bin/sol-fbp-generator/type-store.h
+++ b/src/bin/sol-fbp-generator/type-store.h
@@ -50,6 +50,7 @@ enum option_value_type {
 
     OPTION_VALUE_TYPE_STRING,
     OPTION_VALUE_TYPE_RANGE,
+    OPTION_VALUE_TYPE_SPEC_RANGE,
     OPTION_VALUE_TYPE_RGB,
     OPTION_VALUE_TYPE_DIRECTION_VECTOR
 };
@@ -58,6 +59,12 @@ enum option_value_type {
  * generator. */
 struct option_range_value {
     char *val;
+    char *min;
+    char *max;
+    char *step;
+};
+
+struct option_spec_range_value {
     char *min;
     char *max;
     char *step;
@@ -88,6 +95,7 @@ struct option_description {
     union {
         char *string;
         struct option_range_value range;
+        struct option_spec_range_value spec_range;
         struct option_rgb_value rgb;
         struct option_direction_vector_value direction_vector;
         struct sol_json_token token;

--- a/src/lib/common/include/sol-types.h
+++ b/src/lib/common/include/sol-types.h
@@ -191,6 +191,8 @@ int sol_drange_subtraction(const struct sol_drange *var0, const struct sol_drang
 bool sol_drange_val_equal(double var0, double var1);
 bool sol_drange_equal(const struct sol_drange *var0, const struct sol_drange *var1);
 
+int sol_drange_compose(const struct sol_drange_spec *spec, double value, struct sol_drange *result);
+
 /*** SOL_IRANGE ***/
 
 struct sol_irange {

--- a/src/lib/common/include/sol-types.h
+++ b/src/lib/common/include/sol-types.h
@@ -156,6 +156,12 @@ struct sol_drange {
     double step;
 };
 
+struct sol_drange_spec {
+    double min;
+    double max;
+    double step;
+};
+
 #define SOL_DRANGE_INIT() \
     { \
         .min = -DBL_MAX, \

--- a/src/lib/common/sol-types.c
+++ b/src/lib/common/sol-types.c
@@ -158,6 +158,20 @@ sol_drange_equal(const struct sol_drange *var0, const struct sol_drange *var1)
     return false;
 }
 
+SOL_API int
+sol_drange_compose(const struct sol_drange_spec *spec, double value, struct sol_drange *result)
+{
+    SOL_NULL_CHECK(spec, -EINVAL);
+    SOL_NULL_CHECK(result, -EINVAL);
+
+    result->min = spec->min;
+    result->max = spec->max;
+    result->step = spec->step;
+    result->val = value;
+
+    return 0;
+}
+
 
 /********** SOL_IRANGE **********/
 

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -296,7 +296,7 @@ struct sol_flow_node_options_member_description {
         bool b; /**< option member's default boolean value */
         unsigned char byte; /**< option member's default byte value */
         struct sol_irange i; /**< option member's default integer range value */
-        struct sol_drange f; /**< option member's default float range value */
+        struct sol_drange drange; /**< option member's default float range value */
         struct sol_direction_vector direction_vector; /**< option member's default direction vector value */
         struct sol_rgb rgb; /**< option member's default RGB value */
         const char *s; /**< option member's default string value */

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -213,10 +213,11 @@ enum sol_flow_node_options_member_type {
     SOL_FLOW_NODE_OPTIONS_MEMBER_UNKNOWN,
     SOL_FLOW_NODE_OPTIONS_MEMBER_BOOLEAN,
     SOL_FLOW_NODE_OPTIONS_MEMBER_BYTE,
-    SOL_FLOW_NODE_OPTIONS_MEMBER_IRANGE,
-    SOL_FLOW_NODE_OPTIONS_MEMBER_DRANGE,
-    SOL_FLOW_NODE_OPTIONS_MEMBER_RGB,
     SOL_FLOW_NODE_OPTIONS_MEMBER_DIRECTION_VECTOR,
+    SOL_FLOW_NODE_OPTIONS_MEMBER_DRANGE,
+    SOL_FLOW_NODE_OPTIONS_MEMBER_FLOAT,
+    SOL_FLOW_NODE_OPTIONS_MEMBER_IRANGE,
+    SOL_FLOW_NODE_OPTIONS_MEMBER_RGB,
     SOL_FLOW_NODE_OPTIONS_MEMBER_STRING,
 };
 
@@ -234,6 +235,7 @@ struct sol_flow_node_named_options_member {
         struct sol_rgb rgb;
         struct sol_direction_vector direction_vector;
         const char *string;
+        double f;
     };
 };
 
@@ -301,6 +303,7 @@ struct sol_flow_node_options_member_description {
         struct sol_rgb rgb; /**< option member's default RGB value */
         const char *s; /**< option member's default string value */
         const void *ptr; /**< option member's default "blob" value */
+        double f; /**< option member's default float value */
     } defvalue; /**< option member's default value, according to its #data_type */
     uint16_t offset; /**< option member's offset inside the final options blob for a node */
     uint16_t size; /**< option member's size inside the final options blob for a node */

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -215,6 +215,7 @@ enum sol_flow_node_options_member_type {
     SOL_FLOW_NODE_OPTIONS_MEMBER_BYTE,
     SOL_FLOW_NODE_OPTIONS_MEMBER_DIRECTION_VECTOR,
     SOL_FLOW_NODE_OPTIONS_MEMBER_DRANGE,
+    SOL_FLOW_NODE_OPTIONS_MEMBER_DRANGE_SPEC,
     SOL_FLOW_NODE_OPTIONS_MEMBER_FLOAT,
     SOL_FLOW_NODE_OPTIONS_MEMBER_IRANGE,
     SOL_FLOW_NODE_OPTIONS_MEMBER_RGB,
@@ -232,6 +233,7 @@ struct sol_flow_node_named_options_member {
         unsigned char byte;
         struct sol_irange irange;
         struct sol_drange drange;
+        struct sol_drange_spec drange_spec;
         struct sol_rgb rgb;
         struct sol_direction_vector direction_vector;
         const char *string;
@@ -298,7 +300,8 @@ struct sol_flow_node_options_member_description {
         bool b; /**< option member's default boolean value */
         unsigned char byte; /**< option member's default byte value */
         struct sol_irange i; /**< option member's default integer range value */
-        struct sol_drange drange; /**< option member's default float range value */
+        struct sol_drange drange; /**< option member's default float range value. Deprecated. Use drange_spec and / or f. */
+        struct sol_drange_spec drange_spec; /**< option member's default float range spec */
         struct sol_direction_vector direction_vector; /**< option member's default direction vector value */
         struct sol_rgb rgb; /**< option member's default RGB value */
         const char *s; /**< option member's default string value */

--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -1268,6 +1268,8 @@ get_member_alignment(const struct sol_flow_node_options_member_description *memb
         SOL_STR_TABLE_ITEM("direction-vector",
             __alignof__(member->defvalue.direction_vector)),
         SOL_STR_TABLE_ITEM("drange", __alignof__(member->defvalue.drange)),
+        SOL_STR_TABLE_ITEM("drange-spec",
+            __alignof__(member->defvalue.drange_spec)),
         SOL_STR_TABLE_ITEM("float", __alignof__(member->defvalue.f)),
         SOL_STR_TABLE_ITEM("int", __alignof__(member->defvalue.i)),
         SOL_STR_TABLE_ITEM("rgb", __alignof__(member->defvalue.rgb)),

--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -1262,14 +1262,16 @@ get_member_alignment(const struct sol_flow_node_options_member_description *memb
 {
     struct sol_str_slice t;
     static const struct sol_str_table alignments[] = {
+        SOL_STR_TABLE_ITEM("blob", __alignof__(member->defvalue.ptr)),
         SOL_STR_TABLE_ITEM("boolean", __alignof__(member->defvalue.b)),
         SOL_STR_TABLE_ITEM("byte", __alignof__(member->defvalue.byte)),
+        SOL_STR_TABLE_ITEM("direction-vector",
+            __alignof__(member->defvalue.direction_vector)),
         SOL_STR_TABLE_ITEM("drange", __alignof__(member->defvalue.drange)),
+        SOL_STR_TABLE_ITEM("float", __alignof__(member->defvalue.f)),
         SOL_STR_TABLE_ITEM("int", __alignof__(member->defvalue.i)),
         SOL_STR_TABLE_ITEM("rgb", __alignof__(member->defvalue.rgb)),
         SOL_STR_TABLE_ITEM("string", __alignof__(member->defvalue.s)),
-        SOL_STR_TABLE_ITEM("direction-vector", __alignof__(member->defvalue.direction_vector)),
-        SOL_STR_TABLE_ITEM("blob", __alignof__(member->defvalue.ptr)),
     };
 
     t = SOL_STR_SLICE_STR(member->data_type, strlen(member->data_type));

--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -1264,7 +1264,7 @@ get_member_alignment(const struct sol_flow_node_options_member_description *memb
     static const struct sol_str_table alignments[] = {
         SOL_STR_TABLE_ITEM("boolean", __alignof__(member->defvalue.b)),
         SOL_STR_TABLE_ITEM("byte", __alignof__(member->defvalue.byte)),
-        SOL_STR_TABLE_ITEM("float", __alignof__(member->defvalue.f)),
+        SOL_STR_TABLE_ITEM("drange", __alignof__(member->defvalue.drange)),
         SOL_STR_TABLE_ITEM("int", __alignof__(member->defvalue.i)),
         SOL_STR_TABLE_ITEM("rgb", __alignof__(member->defvalue.rgb)),
         SOL_STR_TABLE_ITEM("string", __alignof__(member->defvalue.s)),

--- a/src/lib/flow/sol-flow-node-options.c
+++ b/src/lib/flow/sol-flow-node-options.c
@@ -480,14 +480,42 @@ string_parse(const char *value, struct sol_flow_node_named_options_member *m)
     return 0;
 }
 
+static int
+float_parse(const char *value, struct sol_flow_node_named_options_member *m)
+{
+    char *endptr;
+    double v;
+
+    if (!strcmp(DBL_MAX_STR, value)) {
+        m->f = DBL_MAX;
+        return 0;
+    }
+
+    if (!strcmp(DBL_MIN_STR, value)) {
+        m->f = -DBL_MAX;
+        return 0;
+    }
+
+    errno = 0;
+    v = strtod_no_locale(value, &endptr);
+    if (value == endptr)
+        return -EINVAL;
+    if (errno != 0)
+        return -errno;
+
+    m->f = v;
+    return 0;
+}
+
 static int(*const options_parse_functions[]) (const char *, struct sol_flow_node_named_options_member *) = {
     [SOL_FLOW_NODE_OPTIONS_MEMBER_UNKNOWN] = NULL,
     [SOL_FLOW_NODE_OPTIONS_MEMBER_BOOLEAN] = boolean_parse,
     [SOL_FLOW_NODE_OPTIONS_MEMBER_BYTE] = byte_parse,
-    [SOL_FLOW_NODE_OPTIONS_MEMBER_IRANGE] = irange_parse,
-    [SOL_FLOW_NODE_OPTIONS_MEMBER_DRANGE] = drange_parse,
-    [SOL_FLOW_NODE_OPTIONS_MEMBER_RGB] = rgb_parse,
     [SOL_FLOW_NODE_OPTIONS_MEMBER_DIRECTION_VECTOR] = direction_vector_parse,
+    [SOL_FLOW_NODE_OPTIONS_MEMBER_DRANGE] = drange_parse,
+    [SOL_FLOW_NODE_OPTIONS_MEMBER_FLOAT] = float_parse,
+    [SOL_FLOW_NODE_OPTIONS_MEMBER_IRANGE] = irange_parse,
+    [SOL_FLOW_NODE_OPTIONS_MEMBER_RGB] = rgb_parse,
     [SOL_FLOW_NODE_OPTIONS_MEMBER_STRING] = string_parse,
 };
 
@@ -594,11 +622,14 @@ set_member(
     case SOL_FLOW_NODE_OPTIONS_MEMBER_BYTE:
         *(unsigned char *)mem = m->byte;
         break;
-    case SOL_FLOW_NODE_OPTIONS_MEMBER_IRANGE:
-        *(struct sol_irange *)mem = m->irange;
-        break;
     case SOL_FLOW_NODE_OPTIONS_MEMBER_DRANGE:
         *(struct sol_drange *)mem = m->drange;
+        break;
+    case SOL_FLOW_NODE_OPTIONS_MEMBER_FLOAT:
+        *(double *)mem = m->f;
+        break;
+    case SOL_FLOW_NODE_OPTIONS_MEMBER_IRANGE:
+        *(struct sol_irange *)mem = m->irange;
         break;
     case SOL_FLOW_NODE_OPTIONS_MEMBER_RGB:
         *(struct sol_rgb *)mem = m->rgb;
@@ -620,10 +651,11 @@ set_member(
 static const struct sol_str_table member_str_to_type[] = {
     SOL_STR_TABLE_ITEM("boolean", SOL_FLOW_NODE_OPTIONS_MEMBER_BOOLEAN),
     SOL_STR_TABLE_ITEM("byte", SOL_FLOW_NODE_OPTIONS_MEMBER_BYTE),
-    SOL_STR_TABLE_ITEM("int", SOL_FLOW_NODE_OPTIONS_MEMBER_IRANGE),
-    SOL_STR_TABLE_ITEM("drange", SOL_FLOW_NODE_OPTIONS_MEMBER_DRANGE),
-    SOL_STR_TABLE_ITEM("rgb", SOL_FLOW_NODE_OPTIONS_MEMBER_RGB),
     SOL_STR_TABLE_ITEM("direction-vector", SOL_FLOW_NODE_OPTIONS_MEMBER_DIRECTION_VECTOR),
+    SOL_STR_TABLE_ITEM("drange", SOL_FLOW_NODE_OPTIONS_MEMBER_DRANGE),
+    SOL_STR_TABLE_ITEM("float", SOL_FLOW_NODE_OPTIONS_MEMBER_FLOAT),
+    SOL_STR_TABLE_ITEM("int", SOL_FLOW_NODE_OPTIONS_MEMBER_IRANGE),
+    SOL_STR_TABLE_ITEM("rgb", SOL_FLOW_NODE_OPTIONS_MEMBER_RGB),
     SOL_STR_TABLE_ITEM("string", SOL_FLOW_NODE_OPTIONS_MEMBER_STRING),
     {}
 };

--- a/src/lib/flow/sol-flow-node-options.c
+++ b/src/lib/flow/sol-flow-node-options.c
@@ -45,6 +45,15 @@
 
 static const char SUBOPTION_SEPARATOR = '|';
 
+static const char INT_MAX_STR[] = "INT32_MAX";
+static const char INT_MIN_STR[] = "INT32_MIN";
+static const size_t INT_LIMIT_STR_LEN = sizeof(INT_MAX_STR) - 1;
+
+static const char DBL_MAX_STR[] = "DBL_MAX";
+static const char DBL_MIN_STR[] = "-DBL_MAX";
+static const size_t DBL_MAX_STR_LEN = sizeof(DBL_MAX_STR) - 1;
+static const size_t DBL_MIN_STR_LEN = sizeof(DBL_MIN_STR) - 1;
+
 static void *
 get_member_memory(const struct sol_flow_node_options_member_description *member, struct sol_flow_node_options *opts)
 {
@@ -196,9 +205,6 @@ irange_parse(const char *value, struct sol_flow_node_named_options_member *m)
     int field_cnt = 0;
     bool keys_schema = false;
     char *min, *max, *step, *val;
-    static const char INT_MAX_STR[] = "INT32_MAX";
-    static const char INT_MIN_STR[] = "INT32_MIN";
-    static const size_t INT_LIMIT_STR_LEN = sizeof(INT_MAX_STR) - 1;
     struct sol_irange *ret = &m->irange;
     int32_t *store_vals[] = { &ret->val, &ret->min, &ret->max, &ret->step };
 
@@ -256,10 +262,6 @@ drange_parse(const char *value, struct sol_flow_node_named_options_member *m)
     int field_cnt = 0;
     bool keys_schema = false;
     char *min, *max, *step, *val;
-    static const char DBL_MAX_STR[] = "DBL_MAX";
-    static const char DBL_MIN_STR[] = "-DBL_MAX";
-    static const size_t DBL_MAX_STR_LEN = sizeof(DBL_MAX_STR) - 1;
-    static const size_t DBL_MIN_STR_LEN = sizeof(DBL_MIN_STR) - 1;
     struct sol_drange *ret = &m->drange;
     double *store_vals[] = { &ret->val, &ret->min, &ret->max, &ret->step };
 
@@ -319,9 +321,6 @@ rgb_parse(const char *value, struct sol_flow_node_named_options_member *m)
     int field_cnt = 0;
     bool keys_schema = false;
     char *red, *green, *blue, *red_max, *green_max, *blue_max;
-    static const char INT_MAX_STR[] = "INT32_MAX";
-    static const char INT_MIN_STR[] = "INT32_MIN";
-    static const size_t INT_LIMIT_STR_LEN = sizeof(INT_MAX_STR) - 1;
     struct sol_rgb *ret = &m->rgb;
     uint32_t *store_vals[] = { &ret->red, &ret->green, &ret->blue,
                                &ret->red_max, &ret->green_max, &ret->blue_max };
@@ -391,10 +390,6 @@ direction_vector_parse(const char *value, struct sol_flow_node_named_options_mem
     int field_cnt = 0;
     bool keys_schema = false;
     char *min, *max, *x, *y, *z;
-    static const char DBL_MAX_STR[] = "DBL_MAX";
-    static const char DBL_MIN_STR[] = "-DBL_MAX";
-    static const size_t DBL_MAX_STR_LEN = sizeof(DBL_MAX_STR) - 1;
-    static const size_t DBL_MIN_STR_LEN = sizeof(DBL_MIN_STR) - 1;
     struct sol_direction_vector *ret = &m->direction_vector;
     double *store_vals[] = { &ret->x, &ret->y, &ret->z, &ret->min, &ret->max };
 

--- a/src/lib/flow/sol-flow-node-options.c
+++ b/src/lib/flow/sol-flow-node-options.c
@@ -505,7 +505,7 @@ set_default_option(struct sol_flow_node_named_options_member *m,
 {
     switch (m->type) {
     case SOL_FLOW_NODE_OPTIONS_MEMBER_DRANGE:
-        m->drange = mdesc->defvalue.f;
+        m->drange = mdesc->defvalue.drange;
         break;
     case SOL_FLOW_NODE_OPTIONS_MEMBER_DIRECTION_VECTOR:
         m->direction_vector = mdesc->defvalue.direction_vector;
@@ -626,7 +626,7 @@ static const struct sol_str_table member_str_to_type[] = {
     SOL_STR_TABLE_ITEM("boolean", SOL_FLOW_NODE_OPTIONS_MEMBER_BOOLEAN),
     SOL_STR_TABLE_ITEM("byte", SOL_FLOW_NODE_OPTIONS_MEMBER_BYTE),
     SOL_STR_TABLE_ITEM("int", SOL_FLOW_NODE_OPTIONS_MEMBER_IRANGE),
-    SOL_STR_TABLE_ITEM("float", SOL_FLOW_NODE_OPTIONS_MEMBER_DRANGE),
+    SOL_STR_TABLE_ITEM("drange", SOL_FLOW_NODE_OPTIONS_MEMBER_DRANGE),
     SOL_STR_TABLE_ITEM("rgb", SOL_FLOW_NODE_OPTIONS_MEMBER_RGB),
     SOL_STR_TABLE_ITEM("direction-vector", SOL_FLOW_NODE_OPTIONS_MEMBER_DIRECTION_VECTOR),
     SOL_STR_TABLE_ITEM("string", SOL_FLOW_NODE_OPTIONS_MEMBER_STRING),

--- a/src/modules/flow/constant/constant.json
+++ b/src/modules/flow/constant/constant.json
@@ -69,7 +69,7 @@
       "options": {
         "members": [
           {
-            "data_type": "float",
+            "data_type": "drange",
             "description": "Value of constant.",
             "name": "value"
           }

--- a/src/modules/flow/converter/converter.c
+++ b/src/modules/flow/converter/converter.c
@@ -129,7 +129,7 @@ irange_true_range_set(struct sol_flow_node *node, void *data, uint16_t port, uin
 static int
 drange_min_value_set(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
 {
-    struct sol_drange *mdata = data;
+    struct sol_drange_spec *mdata = data;
     double value;
     int r;
 
@@ -143,7 +143,7 @@ drange_min_value_set(struct sol_flow_node *node, void *data, uint16_t port, uint
 static int
 drange_max_value_set(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
 {
-    struct sol_irange *mdata = data;
+    struct sol_drange_spec *mdata = data;
     double value;
     int r;
 
@@ -274,7 +274,7 @@ irange_to_boolean_convert(struct sol_flow_node *node, void *data, uint16_t port,
 static int
 boolean_to_drange_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
 {
-    struct sol_drange *mdata = data;
+    struct sol_drange_spec *mdata = data;
     const struct sol_flow_node_type_converter_boolean_to_float_options *opts;
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
@@ -283,8 +283,8 @@ boolean_to_drange_open(struct sol_flow_node *node, void *data, const struct sol_
 
     opts = (const struct sol_flow_node_type_converter_boolean_to_float_options *)options;
 
-    mdata->min = opts->false_value.val;
-    mdata->max = opts->true_value.val;
+    mdata->min = opts->false_value;
+    mdata->max = opts->true_value;
 
     return 0;
 }
@@ -292,7 +292,7 @@ boolean_to_drange_open(struct sol_flow_node *node, void *data, const struct sol_
 static int
 boolean_to_drange_convert(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
 {
-    struct sol_drange *mdata = data;
+    struct sol_drange_spec *mdata = data;
     int r;
     bool in_value;
 
@@ -596,12 +596,15 @@ empty_to_drange_open(struct sol_flow_node *node, void *data, const struct sol_fl
     const struct sol_flow_node_type_converter_empty_to_float_options *opts =
         (const struct sol_flow_node_type_converter_empty_to_float_options *)
         options;
+    int r;
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
         SOL_FLOW_NODE_TYPE_CONVERTER_EMPTY_TO_FLOAT_OPTIONS_API_VERSION,
         -EINVAL);
 
-    *mdata = opts->output_value;
+    r = sol_drange_compose(&opts->output_value_spec, opts->output_value, mdata);
+    SOL_INT_CHECK(r, < 0, r);
+
     return 0;
 }
 
@@ -641,7 +644,7 @@ byte_to_empty_open(struct sol_flow_node *node, void *data, const struct sol_flow
 static int
 drange_to_empty_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
 {
-    struct sol_drange *mdata = data;
+    struct sol_drange_spec *mdata = data;
     const struct sol_flow_node_type_converter_float_to_empty_options *opts =
         (const struct sol_flow_node_type_converter_float_to_empty_options *)
         options;
@@ -778,7 +781,7 @@ byte_to_empty_convert(struct sol_flow_node *node, void *data, uint16_t port, uin
 static int
 drange_to_empty_convert(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
 {
-    struct sol_drange *mdata = data;
+    struct sol_drange_spec *mdata = data;
     double in_value;
     int r;
 

--- a/src/modules/flow/converter/converter.json
+++ b/src/modules/flow/converter/converter.json
@@ -43,15 +43,15 @@
       "options": {
         "members": [
           {
-            "data_type": "drange",
+            "data_type": "float",
             "default": 0,
-            "description": "DRange value of output when input is false.",
+            "description": "Float value of output when input is false.",
             "name": "false_value"
           },
           {
-            "data_type": "drange",
+            "data_type": "float",
             "default": 1,
-            "description": "DRange value of output when input is true.",
+            "description": "Float value of output when input is true.",
             "name": "true_value"
           }
         ],
@@ -64,7 +64,7 @@
           "name": "OUT"
         }
       ],
-      "private_data_type": "sol_drange",
+      "private_data_type": "sol_drange_spec",
       "url": "http://solettaproject.org/doc/latest/node_types/converter/boolean-to-drange.html"
     },
     {
@@ -607,7 +607,7 @@
       "options": {
         "members": [
           {
-            "data_type": "drange",
+            "data_type": "drange-spec",
             "default": {
               "max": 255,
               "min": 1
@@ -679,7 +679,7 @@
       "options": {
         "members": [
           {
-            "data_type": "drange",
+            "data_type": "drange-spec",
             "default": {
               "max": 255,
               "min": 1
@@ -697,7 +697,7 @@
           "name": "OUT"
         }
       ],
-      "private_data_type": "sol_drange",
+      "private_data_type": "sol_drange_spec",
       "url": "http://solettaproject.org/doc/latest/node_types/converter/drange-to-empty.html"
     },
     {
@@ -825,7 +825,7 @@
       "options": {
         "members": [
           {
-            "data_type": "drange",
+            "data_type": "drange-spec",
             "default": {
               "max": "DBL_MAX",
               "min": "-DBL_MAX"
@@ -1058,13 +1058,18 @@
       "options": {
         "members": [
           {
-            "data_type": "drange",
+            "data_type": "drange-spec",
             "default": {
               "max": 1,
               "min": 1,
-              "step": 1,
-              "val": 1
+              "step": 1
             },
+            "description": "Float range and step of output when an empty packet is received.",
+            "name": "output_value_spec"
+          },
+          {
+            "data_type": "float",
+            "default": 1,
             "description": "Float value of output when an empty packet is received.",
             "name": "output_value"
           }
@@ -1523,7 +1528,7 @@
       "options": {
         "members": [
           {
-            "data_type": "drange",
+            "data_type": "drange-spec",
             "default": {
               "max": "DBL_MAX",
               "min": "-DBL_MAX"

--- a/src/modules/flow/converter/converter.json
+++ b/src/modules/flow/converter/converter.json
@@ -43,13 +43,13 @@
       "options": {
         "members": [
           {
-            "data_type": "float",
+            "data_type": "drange",
             "default": 0,
             "description": "DRange value of output when input is false.",
             "name": "false_value"
           },
           {
-            "data_type": "float",
+            "data_type": "drange",
             "default": 1,
             "description": "DRange value of output when input is true.",
             "name": "true_value"
@@ -607,7 +607,7 @@
       "options": {
         "members": [
           {
-            "data_type": "float",
+            "data_type": "drange",
             "default": {
               "max": 255,
               "min": 1
@@ -679,7 +679,7 @@
       "options": {
         "members": [
           {
-            "data_type": "float",
+            "data_type": "drange",
             "default": {
               "max": 255,
               "min": 1
@@ -825,7 +825,7 @@
       "options": {
         "members": [
           {
-            "data_type": "float",
+            "data_type": "drange",
             "default": {
               "max": "DBL_MAX",
               "min": "-DBL_MAX"
@@ -1058,7 +1058,7 @@
       "options": {
         "members": [
           {
-            "data_type": "float",
+            "data_type": "drange",
             "default": {
               "max": 1,
               "min": 1,
@@ -1523,7 +1523,7 @@
       "options": {
         "members": [
           {
-            "data_type": "float",
+            "data_type": "drange",
             "default": {
               "max": "DBL_MAX",
               "min": "-DBL_MAX"

--- a/src/modules/flow/float/float.c
+++ b/src/modules/flow/float/float.c
@@ -271,8 +271,8 @@ abs_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn
 }
 
 struct drange_map_data {
-    struct sol_drange input;
-    struct sol_drange output;
+    struct sol_drange_spec input;
+    struct sol_drange_spec output;
     struct sol_drange output_value;
     bool use_input_range : 1;
 };
@@ -362,7 +362,7 @@ map_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn
 }
 
 struct drange_constrain_data {
-    struct sol_drange val;
+    struct sol_drange_spec val;
     bool use_input_range : 1;
 };
 
@@ -424,11 +424,9 @@ constrain_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_
     r = _constrain(&value);
     SOL_INT_CHECK(r, < 0, r);
 
-    mdata->val = value;
-
     return sol_flow_send_drange_packet(node,
         SOL_FLOW_NODE_TYPE_FLOAT_CONSTRAIN__OUT__OUT,
-        &mdata->val);
+        &value);
 }
 
 static int

--- a/src/modules/flow/float/float.c
+++ b/src/modules/flow/float/float.c
@@ -673,6 +673,21 @@ wave_generator_trapezoidal_process(struct sol_flow_node *node,
                &mdata->t_state.val);
 }
 
+static void
+wave_generator_set_option(int32_t opt, uint32_t *var, int32_t limit,
+    const char *opt_name)
+{
+    if (opt < limit) {
+        SOL_WRN("Wave generator's %s value (%" PRId32 ") "
+            "cannot be less than %" PRId32 ". Assuming %" PRId32 ".",
+            opt_name, opt, limit, limit);
+        *var = limit;
+        return;
+    }
+
+    *var = opt;
+}
+
 static int
 wave_generator_trapezoidal_open(struct sol_flow_node *node,
     void *data,
@@ -690,34 +705,17 @@ wave_generator_trapezoidal_open(struct sol_flow_node *node,
         SOL_ERR("Trapezoidal wave generator's min must be less than its max");
         return -EDOM;
     }
-    if (opts->ticks_inc.val < 1) {
-        SOL_ERR("Trapezoidal wave generator's ticks_inc value (%" PRId32 ") cannot"
-            " be less than 1)", opts->ticks_inc.val);
-        return -EDOM;
-    }
-    if (opts->ticks_dec.val < 1) {
-        SOL_ERR("Trapezoidal wave generator's ticks_dec value (%" PRId32 ") cannot"
-            " be less than 1)", opts->ticks_dec.val);
-        return -EDOM;
-    }
-    if (opts->tick_start.val < 0) {
-        SOL_ERR("Trapezoidal wave generator's tick_start value (%" PRId32 ") cannot"
-            " be less than 0)", opts->tick_start.val);
-        return -EDOM;
-    }
-    if (opts->ticks_at_max.val < 0) {
-        SOL_ERR("Trapezoidal wave generator's ticks_at_max value (%" PRId32 ") cannot"
-            " be less than 0)", opts->ticks_at_max.val);
-        return -EDOM;
-    }
-    if (opts->ticks_at_min.val < 0) {
-        SOL_ERR("Trapezoidal wave generator's ticks_at_min value (%" PRId32 ") cannot"
-            " be less than 0)", opts->ticks_at_min.val);
-        return -EDOM;
-    }
 
-    mdata->ticks_at_min = opts->ticks_at_min.val;
-    mdata->ticks_at_max = opts->ticks_at_max.val;
+    wave_generator_set_option(opts->ticks_inc.val, &mdata->ticks_inc, 1,
+        "ticks_inc");
+    wave_generator_set_option(opts->ticks_dec.val, &mdata->ticks_dec, 1,
+        "ticks_dec");
+    wave_generator_set_option(opts->tick_start.val, &tick_start, 0,
+        "tick_start");
+    wave_generator_set_option(opts->ticks_at_max.val, &mdata->ticks_at_max, 0,
+        "ticks_at_max");
+    wave_generator_set_option(opts->ticks_at_min.val, &mdata->ticks_at_min, 0,
+        "ticks_at_min");
 
     t_state = &mdata->t_state;
     val = &t_state->val;
@@ -727,8 +725,6 @@ wave_generator_trapezoidal_open(struct sol_flow_node *node,
     val->min = opts->min;
     val->max = opts->max;
 
-    mdata->ticks_inc = opts->ticks_inc.val;
-    mdata->ticks_dec = opts->ticks_dec.val;
     mdata->inc_step = (val->max - val->min) / mdata->ticks_inc;
     mdata->dec_step = (val->min - val->max) / mdata->ticks_dec;
 
@@ -737,7 +733,7 @@ wave_generator_trapezoidal_open(struct sol_flow_node *node,
     mdata->period_in_ticks = mdata->ticks_at_min + mdata->ticks_inc
         + mdata->ticks_at_max + mdata->ticks_dec;
 
-    tick_start = opts->tick_start.val % mdata->period_in_ticks;
+    tick_start %= mdata->period_in_ticks;
 
     t_state->max_tick_cnt = 0;
     t_state->min_tick_cnt = mdata->ticks_at_min;
@@ -818,7 +814,7 @@ wave_generator_sinusoidal_open(struct sol_flow_node *node,
 {
     struct drange_wave_generator_sinusoidal_data *mdata = data;
     const struct sol_flow_node_type_float_wave_generator_sinusoidal_options *opts = (const struct sol_flow_node_type_float_wave_generator_sinusoidal_options *)options;
-    uint32_t tick_start;
+    uint32_t tick_start, ticks_per_period;
     struct s_state *s_state;
     struct sol_drange *val;
     unsigned i;
@@ -830,16 +826,11 @@ wave_generator_sinusoidal_open(struct sol_flow_node *node,
             "than zero");
         return -EDOM;
     }
-    if (opts->ticks_per_period.val < 1) {
-        SOL_ERR("Sinusoidal wave generator's ticks_per_period value (%" PRId32 ") cannot"
-            " be less than 1)", opts->ticks_per_period.val);
-        return -EDOM;
-    }
-    if (opts->tick_start.val < 0) {
-        SOL_ERR("Sinusoidal wave generator's tick_start value (%" PRId32 ") cannot"
-            " be less than 0)", opts->tick_start.val);
-        return -EDOM;
-    }
+
+    wave_generator_set_option(opts->ticks_per_period.val, &ticks_per_period, 1,
+        "ticks_per_period");
+    wave_generator_set_option(opts->tick_start.val, &tick_start, 0,
+        "tick_start");
 
     mdata->amplitude = opts->amplitude;
     s_state = &mdata->s_state;
@@ -850,11 +841,11 @@ wave_generator_sinusoidal_open(struct sol_flow_node *node,
     val->min = mdata->amplitude * -1.0;
     val->max = mdata->amplitude;
 
-    mdata->rad_step = 2 * M_PI / opts->ticks_per_period.val;
+    mdata->rad_step = 2 * M_PI / ticks_per_period;
 
     /* calculating starting val from tick_start */
     val->val = 0;
-    tick_start = opts->tick_start.val % opts->ticks_per_period.val;
+    tick_start %= ticks_per_period;
 
     for (i = 0; i < tick_start; i++)
         sinusoidal_calc_next(mdata);

--- a/src/modules/flow/float/float.c
+++ b/src/modules/flow/float/float.c
@@ -523,14 +523,14 @@ float_filter_open(struct sol_flow_node *node, void *data, const struct sol_flow_
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_FLOAT_FILTER_OPTIONS_API_VERSION, -EINVAL);
 
     opts = (const struct sol_flow_node_type_float_filter_options *)options;
-    if (isgreater(opts->max.val, opts->min.val)) {
-        mdata->min = opts->min.val;
-        mdata->max = opts->max.val;
+    if (isgreater(opts->max, opts->min)) {
+        mdata->min = opts->min;
+        mdata->max = opts->max;
     } else {
         SOL_DBG("min (%f) should be smaller than max (%f).",
-            opts->min.val, opts->max.val);
-        mdata->min = opts->max.val;
-        mdata->max = opts->min.val;
+            opts->min, opts->max);
+        mdata->min = opts->max;
+        mdata->max = opts->min;
     }
     mdata->range_override = opts->range_override;
     return 0;
@@ -686,7 +686,7 @@ wave_generator_trapezoidal_open(struct sol_flow_node *node,
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(opts, SOL_FLOW_NODE_TYPE_FLOAT_WAVE_GENERATOR_TRAPEZOIDAL_OPTIONS_API_VERSION, -EINVAL);
 
-    if (isgreaterequal(opts->min.val, opts->max.val)) {
+    if (isgreaterequal(opts->min, opts->max)) {
         SOL_ERR("Trapezoidal wave generator's min must be less than its max");
         return -EDOM;
     }
@@ -724,8 +724,8 @@ wave_generator_trapezoidal_open(struct sol_flow_node *node,
 
     t_state->did_first = false;
 
-    val->min = opts->min.val;
-    val->max = opts->max.val;
+    val->min = opts->min;
+    val->max = opts->max;
 
     mdata->ticks_inc = opts->ticks_inc.val;
     mdata->ticks_dec = opts->ticks_dec.val;
@@ -825,7 +825,7 @@ wave_generator_sinusoidal_open(struct sol_flow_node *node,
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(opts, SOL_FLOW_NODE_TYPE_FLOAT_WAVE_GENERATOR_SINUSOIDAL_OPTIONS_API_VERSION, -EINVAL);
 
-    if (islessequal(opts->amplitude.val, 0)) {
+    if (islessequal(opts->amplitude, 0)) {
         SOL_ERR("Sinusoidal wave generator's multiplier must be greater "
             "than zero");
         return -EDOM;
@@ -841,7 +841,7 @@ wave_generator_sinusoidal_open(struct sol_flow_node *node,
         return -EDOM;
     }
 
-    mdata->amplitude = opts->amplitude.val;
+    mdata->amplitude = opts->amplitude;
     s_state = &mdata->s_state;
     val = &s_state->val;
 

--- a/src/modules/flow/float/float.json
+++ b/src/modules/flow/float/float.json
@@ -241,7 +241,7 @@
       "options": {
         "members": [
           {
-            "data_type": "float",
+            "data_type": "drange",
             "default": {
               "max": 1023,
               "min": 0
@@ -311,7 +311,7 @@
       "options": {
         "members": [
           {
-            "data_type": "float",
+            "data_type": "drange",
             "default": {
               "max": "DBL_MAX",
               "min": "-DBL_MAX",
@@ -321,7 +321,7 @@
             "name": "input_range"
           },
           {
-            "data_type": "float",
+            "data_type": "drange",
             "description": "Output's range.",
             "name": "output_range"
           },
@@ -690,7 +690,7 @@
       "options": {
         "members": [
           {
-            "data_type": "float",
+            "data_type": "drange",
             "description": "Minimum value (inclusive)",
             "name": "min",
             "default" : {
@@ -698,7 +698,7 @@
             }
           },
           {
-            "data_type": "float",
+            "data_type": "drange",
             "description": "Maximum value (inclusive)",
             "name": "max",
             "default" : {
@@ -746,7 +746,7 @@
             "name": "ticks_inc"
           },
           {
-            "data_type": "float",
+            "data_type": "drange",
             "description": "The maximum value of the wave. This must be greater than min.",
             "name": "max"
           },
@@ -759,7 +759,7 @@
             "name": "ticks_dec"
           },
           {
-            "data_type": "float",
+            "data_type": "drange",
             "description": "The minimum value of the wave. This must be less than max.",
             "name": "min"
           },
@@ -825,7 +825,7 @@
             "name": "ticks_per_period"
           },
           {
-            "data_type": "float",
+            "data_type": "drange",
             "default": {
               "val": 1.0
             },

--- a/src/modules/flow/float/float.json
+++ b/src/modules/flow/float/float.json
@@ -690,20 +690,16 @@
       "options": {
         "members": [
           {
-            "data_type": "drange",
+            "data_type": "float",
             "description": "Minimum value (inclusive)",
             "name": "min",
-            "default" : {
-              "val" : "-DBL_MAX"
-            }
+            "default" : "-DBL_MAX"
           },
           {
-            "data_type": "drange",
+            "data_type": "float",
             "description": "Maximum value (inclusive)",
             "name": "max",
-            "default" : {
-              "val" : "DBL_MAX"
-            }
+            "default" : "DBL_MAX"
           },
           {
             "data_type": "boolean",
@@ -746,7 +742,7 @@
             "name": "ticks_inc"
           },
           {
-            "data_type": "drange",
+            "data_type": "float",
             "description": "The maximum value of the wave. This must be greater than min.",
             "name": "max"
           },
@@ -759,7 +755,7 @@
             "name": "ticks_dec"
           },
           {
-            "data_type": "drange",
+            "data_type": "float",
             "description": "The minimum value of the wave. This must be less than max.",
             "name": "min"
           },
@@ -825,10 +821,8 @@
             "name": "ticks_per_period"
           },
           {
-            "data_type": "drange",
-            "default": {
-              "val": 1.0
-            },
+            "data_type": "float",
+            "default": 1.0,
             "description": "The sine wave's amplitude. This must be a positive number, which will multiply the values in the pristine [-1.0, 1.0] range.",
             "name": "amplitude"
           },

--- a/src/modules/flow/float/float.json
+++ b/src/modules/flow/float/float.json
@@ -241,7 +241,7 @@
       "options": {
         "members": [
           {
-            "data_type": "drange",
+            "data_type": "drange-spec",
             "default": {
               "max": 1023,
               "min": 0
@@ -311,7 +311,7 @@
       "options": {
         "members": [
           {
-            "data_type": "drange",
+            "data_type": "drange-spec",
             "default": {
               "max": "DBL_MAX",
               "min": "-DBL_MAX",
@@ -321,7 +321,7 @@
             "name": "input_range"
           },
           {
-            "data_type": "drange",
+            "data_type": "drange-spec",
             "description": "Output's range.",
             "name": "output_range"
           },

--- a/src/modules/flow/grove/grove.c
+++ b/src/modules/flow/grove/grove.c
@@ -332,7 +332,7 @@ temperature_converter_open(struct sol_flow_node *node, void *data, const struct 
     mdata->thermistor_constant = opts->thermistor_constant.val;
     mdata->input_range = 1 << opts->input_range_mask.val;
     mdata->resistance = opts->resistance.val;
-    mdata->reference_temperature = opts->reference_temperature.val;
+    mdata->reference_temperature = opts->reference_temperature;
     mdata->thermistor_resistance = opts->thermistor_resistance.val;
 
     return 0;

--- a/src/modules/flow/grove/grove.json
+++ b/src/modules/flow/grove/grove.json
@@ -42,7 +42,7 @@
             "name": "resistance"
           },
           {
-            "data_type": "float",
+            "data_type": "drange",
             "description": "Thermistor reference temperature",
             "name": "reference_temperature"
           },
@@ -114,7 +114,7 @@
             "name": "resistance"
           },
           {
-            "data_type": "float",
+            "data_type": "drange",
             "default": 298.15,
             "description": "Thermistor reference temperature",
             "name": "reference_temperature"

--- a/src/modules/flow/grove/grove.json
+++ b/src/modules/flow/grove/grove.json
@@ -42,7 +42,7 @@
             "name": "resistance"
           },
           {
-            "data_type": "drange",
+            "data_type": "float",
             "description": "Thermistor reference temperature",
             "name": "reference_temperature"
           },
@@ -114,7 +114,7 @@
             "name": "resistance"
           },
           {
-            "data_type": "drange",
+            "data_type": "float",
             "default": 298.15,
             "description": "Thermistor reference temperature",
             "name": "reference_temperature"

--- a/src/modules/flow/http-server/http-server.json
+++ b/src/modules/flow/http-server/http-server.json
@@ -205,7 +205,7 @@
             "name": "path"
           },
 	  {
-            "data_type": "float",
+            "data_type": "drange",
 	    "default": 0,
             "description": "The initial node's value",
             "name": "value"

--- a/src/modules/flow/magnetometer/lsm303.c
+++ b/src/modules/flow/magnetometer/lsm303.c
@@ -197,7 +197,7 @@ magnetometer_lsm303_open(struct sol_flow_node *node, void *data, const struct so
     }
 
     mdata->slave = opts->i2c_slave.val;
-    mdata->scale = opts->scale.val;
+    mdata->scale = opts->scale;
     mdata->node = node;
 
     lsm303_init(mdata);

--- a/src/modules/flow/magnetometer/magnetometer.json
+++ b/src/modules/flow/magnetometer/magnetometer.json
@@ -39,7 +39,7 @@
            "default": 25
          },
          {
-           "data_type": "drange",
+           "data_type": "float",
            "description": "Scale selection (in Gauss). Ranges from -value to +value. Must be one of 1.3, 1.9, 2.5, 4.0, 4.7, 5,6 or 8.1.",
            "name": "scale",
            "default": 8.1

--- a/src/modules/flow/magnetometer/magnetometer.json
+++ b/src/modules/flow/magnetometer/magnetometer.json
@@ -39,7 +39,7 @@
            "default": 25
          },
          {
-           "data_type": "float",
+           "data_type": "drange",
            "description": "Scale selection (in Gauss). Ranges from -value to +value. Must be one of 1.3, 1.9, 2.5, 4.0, 4.7, 5,6 or 8.1.",
            "name": "scale",
            "default": 8.1

--- a/src/modules/flow/persistence/persistence.json
+++ b/src/modules/flow/persistence/persistence.json
@@ -142,7 +142,7 @@
             "name": "storage"
           },
           {
-            "data_type": "float",
+            "data_type": "drange",
             "default": 0.0,
             "description": "Default value for this node, when there's no previous value persisted",
             "name": "default_value"

--- a/src/test-fbp/converter-float-direction-vector.fbp
+++ b/src/test-fbp/converter-float-direction-vector.fbp
@@ -31,7 +31,7 @@
 XFloat(constant/float:value=20|0|100|1)
 YFloat(constant/float:value=40|0|100|1)
 ZFloat(constant/float:value=70|0|100|1)
-float_to_direction_vector(converter/float-to-direction-vector:out_range=0|0|200|1)
+float_to_direction_vector(converter/float-to-direction-vector:out_range=0|200|1)
 
 XFloat OUT -> X float_to_direction_vector
 YFloat OUT -> Y float_to_direction_vector

--- a/src/test-fbp/converter-float-empty.fbp
+++ b/src/test-fbp/converter-float-empty.fbp
@@ -33,7 +33,7 @@ match_ten(constant/float:value=10)
 
 match_ten OUT -> IN float_to_empty OUT -> IN _(converter/empty-to-boolean) OUT -> RESULT empty_received(test/result)
 
-empty_to_float(converter/empty-to-float:output_value=val:10|min:5|max:15|step:1)
+empty_to_float(converter/empty-to-float:output_value=10,output_value_spec=min:5|max:15|step:1)
 empty(constant/empty)
 
 empty OUT -> IN empty_to_float OUT -> IN[0] equal(float/equal)

--- a/src/test-fbp/converter-int-direction-vector.fbp
+++ b/src/test-fbp/converter-int-direction-vector.fbp
@@ -31,7 +31,7 @@
 XInt(constant/int:value=20|0|100|1)
 YInt(constant/int:value=40|0|100|1)
 ZInt(constant/int:value=70|0|100|1)
-int_to_direction_vector(converter/int-to-direction-vector:out_range=0|0|200|1)
+int_to_direction_vector(converter/int-to-direction-vector:out_range=0|200|1)
 
 XInt OUT -> X int_to_direction_vector
 YInt OUT -> Y int_to_direction_vector

--- a/src/test-stub-gen/dummy.json
+++ b/src/test-stub-gen/dummy.json
@@ -172,7 +172,7 @@
          "name": "opt_byte"
         },
         {
-         "data_type": "float",
+         "data_type": "drange",
          "default": {
              "val": 20.5,
              "min": -10,

--- a/src/test-stub-gen/dummy.json
+++ b/src/test-stub-gen/dummy.json
@@ -183,6 +183,16 @@
          "name": "opt_drange"
         },
         {
+         "data_type": "drange-spec",
+         "default": {
+             "min": -100.5,
+             "max": "DBL_MAX",
+             "step": "DBL_MIN"
+         },
+         "description": "Dummy drange spec option.",
+         "name": "opt_drange_spec"
+        },
+        {
          "data_type": "float",
          "default": 66.6,
          "description": "Dummy float option.",

--- a/src/test-stub-gen/dummy.json
+++ b/src/test-stub-gen/dummy.json
@@ -179,6 +179,12 @@
              "max": 33,
              "step": 0.5
          },
+         "description": "Dummy drange option.",
+         "name": "opt_drange"
+        },
+        {
+         "data_type": "float",
+         "default": 66.6,
          "description": "Dummy float option.",
          "name": "opt_float"
         },


### PR DESCRIPTION
It's the float part of task #724.
The same will be done for integers next.

Since it's not a single float, it's a full drange data,
the name was misleading.

Actually, after some discussion, we get to conclusion this
type will be dropped, and instead another two should
be used:
    * float for single floats
    * float_spec (for min / max / step)

If drange is wanted, two options will be required (float +
        drange_spec).

So, for now, a "deprecated" warning will be displayed when
a type using it is generated.