### PR TITLE
float: New way to map irange values - no need for long double

### DIFF
--- a/src/modules/flow/float/float.c
+++ b/src/modules/flow/float/float.c
@@ -311,13 +311,24 @@ map_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_opti
     return 0;
 }
 
-static int
-_map(long double in_value, long double in_min, long double in_max, long double out_min, long double out_max, long double out_step, double *out_value)
+static double
+_midpoint(double min, double max)
 {
-    long double result;
+    if (min < 0 && max > 0)
+        return (max + min) / 2.0;
 
-    result = (in_value - in_min) * (out_max - out_min) /
-        (in_max - in_min) + out_min;
+    return ((max - min) / 2.0) + min;
+}
+
+static int
+_map(double in_value, double in_min, double in_max, double out_min, double out_max, double out_step, double *out_value)
+{
+    double in_mid = _midpoint(in_min, in_max);
+    double out_mid = _midpoint(out_min, out_max);
+    double in_distance = (in_value - in_mid) / (in_max - in_mid);
+    double result;
+
+    result = out_mid + (out_max - out_mid) * in_distance;
 
     errno = 0;
     result -= fmodl((result - out_min), out_step);

--- a/src/test-fbp/persistence-fs-1.fbp
+++ b/src/test-fbp/persistence-fs-1.fbp
@@ -36,7 +36,6 @@
 
 ## TEST-PRECONDITION rm -f int int_only_val irange byte boolean string double double_only_val drange int_def irange_def byte_def boolean_def string_def double_def drange_def
 ## TEST-SKIP-COMPILE This test uses some files, but path resolution is not decided yet
-## TEST-SKIP-VALGRIND Some float operations yield to [-]NaN on valgrind
 
 int(constant/int:value=-12)
 irange(constant/int:value=-13|-50|50|3)

--- a/src/test-fbp/persistence-fs-2.fbp
+++ b/src/test-fbp/persistence-fs-2.fbp
@@ -35,7 +35,6 @@
 # Those files need to have been created by persistence-fs-1.fbp
 
 ## TEST-SKIP-COMPILE This test uses some files, but path resolution is not decided yet
-## TEST-SKIP-VALGRIND Some float operations yield to [-]NaN on valgrind
 ## TEST-DEPENDS-ON persistence-fs-1.fbp
 
 validator_int(test/int-validator:sequence="-12")

--- a/src/test-fbp/persistence-memmap-1.fbp
+++ b/src/test-fbp/persistence-memmap-1.fbp
@@ -40,7 +40,6 @@
 
 ## TEST-PRECONDITION truncate -s0 memmap-test.bin
 ## TEST-SKIP-COMPILE This test uses some files, but path resolution is not decided yet
-## TEST-SKIP-VALGRIND Some float operations yield to [-]NaN on valgrind
 
 int(constant/int:value=-12)
 int_only(constant/int:value=30)

--- a/src/test-fbp/persistence-memmap-2.fbp
+++ b/src/test-fbp/persistence-memmap-2.fbp
@@ -39,7 +39,6 @@
 # of zeros and have no way to know if they mean something or not.
 
 ## TEST-SKIP-COMPILE This test uses some files, but path resolution is not decided yet
-## TEST-SKIP-VALGRIND Some float operations yield to [-]NaN on valgrind
 ## TEST-DEPENDS-ON persistence-memmap-1.fbp
 
 validator_int(test/int-validator:sequence="-12")


### PR DESCRIPTION
As long double is not always bigger than double, we now do the
calculations without need for a bigger temporary storage.
The idea is to find the distance to interval midpoint on input, and
replicate this distance on output interval. This restric calculations to
normal double variables.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>