### PR TITLE
form: new form/boolean node, for bool state selection (plus lcd output) [v2]

### DIFF
--- a/src/modules/flow/form/form.json
+++ b/src/modules/flow/form/form.json
@@ -21,9 +21,9 @@
         },
         {
           "data_type": "string",
-          "description": "Change the current selection to the item in question.",
+          "description": "Change the current selection to the item in question (useful for initial setups on a flow).",
           "methods": {
-            "process": "selected_set"
+            "process": "selector_selected_set"
           },
           "name": "SELECTED"
         },
@@ -55,15 +55,15 @@
           "data_type": "any",
           "description": "Confirm the selection to be current one, generating output packets on both STRING and SELECTED output ports.",
           "methods": {
-            "process": "select_set"
+            "process": "selector_select_set"
           },
           "name": "SELECT"
         },
         {
           "data_type": "boolean",
-          "description": "Make the interaction possible, otherwise don't produce strings or process NEXT/PREVIOUS/SELECT inputs. In other words, enabled/disable the node at run-time. The node starts in the enabled state. Note that this does not affect the use of the ADD_ITEM/CLEAR ports.",
+          "description": "Make the interaction possible, otherwise don't produce strings or process NEXT/PREVIOUS/SELECT inputs. In other words, enabled/disable the node at run-time. The node starts in the enabled state. Note that this does not affect the use of the ADD_ITEM/CLEAR/SELECTED ports.",
           "methods": {
-            "process": "enabled_set"
+            "process": "selector_enabled_set"
           },
           "name": "ENABLED"
         }
@@ -132,6 +132,102 @@
       ],
       "private_data_type": "selector_data",
       "url": "http://solettaproject.org/doc/latest/node_types/selector.html"
+    },
+    {
+      "category": "io/sw",
+      "description": "Receives packages to control a boolean state. One of the input ports will commit to a state when trigerred, and the boolean value will be outputted. A string output with the current state, defined by a format string, is also outputted.",
+      "in_ports": [
+        {
+          "data_type": "boolean",
+          "description": "Change the current state (useful for initial setups on a flow).",
+          "methods": {
+            "process": "boolean_selected_set"
+          },
+          "name": "SELECTED"
+        },
+        {
+          "data_type": "any",
+          "description": "Toggle the internal state.",
+          "methods": {
+            "process": "toggle_set"
+          },
+          "name": "TOGGLE"
+        },
+        {
+          "data_type": "any",
+          "description": "Confirm the selection to be current one, generating output packets on both STRING and SELECTED output ports.",
+          "methods": {
+            "process": "boolean_select_set"
+          },
+          "name": "SELECT"
+        },
+        {
+          "data_type": "boolean",
+          "description": "Make the interaction possible, otherwise don't produce strings or process TOGGLE/SELECT inputs. In other words, enabled/disable the node at run-time. The node starts in the enabled state. Note that this does not affect the use of the SELECTED port.",
+          "methods": {
+            "process": "boolean_enabled_set"
+          },
+          "name": "ENABLED"
+        }
+      ],
+      "methods": {
+        "close": "boolean_close",
+        "open": "boolean_open"
+      },
+      "name": "form/boolean",
+      "options": {
+        "members": [
+          {
+            "data_type": "int",
+            "description": "The number of available columns to lay out the output string with. It must be a positive integer.",
+            "name": "columns"
+          },
+          {
+            "data_type": "int",
+            "description": "The number of available rows to lay out the output string with. It must be a positive integer.",
+            "name": "rows"
+          },
+          {
+            "data_type": "string",
+            "default": null,
+            "description": "The title string, to be available for referencing when evaluating the format one by means of the '{title}' tag. Any line breaking characters is this string will be translated to a space instead. If no title is provided, a '{title}' tag in the format will be ignored.",
+            "name": "title"
+          },
+          {
+            "data_type": "string",
+            "default": "{value}",
+            "description": "The format string to produce the final STRING output with. The syntax is a free-form string with one '{value}' sub-string in it (and one optional '{title}' one). The value tag will be replaced by the actual true/false strings defined for the node (true_str/false_str options), while the title one will be replaced by the title string option, if set. The title tag must occur before the value one.",
+            "name": "format"
+          },
+          {
+            "data_type": "string",
+            "default": "true",
+            "description": "The string to show for the 'true' boolean item.",
+            "name": "true_str"
+          },
+          {
+            "data_type": "string",
+            "default": "false",
+            "description": "The string to show for the 'false' boolean item.",
+            "name": "false_str"
+          }
+        ],
+        "version": 1
+      },
+      "out_ports": [
+        {
+          "data_type": "string",
+          "description": "The formatted boolean state output. This is meant to feed real display nodes (like grove/lcd-string).",
+          "name": "STRING"
+        },
+        {
+          "data_type": "boolean",
+          "description": "The current boolean state.",
+          "name": "SELECTED"
+        }
+      ],
+      "private_data_type": "boolean_data",
+      "url": "http://solettaproject.org/doc/latest/node_types/boolean.html"
     }
   ]
 }

--- a/src/test-fbp/form-boolean.fbp
+++ b/src/test-fbp/form-boolean.fbp
@@ -1,0 +1,147 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#toggle selection
+boolean_00(form/boolean:rows=3,columns=10)
+_(test/boolean-generator:sequence="TT",interval=20) OUT -> TOGGLE boolean_00
+validator_00(test/string-validator:sequence="true      |false     |true      ")
+boolean_00 STRING -> IN validator_00 OUT -> RESULT _(test/result)
+
+#toggle selection and select
+boolean_01(form/boolean:rows=3,columns=10)
+_(test/boolean-generator:sequence="T",interval=10) OUT -> TOGGLE boolean_01
+_(test/boolean-generator:sequence="T",interval=20) OUT -> SELECT boolean_01
+validator_01(test/string-validator:sequence="true      |false     |false     ")
+validator_items_01(test/boolean-validator:sequence="F")
+and_01(boolean/and)
+boolean_01 STRING -> IN validator_01 OUT -> IN[0] and_01
+boolean_01 SELECTED -> IN validator_items_01 OUT -> IN[1] and_01
+and_01 OUT -> RESULT _(test/result)
+
+#toggle selection and select, one row only
+boolean_02(form/boolean:rows=1,columns=10)
+_(test/boolean-generator:sequence="T",interval=10) OUT -> TOGGLE boolean_02
+_(test/boolean-generator:sequence="T",interval=20) OUT -> SELECT boolean_02
+validator_02(test/string-validator:sequence="true      |false     |false     ")
+validator_items_02(test/boolean-validator:sequence="F")
+and_02(boolean/and)
+boolean_02 STRING -> IN validator_02 OUT -> IN[0] and_02
+boolean_02 SELECTED -> IN validator_items_02 OUT -> IN[1] and_02
+and_02 OUT -> RESULT _(test/result)
+
+#toggle selection and select, with title
+boolean_03(form/boolean:rows=2,columns=10,format="{title}{value}",title="Title")
+_(test/boolean-generator:sequence="T",interval=10) OUT -> TOGGLE boolean_03
+_(test/boolean-generator:sequence="T",interval=20) OUT -> SELECT boolean_03
+validator_03(test/string-validator:sequence="Title     \ntrue      |Title     \nfalse     |Title     \nfalse     ")
+validator_items_03(test/boolean-validator:sequence="F")
+and_03(boolean/and)
+boolean_03 STRING -> IN validator_03 OUT -> IN[0] and_03
+boolean_03 SELECTED -> IN validator_items_03 OUT -> IN[1] and_03
+and_03 OUT -> RESULT _(test/result)
+
+#toggle selection and select, with title and footer
+boolean_04(form/boolean:rows=3,columns=10,format="{title}{value}footer",title="Title")
+_(test/boolean-generator:sequence="T",interval=10) OUT -> TOGGLE boolean_04
+_(test/boolean-generator:sequence="T",interval=20) OUT -> SELECT boolean_04
+validator_04(test/string-validator:sequence="Title     \ntrue      \nfooter    |Title     \nfalse     \nfooter    |Title     \nfalse     \nfooter    ")
+validator_items_04(test/boolean-validator:sequence="F")
+and_04(boolean/and)
+boolean_04 STRING -> IN validator_04 OUT -> IN[0] and_04
+boolean_04 SELECTED -> IN validator_items_04 OUT -> IN[1] and_04
+and_04 OUT -> RESULT _(test/result)
+
+#toggle selection and select, with title and footer, more rows
+boolean_05(form/boolean:rows=5,columns=10,format="{title}{value}footer",title="Title")
+_(test/boolean-generator:sequence="T",interval=10) OUT -> TOGGLE boolean_05
+_(test/boolean-generator:sequence="T",interval=20) OUT -> SELECT boolean_05
+validator_05(test/string-validator:sequence="Title     \ntrue      \nfooter    |Title     \nfalse     \nfooter    |Title     \nfalse     \nfooter    ")
+validator_items_05(test/boolean-validator:sequence="F")
+and_05(boolean/and)
+boolean_05 STRING -> IN validator_05 OUT -> IN[0] and_05
+boolean_05 SELECTED -> IN validator_items_05 OUT -> IN[1] and_05
+and_05 OUT -> RESULT _(test/result)
+
+#toggle selection and select, with title and footer, more rows, less columns
+boolean_06(form/boolean:rows=5,columns=5,format="{title}{value}footer",title="Title")
+_(test/boolean-generator:sequence="T",interval=10) OUT -> TOGGLE boolean_06
+_(test/boolean-generator:sequence="T",interval=20) OUT -> SELECT boolean_06
+validator_06(test/string-validator:sequence="Title\ntrue \nfoote|Title\nfalse\nfoote|Title\nfalse\nfoote")
+validator_items_06(test/boolean-validator:sequence="F")
+and_06(boolean/and)
+boolean_06 STRING -> IN validator_06 OUT -> IN[0] and_06
+boolean_06 SELECTED -> IN validator_items_06 OUT -> IN[1] and_06
+and_06 OUT -> RESULT _(test/result)
+
+#toggle selection and select, with title, footer and intermediate strings
+boolean_07(form/boolean:rows=10,columns=10,format="pre\ntitle{title}inter\nvalue{value}footer\nother_footer",title="Title")
+_(test/boolean-generator:sequence="T",interval=10) OUT -> TOGGLE boolean_07
+_(test/boolean-generator:sequence="T",interval=20) OUT -> SELECT boolean_07
+validator_07(test/string-validator:sequence="pre       \ntitle     \nTitle     \ninter     \nvalue     \ntrue      \nfooter    \nother_foot|pre       \ntitle     \nTitle     \ninter     \nvalue     \nfalse     \nfooter    \nother_foot|pre       \ntitle     \nTitle     \ninter     \nvalue     \nfalse     \nfooter    \nother_foot")
+validator_items_07(test/boolean-validator:sequence="F")
+and_07(boolean/and)
+boolean_07 STRING -> IN validator_07 OUT -> IN[0] and_07
+boolean_07 SELECTED -> IN validator_items_07 OUT -> IN[1] and_07
+and_07 OUT -> RESULT _(test/result)
+
+#toggle selection, while disabled
+boolean_08(form/boolean:rows=3,columns=10)
+_(constant/boolean:value=false) OUT -> ENABLED boolean_08
+_(test/boolean-generator:sequence="TT",interval=20) OUT -> TOGGLE boolean_08
+validator_08(test/string-validator:sequence="true      ")
+boolean_08 STRING -> IN validator_08 OUT -> RESULT _(test/result)
+
+#toggle selection and select, one row only, *with title*
+boolean_09(form/boolean:rows=1,columns=10,format="{title}{value}",title="Title")
+_(test/boolean-generator:sequence="T",interval=09) OUT -> TOGGLE boolean_09
+_(test/boolean-generator:sequence="T",interval=20) OUT -> SELECT boolean_09
+validator_09(test/string-validator:sequence="Title true|Title fals|Title fals")
+validator_items_09(test/boolean-validator:sequence="F")
+and_09(boolean/and)
+boolean_09 STRING -> IN validator_09 OUT -> IN[0] and_09
+boolean_09 SELECTED -> IN validator_items_09 OUT -> IN[1] and_09
+and_09 OUT -> RESULT _(test/result)
+
+#toggle selection, custom labels
+boolean_10(form/boolean:rows=3,columns=10,true_str="yeppers",false_str="nope")
+_(test/boolean-generator:sequence="TT",interval=20) OUT -> TOGGLE boolean_10
+validator_10(test/string-validator:sequence="yeppers   |nope      |yeppers   ")
+boolean_10 STRING -> IN validator_10 OUT -> RESULT _(test/result)
+
+#toggle selection, custom labels, pre-selection (note that the initial
+#status is always the default one, to be update quickly by the
+#SELECTED port's processing afterwards)
+boolean_11(form/boolean:rows=3,columns=10,true_str="yeppers",false_str="nope")
+_(constant/boolean:value=false) OUT -> SELECTED boolean_11
+_(test/boolean-generator:sequence="TT",interval=20) OUT -> TOGGLE boolean_11
+validator_11(test/string-validator:sequence="yeppers   |nope      |yeppers   |nope      ")
+boolean_11 STRING -> IN validator_11 OUT -> RESULT _(test/result)
+
+## TEST-SKIP-VALGRIND The timing we're relying on for the string sequence is blown away by Valgrind, so skip it.

--- a/src/test-fbp/form-selector.fbp
+++ b/src/test-fbp/form-selector.fbp
@@ -157,4 +157,16 @@ selector_10 STRING -> IN validator_10 OUT -> IN[0] and_10
 selector_10 SELECTED -> IN validator_items_10 OUT -> IN[1] and_10
 and_10 OUT -> RESULT _(test/result)
 
+#advance items and select, one row only, *with title and
+#pre-selection*. 3 1st packets are from ADD_ITEM, the last two are
+#from NEXT. note that as soon as the item3-packet gets processed by
+#the node, the selection is updated
+selector_11(form/selector:rows=1,columns=15,format="{title}{value}",title="Title",circular=true)
+_(constant/string:value="item3") OUT -> SELECTED selector_11
+items_11(test/string-generator:sequence="item1 item2 item3",separator=" ")
+items_11 OUT -> ADD_ITEM selector_11
+_(test/boolean-generator:sequence="TT",interval=10) OUT -> NEXT selector_11
+validator_11(test/string-validator:sequence="Title * item1  |Title * item1  |Title item1    |Title item2    |Title * item3  ")
+selector_11 STRING -> IN validator_11 OUT -> RESULT _(test/result)
+
 ## TEST-SKIP-VALGRIND The timing we're relying on for the string sequence is blown away by Valgrind, so skip it.


### PR DESCRIPTION
Changes since v1:
 - checks for overflow on calculating the text's grid mem size
 - commented out test that slipped in by mistake fixed

Tests are included, naturally. The form/selector node got a missing
test, too -- the input SELECTED port.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>