### PR TITLE
Async v5

### DIFF
--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -1331,9 +1331,10 @@ generate_memory_map_struct(const struct sol_ptr_vector *maps, int *elements)
         out("\nstatic const struct sol_memmap_map _memmap%d = {\n"
             "   .version = %d,\n"
             "   .path = \"%s\",\n"
+            "   .timeout = %u,\n"
             "   .entries = _memmap%d_entries\n"
             "};\n",
-            i, map->version, map->path, i);
+            i, map->version, map->path, map->timeout, i);
     }
 
     *elements = i;

--- a/src/lib/io/include/sol-efivarfs-storage.h
+++ b/src/lib/io/include/sol-efivarfs-storage.h
@@ -36,114 +36,182 @@
 #include <stdint.h>
 
 #include "sol-buffer.h"
+#include "sol-log.h"
 #include "sol-types.h"
+#include "sol-util.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int sol_efivars_write_raw(const char *name, const struct sol_buffer *buffer);
+/**
+ * Writes buffer contents to storage.
+ *
+ * Note that as writing operations are asynchronous, to check if it completely
+ * succeded, one needs to register a callback that will inform writing result.
+ * However, right now efivarfs storage does not perform asynchronous writing.
+ * Even though, to keep all persistence APIs uniform, only on callback one can
+ * check if writing completed successfully.
+ *
+ * @param name name of property. It will create a file on filesyste with
+ * this name.
+ * @param blob blob that will be written
+ * @param cb callback to be called when writing finishes. It contains status
+ * of writing: if failed, is lesser than zero.
+ * @param data user data to be sent to callback @c cb
+ *
+ * return 0 on success, a negative number on failure
+ */
+int sol_efivars_write_raw(const char *name, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data);
 int sol_efivars_read_raw(const char *name, struct sol_buffer *buffer);
 
-#define CREATE_BUFFER(_val, _empty) \
+#define CREATE_BUFFER(_val) \
     struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val, \
-    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED); \
-    buf.used = (_empty) ? 0 : sizeof(*(_val));
+    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+
+#define CREATE_BLOB(_val) \
+    struct sol_blob *blob; \
+    size_t _s = sizeof(*_val); \
+    void *v = sol_util_memdup(_val, _s); \
+    SOL_NULL_CHECK(v, -EINVAL); \
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, v, _s); \
+    if (!blob) { \
+        free(v); \
+        return -EINVAL; \
+    }
 
 static inline int
 sol_efivars_read_uint8(const char *name, uint8_t *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-sol_efivars_write_uint8(const char *name, uint8_t value)
+sol_efivars_write_uint8(const char *name, uint8_t value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_efivars_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_efivars_read_bool(const char *name, bool *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-sol_efivars_write_bool(const char *name, bool value)
+sol_efivars_write_bool(const char *name, bool value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_efivars_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_efivars_read_int32(const char *name, int32_t *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-sol_efivars_write_int32(const char *name, int32_t value)
+sol_efivars_write_int32(const char *name, int32_t value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_efivars_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_efivars_read_irange(const char *name, struct sol_irange *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-sol_efivars_write_irange(const char *name, struct sol_irange *value)
+sol_efivars_write_irange(const char *name, struct sol_irange *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(value, false);
+    int r;
 
-    return sol_efivars_write_raw(name, &buf);
+    CREATE_BLOB(value);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_efivars_read_drange(const char *name, struct sol_drange *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-sol_efivars_write_drange(const char *name, struct sol_drange *value)
+sol_efivars_write_drange(const char *name, struct sol_drange *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(value, false);
+    int r;
 
-    return sol_efivars_write_raw(name, &buf);
+    CREATE_BLOB(value);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_efivars_read_double(const char *name, double *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-sol_efivars_write_double(const char *name, double value)
+sol_efivars_write_double(const char *name, double value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_efivars_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
@@ -164,17 +232,37 @@ sol_efivars_read_string(const char *name, char **value)
 }
 
 static inline int
-sol_efivars_write_string(const char *name, const char *value)
+sol_efivars_write_string(const char *name, const char *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS((void *)value, strlen(value),
-        SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
+    int r;
+    struct sol_blob *blob;
+    char *string;
 
-    buf.used = buf.capacity;
+    string = strdup(value);
+    SOL_NULL_CHECK(string, -ENOMEM);
 
-    return sol_efivars_write_raw(name, &buf);
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, string, strlen(value));
+    SOL_NULL_CHECK_GOTO(blob, error);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
+
+error:
+    free(string);
+
+    return -ENOMEM;
 }
 
+/**
+ * @}
+ */
+
 #undef CREATE_BUFFER
+
+#undef CREATE_BLOB
 
 #ifdef __cplusplus
 }

--- a/src/lib/io/include/sol-fs-storage.h
+++ b/src/lib/io/include/sol-fs-storage.h
@@ -36,114 +36,182 @@
 #include <stdint.h>
 
 #include "sol-buffer.h"
+#include "sol-log.h"
 #include "sol-types.h"
+#include "sol-util.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int sol_fs_write_raw(const char *name, const struct sol_buffer *buffer);
+/**
+ * Writes buffer contents to storage.
+ *
+ * Note that as writing operations are asynchronous, to check if it completely
+ * succeded, one needs to register a callback that will inform writing result.
+ * However, right now filesystem storage does not perform asynchronous writing.
+ * Even though, to keep all persistence APIs uniform, only on callback one can
+ * check if writing completed successfully.
+ *
+ * @param name name of property. It will create a file on filesyste with
+ * this name.
+ * @param blob blob that will be written
+ * @param cb callback to be called when writing finishes. It contains status
+ * of writing: if failed, is lesser than zero.
+ * @param data user data to be sent to callback @c cb
+ *
+ * return 0 on success, a negative number on failure
+ */
+int sol_fs_write_raw(const char *name, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data);
 int sol_fs_read_raw(const char *name, struct sol_buffer *buffer);
 
-#define CREATE_BUFFER(_val, _empty) \
+#define CREATE_BUFFER(_val) \
     struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val, \
-    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED); \
-    buf.used = (_empty) ? 0 : sizeof(*(_val));
+    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+
+#define CREATE_BLOB(_val) \
+    struct sol_blob *blob; \
+    size_t _s = sizeof(*_val); \
+    void *v = sol_util_memdup(_val, _s); \
+    SOL_NULL_CHECK(v, -EINVAL); \
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, v, _s); \
+    if (!blob) { \
+        free(v); \
+        return -EINVAL; \
+    }
 
 static inline int
 sol_fs_read_uint8(const char *name, uint8_t *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-sol_fs_write_uint8(const char *name, uint8_t value)
+sol_fs_write_uint8(const char *name, uint8_t value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_fs_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_fs_read_bool(const char *name, bool *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-sol_fs_write_bool(const char *name, bool value)
+sol_fs_write_bool(const char *name, bool value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_fs_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_fs_read_int32(const char *name, int32_t *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-sol_fs_write_int32(const char *name, int32_t value)
+sol_fs_write_int32(const char *name, int32_t value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_fs_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_fs_read_irange(const char *name, struct sol_irange *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-sol_fs_write_irange(const char *name, struct sol_irange *value)
+sol_fs_write_irange(const char *name, struct sol_irange *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(value, false);
+    int r;
 
-    return sol_fs_write_raw(name, &buf);
+    CREATE_BLOB(value);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_fs_read_drange(const char *name, struct sol_drange *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-sol_fs_write_drange(const char *name, struct sol_drange *value)
+sol_fs_write_drange(const char *name, struct sol_drange *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(value, false);
+    int r;
 
-    return sol_fs_write_raw(name, &buf);
+    CREATE_BLOB(value);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_fs_read_double(const char *name, double *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-sol_fs_write_double(const char *name, double value)
+sol_fs_write_double(const char *name, double value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_fs_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
@@ -164,17 +232,37 @@ sol_fs_read_string(const char *name, char **value)
 }
 
 static inline int
-sol_fs_write_string(const char *name, const char *value)
+sol_fs_write_string(const char *name, const char *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS((void *)value, strlen(value),
-        SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
+    int r;
+    struct sol_blob *blob;
+    char *string;
 
-    buf.used = buf.capacity;
+    string = strdup(value);
+    SOL_NULL_CHECK(string, -ENOMEM);
 
-    return sol_fs_write_raw(name, &buf);
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, string, strlen(value));
+    SOL_NULL_CHECK_GOTO(blob, error);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
+
+error:
+    free(string);
+
+    return -ENOMEM;
 }
 
+/**
+ * @}
+ */
+
 #undef CREATE_BUFFER
+
+#undef CREATE_BLOB
 
 #ifdef __cplusplus
 }

--- a/src/lib/io/include/sol-memmap-storage.h
+++ b/src/lib/io/include/sol-memmap-storage.h
@@ -64,6 +64,15 @@ extern "C" {
  * is a @c uint8_t and that versions should start on 1, so Soletta will know
  * if dealing with a totally new storage. It also considers 255 (0xff) as a
  * non-value, so fit new EEPROMs.
+ * Note that a map may define a timeout value to perform writes. This way,
+ * writings can be grouped together, as all writing operations will be
+ * performed at timeout end. That said, it's important to note that when
+ * writing is performed, no order is guaranteed for different keys, i.e.,
+ * writing to 'a' and 'b' can be performed, at timeout end, as 'b' and 'a'
+ * - but for a given key, only the last write will be performed at timeout end.
+ * Multiple writes for the same key before timeout end will result in previous
+ * writes being replaced, and their callbacks will be informed with status
+ * -ECANCELED.
  *
  * @{
  */
@@ -89,7 +98,9 @@ struct sol_memmap_map {
                        * @arg @a devnumber is device number on bus, like 0x50
                        * @arg @a devname is device name, the one recognized by its driver
                        */
-    const struct sol_str_table_ptr *entries; /**< Entries on map, containing name, offset and size */
+    unsigned int timeout; /**< Timeout, in milliseconds, of writing operations. After a write is requested, a timer will run and group all
+                           * writing operations until it expires, when real writing will be performed */
+    const struct sol_str_table_ptr *entries; /**< Entries on map, containing name, offset and size */ /* Memory trick in place, must be last on struct*/
 };
 
 struct sol_memmap_entry {
@@ -155,6 +166,21 @@ int sol_memmap_add_map(const struct sol_memmap_map *map);
  * @return 0 on success, a negative number on failure.
  */
 int sol_memmap_remove_map(const struct sol_memmap_map *map);
+
+/**
+ * Defines map timeout to actually perform write.
+ *
+ * @param map map to have its timeout changed
+ * @param timeout new timeout, in milliseconds.
+ *
+ * @return true if successfuly set map timeout.
+ *
+ * @note This change will take effect after current active timer expires.
+ * Active ones will remain unchanged
+ */
+bool sol_memmap_set_timeout(struct sol_memmap_map *map, unsigned int timeout);
+
+unsigned int sol_memmap_get_timeout(struct sol_memmap_map *map);
 
 #define CREATE_BUFFER(_val) \
     struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val, \

--- a/src/lib/io/include/sol-memmap-storage.h
+++ b/src/lib/io/include/sol-memmap-storage.h
@@ -61,7 +61,8 @@ extern "C" {
  * which will store version of map stored. This API will refuse to work if
  * stored map is different from map version. Note that @c _version field
  * is a @c uint8_t and that versions should start on 1, so Soletta will know
- * if dealing with a totally new storage.
+ * if dealing with a totally new storage. It also considers 255 (0xff) as a
+ * non-value, so fit new EEPROMs.
  *
  * @{
  */

--- a/src/lib/io/sol-efivarfs-storage.c
+++ b/src/lib/io/sol-efivarfs-storage.c
@@ -41,12 +41,21 @@
 
 #include "sol-buffer.h"
 #include "sol-log.h"
+#include "sol-mainloop.h"
 #include "sol-util.h"
 #include "sol-util-file.h"
 
 #define SOLETTA_EFIVARS_GUID "076027a8-c791-41d7-940f-3d465869f821"
 #define EFIVARFS_VAR_DIR "/sys/firmware/efi/efivars/"
 #define EFIVARFS_VAR_PATH EFIVARFS_VAR_DIR "%s-" SOLETTA_EFIVARS_GUID
+
+struct cb_data {
+    char *name;
+    struct sol_blob *blob;
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status);
+    const void *data;
+    int status;
+};
 
 static const int EFIVARS_DEFAULT_ATTR = 0x7;
 
@@ -62,28 +71,74 @@ check_realpath(const char *path)
     return false;
 }
 
-SOL_API int
-sol_efivars_write_raw(const char *name, const struct sol_buffer *buffer)
+static bool
+write_cb(void *data)
 {
-    FILE *file;
+    struct cb_data *cb_data = data;
+
+    if (cb_data->cb)
+        cb_data->cb((void *)cb_data->data, cb_data->name, cb_data->blob,
+            cb_data->status);
+    sol_blob_unref(cb_data->blob);
+
+    free(cb_data->name);
+    free(cb_data);
+
+    return false;
+}
+
+SOL_API int
+sol_efivars_write_raw(const char *name, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
+{
+    FILE *file = NULL;
     char path[PATH_MAX];
     int r;
+    struct cb_data *cb_data = NULL;
 
     SOL_NULL_CHECK(name, -EINVAL);
-    SOL_NULL_CHECK(buffer, -EINVAL);
+    SOL_NULL_CHECK(blob, -EINVAL);
+
+    if (cb) {
+        cb_data = calloc(1, sizeof(struct cb_data));
+        SOL_NULL_CHECK(cb_data, -ENOMEM);
+
+        cb_data->blob = sol_blob_ref(blob);
+        if (!cb_data->blob) {
+            free(cb_data);
+            return -ENOMEM;
+        }
+
+        cb_data->blob = blob;
+        cb_data->data = data;
+        cb_data->cb = cb;
+        cb_data->name = strdup(name);
+        if (!cb_data->name) {
+            sol_blob_unref(blob);
+            free(cb_data);
+            return -ENOMEM;
+        }
+    }
 
     r = snprintf(path, sizeof(path), EFIVARFS_VAR_PATH, name);
     if (r < 0 || r >= PATH_MAX) {
         SOL_WRN("Could not create path for efivars persistence file [%s]", path);
-        return -EINVAL;
+        goto path_error;
     }
+
+    /* From this point on, we return success even on failure, and report
+     * failure on cb, if any. So we have a uniform behaviour among storage
+     * api */
 
     file = fopen(path, "w+e");
     if (!file) {
         SOL_WRN("Could not open persistence file [%s]: %s", path,
             sol_util_strerrora(errno));
-        return -errno;
+        r = -errno;
+        goto end;
     }
+
     if (!check_realpath(path)) {
         /* At this point, a file on an invalid location may have been created.
          * Should we care about it? Is there a 'realpath()' that doesn't need
@@ -100,16 +155,30 @@ sol_efivars_write_raw(const char *name, const struct sol_buffer *buffer)
         goto end;
     }
 
-    fwrite(buffer->data, buffer->used, 1, file);
+    fwrite(blob->mem, blob->size, 1, file);
 
 end:
-    if (fclose(file)) {
+    if (file && fclose(file)) {
         SOL_WRN("Could not close persistence file [%s]: %s", path,
             sol_util_strerrora(errno));
-        return -errno;
+        r = -errno;
     }
 
-    return r;
+    if (cb) {
+        cb_data->status = r;
+        sol_timeout_add(0, write_cb, cb_data);
+    }
+
+    return 0;
+
+path_error:
+    if (cb_data) {
+        sol_blob_unref(blob);
+        free(cb_data->name);
+        free(cb_data);
+    }
+
+    return -ENOMEM;
 }
 
 SOL_API int

--- a/src/lib/io/sol-memmap-storage.c
+++ b/src/lib/io/sol-memmap-storage.c
@@ -166,6 +166,9 @@ sol_memmap_write_raw_do(const char *path, const struct sol_memmap_entry *entry, 
         uint64_t value = 0, old_value;
         uint32_t i, j;
 
+        /* entry->size > 8 implies that no mask should be used */
+        assert(entry->size <= 8);
+
         for (i = 0, j = 0; i < entry->size; i++, j += 8)
             value |= (uint64_t)((uint8_t *)buffer->data)[i] << j;
 

--- a/src/lib/io/sol-memmap-storage.c
+++ b/src/lib/io/sol-memmap-storage.c
@@ -234,7 +234,7 @@ check_version(const struct sol_memmap_map *map)
     }
 
     ret = sol_memmap_read_raw_do(map->path, entry, mask, &buf);
-    if (ret >= 0 && version == 0) {
+    if (ret >= 0 && (version == 0 || version == 255)) {
         /* No version on file, we should be initialising it */
         version = map->version;
         if (sol_memmap_write_raw_do(map->path, entry, mask, &buf) < 0) {

--- a/src/lib/io/sol-memmap-storage.c
+++ b/src/lib/io/sol-memmap-storage.c
@@ -118,7 +118,7 @@ sol_memmap_read_raw_do(const char *path, const struct sol_memmap_entry *entry, u
     if (lseek(fd, entry->offset, SEEK_SET) < 0)
         goto error;
 
-    if (sol_util_fill_buffer(fd, buffer, entry->size) < 0)
+    if ((ret = sol_util_fill_buffer(fd, buffer, entry->size)) < 0)
         goto error;
 
     if (mask) {
@@ -139,7 +139,8 @@ sol_memmap_read_raw_do(const char *path, const struct sol_memmap_entry *entry, u
     return 0;
 
 error:
-    ret = -errno;
+    if (!ret)
+        ret = -errno;
     close(fd);
 
     return ret;

--- a/src/lib/io/sol-memmap-storage.c
+++ b/src/lib/io/sol-memmap-storage.c
@@ -57,14 +57,21 @@
 #define DEV_NUMBER_IDX 3
 #define DEV_NAME_IDX 4
 
-struct map_resolved_path {
-    const struct sol_memmap_map *map;
-    char *resolved_path;
+struct pending_write_data {
+    char *name;
+    const char *path;
+    struct sol_blob *blob;
+    const struct sol_memmap_entry *entry;
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status);
+    const void *data;
+    uint64_t mask;
 };
 
 static struct sol_ptr_vector memory_maps = SOL_PTR_VECTOR_INIT;
 static struct sol_ptr_vector checked_maps = SOL_PTR_VECTOR_INIT;
 static struct sol_ptr_vector resolved_maps_to_free = SOL_PTR_VECTOR_INIT;
+static struct sol_vector pending_writes = SOL_VECTOR_INIT(struct pending_write_data);
+static struct sol_timeout *write_timeout;
 
 static bool
 get_entry_metadata_on_map(const char *name, const struct sol_memmap_map *map, const struct sol_memmap_entry **entry, uint64_t *mask)
@@ -147,16 +154,25 @@ error:
 }
 
 static int
-sol_memmap_write_raw_do(const char *path, const struct sol_memmap_entry *entry, uint64_t mask, const struct sol_buffer *buffer)
+sol_memmap_write_raw_do(const char *path, const char *name, const struct sol_memmap_entry *entry, uint64_t mask, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data, FILE *reuse_file)
 {
-    FILE *file;
+    FILE *file = NULL;
     int ret = 0;
 
-    file = fopen(path, "r+e");
-    if (!file) {
-        SOL_WRN("Could not open memory file [%s]: %s", path,
-            sol_util_strerrora(errno));
-        return -errno;
+    if (!sol_blob_ref(blob))
+        return -ENOMEM;
+
+    if (reuse_file) {
+        file = reuse_file;
+    } else {
+        file = fopen(path, "r+e");
+        if (!file) {
+            SOL_WRN("Could not open memory file [%s]: %s", path,
+                sol_util_strerrora(errno));
+            goto error;
+        }
     }
 
     if (fseek(file, entry->offset, SEEK_SET) < 0)
@@ -170,7 +186,7 @@ sol_memmap_write_raw_do(const char *path, const struct sol_memmap_entry *entry, 
         assert(entry->size <= 8);
 
         for (i = 0, j = 0; i < entry->size; i++, j += 8)
-            value |= (uint64_t)((uint8_t *)buffer->data)[i] << j;
+            value |= (uint64_t)((uint8_t *)blob->mem)[i] << j;
 
         ret = fread(&old_value, entry->size, 1, file);
         if (!ret || ferror(file) || feof(file)) {
@@ -187,7 +203,7 @@ sol_memmap_write_raw_do(const char *path, const struct sol_memmap_entry *entry, 
         value |= (old_value & ~mask);
         fwrite(&value, entry->size, 1, file);
     } else {
-        fwrite(buffer->data, sol_min(entry->size, buffer->used), 1, file);
+        fwrite(blob->mem, sol_min(entry->size, blob->size), 1, file);
     }
 
     if (ferror(file)) {
@@ -195,16 +211,37 @@ sol_memmap_write_raw_do(const char *path, const struct sol_memmap_entry *entry, 
         goto error;
     }
 
-    if (fclose(file) != 0)
-        return -errno;
+    errno = 0;
+    if (!reuse_file)
+        fclose(file);
 
-    return 0;
+    if (cb)
+        cb((void *)data, name, blob, -errno);
+
+    sol_blob_unref(blob);
+
+    return -errno;
 
 error:
+    SOL_DBG("Error writing to file [%s]: %s", path, sol_util_strerrora(errno));
     ret = -errno;
-    fclose(file);
+    if (file && !reuse_file)
+        fclose(file);
+
+    if (cb)
+        cb((void *)data, name, blob, ret);
+
+    sol_blob_unref(blob);
 
     return ret;
+}
+
+static void
+version_write_cb(void *data, const char *name, struct sol_blob *blob, int status)
+{
+    if (status < 0)
+        SOL_WRN("Could not write version to file: %d", status);
+    sol_blob_unref(blob);
 }
 
 static bool
@@ -217,6 +254,7 @@ check_version(const struct sol_memmap_map *map)
     const struct sol_memmap_entry *entry;
     int ret, i;
     uint64_t mask;
+    struct sol_blob *blob;
 
     if (!map->version) {
         SOL_WRN("Invalid memory_map_version. Should not be zero");
@@ -235,10 +273,14 @@ check_version(const struct sol_memmap_map *map)
 
     ret = sol_memmap_read_raw_do(map->path, entry, mask, &buf);
     if (ret >= 0 && (version == 0 || version == 255)) {
+        blob = sol_blob_new(SOL_BLOB_TYPE_NOFREE, NULL, &map->version, sizeof(uint8_t));
+        SOL_NULL_CHECK(blob, false);
+
         /* No version on file, we should be initialising it */
         version = map->version;
-        if (sol_memmap_write_raw_do(map->path, entry, mask, &buf) < 0) {
+        if (sol_memmap_write_raw_do(map->path, MEMMAP_VERSION_ENTRY, entry, mask, blob, version_write_cb, NULL, NULL) < 0) {
             SOL_WRN("Could not write current map version to file");
+            sol_blob_unref(blob);
             return false;
         }
     } else if (ret < 0) {
@@ -255,15 +297,153 @@ check_version(const struct sol_memmap_map *map)
     return sol_ptr_vector_append(&checked_maps, (void *)map) == 0;
 }
 
+static int
+pending_cmp(const void *e1, const void *e2)
+{
+    const struct pending_write_data *p1 = e1;
+    const struct pending_write_data *p2 = e2;
+
+    return strcmp(p1->path, p2->path);
+}
+
+static bool
+perform_pending_writes(void *data)
+{
+    int i, r;
+    struct pending_write_data *pending;
+    FILE *file = NULL;
+    const char *last_path = "";
+
+    write_timeout = NULL;
+
+    /* Order writes by path, so we can open each file only once */
+    qsort(pending_writes.data, pending_writes.len, pending_writes.elem_size, pending_cmp);
+
+    SOL_VECTOR_FOREACH_IDX (&pending_writes, pending, i) {
+        if (!streq(last_path, pending->path)) {
+            if (file) {
+                r = fclose(file);
+                if (r)
+                    SOL_WRN("Error closing file [%s]: %s", last_path,
+                        sol_util_strerrora(errno));
+            }
+            last_path = pending->path;
+            file = fopen(last_path, "r+e");
+            if (!file)
+                SOL_WRN("Error opening file [%s]: %s", last_path,
+                    sol_util_strerrora(errno));
+        }
+
+        sol_memmap_write_raw_do(pending->path, pending->name, pending->entry,
+            pending->mask, pending->blob, pending->cb, pending->data, file);
+        free(pending->name);
+        sol_blob_unref(pending->blob);
+    }
+    if (file) {
+        r = fclose(file);
+        if (r)
+            SOL_WRN("Error closing file [%s]: %s", last_path,
+                sol_util_strerrora(errno));
+    }
+
+    sol_vector_clear(&pending_writes);
+
+    return false;
+}
+
+static bool
+replace_pending_write(const char *path, const char *name,
+    const struct sol_memmap_entry *entry, uint64_t mask, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
+{
+    struct pending_write_data *pending;
+    int i;
+
+    SOL_VECTOR_FOREACH_IDX (&pending_writes, pending, i) {
+        if (streq(pending->name, name)) {
+            if (pending->cb)
+                pending->cb((void *)pending->data, pending->name, pending->blob,
+                    -ECANCELED);
+            sol_blob_unref(pending->blob);
+            pending->blob = sol_blob_ref(blob);
+            if (!pending->blob) {
+                /* If we couldn't ref, let's delete this entry and let
+                 * the caller re-add this write */
+                free(pending->name);
+                sol_vector_del(&pending_writes, i);
+                return false;
+            }
+            pending->cb = cb;
+            pending->data = data;
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static int
+fill_pending_write(struct pending_write_data *pending, const char *path,
+    const char *name, const struct sol_memmap_entry *entry, uint64_t mask,
+    struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
+{
+    pending->blob = sol_blob_ref(blob);
+    SOL_NULL_CHECK(pending->blob, -ENOMEM);
+
+    pending->name = strdup(name);
+    SOL_NULL_CHECK(name, -ENOMEM);
+
+    pending->path = path;
+    pending->entry = entry;
+    pending->mask = mask;
+    pending->cb = cb;
+    pending->data = data;
+
+    return 0;
+}
+
+static int
+add_write(const char *path, const char *name,
+    const struct sol_memmap_entry *entry, uint64_t mask, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
+{
+    struct pending_write_data *pending;
+
+    /* If there's a pending write for the very same entry, we replace it */
+    if (replace_pending_write(path, name, entry, mask, blob, cb, data))
+        return 0;
+
+    pending = sol_vector_append(&pending_writes);
+
+    SOL_NULL_CHECK(pending, -ENOMEM);
+
+    if (fill_pending_write(pending, path, name, entry, mask, blob, cb, data) < 0)
+        return -ENOMEM;
+
+    if (!write_timeout)
+        write_timeout = sol_timeout_add(0, perform_pending_writes, NULL);
+
+    SOL_NULL_CHECK(write_timeout, -ENOMEM);
+
+    return 0;
+}
+
 SOL_API int
-sol_memmap_write_raw(const char *name, const struct sol_buffer *buffer)
+sol_memmap_write_raw(const char *name, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
     const struct sol_memmap_map *map;
     const struct sol_memmap_entry *entry;
     uint64_t mask;
 
     SOL_NULL_CHECK(name, -EINVAL);
-    SOL_NULL_CHECK(buffer, -EINVAL);
+    SOL_NULL_CHECK(blob, -EINVAL);
 
     if (!get_entry_metadata(name, &map, &entry, &mask)) {
         SOL_WRN("No entry on memory map to property [%s]", name);
@@ -273,11 +453,33 @@ sol_memmap_write_raw(const char *name, const struct sol_buffer *buffer)
     if (!check_version(map))
         return -EINVAL;
 
-    if (buffer->used > entry->size)
+    if (blob->size > entry->size)
         SOL_INF("Mapped size for [%s] is %zd, smaller than buffer contents: %zd",
-            name, entry->size, buffer->used);
+            name, entry->size, blob->size);
 
-    return sol_memmap_write_raw_do(map->path, entry, mask, buffer);
+    return add_write(map->path, name, entry, mask, blob, cb, data);
+}
+
+static bool
+read_from_pending(const char *name, struct sol_buffer *buffer)
+{
+    struct pending_write_data *pending;
+    int i;
+
+    SOL_VECTOR_FOREACH_IDX (&pending_writes, pending, i) {
+        if (streq(name, pending->name)) {
+            // TODO maybe a sol_buffer_append_blob?
+            if (sol_buffer_ensure(buffer, pending->blob->size) < 0) {
+                // TODO how bad is this? return old value? fail reading?
+                SOL_WRN("Could not ensure buffer size to fit pending blob");
+                return false;
+            }
+            memcpy(buffer->data, pending->blob->mem, pending->blob->size);
+            return true;
+        }
+    }
+
+    return false;
 }
 
 SOL_API int
@@ -297,6 +499,9 @@ sol_memmap_read_raw(const char *name, struct sol_buffer *buffer)
 
     if (!check_version(map))
         return -EINVAL;
+
+    if (read_from_pending(name, buffer))
+        return 0;
 
     return sol_memmap_read_raw_do(map->path, entry, mask, buffer);
 }

--- a/src/lib/io/sol-memmap-storage.c
+++ b/src/lib/io/sol-memmap-storage.c
@@ -59,7 +59,6 @@
 
 struct pending_write_data {
     char *name;
-    const char *path;
     struct sol_blob *blob;
     const struct sol_memmap_entry *entry;
     void (*cb)(void *data, const char *name, struct sol_blob *blob, int status);
@@ -67,11 +66,16 @@ struct pending_write_data {
     uint64_t mask;
 };
 
+struct map_timeout {
+    const struct sol_memmap_map *map;
+    struct sol_timeout *timeout;
+    struct sol_vector pending_writes;
+};
+
 static struct sol_ptr_vector memory_maps = SOL_PTR_VECTOR_INIT;
 static struct sol_ptr_vector checked_maps = SOL_PTR_VECTOR_INIT;
 static struct sol_ptr_vector resolved_maps_to_free = SOL_PTR_VECTOR_INIT;
-static struct sol_vector pending_writes = SOL_VECTOR_INIT(struct pending_write_data);
-static struct sol_timeout *write_timeout;
+static struct sol_vector write_timeouts = SOL_VECTOR_INIT(struct map_timeout);
 
 static bool
 get_entry_metadata_on_map(const char *name, const struct sol_memmap_map *map, const struct sol_memmap_entry **entry, uint64_t *mask)
@@ -297,13 +301,20 @@ check_version(const struct sol_memmap_map *map)
     return sol_ptr_vector_append(&checked_maps, (void *)map) == 0;
 }
 
-static int
-pending_cmp(const void *e1, const void *e2)
+static struct map_timeout *
+get_map_timeout(const struct sol_memmap_map *map)
 {
-    const struct pending_write_data *p1 = e1;
-    const struct pending_write_data *p2 = e2;
+    struct map_timeout *map_timeout;
+    int i;
 
-    return strcmp(p1->path, p2->path);
+    SOL_VECTOR_FOREACH_IDX (&write_timeouts, map_timeout, i) {
+        if (map_timeout->map == map)
+            return map_timeout;
+    }
+
+    assert(false); /* Should never get here */
+
+    return NULL;
 }
 
 static bool
@@ -312,47 +323,38 @@ perform_pending_writes(void *data)
     int i, r;
     struct pending_write_data *pending;
     FILE *file = NULL;
-    const char *last_path = "";
+    const struct sol_memmap_map *map = data;
+    struct map_timeout *map_timeout = get_map_timeout(map);
 
-    write_timeout = NULL;
+    map_timeout->timeout = NULL;
 
-    /* Order writes by path, so we can open each file only once */
-    qsort(pending_writes.data, pending_writes.len, pending_writes.elem_size, pending_cmp);
+    file = fopen(map->path, "r+e");
+    if (!file) {
+        SOL_WRN("Error opening file [%s]: %s", map->path,
+            sol_util_strerrora(errno));
+        return false;
+    }
 
-    SOL_VECTOR_FOREACH_IDX (&pending_writes, pending, i) {
-        if (!streq(last_path, pending->path)) {
-            if (file) {
-                r = fclose(file);
-                if (r)
-                    SOL_WRN("Error closing file [%s]: %s", last_path,
-                        sol_util_strerrora(errno));
-            }
-            last_path = pending->path;
-            file = fopen(last_path, "r+e");
-            if (!file)
-                SOL_WRN("Error opening file [%s]: %s", last_path,
-                    sol_util_strerrora(errno));
-        }
-
-        sol_memmap_write_raw_do(pending->path, pending->name, pending->entry,
+    SOL_VECTOR_FOREACH_IDX (&map_timeout->pending_writes, pending, i) {
+        sol_memmap_write_raw_do(map->path, pending->name, pending->entry,
             pending->mask, pending->blob, pending->cb, pending->data, file);
         free(pending->name);
         sol_blob_unref(pending->blob);
     }
-    if (file) {
-        r = fclose(file);
-        if (r)
-            SOL_WRN("Error closing file [%s]: %s", last_path,
-                sol_util_strerrora(errno));
-    }
 
-    sol_vector_clear(&pending_writes);
+    r = fclose(file);
+    if (r)
+        SOL_WRN("Error closing file [%s]: %s", map->path,
+            sol_util_strerrora(errno));
+
+    SOL_DBG("Performed pending writes on [%s]", map->path);
+    sol_vector_clear(&map_timeout->pending_writes);
 
     return false;
 }
 
 static bool
-replace_pending_write(const char *path, const char *name,
+replace_pending_write(struct sol_vector *pending_writes, const char *name,
     const struct sol_memmap_entry *entry, uint64_t mask, struct sol_blob *blob,
     void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
     const void *data)
@@ -360,7 +362,7 @@ replace_pending_write(const char *path, const char *name,
     struct pending_write_data *pending;
     int i;
 
-    SOL_VECTOR_FOREACH_IDX (&pending_writes, pending, i) {
+    SOL_VECTOR_FOREACH_IDX (pending_writes, pending, i) {
         if (streq(pending->name, name)) {
             if (pending->cb)
                 pending->cb((void *)pending->data, pending->name, pending->blob,
@@ -371,7 +373,7 @@ replace_pending_write(const char *path, const char *name,
                 /* If we couldn't ref, let's delete this entry and let
                  * the caller re-add this write */
                 free(pending->name);
-                sol_vector_del(&pending_writes, i);
+                sol_vector_del(pending_writes, i);
                 return false;
             }
             pending->cb = cb;
@@ -385,9 +387,8 @@ replace_pending_write(const char *path, const char *name,
 }
 
 static int
-fill_pending_write(struct pending_write_data *pending, const char *path,
-    const char *name, const struct sol_memmap_entry *entry, uint64_t mask,
-    struct sol_blob *blob,
+fill_pending_write(struct pending_write_data *pending, const char *name,
+    const struct sol_memmap_entry *entry, uint64_t mask, struct sol_blob *blob,
     void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
     const void *data)
 {
@@ -397,7 +398,6 @@ fill_pending_write(struct pending_write_data *pending, const char *path,
     pending->name = strdup(name);
     SOL_NULL_CHECK(name, -ENOMEM);
 
-    pending->path = path;
     pending->entry = entry;
     pending->mask = mask;
     pending->cb = cb;
@@ -407,28 +407,30 @@ fill_pending_write(struct pending_write_data *pending, const char *path,
 }
 
 static int
-add_write(const char *path, const char *name,
+add_write(const struct sol_memmap_map *map, const char *name,
     const struct sol_memmap_entry *entry, uint64_t mask, struct sol_blob *blob,
     void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
     const void *data)
 {
     struct pending_write_data *pending;
+    struct map_timeout *map_timeout = get_map_timeout(map);
 
     /* If there's a pending write for the very same entry, we replace it */
-    if (replace_pending_write(path, name, entry, mask, blob, cb, data))
+    if (replace_pending_write(&map_timeout->pending_writes, name, entry, mask, blob, cb, data))
         return 0;
 
-    pending = sol_vector_append(&pending_writes);
+    pending = sol_vector_append(&map_timeout->pending_writes);
 
     SOL_NULL_CHECK(pending, -ENOMEM);
 
-    if (fill_pending_write(pending, path, name, entry, mask, blob, cb, data) < 0)
+    if (fill_pending_write(pending, name, entry, mask, blob, cb, data) < 0)
         return -ENOMEM;
 
-    if (!write_timeout)
-        write_timeout = sol_timeout_add(0, perform_pending_writes, NULL);
+    if (!map_timeout->timeout)
+        map_timeout->timeout = sol_timeout_add(map->timeout,
+            perform_pending_writes, map);
 
-    SOL_NULL_CHECK(write_timeout, -ENOMEM);
+    SOL_NULL_CHECK(map_timeout->timeout, -ENOMEM);
 
     return 0;
 }
@@ -457,25 +459,31 @@ sol_memmap_write_raw(const char *name, struct sol_blob *blob,
         SOL_INF("Mapped size for [%s] is %zd, smaller than buffer contents: %zd",
             name, entry->size, blob->size);
 
-    return add_write(map->path, name, entry, mask, blob, cb, data);
+    return add_write(map, name, entry, mask, blob, cb, data);
 }
 
 static bool
 read_from_pending(const char *name, struct sol_buffer *buffer)
 {
     struct pending_write_data *pending;
-    int i;
+    struct map_timeout *map_timeout;
+    int i, j;
 
-    SOL_VECTOR_FOREACH_IDX (&pending_writes, pending, i) {
-        if (streq(name, pending->name)) {
-            // TODO maybe a sol_buffer_append_blob?
-            if (sol_buffer_ensure(buffer, pending->blob->size) < 0) {
-                // TODO how bad is this? return old value? fail reading?
-                SOL_WRN("Could not ensure buffer size to fit pending blob");
-                return false;
+    SOL_VECTOR_FOREACH_IDX (&write_timeouts, map_timeout, i) {
+        if (!map_timeout->pending_writes.len)
+            continue;
+
+        SOL_VECTOR_FOREACH_IDX (&map_timeout->pending_writes, pending, j) {
+            if (streq(name, pending->name)) {
+                // TODO maybe a sol_buffer_append_blob?
+                if (sol_buffer_ensure(buffer, pending->blob->size) < 0) {
+                    // TODO how bad is this? return old value? fail reading?
+                    SOL_WRN("Could not ensure buffer size to fit pending blob");
+                    return false;
+                }
+                memcpy(buffer->data, pending->blob->mem, pending->blob->size);
+                return true;
             }
-            memcpy(buffer->data, pending->blob->mem, pending->blob->size);
-            return true;
         }
     }
 
@@ -660,6 +668,7 @@ resolve_map(const struct sol_memmap_map *map)
 
         resolved_map->version = map->version;
         resolved_map->entries = map->entries;
+        resolved_map->timeout = map->timeout;
 
         if (resolve_i2c_path(map->path, resolved_map) < 0) {
             SOL_WRN("Could not create i2c EEPROM device using command [%s]", map->path);
@@ -686,6 +695,7 @@ SOL_API int
 sol_memmap_add_map(const struct sol_memmap_map *map)
 {
     struct sol_memmap_map *resolved_map;
+    struct map_timeout *timeout;
     int r;
 
     SOL_NULL_CHECK(map, -EINVAL);
@@ -698,19 +708,40 @@ sol_memmap_add_map(const struct sol_memmap_map *map)
         return -EINVAL;
     }
 
+    timeout = sol_vector_append(&write_timeouts);
+    SOL_NULL_CHECK(timeout, -ENOMEM);
+
+    timeout->map = resolved_map;
+    sol_vector_init(&timeout->pending_writes, sizeof(struct pending_write_data));
+
     r = sol_ptr_vector_append(&memory_maps, (void *)resolved_map);
-    SOL_INT_CHECK(r, < 0, r);
+    SOL_INT_CHECK_GOTO(r, < 0, error);
 
     return 0;
+
+error:
+    sol_vector_del(&write_timeouts, write_timeouts.len - 1);
+    return r;
 }
 
 SOL_API int
 sol_memmap_remove_map(const struct sol_memmap_map *map)
 {
     struct sol_memmap_map *iter;
+    struct map_timeout *map_timeout;
     int i;
 
     SOL_NULL_CHECK(map, -EINVAL);
+
+    SOL_VECTOR_FOREACH_IDX (&write_timeouts, map_timeout, i) {
+        if (map_timeout->map->entries == map->entries) {
+            if (map_timeout->timeout) {
+                perform_pending_writes((void *)map_timeout->map);
+                sol_timeout_del(map_timeout->timeout);
+                break;
+            }
+        }
+    }
 
     SOL_PTR_VECTOR_FOREACH_REVERSE_IDX (&resolved_maps_to_free, iter, i) {
         if (iter->entries == map->entries) {
@@ -721,4 +752,48 @@ sol_memmap_remove_map(const struct sol_memmap_map *map)
     }
 
     return sol_ptr_vector_remove(&memory_maps, map);
+}
+
+SOL_API bool
+sol_memmap_set_timeout(struct sol_memmap_map *map, unsigned int timeout)
+{
+    struct sol_memmap_map *iter;
+    int i;
+
+    SOL_NULL_CHECK(map, false);
+
+    /* Rememeber, as we may have a copy of map (due to device resolving),
+     * we need to update our proper copy */
+    SOL_PTR_VECTOR_FOREACH_IDX (&memory_maps, iter, i) {
+        if (iter->entries == map->entries) {
+            map->timeout = timeout;
+            iter->timeout = timeout;
+            return true;
+        }
+    }
+
+    SOL_WRN("Map %p was not previously added. Call 'sol_memmap_add_map' before.",
+        map);
+    return false;
+}
+
+SOL_API unsigned int
+sol_memmap_get_timeout(struct sol_memmap_map *map)
+{
+    struct sol_memmap_map *iter;
+    int i;
+
+    SOL_NULL_CHECK(map, false);
+
+    /* Rememeber, as we may have a copy of map (due to device resolving),
+     * we need to check our proper copy */
+    SOL_PTR_VECTOR_FOREACH_IDX (&memory_maps, iter, i) {
+        if (iter->entries == map->entries) {
+            return iter->timeout;
+        }
+    }
+
+    SOL_WRN("Map %p was not previously added. Call 'sol_memmap_add_map' before.",
+        map);
+    return 0;
 }

--- a/src/modules/flow/int/int.c
+++ b/src/modules/flow/int/int.c
@@ -236,12 +236,9 @@ set_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn
      */
     if (value == mdata->val.val) return 0;
 
-    if (value < mdata->val.min || value > mdata->val.max) {
-        SOL_WRN("Discarding value out of range [%" PRId32 "] to accumulator %p,"
-            " whose range is from [%" PRId32 "] to [%" PRId32 "]", value, node,
-            mdata->val.min, mdata->val.max);
-        return -EINVAL;
-    }
+    if (value < mdata->val.min || value > mdata->val.max)
+        return sol_flow_send_error_packet_errno(node, ERANGE);
+
     mdata->val.val = value;
 
     return sol_flow_send_irange_packet(node,

--- a/src/samples/flow/minnow-calamari/calamari-button-accumulator-persistence.fbp
+++ b/src/samples/flow/minnow-calamari/calamari-button-accumulator-persistence.fbp
@@ -38,8 +38,10 @@
 # to 'create' the i2c device. Alternatively, it could be a path to EEPROM file
 # on sysfs, considering it's already created. In this case, path would be
 # '/sys/bus/i2c/devices/7-0050/eeprom'
-# Note also that for this sample to work, one must zero at least EEPROM position
-# where offset is saved (byte 200). Or use 255 as map version on sol-flow.json.
+# Note that to handle EEPROM initial value being 0xff (255), we catch accumulator
+# ERROR packet to reset value to zero. Accumulator will send an error packet
+# because it will receive a value (255) out of its range [0-15], so we can
+# handle properly.
 
 btn1(Button1)
 btn2(Button2)
@@ -48,10 +50,10 @@ seg(SevenSegments)
 persistence(persistence/int:storage="memmap",name="accumulated",default_value=0)
 
 persistence OUT -> SET accumulator
+persistence OUT -> VALUE seg
 
 btn1 OUT -> IN _(boolean/filter) TRUE -> INC accumulator
 btn2 OUT -> IN _(boolean/filter) TRUE -> DEC accumulator
 
 accumulator OUT -> IN persistence
-
-persistence OUT -> VALUE seg
+accumulator ERROR -> RESET accumulator

--- a/src/test-fbp/sol-flow.json
+++ b/src/test-fbp/sol-flow.json
@@ -13,6 +13,7 @@
         {
             "version": 1,
             "path": "memmap-test.bin",
+            "timeout": 25,
             "entries": [
                 {
                     "name": "_version",

--- a/src/test/.gitignore
+++ b/src/test/.gitignore
@@ -19,6 +19,7 @@
 /test-mainloop-linux
 /test-monitors
 /test-parser
+/test-persistence-memmap
 /test-scanner
 /test-str-slice
 /test-str-split

--- a/src/test/Kconfig
+++ b/src/test/Kconfig
@@ -100,3 +100,8 @@ config TEST_COMPOSED_TYPE
 config TEST_MESSAGE_DIGEST
       bool "crypto message-digest"
       default y
+
+config TEST_PERSISTENCE_MEMMAP
+	bool "Memmap persistence API"
+	depends on USE_MEMMAP
+	default y

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -71,3 +71,6 @@ test-test-composed-type-$(TEST_COMPOSED_TYPE) := test.c test-composed-type.c
 
 test-$(TEST_MESSAGE_DIGEST) += test-message-digest
 test-test-message-digest-$(TEST_MESSAGE_DIGEST) := test.c test-message-digest.c
+
+test-$(TEST_PERSISTENCE_MEMMAP) += test-persistence-memmap
+test-test-persistence-memmap-$(TEST_PERSISTENCE_MEMMAP) := test.c test-persistence-memmap.c

--- a/src/test/test-persistence-memmap.c
+++ b/src/test/test-persistence-memmap.c
@@ -1,0 +1,366 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sol-mainloop.h"
+#include "sol-memmap-storage.h"
+
+#include "test.h"
+
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry0, 2, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry1, 3, 1, 0, 1);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry2, 3, 4, 1, 30);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry3, 0, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry4, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry5, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry6, 0, 10, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry7, 0, 32, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry8, 0, 8, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry9, 0, 32, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry10, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry11, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry12, 0, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry13, 0, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry14, 0, 10, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry15, 0, 32, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry16, 0, 32, 0, 0);
+
+static const struct sol_str_table_ptr _memmap0_entries[] = {
+    SOL_STR_TABLE_PTR_ITEM("_version", &map0_entry0),
+    SOL_STR_TABLE_PTR_ITEM("boolean", &map0_entry1),
+    SOL_STR_TABLE_PTR_ITEM("int_only_val", &map0_entry2),
+    SOL_STR_TABLE_PTR_ITEM("byte", &map0_entry3),
+    SOL_STR_TABLE_PTR_ITEM("int", &map0_entry4),
+    SOL_STR_TABLE_PTR_ITEM("irange", &map0_entry5),
+    SOL_STR_TABLE_PTR_ITEM("string", &map0_entry6),
+    SOL_STR_TABLE_PTR_ITEM("double", &map0_entry7),
+    SOL_STR_TABLE_PTR_ITEM("double_only_val", &map0_entry8),
+    SOL_STR_TABLE_PTR_ITEM("drange", &map0_entry9),
+    SOL_STR_TABLE_PTR_ITEM("int_def", &map0_entry10),
+    SOL_STR_TABLE_PTR_ITEM("irange_def", &map0_entry11),
+    SOL_STR_TABLE_PTR_ITEM("byte_def", &map0_entry12),
+    SOL_STR_TABLE_PTR_ITEM("boolean_def", &map0_entry13),
+    SOL_STR_TABLE_PTR_ITEM("string_def", &map0_entry14),
+    SOL_STR_TABLE_PTR_ITEM("double_def", &map0_entry15),
+    SOL_STR_TABLE_PTR_ITEM("drange_def", &map0_entry16),
+    { }
+};
+
+static const struct sol_memmap_map _memmap0 = {
+    .version = 1,
+    .path = "memmap-test.bin",
+    .entries = _memmap0_entries
+};
+
+static struct sol_irange irange_not_delayed = {
+    .val = -23,
+    .min = -1000,
+    .max = 1000,
+    .step = 1
+};
+
+static struct sol_drange drange_not_delayed = {
+    .val = -2.3,
+    .min = -100.0,
+    .max = 100.0,
+    .step = 0.1
+};
+
+static struct sol_irange irange_delayed = {
+    .val = -33,
+    .min = -10000,
+    .max = 10000,
+    .step = 3
+};
+
+static struct sol_drange drange_delayed = {
+    .val = -9.8,
+    .min = -1000.0,
+    .max = 1000.0,
+    .step = 0.2
+};
+
+static void
+write_cb(void *data, const char *name, struct sol_blob *blob, int status)
+{
+    ASSERT_INT_EQ(status, 0);
+}
+
+static void
+write_cancelled_cb(void *data, const char *name, struct sol_blob *blob, int status)
+{
+    ASSERT_INT_EQ(status, -ECANCELED);
+}
+
+static void
+write_one(void)
+{
+    int r;
+
+    r = sol_memmap_write_bool("boolean", true, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_uint8("byte", 78, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_int32("int_only_val", 7804, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_irange("irange", &irange_not_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_drange("drange", &drange_not_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_double("double_only_val", 97.36, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_string("string", "gama delta", write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+}
+
+static void
+read_one(void)
+{
+    int r, i;
+    struct sol_irange irange;
+    struct sol_drange drange;
+    double d;
+    bool b;
+    uint8_t u;
+    char *string;
+
+    r = sol_memmap_read_bool("boolean", &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(b);
+
+    r = sol_memmap_read_uint8("byte", &u);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(u, 78);
+
+    r = sol_memmap_read_int32("int_only_val", &i);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(i, 7804);
+
+    r = sol_memmap_read_irange("irange", &irange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_irange_equal(&irange, &irange_not_delayed));
+
+    r = sol_memmap_read_drange("drange", &drange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_equal(&drange, &drange_not_delayed));
+
+    r = sol_memmap_read_double("double_only_val", &d);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_val_equal(d, 97.36));
+
+    r = sol_memmap_read_string("string", &string);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_STR_EQ(string, "gama delta");
+    free(string);
+}
+
+static void
+write_two(void)
+{
+    int r;
+
+    r = sol_memmap_write_bool("boolean", false, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_uint8("byte", 88, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_int32("int_only_val", 7814, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_irange("irange", &irange_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_drange("drange", &drange_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_double("double_only_val", 107.36, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_string("string", "alfa beta", write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+}
+
+static void
+read_two(void)
+{
+    int r, i;
+    struct sol_irange irange;
+    struct sol_drange drange;
+    double d;
+    bool b;
+    uint8_t u;
+    char *string;
+
+    r = sol_memmap_read_bool("boolean", &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(!b);
+
+    r = sol_memmap_read_uint8("byte", &u);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(u, 88);
+
+    r = sol_memmap_read_int32("int_only_val", &i);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(i, 7814);
+
+    r = sol_memmap_read_irange("irange", &irange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_irange_equal(&irange, &irange_delayed));
+
+    r = sol_memmap_read_drange("drange", &drange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_equal(&drange, &drange_delayed));
+
+    r = sol_memmap_read_double("double_only_val", &d);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_val_equal(d, 107.36));
+
+    r = sol_memmap_read_string("string", &string);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_STR_EQ(string, "alfa beta");
+    free(string);
+}
+
+static bool
+read_two_after(void *data)
+{
+    read_two();
+
+    return false;
+}
+
+static void
+write_one_cancelled(void)
+{
+    int r;
+
+    r = sol_memmap_write_bool("boolean", true, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_uint8("byte", 78, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_int32("int_only_val", 7804, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_irange("irange", &irange_not_delayed, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_drange("drange", &drange_not_delayed, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_double("double_only_val", 97.36, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_string("string", "gama delta", write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+}
+
+static bool
+write_two_timeout(void *data)
+{
+    write_two();
+    read_two();
+
+    return false;
+}
+
+static bool
+read_one_after_mainloop(void *data)
+{
+    read_one();
+
+    return false;
+}
+
+static bool
+write_cancelled_timeout(void *data)
+{
+    write_one_cancelled();
+    read_one(); /* write_one_cancelled writes same values as write_one */
+
+    write_two(); /* reuse second part of test */
+    read_two();
+
+    sol_quit();
+
+    return false;
+}
+
+static bool
+perform_tests(void *data)
+{
+    char command[128];
+    int n;
+
+    sol_memmap_add_map(&_memmap0);
+
+    n = snprintf(command, sizeof(command), "truncate -s0 %s && truncate -s128 %s",
+        _memmap0.path, _memmap0.path);
+    ASSERT(n > 0 && (size_t)n < sizeof(command));
+
+    n = system(command);
+    ASSERT(!n);
+
+    write_one();
+    read_one(); /* This one should happen before actually writing data */
+    sol_timeout_add(0, read_one_after_mainloop, NULL); /* This one should be after a main loop */
+    sol_timeout_add(50, write_two_timeout, NULL); /* This, much after */
+    sol_timeout_add(1000, read_two_after, NULL); /* Even later */
+
+    sol_timeout_add(2000, write_cancelled_timeout, NULL);
+
+    return false;
+}
+
+int
+main(int argc, char *argv[])
+{
+    int err;
+
+    err = sol_init();
+    ASSERT(!err);
+
+    sol_idle_add(perform_tests, NULL);
+
+    sol_run();
+
+    sol_shutdown();
+
+    return 0;
+}

--- a/src/test/test-persistence-memmap.c
+++ b/src/test/test-persistence-memmap.c
@@ -80,6 +80,51 @@ static const struct sol_memmap_map _memmap0 = {
     .entries = _memmap0_entries
 };
 
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry0, 2, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry1, 3, 1, 0, 1);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry2, 3, 4, 1, 30);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry3, 0, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry4, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry5, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry6, 0, 10, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry7, 0, 32, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry8, 0, 8, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry9, 0, 32, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry10, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry11, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry12, 0, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry13, 0, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry14, 0, 10, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry15, 0, 32, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry16, 0, 32, 0, 0);
+
+static const struct sol_str_table_ptr _memmap1_entries[] = {
+    SOL_STR_TABLE_PTR_ITEM("_version", &map1_entry0),
+    SOL_STR_TABLE_PTR_ITEM("boolean2", &map1_entry1),
+    SOL_STR_TABLE_PTR_ITEM("int_only_val2", &map1_entry2),
+    SOL_STR_TABLE_PTR_ITEM("byte2", &map1_entry3),
+    SOL_STR_TABLE_PTR_ITEM("int2", &map1_entry4),
+    SOL_STR_TABLE_PTR_ITEM("irange2", &map1_entry5),
+    SOL_STR_TABLE_PTR_ITEM("string2", &map1_entry6),
+    SOL_STR_TABLE_PTR_ITEM("double2", &map1_entry7),
+    SOL_STR_TABLE_PTR_ITEM("double_only_val2", &map1_entry8),
+    SOL_STR_TABLE_PTR_ITEM("drange2", &map1_entry9),
+    SOL_STR_TABLE_PTR_ITEM("int_def2", &map1_entry10),
+    SOL_STR_TABLE_PTR_ITEM("irange_def2", &map1_entry11),
+    SOL_STR_TABLE_PTR_ITEM("byte_def2", &map1_entry12),
+    SOL_STR_TABLE_PTR_ITEM("boolean_def2", &map1_entry13),
+    SOL_STR_TABLE_PTR_ITEM("string_def2", &map1_entry14),
+    SOL_STR_TABLE_PTR_ITEM("double_def2", &map1_entry15),
+    SOL_STR_TABLE_PTR_ITEM("drange_def2", &map1_entry16),
+    { }
+};
+
+static const struct sol_memmap_map _memmap1 = {
+    .version = 1,
+    .path = "memmap-test2.bin",
+    .entries = _memmap1_entries
+};
+
 static struct sol_irange irange_not_delayed = {
     .val = -23,
     .min = -1000,
@@ -145,6 +190,27 @@ write_one(void)
 
     r = sol_memmap_write_string("string", "gama delta", write_cb, NULL);
     ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_bool("boolean2", true, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_uint8("byte2", 78, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_int32("int_only_val2", 7804, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_irange("irange2", &irange_not_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_drange("drange2", &drange_not_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_double("double_only_val2", 97.36, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_string("string2", "gama delta", write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
 }
 
 static void
@@ -186,6 +252,35 @@ read_one(void)
     ASSERT_INT_EQ(r, 0);
     ASSERT_STR_EQ(string, "gama delta");
     free(string);
+
+    r = sol_memmap_read_bool("boolean2", &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(b);
+
+    r = sol_memmap_read_uint8("byte2", &u);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(u, 78);
+
+    r = sol_memmap_read_int32("int_only_val2", &i);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(i, 7804);
+
+    r = sol_memmap_read_irange("irange2", &irange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_irange_equal(&irange, &irange_not_delayed));
+
+    r = sol_memmap_read_drange("drange2", &drange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_equal(&drange, &drange_not_delayed));
+
+    r = sol_memmap_read_double("double_only_val2", &d);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_val_equal(d, 97.36));
+
+    r = sol_memmap_read_string("string2", &string);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_STR_EQ(string, "gama delta");
+    free(string);
 }
 
 static void
@@ -212,6 +307,27 @@ write_two(void)
     ASSERT_INT_EQ(r, 0);
 
     r = sol_memmap_write_string("string", "alfa beta", write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_bool("boolean2", false, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_uint8("byte2", 88, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_int32("int_only_val2", 7814, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_irange("irange2", &irange_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_drange("drange2", &drange_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_double("double_only_val2", 107.36, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_string("string2", "alfa beta", write_cb, NULL);
     ASSERT_INT_EQ(r, 0);
 }
 
@@ -254,6 +370,35 @@ read_two(void)
     ASSERT_INT_EQ(r, 0);
     ASSERT_STR_EQ(string, "alfa beta");
     free(string);
+
+    r = sol_memmap_read_bool("boolean2", &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(!b);
+
+    r = sol_memmap_read_uint8("byte2", &u);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(u, 88);
+
+    r = sol_memmap_read_int32("int_only_val2", &i);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(i, 7814);
+
+    r = sol_memmap_read_irange("irange2", &irange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_irange_equal(&irange, &irange_delayed));
+
+    r = sol_memmap_read_drange("drange2", &drange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_equal(&drange, &drange_delayed));
+
+    r = sol_memmap_read_double("double_only_val2", &d);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_val_equal(d, 107.36));
+
+    r = sol_memmap_read_string("string2", &string);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_STR_EQ(string, "alfa beta");
+    free(string);
 }
 
 static bool
@@ -288,6 +433,27 @@ write_one_cancelled(void)
     ASSERT_INT_EQ(r, 0);
 
     r = sol_memmap_write_string("string", "gama delta", write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_bool("boolean2", true, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_uint8("byte2", 78, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_int32("int_only_val2", 7804, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_irange("irange2", &irange_not_delayed, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_drange("drange2", &drange_not_delayed, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_double("double_only_val2", 97.36, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_string("string2", "gama delta", write_cancelled_cb, NULL);
     ASSERT_INT_EQ(r, 0);
 }
 
@@ -329,9 +495,17 @@ perform_tests(void *data)
     int n;
 
     sol_memmap_add_map(&_memmap0);
+    sol_memmap_add_map(&_memmap1);
 
     n = snprintf(command, sizeof(command), "truncate -s0 %s && truncate -s128 %s",
         _memmap0.path, _memmap0.path);
+    ASSERT(n > 0 && (size_t)n < sizeof(command));
+
+    n = system(command);
+    ASSERT(!n);
+
+    n = snprintf(command, sizeof(command), "truncate -s0 %s && truncate -s128 %s",
+        _memmap1.path, _memmap1.path);
     ASSERT(n > 0 && (size_t)n < sizeof(command));
 
     n = system(command);


### PR DESCRIPTION
v5:
Less memory allocation (and leaks)

v4:
Fixed issues with timeouted implementation of memmap.

v3:
No more delayed as API parameter. It's now exclusive to memmap, defined via mapping file and adjustable via C API. Tests updated to check it.
Commit order changed so fixes and EEPROM map version happen before async stuff.

v2:
Fixed pointed issues;
Added assert that _FORTIFY_SOURCE=2 complained, thanks to @lpereira;
EEPROM starts with 0xff, and not 0x00. Added code to handle version 0xff as no version of memory map. Updated calamari sample to make use of that;
Added a commit that has a delayed option, so some requests can be delayed by up to SOL_PERSISTENCE_WRITE_TIMEOUT envvar. It's separated from main commit of async, as I'm not sure about this approach. If it goes in, it should (probably) be squashed onto that commit - or it maybe dropped altogether.

First try at making persistence APIs async. Although memory map, file system and efivars were changed in a uniform fashion, only memory map actually does async writing - but all of them return the real result of writing on a callback.
Tests were also added, memap only now - although make check-valgrind failed here in a way I couldn't understand, no leaks, but an assert failure o.O.
