### PR TITLE
Create a node to build URLs. v2

### DIFF
--- a/src/lib/comms/include/sol-http.h
+++ b/src/lib/comms/include/sol-http.h
@@ -240,6 +240,10 @@ void sol_http_param_free(struct sol_http_param *params);
 
 int sol_http_escape_string(char **escaped, const char *value);
 
+int sol_http_build_uri(char **uri, const char *base, const struct sol_http_param *params);
+
+int sol_http_encode_params(char **encoded_params, enum sol_http_param_type type, const struct sol_http_param *params);
+
 /**
  * @}
  */

--- a/src/lib/comms/sol-http-client-impl-curl.c
+++ b/src/lib/comms/sol-http-client-impl-curl.c
@@ -543,101 +543,6 @@ free_buffer:
     return NULL;
 }
 
-static char *
-encode_key_values(CURL *curl, enum sol_http_param_type type,
-    const struct sol_http_param *params, char *initial_value)
-{
-    struct sol_http_param_value *iter;
-    uint16_t idx;
-    bool first = true;
-
-    if (type != SOL_HTTP_PARAM_QUERY_PARAM &&
-        type != SOL_HTTP_PARAM_POST_FIELD &&
-        type != SOL_HTTP_PARAM_COOKIE) {
-        free(initial_value);
-        errno = EINVAL;
-        return NULL;
-    }
-
-    SOL_VECTOR_FOREACH_IDX (&params->params, iter, idx) {
-        const char *key = iter->value.key_value.key;
-        const char *value = iter->value.key_value.value;
-        char *tmp, *encoded_key, *encoded_value;
-        int r;
-
-        if (iter->type != type)
-            continue;
-
-        encoded_key = curl_easy_escape(curl, key, strlen(key));
-        if (!encoded_key)
-            goto cleanup;
-        encoded_value = curl_easy_escape(curl, value, strlen(value));
-        if (!encoded_value) {
-            curl_free(encoded_key);
-            goto cleanup;
-        }
-
-        if (type == SOL_HTTP_PARAM_COOKIE) {
-            r = asprintf(&tmp, "%s%s%s=%s;", initial_value, first ? "" : " ",
-                encoded_key, encoded_value);
-        } else {
-            r = asprintf(&tmp, "%s%s%s=%s", initial_value, first ? "" : "&",
-                encoded_key, encoded_value);
-        }
-
-        curl_free(encoded_key);
-        curl_free(encoded_value);
-
-        if (r < 0)
-            goto cleanup;
-
-        free(initial_value);
-        initial_value = tmp;
-        first = false;
-    }
-
-    return initial_value;
-
-cleanup:
-    free(initial_value);
-    errno = ENOMEM;
-    return NULL;
-}
-
-static char *
-build_uri(CURL *curl, const char *base, const struct sol_http_param *params)
-{
-    char *initial_value;
-    char *built_uri;
-
-    if (asprintf(&initial_value, "%s?", base) < 0) {
-        errno = ENOMEM;
-        return NULL;
-    }
-
-    built_uri = encode_key_values(curl, SOL_HTTP_PARAM_QUERY_PARAM, params,
-        initial_value);
-    if (built_uri == initial_value) {
-        free(initial_value);
-        return strdup(base);
-    }
-
-    return built_uri;
-}
-
-static char *
-build_cookies(CURL *curl, const struct sol_http_param *params)
-{
-    return encode_key_values(curl, SOL_HTTP_PARAM_COOKIE, params, strdup(""));
-}
-
-static char *
-build_post_fields(CURL *curl, const struct sol_http_param *params)
-{
-    return encode_key_values(curl, SOL_HTTP_PARAM_POST_FIELD, params,
-        strdup(""));
-}
-
 static bool
 set_headers_from_params(CURL *curl, struct sol_arena *arena,
     const struct sol_http_param *params, struct curl_slist **headers)
@@ -746,9 +651,13 @@ static bool
 set_cookies_from_params(CURL *curl, struct sol_arena *arena,
     const struct sol_http_param *params)
 {
-    char *cookies = build_cookies(curl, params);
+    char *cookies;
+    int r;
 
-    if (cookies && !*cookies) {
+    r = sol_http_encode_params(&cookies, SOL_HTTP_PARAM_COOKIE, params);
+    SOL_INT_CHECK(r, < 0, false);
+
+    if (!*cookies) {
         free(cookies);
         return true;
     }
@@ -759,7 +668,11 @@ static bool
 set_uri_from_params(CURL *curl, struct sol_arena *arena, const char *base,
     const struct sol_http_param *params)
 {
-    char *full_uri = build_uri(curl, base, params);
+    char *full_uri;
+    int r;
+
+    r = sol_http_build_uri(&full_uri, base, params);
+    SOL_INT_CHECK(r, < 0, false);
 
     return set_string_option(curl, CURLOPT_URL, arena, full_uri);
 }
@@ -768,7 +681,11 @@ static bool
 set_post_fields_from_params(CURL *curl, struct sol_arena *arena,
     const struct sol_http_param *params)
 {
-    char *post = build_post_fields(curl, params);
+    char *post;
+    int r;
+
+    r = sol_http_encode_params(&post, SOL_HTTP_PARAM_POST_FIELD, params);
+    SOL_INT_CHECK(r, < 0, false);
 
     return set_string_option(curl, CURLOPT_POSTFIELDS, arena, post);
 }

--- a/src/lib/comms/sol-http-common.c
+++ b/src/lib/comms/sol-http-common.c
@@ -123,3 +123,94 @@ end:
     sol_buffer_fini(&buf);
     return r;
 }
+
+SOL_API int
+sol_http_encode_params(char **encoded_params, enum sol_http_param_type type,
+    const struct sol_http_param *params)
+{
+    struct sol_buffer buf;
+    struct sol_http_param_value *iter;
+    char *encoded_key, *encoded_value;
+    uint16_t idx;
+    bool first = true;
+    int r;
+
+    SOL_NULL_CHECK(encoded_params, -EINVAL);
+    SOL_NULL_CHECK(params, -EINVAL);
+
+    if (type != SOL_HTTP_PARAM_QUERY_PARAM &&
+        type != SOL_HTTP_PARAM_POST_FIELD &&
+        type != SOL_HTTP_PARAM_COOKIE) {
+        return -EINVAL;
+    }
+
+    sol_buffer_init(&buf);
+
+    encoded_key = encoded_value = NULL;
+    SOL_HTTP_PARAM_FOREACH_IDX (params, iter, idx) {
+        if (iter->type != type)
+            continue;
+
+        r = sol_http_escape_string(&encoded_key, iter->value.key_value.key);
+        SOL_INT_CHECK_GOTO(r, < 0, clean_up);
+
+        r = sol_http_escape_string(&encoded_value, iter->value.key_value.value);
+        SOL_INT_CHECK_GOTO(r, < 0, clean_up);
+
+        if (type == SOL_HTTP_PARAM_COOKIE) {
+            r = sol_buffer_append_printf(&buf, "%s%s=%s;", first ? "" : " ",
+                encoded_key, encoded_value);
+        } else {
+            r = sol_buffer_append_printf(&buf, "%s%s=%s", first ? "" : "&",
+                encoded_key, encoded_value);
+        }
+
+        SOL_INT_CHECK_GOTO(r, < 0, clean_up);
+
+        first = false;
+        free(encoded_key);
+        free(encoded_value);
+        encoded_value = encoded_key = NULL;
+    }
+
+    r = sol_buffer_ensure_nul_byte(&buf);
+    SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+    *encoded_params = sol_buffer_steal(&buf, NULL);
+
+    sol_buffer_fini(&buf);
+
+    return 0;
+
+clean_up:
+    free(encoded_key);
+    free(encoded_value);
+err_exit:
+    sol_buffer_fini(&buf);
+    return r;
+}
+
+SOL_API int
+sol_http_build_uri(char **uri, const char *base,
+    const struct sol_http_param *params)
+{
+    char *encoded_params;
+    int r;
+
+    SOL_NULL_CHECK(uri, -EINVAL);
+    SOL_NULL_CHECK(base, -EINVAL);
+    SOL_NULL_CHECK(params, -EINVAL);
+
+    r = sol_http_encode_params(&encoded_params, SOL_HTTP_PARAM_QUERY_PARAM,
+        params);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (asprintf(uri, "%s%s%s", base, *encoded_params ? "?" : "",
+        encoded_params) < 0) {
+        r = -ENOMEM;
+        SOL_ERR("Could not create the URL with the encoded parameters."
+            "URL:%s, parameters:%s", base, encoded_params);
+    }
+
+    free(encoded_params);
+    return r;
+}

--- a/src/modules/flow/http-client/http-client.json
+++ b/src/modules/flow/http-client/http-client.json
@@ -436,6 +436,69 @@
       ]
     },
     {
+      "name": "http-client/build-url",
+      "private_data_type": "build_url_data",
+      "category": "http-generic",
+      "description": "Builds an encoded URL",
+      "url": "http://solettaproject.org/doc/latest/node_types/http-client/build-url.html",
+      "methods": {
+        "close": "build_url_close",
+        "open": "build_url_open"
+      },
+      "options": {
+        "members": [
+          {
+            "data_type": "string",
+            "default": null,
+            "description": "The base URL, it will not be encoded",
+            "name": "url"
+          }
+        ],
+        "version": 1
+      },
+      "in_ports": [
+        {
+          "data_type": "string",
+          "description": "The base URL, it will not be encoded",
+          "name": "URL",
+          "methods": {
+            "process": "build_url_url_process"
+          }
+        },
+        {
+          "data_type": "composed:string,string",
+          "description": "The URL parameters to be encoded",
+          "name": "PARAM",
+          "methods": {
+            "process": "build_url_param_process"
+          }
+        },
+        {
+          "data_type": "any",
+          "description": "Clear all URL parameters",
+          "name": "CLEAR",
+          "methods": {
+            "process": "build_url_clear_process"
+          }
+        },
+        {
+          "data_type": "any",
+          "description": "Process the params and generate an encoded URL",
+          "name": "TRIGGER",
+          "methods": {
+            "process": "build_url_trigger"
+          }
+        }
+      ],
+      "out_ports": [
+        {
+          "data_type": "string",
+          "description": "The enconded URL",
+          "name": "OUT"
+        }
+      ]
+    },
+    {
       "name": "http-client/request",
       "private_data_type": "http_request_data",
       "category": "http-generic",

--- a/src/test-fbp/encoded_url.fbp
+++ b/src/test-fbp/encoded_url.fbp
@@ -1,0 +1,51 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+DECLARE=Param:composed-new:KEY(string)|VALUE(string)
+
+UrlNoParams(http-client/build-url) OUT -> IN[0] CmpNoParams(string/compare) EQUAL -> RESULT UrlNoParamsTest(test/result)
+UrlNoParamsString(constant/string:value="http://www.example.com") OUT -> IN[1] CmpNoParams
+UrlNoParamsString OUT -> URL UrlNoParams
+UrlNoParamsString OUT -> TRIGGER UrlNoParams
+
+UrlWithParams(http-client/build-url:url="http://www.example.com") OUT -> IN[0] CmpWithParams(string/compare) EQUAL -> RESULT UrlWithParamsTest(test/result)
+
+EncodedParam(Param) OUT -> PARAM UrlWithParams
+NotEncodedParam(Param) OUT -> PARAM UrlWithParams
+
+_(constant/string:value="This Key Should be encoded !!*/&%$$¨") OUT -> KEY EncodedParam
+_(constant/string:value="My precious value %#&**(),,") OUT -> VALUE EncodedParam
+
+_(constant/string:value="SimpleKey") OUT -> KEY NotEncodedParam
+_(constant/string:value="SimpleValue") OUT -> VALUE NotEncodedParam
+
+NotEncodedParam OUT -> TRIGGER UrlWithParams
+
+_(constant/string:value="http://www.example.com?This%20Key%20Should%20be%20encoded%20%21%21%2A%2F%26%25%24%24%C2%A8=My%20precious%20value%20%25%23%26%2A%2A%28%29%2C%2C&SimpleKey=SimpleValue") OUT -> IN[1] CmpWithParams


### PR DESCRIPTION
Changes since v1:

* Initializing encoded_key and encoded_value variables outside the loop.
* Replacing param value with a key is already present in the params array.

------
Some applications may need to construct an URL before a request may be performed.
This new node will make it easier to construct an URL.

Signed-off-by: Guilherme Iscaro <guilherme.iscaro@intel.com>

