### PR TITLE
linux-micro: attach a gdbserver if on debug mode

### DIFF
--- a/src/lib/common/sol-mainloop.c
+++ b/src/lib/common/sol-mainloop.c
@@ -385,6 +385,9 @@ sol_mainloop_default_main(const struct sol_main_callbacks *callbacks, int argc, 
 {
     int r;
 
+    _argc = argc;
+    _argv = argv;
+
     if (unlikely(!callbacks || !callbacks->startup)) {
         SOL_CRI("Missing startup function.");
         return EXIT_FAILURE;
@@ -395,8 +398,6 @@ sol_mainloop_default_main(const struct sol_main_callbacks *callbacks, int argc, 
         return EXIT_FAILURE;
     }
 
-    _argc = argc;
-    _argv = argv;
     sol_idle_add(idle_startup, (void *)callbacks);
 
     r = sol_run();


### PR DESCRIPTION
This patch introduces the sol-debug=1 and sol-debug-comm=* arguments to
be used when linux-micro is running as pid1.

If these arguments are provided by kernel command line, the linux micro
platform implementation will exec() a gdbserver process and attach it to
the current pid1 - as soon as the platform init process takes place.

The sol-debug-comm=* argument is used to determine the comm to be used
by the gdbserver and if not provided /dev/tty0 is assumed as default.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>