### PR TITLE
str-slice: implement trailing + leading whitespace helpers

### DIFF
--- a/src/lib/datatypes/include/sol-str-slice.h
+++ b/src/lib/datatypes/include/sol-str-slice.h
@@ -32,6 +32,7 @@
 
 #pragma once
 
+#include <ctype.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -123,6 +124,44 @@ sol_str_slice_to_string(const struct sol_str_slice slice)
     return strndup(slice.data, slice.len);
 }
 
+static inline struct sol_str_slice
+sol_str_slice_remove_leading_whitespace(struct sol_str_slice slice)
+{
+    struct sol_str_slice copy = slice;
+
+    while (copy.len && isspace(*copy.data)) {
+        copy.data++;
+        copy.len--;
+    }
+
+    return copy;
+}
+
+static inline struct sol_str_slice
+sol_str_slice_remove_trailing_whitespace(struct sol_str_slice slice)
+{
+    struct sol_str_slice copy = slice;
+
+    while (copy.len != 0) {
+        char c = copy.data[copy.len - 1];
+        if (isspace(c))
+            copy.len--;
+        else
+            break;
+    }
+
+    if (slice.len - copy.len)
+        return copy;
+
+    return slice;
+}
+
+static inline struct sol_str_slice
+sol_str_slice_trim(struct sol_str_slice slice)
+{
+    return sol_str_slice_remove_trailing_whitespace
+               (sol_str_slice_remove_leading_whitespace(slice));
+}
 /**
  * @}
  */

--- a/src/test/test-str-slice.c
+++ b/src/test/test-str-slice.c
@@ -108,6 +108,125 @@ test_str_slice_str_eq(void)
 #undef TEST_NOT_EQUAL
 }
 
+DEFINE_TEST(test_str_slice_remove_leading_whitespace);
+
+static void
+test_str_slice_remove_leading_whitespace(void)
+{
+    unsigned int i;
+
+#define TEST_EQUAL(X) { SOL_STR_SLICE_LITERAL(X), true }
+#define TEST_NOT_EQUAL(X) { SOL_STR_SLICE_LITERAL(X), false }
+#define TEST_NOT_EQUAL_SHIFT(X, S) { SOL_STR_SLICE_LITERAL(X + S), false }
+
+    static const struct {
+        struct sol_str_slice input;
+        bool equal;
+    } table[] = {
+        TEST_NOT_EQUAL(" with one leading whitespace"),
+        TEST_NOT_EQUAL("  with two leading whitespace"),
+        TEST_NOT_EQUAL(" "),
+        TEST_NOT_EQUAL("\twith one leading whitespace"),
+        TEST_NOT_EQUAL("\t\twith two leading whitespace"),
+        TEST_NOT_EQUAL("\t"),
+        TEST_NOT_EQUAL("\nwith one leading whitespace"),
+        TEST_NOT_EQUAL("\n\nwith two leading whitespace"),
+        TEST_NOT_EQUAL("\n"),
+        TEST_NOT_EQUAL_SHIFT("        with leading whitespace and shifted", 4),
+        TEST_EQUAL(""),
+        TEST_EQUAL("without leading whitespace"),
+    };
+
+    for (i = 0; i < ARRAY_SIZE(table); i++) {
+        struct sol_str_slice slice;
+        slice = sol_str_slice_remove_leading_whitespace(table[i].input);
+        ASSERT(sol_str_slice_eq(table[i].input, slice) == table[i].equal);
+    }
+
+#undef TEST_EQUAL
+#undef TEST_NOT_EQUAL
+}
+
+DEFINE_TEST(test_str_slice_remove_trailing_whitespace);
+
+static void
+test_str_slice_remove_trailing_whitespace(void)
+{
+    unsigned int i;
+
+#define TEST_EQUAL(X) { SOL_STR_SLICE_LITERAL(X), true }
+#define TEST_NOT_EQUAL(X) { SOL_STR_SLICE_LITERAL(X), false }
+
+    static const struct {
+        struct sol_str_slice input;
+        bool equal;
+    } table[] = {
+        TEST_NOT_EQUAL("with one trailing whitespace "),
+        TEST_NOT_EQUAL("with two trailing whitespace  "),
+        TEST_NOT_EQUAL(" "),
+        TEST_NOT_EQUAL("with one trailing whitespace\t"),
+        TEST_NOT_EQUAL("with two trailing whitespace\t\t"),
+        TEST_NOT_EQUAL("\t"),
+        TEST_NOT_EQUAL("with one trailing whitespace\n"),
+        TEST_NOT_EQUAL("with two trailing whitespace\n\n"),
+        TEST_NOT_EQUAL("\n"),
+        TEST_EQUAL(""),
+        TEST_EQUAL("without trailing whitespace"),
+    };
+
+    for (i = 0; i < ARRAY_SIZE(table); i++) {
+        struct sol_str_slice slice;
+        slice = sol_str_slice_remove_trailing_whitespace(table[i].input);
+        ASSERT(sol_str_slice_eq(table[i].input, slice) == table[i].equal);
+    }
+
+#undef TEST_EQUAL
+#undef TEST_NOT_EQUAL
+}
+
+DEFINE_TEST(test_str_slice_trim);
+
+static void
+test_str_slice_trim(void)
+{
+    unsigned int i;
+
+#define TEST_EQUAL(X) { SOL_STR_SLICE_LITERAL(X), true }
+#define TEST_NOT_EQUAL(X) { SOL_STR_SLICE_LITERAL(X), false }
+
+    static const struct {
+        struct sol_str_slice input;
+        bool equal;
+    } table[] = {
+        TEST_NOT_EQUAL("with one trailing whitespace "),
+        TEST_NOT_EQUAL("with two trailing whitespace  "),
+        TEST_NOT_EQUAL(" "),
+        TEST_NOT_EQUAL("with one trailing whitespace\t"),
+        TEST_NOT_EQUAL("with two trailing whitespace\t\t"),
+        TEST_NOT_EQUAL("\t"),
+        TEST_NOT_EQUAL("with one trailing whitespace\n"),
+        TEST_NOT_EQUAL("with two trailing whitespace\n\n"),
+        TEST_NOT_EQUAL("\n"),
+        TEST_NOT_EQUAL(" with one whitespace "),
+        TEST_NOT_EQUAL("  with two whitespace  "),
+        TEST_NOT_EQUAL("\twith one whitespace\t"),
+        TEST_NOT_EQUAL("\t\twith two whitespace\t\t"),
+        TEST_NOT_EQUAL("\nwith one whitespace\n"),
+        TEST_NOT_EQUAL("\n\nwith two whitespace\n\n"),
+        TEST_EQUAL(""),
+        TEST_EQUAL("without trailing whitespace"),
+    };
+
+    for (i = 0; i < ARRAY_SIZE(table); i++) {
+        struct sol_str_slice slice;
+        slice = sol_str_slice_trim(table[i].input);
+        ASSERT(sol_str_slice_eq(table[i].input, slice) == table[i].equal);
+    }
+
+#undef TEST_EQUAL
+#undef TEST_NOT_EQUAL
+}
+
 DEFINE_TEST(test_str_slice_to_string);
 
 static void


### PR DESCRIPTION
## Changes ##
  - fixed the issues pointed by @lpereira on PR #960;
  - added the underflow test suggested by @lpereira  on PR #960;
  - added ```sol_str_slice_trim()``` function so once can remove trailing and leading white space in a single call;

## Notes ##
This patch was got from my ```linux-micro``` series so we can individually integrate this one so @cabelitos can use in his work.

## Rationale ##
This patch introduces the sol_str_slice_remove_leading_whitespace() and
sol_str_slice_remove_trailing_whitespace() helpers.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>