### PR TITLE
generator: it depends on flow, so enforce this dep

### DIFF
--- a/src/bin/sol-fbp-generator/Kconfig
+++ b/src/bin/sol-fbp-generator/Kconfig
@@ -1,3 +1,4 @@
 config FBP_GENERATOR
 	bool "fbp generator"
+	depends on FLOW
 	default y


### PR DESCRIPTION
The generator code needs the flow support, it will not compile if flow
is disabled since it requires sol-flow-static.h and sol-flow-metatype.h
due the use of SOL_FLOW_NODE_PORT_ERROR_NAME, SOL_FLOW_NODE_PORT_ERROR
and so on.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>