### PR TITLE
samples: c-api samples should depend on flow

### DIFF
--- a/src/samples/flow/c-api/Kconfig
+++ b/src/samples/flow/c-api/Kconfig
@@ -1,15 +1,19 @@
 config FLOW_C_API_CUSTOM_NODE_TYPES_SAMPLE
 	bool
+	depends on FLOW
 	default y
 
 config FLOW_C_API_HIGHLEVEL_SAMPLE
 	bool
+	depends on FLOW
 	default y
 
 config FLOW_C_API_LOWLEVEL_SAMPLE
 	bool
+	depends on FLOW
 	default y
 
 config FLOW_C_API_SIMPLECTYPE_SAMPLE
 	bool
+	depends on FLOW
 	default y


### PR DESCRIPTION
Since they use the flow api it doesn't make any sense to build it if
we've disabled flow support.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>