### PR TITLE
Fix FBP_GENERATOR dependency to correct name

### DIFF
--- a/src/bin/sol-fbp-generator/Kconfig
+++ b/src/bin/sol-fbp-generator/Kconfig
@@ -1,4 +1,4 @@
 config FBP_GENERATOR
 	bool "fbp generator"
-	depends on FLOW
+	depends on FLOW_SUPPORT
 	default y


### PR DESCRIPTION
Building soletta with generator support was not possible because
generator dependency was incorrect

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>