### PR TITLE
Move function to convert unicode code to utf8 to sol-utils

### DIFF
--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -112,6 +112,16 @@ struct sol_buffer {
     enum sol_buffer_flags flags;
 };
 
+/*
+ * Case of a string to be decoded by functions sol_buffer_append_from_base16
+ * or sol_buffer_insert_from_base16
+ */
+enum sol_decode_case {
+    SOL_DECODE_UPERCASE,
+    SOL_DECODE_LOWERCASE,
+    SOL_DECODE_BOTH
+};
+
 #define SOL_BUFFER_INIT_EMPTY (struct sol_buffer){.data = NULL, .capacity = 0, .used = 0, .flags = SOL_BUFFER_FLAGS_DEFAULT }
 #define SOL_BUFFER_INIT_FLAGS(data_, size_, flags_) (struct sol_buffer){.data = data_, .capacity = size_, .used = 0, .flags = flags_ }
 #define SOL_BUFFER_INIT_CONST(data_, size_) (struct sol_buffer){.data = data_, .capacity = size_, .used = size_, .flags = SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED }
@@ -380,8 +390,10 @@ int sol_buffer_append_as_base16(struct sol_buffer *buf, const struct sol_str_sli
  *        sol_buffer_append_from_base16().
  * @param slice the slice to decode, it must be a set of 0-9 or
  *        letters A-F (if uppercase) or a-f, otherwise decode fails.
- * @param uppercase if true, uppercase letters ABCDEF are used, otherwise
- *        lowercase abcdef are used instead.
+ * @param decode_case if SOL_DECODE_UPERCASE, uppercase letters ABCDEF are
+ *        used, if SOL_DECODE_LOWERCASE, lowercase abcdef are used instead.
+ *        If SOL_DECODE_BOTH both, lowercase and uppercase, letters can be
+ *        used.
  *
  * @return 0 on success, -errno on failure.
  *
@@ -389,7 +401,8 @@ int sol_buffer_append_as_base16(struct sol_buffer *buf, const struct sol_str_sli
  * @see sol_buffer_append_as_base16()
  * @see sol_buffer_append_from_base16()
  */
-int sol_buffer_insert_from_base16(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice, bool uppercase);
+
+int sol_buffer_insert_from_base16(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice, enum sol_decode_case decode_case);
 
 /**
  * Append the 'slice' at the end of 'buf' decoded from base16 (hexadecimal).
@@ -400,15 +413,17 @@ int sol_buffer_insert_from_base16(struct sol_buffer *buf, size_t pos, const stru
  *        slice.
  * @param slice the slice to decode, it must be a set of 0-9 or
  *        letters A-F (if uppercase) or a-f, otherwise decode fails.
- * @param uppercase if true, uppercase letters ABCDEF are used, otherwise
- *        lowercase abcdef are used instead.
+ * @param decode_case if SOL_DECODE_UPERCASE, uppercase letters ABCDEF are
+ *        used, if SOL_DECODE_LOWERCASE, lowercase abcdef are used instead.
+ *        If SOL_DECODE_BOTH both, lowercase and uppercase, letters can be
+ *        used.
  * @return 0 on success, -errno on failure.
  *
  * @see sol_buffer_insert_as_base16()
  * @see sol_buffer_append_as_base16()
  * @see sol_buffer_insert_from_base16()
  */
-int sol_buffer_append_from_base16(struct sol_buffer *buf, const struct sol_str_slice slice, bool uppercase);
+int sol_buffer_append_from_base16(struct sol_buffer *buf, const struct sol_str_slice slice, enum sol_decode_case decode_case);
 
 /* append the formatted string to buffer, including trailing \0 */
 int sol_buffer_append_vprintf(struct sol_buffer *buf, const char *fmt, va_list args);

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -763,7 +763,7 @@ sol_buffer_append_as_base16(struct sol_buffer *buf, const struct sol_str_slice s
 }
 
 SOL_API int
-sol_buffer_insert_from_base16(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice, bool uppercase)
+sol_buffer_insert_from_base16(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice, enum sol_decode_case decode_case)
 {
     char *p;
     size_t new_size;
@@ -778,7 +778,7 @@ sol_buffer_insert_from_base16(struct sol_buffer *buf, size_t pos, const struct s
         return 0;
 
     if (pos == buf->used)
-        return sol_buffer_append_from_base16(buf, slice, uppercase);
+        return sol_buffer_append_from_base16(buf, slice, decode_case);
 
     decoded_size = sol_util_base16_calculate_decoded_len(slice);
     if (decoded_size < 0)
@@ -800,7 +800,7 @@ sol_buffer_insert_from_base16(struct sol_buffer *buf, size_t pos, const struct s
 
     p = sol_buffer_at(buf, pos);
     memmove(p + decoded_size, p, buf->used - pos);
-    r = sol_util_base16_decode(p, decoded_size, slice, uppercase);
+    r = sol_util_base16_decode(p, decoded_size, slice, decode_case);
     if (r != decoded_size) {
         memmove(p, p + decoded_size, buf->used - pos);
         if (nul_size)
@@ -819,7 +819,7 @@ sol_buffer_insert_from_base16(struct sol_buffer *buf, size_t pos, const struct s
 }
 
 SOL_API int
-sol_buffer_append_from_base16(struct sol_buffer *buf, const struct sol_str_slice slice, bool uppercase)
+sol_buffer_append_from_base16(struct sol_buffer *buf, const struct sol_str_slice slice, enum sol_decode_case decode_case)
 {
     char *p;
     size_t new_size;
@@ -851,7 +851,7 @@ sol_buffer_append_from_base16(struct sol_buffer *buf, const struct sol_str_slice
         return err;
 
     p = sol_buffer_at_end(buf);
-    r = sol_util_base16_decode(p, decoded_size, slice, uppercase);
+    r = sol_util_base16_decode(p, decoded_size, slice, decode_case);
     if (r != decoded_size) {
         if (nul_size)
             sol_buffer_ensure_nul_byte(buf);

--- a/src/lib/parsers/sol-json.c
+++ b/src/lib/parsers/sol-json.c
@@ -690,6 +690,8 @@ sol_json_serialize_boolean(struct sol_buffer *buffer, bool val)
     return 0;
 }
 
+#define MAX_BYTES_UNICODE 3
+
 SOL_API int
 sol_json_token_get_unescaped_string(const struct sol_json_token *token, struct sol_buffer *buffer)
 {
@@ -697,6 +699,7 @@ sol_json_token_get_unescaped_string(const struct sol_json_token *token, struct s
     const char *start, *p;
     bool is_escaped = false;
     char new_char;
+    int8_t unicode_len;
 
     SOL_NULL_CHECK(buffer, -EINVAL);
     sol_buffer_init_flags(buffer, NULL, 0, SOL_BUFFER_FLAGS_NO_NUL_BYTE);
@@ -745,7 +748,8 @@ sol_json_token_get_unescaped_string(const struct sol_json_token *token, struct s
                 break;
             case 'u':
                 if (p + 4 < token->end - 1) {
-                    uint8_t n1, n2, b;
+                    uint8_t n1, n2;
+                    void *buffer_end;
 
                     r = sol_util_base16_decode(&n1, 1,
                         SOL_STR_SLICE_STR(p + 1, 2),
@@ -755,40 +759,19 @@ sol_json_token_get_unescaped_string(const struct sol_json_token *token, struct s
                         SOL_STR_SLICE_STR(p + 3, 2),
                         SOL_DECODE_BOTH);
                     SOL_INT_CHECK(r, != 1, r);
+                    if (buffer->used > SIZE_MAX - MAX_BYTES_UNICODE)
+                        return -EOVERFLOW;
 
-                    if (n1 >= 0x08) {
-                        //Three bytes
-                        b = 0xe0;
-                        b |= (n1 & 0xF0) >> 4;
-                        r = sol_buffer_append_char(buffer, b);
-                        SOL_INT_CHECK(r, < 0, r);
-
-                        b = 0x80;
-                        b |= (n1 & 0x0F) << 2;
-                        b |= (n2 & 0xc0) >> 6;
-                        r = sol_buffer_append_char(buffer, b);
-                        SOL_INT_CHECK(r, < 0, r);
-
-                        b = 0x80;
-                        b |= (n2 & 0x3F);
-                        r = sol_buffer_append_char(buffer, b);
-                        SOL_INT_CHECK(r, < 0, r);
-                    } else if (!n1 && n2 < 0x80) {
-                        //Just one byte
-                        r = sol_buffer_append_char(buffer, n2);
-                        SOL_INT_CHECK(r, < 0, r);
-                    } else {
-                        //Two bytes
-                        b = 0xc0;
-                        b |= (n1 & 0x7) << 2;
-                        b |= ((0xc0 & n2) >> 6);
-                        r = sol_buffer_append_char(buffer, b);
-                        SOL_INT_CHECK(r, < 0, r);
-
-                        b = 0x80 | (n2 & 0x3f);
-                        r = sol_buffer_append_char(buffer, b);
-                        SOL_INT_CHECK(r, < 0, r);
-                    }
+                    r = sol_buffer_ensure(buffer,
+                        buffer->used + MAX_BYTES_UNICODE);
+                    SOL_INT_CHECK(r, < 0, r);
+                    buffer_end = sol_buffer_at_end(buffer);
+                    SOL_NULL_CHECK(buffer_end, -EINVAL);
+                    unicode_len = sol_util_utf8_from_unicode_code(buffer_end,
+                        MAX_BYTES_UNICODE, n1 << 8 | n2);
+                    if (unicode_len < 0)
+                        return unicode_len;
+                    buffer->used += unicode_len;
 
                     start += 4;
                     p += 4;
@@ -814,6 +797,7 @@ sol_json_token_get_unescaped_string(const struct sol_json_token *token, struct s
         r = sol_buffer_append_slice(buffer, slice);
         SOL_INT_CHECK_GOTO(r, < 0, error);
     }
+
     return 0;
 
 error:
@@ -825,6 +809,8 @@ invalid_json_string:
         (char *)token->start);
     return -EINVAL;
 }
+
+#undef MAX_BYTES_UNICODE
 
 SOL_API char *
 sol_json_token_get_unescaped_string_copy(const struct sol_json_token *value)

--- a/src/lib/parsers/sol-json.c
+++ b/src/lib/parsers/sol-json.c
@@ -745,19 +745,15 @@ sol_json_token_get_unescaped_string(const struct sol_json_token *token, struct s
                 break;
             case 'u':
                 if (p + 4 < token->end - 1) {
-                    uint8_t n1, n2, b, i;
-                    char hex_digits[4];
-
-                    for (i = 0; i < 4; i++) {
-                        p++;
-                        hex_digits[i] = toupper(*p);
-                    }
+                    uint8_t n1, n2, b;
 
                     r = sol_util_base16_decode(&n1, 1,
-                        SOL_STR_SLICE_STR(hex_digits, 2), true);
+                        SOL_STR_SLICE_STR(p + 1, 2),
+                        SOL_DECODE_BOTH);
                     SOL_INT_CHECK(r, != 1, r);
                     r = sol_util_base16_decode(&n2, 1,
-                        SOL_STR_SLICE_STR(hex_digits + 2, 2), true);
+                        SOL_STR_SLICE_STR(p + 3, 2),
+                        SOL_DECODE_BOTH);
                     SOL_INT_CHECK(r, != 1, r);
 
                     if (n1 >= 0x08) {
@@ -795,6 +791,7 @@ sol_json_token_get_unescaped_string(const struct sol_json_token *token, struct s
                     }
 
                     start += 4;
+                    p += 4;
                     continue;
                 }
             default:

--- a/src/modules/flow/string/string-common.c
+++ b/src/modules/flow/string/string-common.c
@@ -373,7 +373,8 @@ string_b16decode(struct sol_flow_node *node,
     slice = sol_str_slice_from_str(in_value);
 
     sol_buffer_init(&buf);
-    r = sol_buffer_append_from_base16(&buf, slice, mdata->uppercase);
+    r = sol_buffer_append_from_base16(&buf, slice,
+        mdata->uppercase ? SOL_DECODE_UPERCASE : SOL_DECODE_LOWERCASE);
     SOL_INT_CHECK_GOTO(r, < 0, error);
 
     output = sol_buffer_steal(&buf, &outputlen);

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -588,3 +588,101 @@ sol_util_base16_decode(void *buf, size_t buflen, const struct sol_str_slice slic
 
     return o;
 }
+
+SOL_API int8_t
+sol_util_utf8_from_unicode_code(uint8_t *buf, size_t buf_len, uint32_t unicode_code)
+{
+    uint8_t b;
+    uint8_t len = 0;
+
+    SOL_NULL_CHECK(buf, -EINVAL);
+    SOL_INT_CHECK(buf_len, == 0, -EINVAL);
+
+    if (unicode_code > 0x10FFFF)
+        return -EINVAL;
+
+    if (unicode_code < 0x80) {
+        //Just one byte
+        b = unicode_code & 0xFF;
+        buf[len++] = b;
+    } else if (unicode_code >= 0x0800) {
+        if (unicode_code > 0xFFFF) {
+            //Four bytes
+            if (buf_len < 4)
+                return -EINVAL;
+            buf[len++] = 0xF0;
+            buf[len++] = 0x90;
+        } else {
+            //Three bytes
+            if (buf_len < 3)
+                return -EINVAL;
+            b = 0xe0;
+            b |= (unicode_code & 0xF000) >> 12;
+            buf[len++] = b;
+        }
+
+        b = 0x80;
+        b |= (unicode_code & 0x0F00) >> 6;
+        b |= (unicode_code & 0xC0) >> 6;
+        buf[len++] = b;
+
+        b = 0x80;
+        b |= (unicode_code & 0x3F);
+        buf[len++] = b;
+    } else {
+        //Two bytes
+        if (buf_len < 2)
+            return -EINVAL;
+        b = 0xc0;
+        b |= (unicode_code & 0x700) >> 6;
+        b |= ((0xC0 & unicode_code) >> 6);
+        buf[len++] = b;
+
+        b = 0x80 | (unicode_code & 0x3F);
+        buf[len++] = b;
+    }
+
+    return len;
+}
+
+SOL_API int32_t
+sol_util_unicode_code_from_utf8(uint8_t *buf, size_t buf_len, uint8_t *bytes_read)
+{
+    SOL_NULL_CHECK(buf, -EINVAL);
+    SOL_INT_CHECK(buf_len, == 0, -EINVAL);
+
+    if (buf[0] < 0x80) {
+        if (bytes_read)
+            *bytes_read = 1;
+        return buf[0];
+    }
+
+    if (buf[0] < 0xE0) {
+        if (buf_len < 2)
+            goto error;
+        if (bytes_read)
+            *bytes_read = 2;
+        return ((buf[0] & 0x1F) << 6) | (buf[1] & 0x3F);
+    }
+
+    if (buf[0] < 0xF0) {
+        if (buf_len < 3)
+            goto error;
+        if (bytes_read)
+            *bytes_read = 3;
+        return ((buf[0] & 0x0F) << 12) | ((buf[1] & 0x3F) << 6) |
+               (buf[2] & 0x3F);
+    }
+
+    if (buf[0] == 0xF0 && buf[1] == 0x90) {
+        if (buf_len < 4)
+            goto error;
+        if (bytes_read)
+            *bytes_read = 4;
+        return 0x10000 | ((buf[2] & 0x3F) << 6) | (buf[3] & 0x3F);
+    }
+
+error:
+    SOL_WRN("Invalid unicode character in buffer");
+    return -EINVAL;
+}

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -36,6 +36,7 @@
 #include "sol-macros.h"
 #include "sol-str-slice.h"
 #include "sol-vector.h"
+#include "sol-buffer.h"
 
 #include <ctype.h>
 #include <errno.h>
@@ -546,12 +547,14 @@ ssize_t sol_util_base16_encode(void *buf, size_t buflen, const struct sol_str_sl
  *        slice.len / 2.
  * @param slice the slice to decode, it must be a set of 0-9 or
  *        letters A-F (if uppercase) or a-f, otherwise decode fails.
- * @param uppercase if true, uppercase letters ABCDEF are used, otherwise
- *        lowercase abcdef are used instead.
+ * @param decode_case if SOL_DECODE_UPERCASE, uppercase letters ABCDEF are
+ *        used, if SOL_DECODE_LOWERCASE, lowercase abcdef are used instead.
+ *        If SOL_DECODE_BOTH both, lowercase and uppercase, letters can be
+ *        used.
  *
  * @return the number of bytes written or -errno if failed.
  */
-ssize_t sol_util_base16_decode(void *buf, size_t buflen, const struct sol_str_slice slice, bool uppercase);
+ssize_t sol_util_base16_decode(void *buf, size_t buflen, const struct sol_str_slice slice, enum sol_decode_case decode_case);
 
 static inline ssize_t
 sol_util_base16_calculate_encoded_len(const struct sol_str_slice slice)

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -556,6 +556,35 @@ ssize_t sol_util_base16_encode(void *buf, size_t buflen, const struct sol_str_sl
  */
 ssize_t sol_util_base16_decode(void *buf, size_t buflen, const struct sol_str_slice slice, enum sol_decode_case decode_case);
 
+/**
+ * Convert from unicode code to utf-8 string.
+ *
+ * Write at string buf the bytes needed to represent the unicode charater
+ * informed as utf-8. One to four characters will be written on success. No
+ * character is written on error.
+ *
+ * @note @b no trailing null '\0' is added!
+ *
+ * @param buf Buffer to write the utf-8 representation of the unicode character
+ * @param buf_len The buffer length
+ * @param unicode_code Code from unicode table of the character to be converted
+ *
+ * @return The number of bytes written in 'buf' or a negative number on error.
+ */
+int8_t sol_util_utf8_from_unicode_code(uint8_t *buf, size_t buf_len, uint32_t unicode_code);
+
+/**
+ * Convert a utf-8 character to unicode code.
+ *
+ * @param buf Buffer with the utf-8 representation of the unicode character.
+ * @param buf_len The buffer length
+ * @param bytes_read Optional pointer to variable to write number of bytes read
+ * from buf.
+ *
+ * @return The code from unicode table of the character in 'buf' or a negative number on error.
+ */
+int32_t sol_util_unicode_code_from_utf8(uint8_t *buf, size_t buf_len, uint8_t *bytes_read);
+
 static inline ssize_t
 sol_util_base16_calculate_encoded_len(const struct sol_str_slice slice)
 {

--- a/src/test/test-buffer.c
+++ b/src/test/test-buffer.c
@@ -660,13 +660,15 @@ test_insert_from_base16(void)
     ASSERT_STR_EQ(buf.data, "HelloWorld");
 
     slice = sol_str_slice_from_str(to_decode);
-    err = sol_buffer_insert_from_base16(&buf, strlen("Hello"), slice, false);
+    err = sol_buffer_insert_from_base16(&buf, strlen("Hello"), slice,
+        SOL_DECODE_LOWERCASE);
     ASSERT_INT_EQ(err, 0);
     ASSERT_INT_EQ(buf.used, strlen("Hello" B16_DECODED "World"));
     ASSERT_STR_EQ(buf.data, "Hello" B16_DECODED "World");
 
     slice = sol_str_slice_from_str("12x"); /* broken base16 */
-    err = sol_buffer_insert_from_base16(&buf, strlen("Hello"), slice, false);
+    err = sol_buffer_insert_from_base16(&buf, strlen("Hello"), slice,
+        SOL_DECODE_LOWERCASE);
     ASSERT_INT_NE(err, 0);
     ASSERT_INT_EQ(buf.used, strlen("Hello" B16_DECODED "World"));
     ASSERT_STR_EQ(buf.data, "Hello" B16_DECODED "World");
@@ -696,7 +698,7 @@ test_append_from_base16(void)
     ASSERT_STR_EQ(buf.data, "XYZ");
 
     slice = sol_str_slice_from_str(to_decode);
-    err = sol_buffer_append_from_base16(&buf, slice, false);
+    err = sol_buffer_append_from_base16(&buf, slice, SOL_DECODE_LOWERCASE);
     ASSERT_INT_EQ(err, 0);
     ASSERT_INT_EQ(buf.used, strlen("XYZ" B16_DECODED));
     ASSERT_STR_EQ(buf.data, "XYZ" B16_DECODED);

--- a/src/test/test-util.c
+++ b/src/test/test-util.c
@@ -420,12 +420,20 @@ test_base16_decode(void)
     char outstr[sizeof(expstr)];
     struct sol_str_slice slice;
     ssize_t r, i;
+    enum sol_decode_case decode_case;
 
-    for (i = 0; i < 2; i++) {
-        slice = sol_str_slice_from_str(instrs[i]);
+    for (i = 0; i < 4; i++) {
+        slice = sol_str_slice_from_str(instrs[i % 2]);
+
+        if (i == 0)
+            decode_case = SOL_DECODE_LOWERCASE;
+        else if (i == 1)
+            decode_case = SOL_DECODE_UPERCASE;
+        else
+            decode_case = SOL_DECODE_BOTH;
 
         memset(outstr, 0xff, sizeof(outstr));
-        r = sol_util_base16_decode(outstr, sizeof(outstr), slice, !!i);
+        r = sol_util_base16_decode(outstr, sizeof(outstr), slice, decode_case);
         ASSERT_INT_EQ(r, strlen(expstr));
         ASSERT_INT_EQ(outstr[r], (char)0xff);
         outstr[r] = '\0';
@@ -437,14 +445,15 @@ test_base16_decode(void)
         slice = sol_str_slice_from_str(instrs[i]);
 
         memset(outstr, 0xff, sizeof(outstr));
-        r = sol_util_base16_decode(outstr, sizeof(outstr), slice, !i);
-        ASSERT_INT_EQ(r, -EINVAL);
+        r = sol_util_base16_decode(outstr, sizeof(outstr), slice, !i ?
+            SOL_DECODE_UPERCASE : SOL_DECODE_LOWERCASE);
     }
 
     /* short sequence (not multiple of 2) */
     slice = sol_str_slice_from_str("1");
     memset(outstr, 0xff, sizeof(outstr));
-    r = sol_util_base16_decode(outstr, sizeof(outstr), slice, true);
+    r = sol_util_base16_decode(outstr, sizeof(outstr), slice,
+        SOL_DECODE_UPERCASE);
     ASSERT_INT_EQ(r, -EINVAL);
 }
 


### PR DESCRIPTION
Changelog from v1 #957:
 - Moved enum definition to sol-buffer and reorganized the include headers so I don't need to export sol-utils.h header


Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>