### PR TITLE
flow: options parser shouldn't allow more subfields than expected

### DIFF
--- a/src/lib/flow/sol-flow-node-options.c
+++ b/src/lib/flow/sol-flow-node-options.c
@@ -98,6 +98,7 @@ get_member_memory(const struct sol_flow_node_options_member_description *member,
             if (errno != 0) goto err;                                   \
             field_cnt++;                                                \
             *end = backup;                                              \
+            start = NULL; \
             if (backup == '\0') break;                                  \
             start = end + 1;                                            \
             if (!start) break;                                          \
@@ -106,6 +107,7 @@ get_member_memory(const struct sol_flow_node_options_member_description *member,
             backup = *end;                                              \
             *end = '\0';                                                \
         }                                                               \
+        if (start) goto err; \
     } while (0)
 
 #define ASSIGN_KEY_VAL(_type, _key, _parse_func, _only_not_negative, \

--- a/src/test-fbp/parser-errors/node-with-many-subfields.fbp
+++ b/src/test-fbp/parser-errors/node-with-many-subfields.fbp
@@ -1,0 +1,38 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# it has a subfield more than expected
+foo(int/accumulator:setup_value=0|10|25|1|10)
+
+## TEST-EXPECTS-ERROR
+
+## TEST-OUTPUT
+# node-with-many-subfields.fbp:32:21 Couldn't parse value '0|10|25|1|10' for option 'setup_value' (irange) of node 'foo'
+## TEST-SKIP-COMPILE This test should not be generated + compiled, test parser errors is its sole purpose


### PR DESCRIPTION
It fixes such issue for subfields written in linear form, like:
 value=0|10|10|100

Issue remains for named subfields, like:
 value=min:10|max:50|invalid:100

Where extra fields can be written, or wrong subfields. In both
cases such keys are just ignored and default values are used
for subfields not set.

@glima please take a look on that

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>