### PR TITLE
build: fix dependency chain for Soletta objects

### DIFF
--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -317,12 +317,12 @@ $(foreach curr,$(tests-internal),$(eval $(call make-test-internal,$(curr))))
 find-gen-hdrs = $(foreach gen,$($(2)-gens),$($(gen)-hdr))
 
 define make-object
-$(1): $(PRE_GEN) $($(1)-src) $(call find-deps,$(2)) $(find-gen-hdrs) $(all-hdr)
+$(1): $($(1)-src) $(1).dep $(call find-deps,$(2)) $(find-gen-hdrs)
 	$(Q)echo "      "CC"   "$$@
 	$(Q)$(MKDIR) -p $(dir $(1))
 	$(Q)$(TARGETCC) $(OBJ_CFLAGS) $($(2)-gen-cflags) $(sort $($(2)-cflags)) $($(1)-src) -c -o $(1) $(3)
 
-$(1).dep: $(PRE_GEN) $($(1)-src) $(all-hdr) $(KCONFIG_CONFIG)
+$(1).dep: $($(1)-src) $(all-hdr) $(KCONFIG_CONFIG)
 	$(Q)$(MKDIR) -p $(dir $(1))
 	$(Q)$(TARGETCC) $(OBJ_CFLAGS) $($(2)-gen-cflags) $(sort $($(2)-cflags)) -MM -MG $($(1)-src) -MT "$(1)" > $(1).dep
 endef


### PR DESCRIPTION
The objects were depending on *all headers*, according to the PRE_GEN
makefile variable, which is not needed there. We leave it only to the
general default_target rule.

There was another serious dependency bug too: the .dep files, listing
specific dependencies for each module, were dangling in the
Makefile.rules file. Now each module object depends on them again, and
the specific headers for the object are checked for dependency, as it
should be.

Test plan: build till the end, touch some flow module's .json file,
build again. Only the module's .o should be rebuilt and, if it's
built-in, Soletta lib's .so and the rest of the modules are them
re-linked only.

Thanks to Dorileo for the help.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>