### PR TITLE
mqtt: Fix dependency check for libmosquitto

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -141,7 +141,7 @@
       "headers": [
         "<mosquitto.h>"
       ],
-      "fragment": "mosquitto_lib_init();",
+      "fragment": "mosquitto_opts_set(0, 0, 0);",
       "ldflags": {
         "value": "-lmosquitto"
       }


### PR DESCRIPTION
mosquitto_lib_init() is not enough to check for the proper version of
libmosquitto since it has the same signature in incompatible versions.

mosquitto_opts_set is a new API added in mosquitto 1.4. All versions
after 1.4 are compatible with soletta.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>