### PR TITLE
Persistence fixes

### DIFF
--- a/src/lib/io/include/sol-memmap-storage.h
+++ b/src/lib/io/include/sol-memmap-storage.h
@@ -61,7 +61,8 @@ extern "C" {
  * which will store version of map stored. This API will refuse to work if
  * stored map is different from map version. Note that @c _version field
  * is a @c uint8_t and that versions should start on 1, so Soletta will know
- * if dealing with a totally new storage.
+ * if dealing with a totally new storage. It also considers 255 (0xff) as a
+ * non-value, so fit new EEPROMs.
  *
  * @{
  */

--- a/src/lib/io/sol-memmap-storage.c
+++ b/src/lib/io/sol-memmap-storage.c
@@ -166,6 +166,9 @@ sol_memmap_write_raw_do(const char *path, const struct sol_memmap_entry *entry, 
         uint64_t value = 0, old_value;
         uint32_t i, j;
 
+        /* entry->size > 8 implies that no mask should be used */
+        assert(entry->size <= 8);
+
         for (i = 0, j = 0; i < entry->size; i++, j += 8)
             value |= (uint64_t)((uint8_t *)buffer->data)[i] << j;
 

--- a/src/lib/io/sol-memmap-storage.c
+++ b/src/lib/io/sol-memmap-storage.c
@@ -218,8 +218,9 @@ check_version(const struct sol_memmap_map *map)
     int ret, i;
     uint64_t mask;
 
-    if (!map->version) {
-        SOL_WRN("Invalid memory_map_version. Should not be zero");
+    if (!map->version || map->version == 255) {
+        SOL_WRN("Invalid memory_map_version. Should be between 1 and 255. Found %d",
+            map->version);
         return false;
     }
 
@@ -234,7 +235,7 @@ check_version(const struct sol_memmap_map *map)
     }
 
     ret = sol_memmap_read_raw_do(map->path, entry, mask, &buf);
-    if (ret >= 0 && version == 0) {
+    if (ret >= 0 && (version == 0 || version == 255)) {
         /* No version on file, we should be initialising it */
         version = map->version;
         if (sol_memmap_write_raw_do(map->path, entry, mask, &buf) < 0) {

--- a/src/lib/io/sol-memmap-storage.c
+++ b/src/lib/io/sol-memmap-storage.c
@@ -118,7 +118,7 @@ sol_memmap_read_raw_do(const char *path, const struct sol_memmap_entry *entry, u
     if (lseek(fd, entry->offset, SEEK_SET) < 0)
         goto error;
 
-    if (sol_util_fill_buffer(fd, buffer, entry->size) < 0)
+    if ((ret = sol_util_fill_buffer(fd, buffer, entry->size)) < 0)
         goto error;
 
     if (mask) {
@@ -139,7 +139,8 @@ sol_memmap_read_raw_do(const char *path, const struct sol_memmap_entry *entry, u
     return 0;
 
 error:
-    ret = -errno;
+    if (!ret)
+        ret = -errno;
     close(fd);
 
     return ret;

--- a/src/samples/flow/minnow-calamari/calamari-button-accumulator-persistence.fbp
+++ b/src/samples/flow/minnow-calamari/calamari-button-accumulator-persistence.fbp
@@ -38,8 +38,10 @@
 # to 'create' the i2c device. Alternatively, it could be a path to EEPROM file
 # on sysfs, considering it's already created. In this case, path would be
 # '/sys/bus/i2c/devices/7-0050/eeprom'
-# Note also that for this sample to work, one must zero at least EEPROM position
-# where offset is saved (byte 200). Or use 255 as map version on sol-flow.json.
+# Note that to handle EEPROM initial value being 0xff (255), we catch accumulator
+# ERROR packet to reset value to zero. Accumulator will send an error packet
+# because it will receive a value (255) out of its range [0-15], so we can
+# handle properly.
 
 btn1(Button1)
 btn2(Button2)
@@ -48,10 +50,10 @@ seg(SevenSegments)
 persistence(persistence/int:storage="memmap",name="accumulated",default_value=0)
 
 persistence OUT -> SET accumulator
+persistence OUT -> VALUE seg
 
 btn1 OUT -> IN _(boolean/filter) TRUE -> INC accumulator
 btn2 OUT -> IN _(boolean/filter) TRUE -> DEC accumulator
 
 accumulator OUT -> IN persistence
-
-persistence OUT -> VALUE seg
+accumulator ERROR -> RESET accumulator


### PR DESCRIPTION
This PR replaces part of #966 - it does the 'simple fixes', so it can be merged faster.

Added assert that _FORTIFY_SOURCE=2 complained, thanks to @lpereira;
EEPROM starts with 0xff, and not 0x00. Added code to handle version 0xff as no version of memory map. Updated calamari sample to make use of that;