### PR TITLE
Async v6

### DIFF
--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -1326,9 +1326,10 @@ generate_memory_map_struct(const struct sol_ptr_vector *maps, int *elements)
         out("\nstatic const struct sol_memmap_map _memmap%d = {\n"
             "   .version = %d,\n"
             "   .path = \"%s\",\n"
+            "   .timeout = %u,\n"
             "   .entries = _memmap%d_entries\n"
             "};\n",
-            i, map->version, map->path, i);
+            i, map->version, map->path, map->timeout, i);
     }
 
     *elements = i;

--- a/src/lib/io/include/sol-efivarfs-storage.h
+++ b/src/lib/io/include/sol-efivarfs-storage.h
@@ -36,114 +36,179 @@
 #include <stdint.h>
 
 #include "sol-buffer.h"
+#include "sol-log.h"
 #include "sol-types.h"
+#include "sol-util.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int sol_efivars_write_raw(const char *name, const struct sol_buffer *buffer);
+/**
+ * Writes buffer contents to storage.
+ *
+ * Note that as writing operations are asynchronous, to check if it completely
+ * succeded, one needs to register a callback that will inform writing result.
+ *
+ * @param name name of property. It will create a file on filesyste with
+ * this name.
+ * @param blob blob that will be written
+ * @param cb callback to be called when writing finishes. It contains status
+ * of writing: if failed, is lesser than zero.
+ * @param data user data to be sent to callback @c cb
+ *
+ * return 0 on success, a negative number on failure
+ */
+int sol_efivars_write_raw(const char *name, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data);
 int sol_efivars_read_raw(const char *name, struct sol_buffer *buffer);
 
-#define CREATE_BUFFER(_val, _empty) \
+#define CREATE_BUFFER(_val) \
     struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val, \
-    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED); \
-    buf.used = (_empty) ? 0 : sizeof(*(_val));
+    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+
+#define CREATE_BLOB(_val) \
+    struct sol_blob *blob; \
+    size_t _s = sizeof(*_val); \
+    void *v = sol_util_memdup(_val, _s); \
+    SOL_NULL_CHECK(v, -EINVAL); \
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, v, _s); \
+    if (!blob) { \
+        free(v); \
+        return -EINVAL; \
+    }
 
 static inline int
 sol_efivars_read_uint8(const char *name, uint8_t *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-sol_efivars_write_uint8(const char *name, uint8_t value)
+sol_efivars_write_uint8(const char *name, uint8_t value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_efivars_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_efivars_read_bool(const char *name, bool *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-sol_efivars_write_bool(const char *name, bool value)
+sol_efivars_write_bool(const char *name, bool value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_efivars_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_efivars_read_int32(const char *name, int32_t *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-sol_efivars_write_int32(const char *name, int32_t value)
+sol_efivars_write_int32(const char *name, int32_t value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_efivars_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_efivars_read_irange(const char *name, struct sol_irange *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-sol_efivars_write_irange(const char *name, struct sol_irange *value)
+sol_efivars_write_irange(const char *name, struct sol_irange *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(value, false);
+    int r;
 
-    return sol_efivars_write_raw(name, &buf);
+    CREATE_BLOB(value);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_efivars_read_drange(const char *name, struct sol_drange *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-sol_efivars_write_drange(const char *name, struct sol_drange *value)
+sol_efivars_write_drange(const char *name, struct sol_drange *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(value, false);
+    int r;
 
-    return sol_efivars_write_raw(name, &buf);
+    CREATE_BLOB(value);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_efivars_read_double(const char *name, double *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_efivars_read_raw(name, &buf);
 }
 
 static inline int
-sol_efivars_write_double(const char *name, double value)
+sol_efivars_write_double(const char *name, double value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_efivars_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
@@ -164,17 +229,37 @@ sol_efivars_read_string(const char *name, char **value)
 }
 
 static inline int
-sol_efivars_write_string(const char *name, const char *value)
+sol_efivars_write_string(const char *name, const char *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS((void *)value, strlen(value),
-        SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
+    int r;
+    struct sol_blob *blob;
+    char *string;
 
-    buf.used = buf.capacity;
+    string = strdup(value);
+    SOL_NULL_CHECK(string, -ENOMEM);
 
-    return sol_efivars_write_raw(name, &buf);
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, string, strlen(value));
+    SOL_NULL_CHECK_GOTO(blob, error);
+
+    r = sol_efivars_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
+
+error:
+    free(string);
+
+    return -ENOMEM;
 }
 
+/**
+ * @}
+ */
+
 #undef CREATE_BUFFER
+
+#undef CREATE_BLOB
 
 #ifdef __cplusplus
 }

--- a/src/lib/io/include/sol-fs-storage.h
+++ b/src/lib/io/include/sol-fs-storage.h
@@ -36,114 +36,179 @@
 #include <stdint.h>
 
 #include "sol-buffer.h"
+#include "sol-log.h"
 #include "sol-types.h"
+#include "sol-util.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int sol_fs_write_raw(const char *name, const struct sol_buffer *buffer);
+/**
+ * Writes buffer contents to storage.
+ *
+ * Note that as writing operations are asynchronous, to check if it completely
+ * succeded, one needs to register a callback that will inform writing result.
+ *
+ * @param name name of property. It will create a file on filesyste with
+ * this name.
+ * @param blob blob that will be written
+ * @param cb callback to be called when writing finishes. It contains status
+ * of writing: if failed, is lesser than zero.
+ * @param data user data to be sent to callback @c cb
+ *
+ * return 0 on success, a negative number on failure
+ */
+int sol_fs_write_raw(const char *name, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data);
 int sol_fs_read_raw(const char *name, struct sol_buffer *buffer);
 
-#define CREATE_BUFFER(_val, _empty) \
+#define CREATE_BUFFER(_val) \
     struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val, \
-    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED); \
-    buf.used = (_empty) ? 0 : sizeof(*(_val));
+    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+
+#define CREATE_BLOB(_val) \
+    struct sol_blob *blob; \
+    size_t _s = sizeof(*_val); \
+    void *v = sol_util_memdup(_val, _s); \
+    SOL_NULL_CHECK(v, -EINVAL); \
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, v, _s); \
+    if (!blob) { \
+        free(v); \
+        return -EINVAL; \
+    }
 
 static inline int
 sol_fs_read_uint8(const char *name, uint8_t *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-sol_fs_write_uint8(const char *name, uint8_t value)
+sol_fs_write_uint8(const char *name, uint8_t value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_fs_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_fs_read_bool(const char *name, bool *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-sol_fs_write_bool(const char *name, bool value)
+sol_fs_write_bool(const char *name, bool value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_fs_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_fs_read_int32(const char *name, int32_t *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-sol_fs_write_int32(const char *name, int32_t value)
+sol_fs_write_int32(const char *name, int32_t value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_fs_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_fs_read_irange(const char *name, struct sol_irange *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-sol_fs_write_irange(const char *name, struct sol_irange *value)
+sol_fs_write_irange(const char *name, struct sol_irange *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(value, false);
+    int r;
 
-    return sol_fs_write_raw(name, &buf);
+    CREATE_BLOB(value);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_fs_read_drange(const char *name, struct sol_drange *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-sol_fs_write_drange(const char *name, struct sol_drange *value)
+sol_fs_write_drange(const char *name, struct sol_drange *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(value, false);
+    int r;
 
-    return sol_fs_write_raw(name, &buf);
+    CREATE_BLOB(value);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_fs_read_double(const char *name, double *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_fs_read_raw(name, &buf);
 }
 
 static inline int
-sol_fs_write_double(const char *name, double value)
+sol_fs_write_double(const char *name, double value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_fs_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
@@ -164,17 +229,37 @@ sol_fs_read_string(const char *name, char **value)
 }
 
 static inline int
-sol_fs_write_string(const char *name, const char *value)
+sol_fs_write_string(const char *name, const char *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS((void *)value, strlen(value),
-        SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
+    int r;
+    struct sol_blob *blob;
+    char *string;
 
-    buf.used = buf.capacity;
+    string = strdup(value);
+    SOL_NULL_CHECK(string, -ENOMEM);
 
-    return sol_fs_write_raw(name, &buf);
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, string, strlen(value));
+    SOL_NULL_CHECK_GOTO(blob, error);
+
+    r = sol_fs_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
+
+error:
+    free(string);
+
+    return -ENOMEM;
 }
 
+/**
+ * @}
+ */
+
 #undef CREATE_BUFFER
+
+#undef CREATE_BLOB
 
 #ifdef __cplusplus
 }

--- a/src/lib/io/include/sol-memmap-storage.h
+++ b/src/lib/io/include/sol-memmap-storage.h
@@ -62,7 +62,17 @@ extern "C" {
  * which will store version of map stored. This API will refuse to work if
  * stored map is different from map version. Note that @c _version field
  * is a @c uint8_t and that versions should start on 1, so Soletta will know
- * if dealing with a totally new storage.
+ * if dealing with a totally new storage. It also considers 255 (0xff) as a
+ * non-value, so fit new EEPROMs.
+ * Note that a map may define a timeout value to perform writes. This way,
+ * writings can be grouped together, as all writing operations will be
+ * performed at timeout end. That said, it's important to note that when
+ * writing is performed, no order is guaranteed for different keys, i.e.,
+ * writing to 'a' and 'b' can be performed, at timeout end, as 'b' and 'a'
+ * - but for a given key, only the last write will be performed at timeout end.
+ * Multiple writes for the same key before timeout end will result in previous
+ * writes being replaced, and their callbacks will be informed with status
+ * -ECANCELED.
  *
  * @{
  */
@@ -88,7 +98,9 @@ struct sol_memmap_map {
                        * @arg @a devnumber is device number on bus, like 0x50
                        * @arg @a devname is device name, the one recognized by its driver
                        */
-    const struct sol_str_table_ptr *entries; /**< Entries on map, containing name, offset and size */
+    unsigned int timeout; /**< Timeout, in milliseconds, of writing operations. After a write is requested, a timer will run and group all
+                           * writing operations until it expires, when real writing will be performed */
+    const struct sol_str_table_ptr *entries; /**< Entries on map, containing name, offset and size */ /* Memory trick in place, must be last on struct*/
 };
 
 struct sol_memmap_entry {
@@ -154,6 +166,21 @@ int sol_memmap_add_map(const struct sol_memmap_map *map);
  * @return 0 on success, a negative number on failure.
  */
 int sol_memmap_remove_map(const struct sol_memmap_map *map);
+
+/**
+ * Defines map timeout to actually perform write.
+ *
+ * @param map map to have its timeout changed
+ * @param timeout new timeout, in milliseconds.
+ *
+ * @return true if successfuly set map timeout.
+ *
+ * @note This change will take effect after current active timer expires.
+ * Active ones will remain unchanged
+ */
+bool sol_memmap_set_timeout(struct sol_memmap_map *map, unsigned int timeout);
+
+unsigned int sol_memmap_get_timeout(const struct sol_memmap_map *map);
 
 #define CREATE_BUFFER(_val) \
     struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val, \

--- a/src/lib/io/include/sol-memmap-storage.h
+++ b/src/lib/io/include/sol-memmap-storage.h
@@ -36,9 +36,10 @@
 #include <stdint.h>
 
 #include "sol-buffer.h"
+#include "sol-log.h"
 #include "sol-str-table.h"
 #include "sol-types.h"
-#include "sol-log.h"
+#include "sol-util.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -100,14 +101,25 @@ struct sol_memmap_entry {
 /**
  * Writes buffer contents to storage.
  *
+ * Note that as writing operations are asynchronous, to check if it completely
+ * succeded, one needs to register a callback that will inform writing result.
+ * A negative status on callback means failure; -ECANCELED for instance, means
+ * that another write to the same property took place before this one was
+ * completed.
+ *
  * @param name name of property. must be present in one of maps previoulsy
  * added via @c sol_memmap_add_map (if present in more than one,
  * behaviour is undefined)
- * @param buffer buffer that will be written, according to its entry on map.
+ * @param blob blob that will be written, according to its entry on map.
+ * @param cb callback to be called when writing finishes. It contains status
+ * of writing: if failed, is lesser than zero.
+ * @param data user data to be sent to callback @c cb
  *
  * return 0 on success, a negative number on failure
  */
-int sol_memmap_write_raw(const char *name, const struct sol_buffer *buffer);
+int sol_memmap_write_raw(const char *name, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data);
 
 /**
  * Read storage contents to buffer.
@@ -143,105 +155,151 @@ int sol_memmap_add_map(const struct sol_memmap_map *map);
  */
 int sol_memmap_remove_map(const struct sol_memmap_map *map);
 
-#define CREATE_BUFFER(_val, _empty) \
+#define CREATE_BUFFER(_val) \
     struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val, \
-    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE); \
-    buf.used = (_empty) ? 0 : sizeof(*(_val));
+    sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+
+#define CREATE_BLOB(_val) \
+    struct sol_blob *blob; \
+    size_t _s = sizeof(*_val); \
+    void *v = sol_util_memdup(_val, _s); \
+    SOL_NULL_CHECK(v, -EINVAL); \
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, v, _s); \
+    if (!blob) { \
+        free(v); \
+        return -EINVAL; \
+    }
 
 static inline int
 sol_memmap_read_uint8(const char *name, uint8_t *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_memmap_read_raw(name, &buf);
 }
 
 static inline int
-sol_memmap_write_uint8(const char *name, uint8_t value)
+sol_memmap_write_uint8(const char *name, uint8_t value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_memmap_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_memmap_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_memmap_read_bool(const char *name, bool *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_memmap_read_raw(name, &buf);
 }
 
 static inline int
-sol_memmap_write_bool(const char *name, bool value)
+sol_memmap_write_bool(const char *name, bool value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_memmap_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_memmap_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_memmap_read_int32(const char *name, int32_t *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_memmap_read_raw(name, &buf);
 }
 
 static inline int
-sol_memmap_write_int32(const char *name, int32_t value)
+sol_memmap_write_int32(const char *name, int32_t value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_memmap_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_memmap_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_memmap_read_irange(const char *name, struct sol_irange *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_memmap_read_raw(name, &buf);
 }
 
 static inline int
-sol_memmap_write_irange(const char *name, struct sol_irange *value)
+sol_memmap_write_irange(const char *name, struct sol_irange *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(value, false);
+    int r;
 
-    return sol_memmap_write_raw(name, &buf);
+    CREATE_BLOB(value);
+
+    r = sol_memmap_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_memmap_read_drange(const char *name, struct sol_drange *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_memmap_read_raw(name, &buf);
 }
 
 static inline int
-sol_memmap_write_drange(const char *name, struct sol_drange *value)
+sol_memmap_write_drange(const char *name, struct sol_drange *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(value, false);
+    int r;
 
-    return sol_memmap_write_raw(name, &buf);
+    CREATE_BLOB(value);
+
+    r = sol_memmap_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
 sol_memmap_read_double(const char *name, double *value)
 {
-    CREATE_BUFFER(value, true);
+    CREATE_BUFFER(value);
 
     return sol_memmap_read_raw(name, &buf);
 }
 
 static inline int
-sol_memmap_write_double(const char *name, double value)
+sol_memmap_write_double(const char *name, double value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    CREATE_BUFFER(&value, false);
+    int r;
 
-    return sol_memmap_write_raw(name, &buf);
+    CREATE_BLOB(&value);
+
+    r = sol_memmap_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
 }
 
 static inline int
@@ -262,14 +320,28 @@ sol_memmap_read_string(const char *name, char **value)
 }
 
 static inline int
-sol_memmap_write_string(const char *name, const char *value)
+sol_memmap_write_string(const char *name, const char *value,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
-    struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS((void *)value, strlen(value),
-        SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
+    int r;
+    struct sol_blob *blob;
+    char *string;
 
-    buf.used = buf.capacity;
+    string = strdup(value);
+    SOL_NULL_CHECK(string, -ENOMEM);
 
-    return sol_memmap_write_raw(name, &buf);
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, string, strlen(value) + 1);
+    SOL_NULL_CHECK_GOTO(blob, error);
+
+    r = sol_memmap_write_raw(name, blob, cb, data);
+    sol_blob_unref(blob);
+    return r;
+
+error:
+    free(string);
+
+    return -ENOMEM;
 }
 
 /**
@@ -277,6 +349,8 @@ sol_memmap_write_string(const char *name, const char *value)
  */
 
 #undef CREATE_BUFFER
+
+#undef CREATE_BLOB
 
 #ifdef __cplusplus
 }

--- a/src/lib/io/sol-efivarfs-storage.c
+++ b/src/lib/io/sol-efivarfs-storage.c
@@ -41,12 +41,23 @@
 
 #include "sol-buffer.h"
 #include "sol-log.h"
+#include "sol-mainloop.h"
 #include "sol-util.h"
 #include "sol-util-file.h"
 
 #define SOLETTA_EFIVARS_GUID "076027a8-c791-41d7-940f-3d465869f821"
 #define EFIVARFS_VAR_DIR "/sys/firmware/efi/efivars/"
 #define EFIVARFS_VAR_PATH EFIVARFS_VAR_DIR "%s-" SOLETTA_EFIVARS_GUID
+
+struct pending_write_data {
+    char *name;
+    struct sol_blob *blob;
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status);
+    const void *data;
+    int status;
+};
+
+static struct sol_ptr_vector pending_writes = SOL_PTR_VECTOR_INIT;
 
 static const int EFIVARS_DEFAULT_ATTR = 0x7;
 
@@ -62,54 +73,145 @@ check_realpath(const char *path)
     return false;
 }
 
-SOL_API int
-sol_efivars_write_raw(const char *name, const struct sol_buffer *buffer)
+static bool
+perform_pending_write(void *data)
 {
-    FILE *file;
+    FILE *file = NULL;
     char path[PATH_MAX];
+    struct pending_write_data *pending_write = data;
     int r;
 
-    SOL_NULL_CHECK(name, -EINVAL);
-    SOL_NULL_CHECK(buffer, -EINVAL);
+    if (pending_write->status == -ECANCELED)
+        goto callback;
 
-    r = snprintf(path, sizeof(path), EFIVARFS_VAR_PATH, name);
+    r = snprintf(path, sizeof(path), EFIVARFS_VAR_PATH, pending_write->name);
     if (r < 0 || r >= PATH_MAX) {
         SOL_WRN("Could not create path for efivars persistence file [%s]", path);
-        return -EINVAL;
+        pending_write->status = -EINVAL;
+        goto callback;
     }
 
     file = fopen(path, "w+e");
     if (!file) {
         SOL_WRN("Could not open persistence file [%s]: %s", path,
             sol_util_strerrora(errno));
-        return -errno;
+        pending_write->status = -errno;
+        goto callback;
     }
+
     if (!check_realpath(path)) {
         /* At this point, a file on an invalid location may have been created.
          * Should we care about it? Is there a 'realpath()' that doesn't need
          * the file to exist? Or a string path santiser? */
-        SOL_WRN("Invalid name for efivars persistence packet [%s]", name);
-        r = -EINVAL;
-        goto end;
+        SOL_WRN("Invalid pending_write->name for efivars persistence packet [%s]",
+            pending_write->name);
+        pending_write->status = -EINVAL;
+
+        goto close;
     }
 
     fwrite(&EFIVARS_DEFAULT_ATTR, sizeof(EFIVARS_DEFAULT_ATTR), 1, file);
     if (ferror(file)) {
         SOL_WRN("Coud not write peristence file [%s] attributes", path);
         r = -EIO;
-        goto end;
+        goto close;
     }
 
-    fwrite(buffer->data, buffer->used, 1, file);
-
-end:
-    if (fclose(file)) {
-        SOL_WRN("Could not close persistence file [%s]: %s", path,
-            sol_util_strerrora(errno));
-        return -errno;
+    fwrite(pending_write->blob->mem, pending_write->blob->size, 1, file);
+    if (ferror(file)) {
+        SOL_WRN("Could not write to persistence file [%s]", path);
+        pending_write->status = -EIO;
     }
 
-    return r;
+close:
+    if (fclose(file) < 0 && !pending_write->status)
+        pending_write->status = -errno;
+
+callback:
+    pending_write->cb((void *)pending_write->data, pending_write->name,
+        pending_write->blob, pending_write->status);
+
+    sol_blob_unref(pending_write->blob);
+    free(pending_write->name);
+    sol_ptr_vector_remove(&pending_writes, pending_write);
+    free(pending_write);
+
+    return false;
+}
+
+static void
+cancel_pending_write(const char *name)
+{
+    struct pending_write_data *pending_write;
+    int i;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&pending_writes, pending_write, i) {
+        if (streq(pending_write->name, name))
+            pending_write->status = -ECANCELED;
+    }
+}
+
+static bool
+read_from_pending(const char *name, struct sol_buffer *buffer)
+{
+    struct pending_write_data *pending_write;
+    int i;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&pending_writes, pending_write, i) {
+        if (streq(pending_write->name, name)) {
+            if (sol_buffer_ensure(buffer, pending_write->blob->size) < 0) {
+                SOL_WRN("Could not ensure buffer size to fit pending blob");
+                return false;
+            }
+            memcpy(buffer->data, pending_write->blob->mem, pending_write->blob->size);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+SOL_API int
+sol_efivars_write_raw(const char *name, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
+{
+    struct pending_write_data *pending_write;
+    struct sol_timeout *timeout;
+
+    SOL_NULL_CHECK(name, -EINVAL);
+    SOL_NULL_CHECK(blob, -EINVAL);
+    SOL_NULL_CHECK(cb, -EINVAL);
+
+    cancel_pending_write(name);
+
+    pending_write = calloc(1, sizeof(struct pending_write_data));
+    SOL_NULL_CHECK(pending_write, -ENOMEM);
+
+    pending_write->blob = sol_blob_ref(blob);
+    SOL_NULL_CHECK_GOTO(pending_write->blob, error);
+
+    pending_write->blob = blob;
+    pending_write->data = data;
+    pending_write->cb = cb;
+    pending_write->name = strdup(name);
+    SOL_NULL_CHECK_GOTO(pending_write->name, error);
+
+    timeout = sol_timeout_add(0, perform_pending_write, pending_write);
+    SOL_NULL_CHECK_GOTO(timeout, error);
+
+    if (sol_ptr_vector_append(&pending_writes, pending_write) < 0)
+        goto error;
+
+error:
+    if (pending_write->blob)
+        sol_blob_unref(blob);
+
+    free(pending_write->name);
+    sol_ptr_vector_remove(&pending_writes, pending_write);
+    free(pending_write);
+
+    return -ENOMEM;
 }
 
 SOL_API int
@@ -123,6 +225,9 @@ sol_efivars_read_raw(const char *name, struct sol_buffer *buffer)
 
     SOL_NULL_CHECK(name, -EINVAL);
     SOL_NULL_CHECK(buffer, -EINVAL);
+
+    if (read_from_pending(name, buffer))
+        return 0;
 
     r = snprintf(path, sizeof(path), EFIVARFS_VAR_PATH, name);
     if (r < 0 || r >= PATH_MAX) {

--- a/src/lib/io/sol-fs-storage.c
+++ b/src/lib/io/sol-fs-storage.c
@@ -41,38 +41,131 @@
 
 #include "sol-buffer.h"
 #include "sol-log.h"
+#include "sol-mainloop.h"
 #include "sol-util.h"
 #include "sol-util-file.h"
 
-SOL_API int
-sol_fs_write_raw(const char *name, const struct sol_buffer *buffer)
+struct pending_write_data {
+    char *name;
+    struct sol_blob *blob;
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status);
+    const void *data;
+    int status;
+};
+
+static struct sol_ptr_vector pending_writes = SOL_PTR_VECTOR_INIT;
+
+static bool
+perform_pending_write(void *data)
 {
     FILE *file;
-    int ret = 0;
+    struct pending_write_data *pending_write = data;
+
+    if (pending_write->status == -ECANCELED)
+        goto callback;
+
+    file = fopen(pending_write->name, "w+e");
+    if (!file) {
+        SOL_WRN("Could not open persistence file [%s]: %s", pending_write->name,
+            sol_util_strerrora(errno));
+        pending_write->status = -errno;
+        goto callback;
+    }
+
+    fwrite(pending_write->blob->mem, pending_write->blob->size, 1, file);
+    if (ferror(file)) {
+        SOL_WRN("Could not write to persistence file [%s]", pending_write->name);
+        pending_write->status = -EIO;
+    }
+    if (fclose(file) < 0 && !pending_write->status)
+        pending_write->status = -errno;
+
+callback:
+    pending_write->cb((void *)pending_write->data, pending_write->name,
+        pending_write->blob, pending_write->status);
+
+    sol_blob_unref(pending_write->blob);
+    free(pending_write->name);
+    sol_ptr_vector_remove(&pending_writes, pending_write);
+    free(pending_write);
+
+    return false;
+}
+
+static void
+cancel_pending_write(const char *name)
+{
+    struct pending_write_data *pending_write;
+    int i;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&pending_writes, pending_write, i) {
+        if (streq(pending_write->name, name))
+            pending_write->status = -ECANCELED;
+    }
+}
+
+static bool
+read_from_pending(const char *name, struct sol_buffer *buffer)
+{
+    struct pending_write_data *pending_write;
+    int i;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&pending_writes, pending_write, i) {
+        if (streq(pending_write->name, name)) {
+            if (sol_buffer_ensure(buffer, pending_write->blob->size) < 0) {
+                SOL_WRN("Could not ensure buffer size to fit pending blob");
+                return false;
+            }
+            memcpy(buffer->data, pending_write->blob->mem, pending_write->blob->size);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+SOL_API int
+sol_fs_write_raw(const char *name, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
+{
+    struct pending_write_data *pending_write;
+    struct sol_timeout *timeout;
 
     SOL_NULL_CHECK(name, -EINVAL);
-    SOL_NULL_CHECK(buffer, -EINVAL);
+    SOL_NULL_CHECK(blob, -EINVAL);
+    SOL_NULL_CHECK(cb, -EINVAL);
 
-    file = fopen(name, "w+e");
-    if (!file) {
-        SOL_WRN("Could not open persistence file [%s]: %s", name,
-            sol_util_strerrora(errno));
-        return -errno;
-    }
+    cancel_pending_write(name);
 
-    fwrite(buffer->data, buffer->used, 1, file);
-    if (ferror(file)) {
-        SOL_WRN("Could not write to persistence file [%s]", name);
-        ret = -EIO;
-    }
+    pending_write = calloc(1, sizeof(struct pending_write_data));
+    SOL_NULL_CHECK(pending_write, -ENOMEM);
 
-    if (fclose(file)) {
-        SOL_WRN("Could not close persistence file [%s]: %s", name,
-            sol_util_strerrora(errno));
-        return -errno;
-    }
+    pending_write->blob = sol_blob_ref(blob);
+    SOL_NULL_CHECK_GOTO(pending_write->blob, error);
 
-    return ret;
+    pending_write->blob = blob;
+    pending_write->data = data;
+    pending_write->cb = cb;
+    pending_write->name = strdup(name);
+    SOL_NULL_CHECK_GOTO(pending_write->name, error);
+
+    timeout = sol_timeout_add(0, perform_pending_write, pending_write);
+    SOL_NULL_CHECK_GOTO(timeout, error);
+
+    if (sol_ptr_vector_append(&pending_writes, pending_write) < 0)
+        goto error;
+
+    return 0;
+error:
+    if (pending_write->blob)
+        sol_blob_unref(pending_write->blob);
+
+    free(pending_write->name);
+    sol_ptr_vector_remove(&pending_writes, pending_write);
+    free(pending_write);
+
+    return -ENOMEM;
 }
 
 SOL_API int
@@ -82,6 +175,9 @@ sol_fs_read_raw(const char *name, struct sol_buffer *buffer)
 
     SOL_NULL_CHECK(name, -EINVAL);
     SOL_NULL_CHECK(buffer, -EINVAL);
+
+    if (read_from_pending(name, buffer))
+        return 0;
 
     fd = open(name, O_RDONLY | O_CLOEXEC);
     if (fd < 0) {

--- a/src/lib/io/sol-memmap-storage.c
+++ b/src/lib/io/sol-memmap-storage.c
@@ -57,14 +57,21 @@
 #define DEV_NUMBER_IDX 3
 #define DEV_NAME_IDX 4
 
-struct map_resolved_path {
-    const struct sol_memmap_map *map;
-    char *resolved_path;
+struct pending_write_data {
+    char *name;
+    const char *path;
+    struct sol_blob *blob;
+    const struct sol_memmap_entry *entry;
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status);
+    const void *data;
+    uint64_t mask;
 };
 
 static struct sol_ptr_vector memory_maps = SOL_PTR_VECTOR_INIT;
 static struct sol_ptr_vector checked_maps = SOL_PTR_VECTOR_INIT;
 static struct sol_ptr_vector resolved_maps_to_free = SOL_PTR_VECTOR_INIT;
+static struct sol_vector pending_writes = SOL_VECTOR_INIT(struct pending_write_data);
+static struct sol_timeout *write_timeout;
 
 static bool
 get_entry_metadata_on_map(const char *name, const struct sol_memmap_map *map, const struct sol_memmap_entry **entry, uint64_t *mask)
@@ -146,16 +153,25 @@ error:
 }
 
 static int
-sol_memmap_write_raw_do(const char *path, const struct sol_memmap_entry *entry, uint64_t mask, const struct sol_buffer *buffer)
+sol_memmap_write_raw_do(const char *path, const char *name, const struct sol_memmap_entry *entry, uint64_t mask, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data, FILE *reuse_file)
 {
-    FILE *file;
+    FILE *file = NULL;
     int ret = 0;
 
-    file = fopen(path, "r+e");
-    if (!file) {
-        SOL_WRN("Could not open memory file [%s]: %s", path,
-            sol_util_strerrora(errno));
-        return -errno;
+    if (!sol_blob_ref(blob))
+        return -ENOMEM;
+
+    if (reuse_file) {
+        file = reuse_file;
+    } else {
+        file = fopen(path, "r+e");
+        if (!file) {
+            SOL_WRN("Could not open memory file [%s]: %s", path,
+                sol_util_strerrora(errno));
+            goto error;
+        }
     }
 
     if (fseek(file, entry->offset, SEEK_SET) < 0)
@@ -166,7 +182,7 @@ sol_memmap_write_raw_do(const char *path, const struct sol_memmap_entry *entry, 
         uint32_t i, j;
 
         for (i = 0, j = 0; i < entry->size; i++, j += 8)
-            value |= (uint64_t)((uint8_t *)buffer->data)[i] << j;
+            value |= (uint64_t)((uint8_t *)blob->mem)[i] << j;
 
         ret = fread(&old_value, entry->size, 1, file);
         if (!ret || ferror(file) || feof(file)) {
@@ -183,7 +199,7 @@ sol_memmap_write_raw_do(const char *path, const struct sol_memmap_entry *entry, 
         value |= (old_value & ~mask);
         fwrite(&value, entry->size, 1, file);
     } else {
-        fwrite(buffer->data, sol_min(entry->size, buffer->used), 1, file);
+        fwrite(blob->mem, sol_min(entry->size, blob->size), 1, file);
     }
 
     if (ferror(file)) {
@@ -191,16 +207,37 @@ sol_memmap_write_raw_do(const char *path, const struct sol_memmap_entry *entry, 
         goto error;
     }
 
-    if (fclose(file) != 0)
-        return -errno;
+    errno = 0;
+    if (!reuse_file)
+        fclose(file);
 
-    return 0;
+    if (cb)
+        cb((void *)data, name, blob, -errno);
+
+    sol_blob_unref(blob);
+
+    return -errno;
 
 error:
+    SOL_DBG("Error writing to file [%s]: %s", path, sol_util_strerrora(errno));
     ret = -errno;
-    fclose(file);
+    if (file && !reuse_file)
+        fclose(file);
+
+    if (cb)
+        cb((void *)data, name, blob, ret);
+
+    sol_blob_unref(blob);
 
     return ret;
+}
+
+static void
+version_write_cb(void *data, const char *name, struct sol_blob *blob, int status)
+{
+    if (status < 0)
+        SOL_WRN("Could not write version to file: %d", status);
+    sol_blob_unref(blob);
 }
 
 static bool
@@ -213,6 +250,7 @@ check_version(const struct sol_memmap_map *map)
     const struct sol_memmap_entry *entry;
     int ret, i;
     uint64_t mask;
+    struct sol_blob *blob;
 
     if (!map->version) {
         SOL_WRN("Invalid memory_map_version. Should not be zero");
@@ -231,10 +269,14 @@ check_version(const struct sol_memmap_map *map)
 
     ret = sol_memmap_read_raw_do(map->path, entry, mask, &buf);
     if (ret >= 0 && version == 0) {
+        blob = sol_blob_new(SOL_BLOB_TYPE_NOFREE, NULL, &map->version, sizeof(uint8_t));
+        SOL_NULL_CHECK(blob, false);
+
         /* No version on file, we should be initialising it */
         version = map->version;
-        if (sol_memmap_write_raw_do(map->path, entry, mask, &buf) < 0) {
+        if (sol_memmap_write_raw_do(map->path, MEMMAP_VERSION_ENTRY, entry, mask, blob, version_write_cb, NULL, NULL) < 0) {
             SOL_WRN("Could not write current map version to file");
+            sol_blob_unref(blob);
             return false;
         }
     } else if (ret < 0) {
@@ -251,15 +293,153 @@ check_version(const struct sol_memmap_map *map)
     return sol_ptr_vector_append(&checked_maps, (void *)map) == 0;
 }
 
+static int
+pending_cmp(const void *e1, const void *e2)
+{
+    const struct pending_write_data *p1 = e1;
+    const struct pending_write_data *p2 = e2;
+
+    return strcmp(p1->path, p2->path);
+}
+
+static bool
+perform_pending_writes(void *data)
+{
+    int i, r;
+    struct pending_write_data *pending;
+    FILE *file = NULL;
+    const char *last_path = "";
+
+    write_timeout = NULL;
+
+    /* Order writes by path, so we can open each file only once */
+    qsort(pending_writes.data, pending_writes.len, pending_writes.elem_size, pending_cmp);
+
+    SOL_VECTOR_FOREACH_IDX (&pending_writes, pending, i) {
+        if (!streq(last_path, pending->path)) {
+            if (file) {
+                r = fclose(file);
+                if (r)
+                    SOL_WRN("Error closing file [%s]: %s", last_path,
+                        sol_util_strerrora(errno));
+            }
+            last_path = pending->path;
+            file = fopen(last_path, "r+e");
+            if (!file)
+                SOL_WRN("Error opening file [%s]: %s", last_path,
+                    sol_util_strerrora(errno));
+        }
+
+        sol_memmap_write_raw_do(pending->path, pending->name, pending->entry,
+            pending->mask, pending->blob, pending->cb, pending->data, file);
+        free(pending->name);
+        sol_blob_unref(pending->blob);
+    }
+    if (file) {
+        r = fclose(file);
+        if (r)
+            SOL_WRN("Error closing file [%s]: %s", last_path,
+                sol_util_strerrora(errno));
+    }
+
+    sol_vector_clear(&pending_writes);
+
+    return false;
+}
+
+static bool
+replace_pending_write(const char *path, const char *name,
+    const struct sol_memmap_entry *entry, uint64_t mask, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
+{
+    struct pending_write_data *pending;
+    int i;
+
+    SOL_VECTOR_FOREACH_IDX (&pending_writes, pending, i) {
+        if (streq(pending->name, name)) {
+            if (pending->cb)
+                pending->cb((void *)pending->data, pending->name, pending->blob,
+                    -ECANCELED);
+            sol_blob_unref(pending->blob);
+            pending->blob = sol_blob_ref(blob);
+            if (!pending->blob) {
+                /* If we couldn't ref, let's delete this entry and let
+                 * the caller re-add this write */
+                free(pending->name);
+                sol_vector_del(&pending_writes, i);
+                return false;
+            }
+            pending->cb = cb;
+            pending->data = data;
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static int
+fill_pending_write(struct pending_write_data *pending, const char *path,
+    const char *name, const struct sol_memmap_entry *entry, uint64_t mask,
+    struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
+{
+    pending->blob = sol_blob_ref(blob);
+    SOL_NULL_CHECK(pending->blob, -ENOMEM);
+
+    pending->name = strdup(name);
+    SOL_NULL_CHECK(name, -ENOMEM);
+
+    pending->path = path;
+    pending->entry = entry;
+    pending->mask = mask;
+    pending->cb = cb;
+    pending->data = data;
+
+    return 0;
+}
+
+static int
+add_write(const char *path, const char *name,
+    const struct sol_memmap_entry *entry, uint64_t mask, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
+{
+    struct pending_write_data *pending;
+
+    /* If there's a pending write for the very same entry, we replace it */
+    if (replace_pending_write(path, name, entry, mask, blob, cb, data))
+        return 0;
+
+    pending = sol_vector_append(&pending_writes);
+
+    SOL_NULL_CHECK(pending, -ENOMEM);
+
+    if (fill_pending_write(pending, path, name, entry, mask, blob, cb, data) < 0)
+        return -ENOMEM;
+
+    if (!write_timeout)
+        write_timeout = sol_timeout_add(0, perform_pending_writes, NULL);
+
+    SOL_NULL_CHECK(write_timeout, -ENOMEM);
+
+    return 0;
+}
+
 SOL_API int
-sol_memmap_write_raw(const char *name, const struct sol_buffer *buffer)
+sol_memmap_write_raw(const char *name, struct sol_blob *blob,
+    void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
+    const void *data)
 {
     const struct sol_memmap_map *map;
     const struct sol_memmap_entry *entry;
     uint64_t mask;
 
     SOL_NULL_CHECK(name, -EINVAL);
-    SOL_NULL_CHECK(buffer, -EINVAL);
+    SOL_NULL_CHECK(blob, -EINVAL);
 
     if (!get_entry_metadata(name, &map, &entry, &mask)) {
         SOL_WRN("No entry on memory map to property [%s]", name);
@@ -269,11 +449,33 @@ sol_memmap_write_raw(const char *name, const struct sol_buffer *buffer)
     if (!check_version(map))
         return -EINVAL;
 
-    if (buffer->used > entry->size)
+    if (blob->size > entry->size)
         SOL_INF("Mapped size for [%s] is %zd, smaller than buffer contents: %zd",
-            name, entry->size, buffer->used);
+            name, entry->size, blob->size);
 
-    return sol_memmap_write_raw_do(map->path, entry, mask, buffer);
+    return add_write(map->path, name, entry, mask, blob, cb, data);
+}
+
+static bool
+read_from_pending(const char *name, struct sol_buffer *buffer)
+{
+    struct pending_write_data *pending;
+    int i;
+
+    SOL_VECTOR_FOREACH_IDX (&pending_writes, pending, i) {
+        if (streq(name, pending->name)) {
+            // TODO maybe a sol_buffer_append_blob?
+            if (sol_buffer_ensure(buffer, pending->blob->size) < 0) {
+                // TODO how bad is this? return old value? fail reading?
+                SOL_WRN("Could not ensure buffer size to fit pending blob");
+                return false;
+            }
+            memcpy(buffer->data, pending->blob->mem, pending->blob->size);
+            return true;
+        }
+    }
+
+    return false;
 }
 
 SOL_API int
@@ -293,6 +495,9 @@ sol_memmap_read_raw(const char *name, struct sol_buffer *buffer)
 
     if (!check_version(map))
         return -EINVAL;
+
+    if (read_from_pending(name, buffer))
+        return 0;
 
     return sol_memmap_read_raw_do(map->path, entry, mask, buffer);
 }

--- a/src/test-fbp/sol-flow.json
+++ b/src/test-fbp/sol-flow.json
@@ -13,6 +13,7 @@
         {
             "version": 1,
             "path": "memmap-test.bin",
+            "timeout": 25,
             "entries": [
                 {
                     "name": "_version",

--- a/src/test/.gitignore
+++ b/src/test/.gitignore
@@ -19,6 +19,7 @@
 /test-mainloop-linux
 /test-monitors
 /test-parser
+/test-persistence-memmap
 /test-scanner
 /test-str-slice
 /test-str-split

--- a/src/test/Kconfig
+++ b/src/test/Kconfig
@@ -100,3 +100,8 @@ config TEST_COMPOSED_TYPE
 config TEST_MESSAGE_DIGEST
       bool "crypto message-digest"
       default y
+
+config TEST_PERSISTENCE_MEMMAP
+	bool "Memmap persistence API"
+	depends on USE_MEMMAP
+	default y

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -74,3 +74,6 @@ test-test-composed-type-$(TEST_COMPOSED_TYPE) := test.c test-composed-type.c
 
 test-$(TEST_MESSAGE_DIGEST) += test-message-digest
 test-test-message-digest-$(TEST_MESSAGE_DIGEST) := test.c test-message-digest.c
+
+test-$(TEST_PERSISTENCE_MEMMAP) += test-persistence-memmap
+test-test-persistence-memmap-$(TEST_PERSISTENCE_MEMMAP) := test.c test-persistence-memmap.c

--- a/src/test/test-persistence-memmap.c
+++ b/src/test/test-persistence-memmap.c
@@ -1,0 +1,366 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sol-mainloop.h"
+#include "sol-memmap-storage.h"
+
+#include "test.h"
+
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry0, 2, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry1, 3, 1, 0, 1);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry2, 3, 4, 1, 30);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry3, 0, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry4, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry5, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry6, 0, 10, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry7, 0, 32, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry8, 0, 8, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry9, 0, 32, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry10, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry11, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry12, 0, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry13, 0, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry14, 0, 10, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry15, 0, 32, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map0_entry16, 0, 32, 0, 0);
+
+static const struct sol_str_table_ptr _memmap0_entries[] = {
+    SOL_STR_TABLE_PTR_ITEM("_version", &map0_entry0),
+    SOL_STR_TABLE_PTR_ITEM("boolean", &map0_entry1),
+    SOL_STR_TABLE_PTR_ITEM("int_only_val", &map0_entry2),
+    SOL_STR_TABLE_PTR_ITEM("byte", &map0_entry3),
+    SOL_STR_TABLE_PTR_ITEM("int", &map0_entry4),
+    SOL_STR_TABLE_PTR_ITEM("irange", &map0_entry5),
+    SOL_STR_TABLE_PTR_ITEM("string", &map0_entry6),
+    SOL_STR_TABLE_PTR_ITEM("double", &map0_entry7),
+    SOL_STR_TABLE_PTR_ITEM("double_only_val", &map0_entry8),
+    SOL_STR_TABLE_PTR_ITEM("drange", &map0_entry9),
+    SOL_STR_TABLE_PTR_ITEM("int_def", &map0_entry10),
+    SOL_STR_TABLE_PTR_ITEM("irange_def", &map0_entry11),
+    SOL_STR_TABLE_PTR_ITEM("byte_def", &map0_entry12),
+    SOL_STR_TABLE_PTR_ITEM("boolean_def", &map0_entry13),
+    SOL_STR_TABLE_PTR_ITEM("string_def", &map0_entry14),
+    SOL_STR_TABLE_PTR_ITEM("double_def", &map0_entry15),
+    SOL_STR_TABLE_PTR_ITEM("drange_def", &map0_entry16),
+    { }
+};
+
+static const struct sol_memmap_map _memmap0 = {
+    .version = 1,
+    .path = "memmap-test.bin",
+    .entries = _memmap0_entries
+};
+
+static struct sol_irange irange_not_delayed = {
+    .val = -23,
+    .min = -1000,
+    .max = 1000,
+    .step = 1
+};
+
+static struct sol_drange drange_not_delayed = {
+    .val = -2.3,
+    .min = -100.0,
+    .max = 100.0,
+    .step = 0.1
+};
+
+static struct sol_irange irange_delayed = {
+    .val = -33,
+    .min = -10000,
+    .max = 10000,
+    .step = 3
+};
+
+static struct sol_drange drange_delayed = {
+    .val = -9.8,
+    .min = -1000.0,
+    .max = 1000.0,
+    .step = 0.2
+};
+
+static void
+write_cb(void *data, const char *name, struct sol_blob *blob, int status)
+{
+    ASSERT_INT_EQ(status, 0);
+}
+
+static void
+write_cancelled_cb(void *data, const char *name, struct sol_blob *blob, int status)
+{
+    ASSERT_INT_EQ(status, -ECANCELED);
+}
+
+static void
+write_one(void)
+{
+    int r;
+
+    r = sol_memmap_write_bool("boolean", true, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_uint8("byte", 78, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_int32("int_only_val", 7804, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_irange("irange", &irange_not_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_drange("drange", &drange_not_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_double("double_only_val", 97.36, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_string("string", "gama delta", write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+}
+
+static void
+read_one(void)
+{
+    int r, i;
+    struct sol_irange irange;
+    struct sol_drange drange;
+    double d;
+    bool b;
+    uint8_t u;
+    char *string;
+
+    r = sol_memmap_read_bool("boolean", &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(b);
+
+    r = sol_memmap_read_uint8("byte", &u);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(u, 78);
+
+    r = sol_memmap_read_int32("int_only_val", &i);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(i, 7804);
+
+    r = sol_memmap_read_irange("irange", &irange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_irange_equal(&irange, &irange_not_delayed));
+
+    r = sol_memmap_read_drange("drange", &drange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_equal(&drange, &drange_not_delayed));
+
+    r = sol_memmap_read_double("double_only_val", &d);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_val_equal(d, 97.36));
+
+    r = sol_memmap_read_string("string", &string);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_STR_EQ(string, "gama delta");
+    free(string);
+}
+
+static void
+write_two(void)
+{
+    int r;
+
+    r = sol_memmap_write_bool("boolean", false, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_uint8("byte", 88, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_int32("int_only_val", 7814, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_irange("irange", &irange_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_drange("drange", &drange_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_double("double_only_val", 107.36, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_string("string", "alfa beta", write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+}
+
+static void
+read_two(void)
+{
+    int r, i;
+    struct sol_irange irange;
+    struct sol_drange drange;
+    double d;
+    bool b;
+    uint8_t u;
+    char *string;
+
+    r = sol_memmap_read_bool("boolean", &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(!b);
+
+    r = sol_memmap_read_uint8("byte", &u);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(u, 88);
+
+    r = sol_memmap_read_int32("int_only_val", &i);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(i, 7814);
+
+    r = sol_memmap_read_irange("irange", &irange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_irange_equal(&irange, &irange_delayed));
+
+    r = sol_memmap_read_drange("drange", &drange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_equal(&drange, &drange_delayed));
+
+    r = sol_memmap_read_double("double_only_val", &d);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_val_equal(d, 107.36));
+
+    r = sol_memmap_read_string("string", &string);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_STR_EQ(string, "alfa beta");
+    free(string);
+}
+
+static bool
+read_two_after(void *data)
+{
+    read_two();
+
+    return false;
+}
+
+static void
+write_one_cancelled(void)
+{
+    int r;
+
+    r = sol_memmap_write_bool("boolean", true, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_uint8("byte", 78, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_int32("int_only_val", 7804, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_irange("irange", &irange_not_delayed, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_drange("drange", &drange_not_delayed, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_double("double_only_val", 97.36, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_string("string", "gama delta", write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+}
+
+static bool
+write_two_timeout(void *data)
+{
+    write_two();
+    read_two();
+
+    return false;
+}
+
+static bool
+read_one_after_mainloop(void *data)
+{
+    read_one();
+
+    return false;
+}
+
+static bool
+write_cancelled_timeout(void *data)
+{
+    write_one_cancelled();
+    read_one(); /* write_one_cancelled writes same values as write_one */
+
+    write_two(); /* reuse second part of test */
+    read_two();
+
+    sol_quit();
+
+    return false;
+}
+
+static bool
+perform_tests(void *data)
+{
+    char command[128];
+    int n;
+
+    sol_memmap_add_map(&_memmap0);
+
+    n = snprintf(command, sizeof(command), "truncate -s0 %s && truncate -s128 %s",
+        _memmap0.path, _memmap0.path);
+    ASSERT(n > 0 && (size_t)n < sizeof(command));
+
+    n = system(command);
+    ASSERT(!n);
+
+    write_one();
+    read_one(); /* This one should happen before actually writing data */
+    sol_timeout_add(0, read_one_after_mainloop, NULL); /* This one should be after a main loop */
+    sol_timeout_add(50, write_two_timeout, NULL); /* This, much after */
+    sol_timeout_add(1000, read_two_after, NULL); /* Even later */
+
+    sol_timeout_add(2000, write_cancelled_timeout, NULL);
+
+    return false;
+}
+
+int
+main(int argc, char *argv[])
+{
+    int err;
+
+    err = sol_init();
+    ASSERT(!err);
+
+    sol_idle_add(perform_tests, NULL);
+
+    sol_run();
+
+    sol_shutdown();
+
+    return 0;
+}

--- a/src/test/test-persistence-memmap.c
+++ b/src/test/test-persistence-memmap.c
@@ -80,6 +80,51 @@ static const struct sol_memmap_map _memmap0 = {
     .entries = _memmap0_entries
 };
 
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry0, 2, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry1, 3, 1, 0, 1);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry2, 3, 4, 1, 30);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry3, 0, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry4, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry5, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry6, 0, 10, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry7, 0, 32, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry8, 0, 8, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry9, 0, 32, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry10, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry11, 0, 16, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry12, 0, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry13, 0, 1, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry14, 0, 10, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry15, 0, 32, 0, 0);
+SOL_MEMMAP_ENTRY_BIT_SIZE(map1_entry16, 0, 32, 0, 0);
+
+static const struct sol_str_table_ptr _memmap1_entries[] = {
+    SOL_STR_TABLE_PTR_ITEM("_version", &map1_entry0),
+    SOL_STR_TABLE_PTR_ITEM("boolean2", &map1_entry1),
+    SOL_STR_TABLE_PTR_ITEM("int_only_val2", &map1_entry2),
+    SOL_STR_TABLE_PTR_ITEM("byte2", &map1_entry3),
+    SOL_STR_TABLE_PTR_ITEM("int2", &map1_entry4),
+    SOL_STR_TABLE_PTR_ITEM("irange2", &map1_entry5),
+    SOL_STR_TABLE_PTR_ITEM("string2", &map1_entry6),
+    SOL_STR_TABLE_PTR_ITEM("double2", &map1_entry7),
+    SOL_STR_TABLE_PTR_ITEM("double_only_val2", &map1_entry8),
+    SOL_STR_TABLE_PTR_ITEM("drange2", &map1_entry9),
+    SOL_STR_TABLE_PTR_ITEM("int_def2", &map1_entry10),
+    SOL_STR_TABLE_PTR_ITEM("irange_def2", &map1_entry11),
+    SOL_STR_TABLE_PTR_ITEM("byte_def2", &map1_entry12),
+    SOL_STR_TABLE_PTR_ITEM("boolean_def2", &map1_entry13),
+    SOL_STR_TABLE_PTR_ITEM("string_def2", &map1_entry14),
+    SOL_STR_TABLE_PTR_ITEM("double_def2", &map1_entry15),
+    SOL_STR_TABLE_PTR_ITEM("drange_def2", &map1_entry16),
+    { }
+};
+
+static const struct sol_memmap_map _memmap1 = {
+    .version = 1,
+    .path = "memmap-test2.bin",
+    .entries = _memmap1_entries
+};
+
 static struct sol_irange irange_not_delayed = {
     .val = -23,
     .min = -1000,
@@ -145,6 +190,27 @@ write_one(void)
 
     r = sol_memmap_write_string("string", "gama delta", write_cb, NULL);
     ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_bool("boolean2", true, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_uint8("byte2", 78, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_int32("int_only_val2", 7804, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_irange("irange2", &irange_not_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_drange("drange2", &drange_not_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_double("double_only_val2", 97.36, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_string("string2", "gama delta", write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
 }
 
 static void
@@ -186,6 +252,35 @@ read_one(void)
     ASSERT_INT_EQ(r, 0);
     ASSERT_STR_EQ(string, "gama delta");
     free(string);
+
+    r = sol_memmap_read_bool("boolean2", &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(b);
+
+    r = sol_memmap_read_uint8("byte2", &u);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(u, 78);
+
+    r = sol_memmap_read_int32("int_only_val2", &i);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(i, 7804);
+
+    r = sol_memmap_read_irange("irange2", &irange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_irange_equal(&irange, &irange_not_delayed));
+
+    r = sol_memmap_read_drange("drange2", &drange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_equal(&drange, &drange_not_delayed));
+
+    r = sol_memmap_read_double("double_only_val2", &d);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_val_equal(d, 97.36));
+
+    r = sol_memmap_read_string("string2", &string);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_STR_EQ(string, "gama delta");
+    free(string);
 }
 
 static void
@@ -212,6 +307,27 @@ write_two(void)
     ASSERT_INT_EQ(r, 0);
 
     r = sol_memmap_write_string("string", "alfa beta", write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_bool("boolean2", false, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_uint8("byte2", 88, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_int32("int_only_val2", 7814, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_irange("irange2", &irange_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_drange("drange2", &drange_delayed, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_double("double_only_val2", 107.36, write_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_string("string2", "alfa beta", write_cb, NULL);
     ASSERT_INT_EQ(r, 0);
 }
 
@@ -254,6 +370,35 @@ read_two(void)
     ASSERT_INT_EQ(r, 0);
     ASSERT_STR_EQ(string, "alfa beta");
     free(string);
+
+    r = sol_memmap_read_bool("boolean2", &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(!b);
+
+    r = sol_memmap_read_uint8("byte2", &u);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(u, 88);
+
+    r = sol_memmap_read_int32("int_only_val2", &i);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(i, 7814);
+
+    r = sol_memmap_read_irange("irange2", &irange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_irange_equal(&irange, &irange_delayed));
+
+    r = sol_memmap_read_drange("drange2", &drange);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_equal(&drange, &drange_delayed));
+
+    r = sol_memmap_read_double("double_only_val2", &d);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_drange_val_equal(d, 107.36));
+
+    r = sol_memmap_read_string("string2", &string);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_STR_EQ(string, "alfa beta");
+    free(string);
 }
 
 static bool
@@ -288,6 +433,27 @@ write_one_cancelled(void)
     ASSERT_INT_EQ(r, 0);
 
     r = sol_memmap_write_string("string", "gama delta", write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_bool("boolean2", true, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_uint8("byte2", 78, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_int32("int_only_val2", 7804, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_irange("irange2", &irange_not_delayed, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_drange("drange2", &drange_not_delayed, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_double("double_only_val2", 97.36, write_cancelled_cb, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memmap_write_string("string2", "gama delta", write_cancelled_cb, NULL);
     ASSERT_INT_EQ(r, 0);
 }
 
@@ -329,9 +495,17 @@ perform_tests(void *data)
     int n;
 
     sol_memmap_add_map(&_memmap0);
+    sol_memmap_add_map(&_memmap1);
 
     n = snprintf(command, sizeof(command), "truncate -s0 %s && truncate -s128 %s",
         _memmap0.path, _memmap0.path);
+    ASSERT(n > 0 && (size_t)n < sizeof(command));
+
+    n = system(command);
+    ASSERT(!n);
+
+    n = snprintf(command, sizeof(command), "truncate -s0 %s && truncate -s128 %s",
+        _memmap1.path, _memmap1.path);
     ASSERT(n > 0 && (size_t)n < sizeof(command));
 
     n = system(command);


### PR DESCRIPTION
This commit replaces the async part of #966 

v6:
Every write happens on timer, even on filesystem and efivars, so callbacks are required;
Fixed callback changing sol-vector on the fly;
Fixed timeout deletion;
Added structure to keep track of memmap internal data, like resolved path and timeout - this simplified some code;


v5:
Less memory allocation (and leaks)

v4:
Fixed issues with timeouted implementation of memmap.

v3:
No more delayed as API parameter. It's now exclusive to memmap, defined via mapping file and adjustable via C API. Tests updated to check it.
Commit order changed so fixes and EEPROM map version happen before async stuff.

v2:
Fixed pointed issues;