### PR TITLE
Add DTLS wrapper for sol_socket & update OIC client/server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "src/thirdparty/tinycbor"]
 	path = src/thirdparty/tinycbor
 	url = https://github.com/01org/tinycbor/
+[submodule "src/thirdparty/tinydtls"]
+	path = src/thirdparty/tinydtls
+	url = git://git.code.sf.net/p/tinydtls/code

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -498,6 +498,17 @@
       "dependency": "openssl",
       "type": "pkg-config",
       "pkgname": "openssl"
+    },
+    {
+      "dependency": "tinydtls_src",
+      "type": "filesystem",
+      "files": [
+        "dtls.h"
+      ],
+      "path": {
+        "in-tree": "{TOP_SRCDIR}/src/thirdparty/tinydtls",
+        "out-of-tree": "{TINYDTLS_SRC}"
+      }
     }
   ]
 }

--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -1201,7 +1201,7 @@ server_resource_init(struct server_resource *resource, struct sol_flow_node *nod
 {
     log_init();
 
-    if (sol_oic_server_init(DEFAULT_UDP_PORT) != 0) {
+    if (sol_oic_server_init() != 0) {
         SOL_WRN("Could not create %%.*s server", SOL_STR_SLICE_PRINT(resource_type));
         return -ENOTCONN;
     }

--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -1286,6 +1286,12 @@ client_resource_init(struct sol_flow_node *node, struct client_resource *resourc
     resource->client.server = sol_coap_server_new(0);
     SOL_NULL_CHECK(resource->client.server, -ENOMEM);
 
+    resource->client.dtls_server = sol_coap_secure_server_new(0);
+    if (!resource->client.dtls_server) {
+        SOL_INT_CHECK_GOTO(errno, != ENOSYS, nomem);
+        SOL_INF("DTLS support not built-in, only making non-secure requests");
+    }
+
     resource->device_id = hex_ascii_to_binary(device_id);
     SOL_NULL_CHECK_GOTO(resource->device_id, nomem);
 
@@ -1334,6 +1340,8 @@ client_resource_close(struct client_resource *resource)
     }
 
     sol_coap_server_unref(resource->client.server);
+    if (resource->client.dtls_server)
+        sol_coap_server_unref(resource->client.dtls_server);
 }
 
 static bool

--- a/src/lib/comms/Kconfig
+++ b/src/lib/comms/Kconfig
@@ -6,6 +6,16 @@ config NETWORK
             making it possible to observe events, to inquire available links
             and to set their states.
 
+config DTLS
+	bool "Enable DTLS (Datagram Transport Layer Security) support"
+	default y
+	depends on HAVE_TINYDTLS_SRC
+	help
+	    This enables support for DTLS (a derivation from the SSL protocol)
+	    support in the socket abstraction layer.
+
+	    If unsure, say Y.
+
 config COAP
 	bool "CoAP"
 	default y

--- a/src/lib/comms/Makefile
+++ b/src/lib/comms/Makefile
@@ -4,6 +4,30 @@ obj-networking-$(NETWORK) := \
     sol-comms.o \
     sol-socket.o
 
+obj-networking-$(DTLS) += \
+    $(TINYDTLS_SRC_PATH)/ccm.o \
+    $(TINYDTLS_SRC_PATH)/crypto.o \
+    $(TINYDTLS_SRC_PATH)/dtls.o \
+    $(TINYDTLS_SRC_PATH)/dtls_time.o \
+    $(TINYDTLS_SRC_PATH)/hmac.o \
+    $(TINYDTLS_SRC_PATH)/netq.o \
+    $(TINYDTLS_SRC_PATH)/peer.o \
+    $(TINYDTLS_SRC_PATH)/session.o \
+    $(TINYDTLS_SRC_PATH)/ecc/ecc.o \
+    $(TINYDTLS_SRC_PATH)/aes/rijndael.o \
+    $(TINYDTLS_SRC_PATH)/sha2/sha2.o
+
+obj-networking-$(DTLS)-extra-cflags += \
+    -I$(TINYDTLS_SRC_PATH) \
+    -Wno-sign-compare \
+    -Wno-discarded-qualifiers \
+    -Wno-old-style-definition \
+    -Wno-old-style-declaration \
+    -Wno-strict-prototypes \
+    -Wno-shadow \
+    -Wno-missing-prototypes \
+    -Wno-incompatible-pointer-types
+
 obj-networking-$(PLATFORM_RIOTOS) += \
     sol-network-impl-riot.o \
     sol-socket-impl-riot.o
@@ -25,7 +49,7 @@ obj-networking-$(OIC) += \
     $(TINYCBOR_SRC_PATH)/cborparser.o \
     $(TINYCBOR_SRC_PATH)/cborpretty.o
 
-obj-networking-$(OIC)-extra-cflags := \
+obj-networking-$(OIC)-extra-cflags += \
     -I$(TINYCBOR_SRC_PATH) \
     -Wno-cpp \
     -Wno-declaration-after-statement \

--- a/src/lib/comms/Makefile
+++ b/src/lib/comms/Makefile
@@ -1,7 +1,8 @@
 obj-$(NETWORK) += networking.mod
 
 obj-networking-$(NETWORK) := \
-    sol-comms.o
+    sol-comms.o \
+    sol-socket.o
 
 obj-networking-$(PLATFORM_RIOTOS) += \
     sol-network-impl-riot.o \

--- a/src/lib/comms/Makefile
+++ b/src/lib/comms/Makefile
@@ -15,7 +15,9 @@ obj-networking-$(DTLS) += \
     $(TINYDTLS_SRC_PATH)/session.o \
     $(TINYDTLS_SRC_PATH)/ecc/ecc.o \
     $(TINYDTLS_SRC_PATH)/aes/rijndael.o \
-    $(TINYDTLS_SRC_PATH)/sha2/sha2.o
+    $(TINYDTLS_SRC_PATH)/sha2/sha2.o \
+    $(TINYDTLS_SRC_PATH)/debug.o \
+    sol-socket-dtls-impl-tinydtls.o
 
 obj-networking-$(DTLS)-extra-cflags += \
     -I$(TINYDTLS_SRC_PATH) \

--- a/src/lib/comms/dtls_config.h
+++ b/src/lib/comms/dtls_config.h
@@ -1,0 +1,91 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "sol-common-buildopts.h"
+#include "sol_config.h"
+
+/* This file is required to build TinyDLS, and uses the constants defined
+ * by Soletta's build system to create one that TinyDTLS will be happy
+ * with, without actually running or generating its configure script. */
+
+#define NDEBUG
+
+#define DTLSv12 1
+
+#define DTLS_ECC 1
+#define DTLS_PSK 1
+
+#define SHA2_USE_INTTYPES_H 1
+#define WITH_SHA256 1
+
+#ifdef SOL_PLATFORM_CONTIKI
+/* Enabling WITH_CONTIKI will generate Contiki-only code paths, including
+ * generating code that does not depend on pthreads.  */
+#define WITH_CONTIKI 1
+#elif defined(PTHREAD) && PTHREAD == 1
+/* Pthread implementation exists, so use it.  */
+#else
+/* For TinyDTLS, if platform is not Contiki, it requires pthread because of
+ * a mutex in crypto.c.  Provide stub versions of pthread_mutex_t in this
+ * case, as Soletta is single-threaded.
+ *
+ * This is not optimal, though. Some cleanup must be performed in TinyDTLS
+ * in order to make it not assume Contiki when working with small embedded
+ * systems.  */
+typedef char pthread_mutex_t;
+
+static inline void
+pthread_mutex_lock(pthread_mutex_t *mtx)
+{
+    (void)mtx;
+}
+
+static inline void
+pthread_mutex_unlock(pthread_mutex_t *mtx)
+{
+    (void)mtx;
+}
+#endif
+
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define WORDS_BIGENDIAN 1
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#undef WORDS_BIGENDIAN
+#else
+#error "Unknown byte order"
+#endif
+
+#define HAVE_ASSERT_H 1
+#define HAVE_SYS_TIME_H 1
+#define HAVE_TIME_H 1

--- a/src/lib/comms/dtls_config.h
+++ b/src/lib/comms/dtls_config.h
@@ -89,3 +89,4 @@ pthread_mutex_unlock(pthread_mutex_t *mtx)
 #define HAVE_ASSERT_H 1
 #define HAVE_SYS_TIME_H 1
 #define HAVE_TIME_H 1
+#define HAVE_VPRINTF 1

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -188,6 +188,7 @@ void sol_coap_header_set_code(struct sol_coap_packet *pkt, uint8_t code);
 void sol_coap_header_set_id(struct sol_coap_packet *pkt, uint16_t id);
 
 struct sol_coap_server *sol_coap_server_new(int port);
+struct sol_coap_server *sol_coap_secure_server_new(int port);
 struct sol_coap_server *sol_coap_server_ref(struct sol_coap_server *server);
 void sol_coap_server_unref(struct sol_coap_server *server);
 

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -158,16 +158,20 @@ struct sol_coap_resource {
     /*
      * handlers for the CoAP defined methods.
      */
-    int (*get)(const struct sol_coap_resource *resource,
+    int (*get)(struct sol_coap_server *server,
+        const struct sol_coap_resource *resource,
         struct sol_coap_packet *req,
         const struct sol_network_link_addr *cliaddr, void *data);
-    int (*post)(const struct sol_coap_resource *resource,
+    int (*post)(struct sol_coap_server *server,
+        const struct sol_coap_resource *resource,
         struct sol_coap_packet *req,
         const struct sol_network_link_addr *cliaddr, void *data);
-    int (*put)(const struct sol_coap_resource *resource,
+    int (*put)(struct sol_coap_server *server,
+        const struct sol_coap_resource *resource,
         struct sol_coap_packet *req,
         const struct sol_network_link_addr *cliaddr, void *data);
-    int (*delete)(const struct sol_coap_resource *resource,
+    int (*delete)(struct sol_coap_server *server,
+        const struct sol_coap_resource *resource,
         struct sol_coap_packet *req,
         const struct sol_network_link_addr *cliaddr, void *data);
     enum sol_coap_flags flags;
@@ -219,9 +223,9 @@ int sol_coap_send_packet(struct sol_coap_server *server, struct sol_coap_packet 
 
 int sol_coap_send_packet_with_reply(struct sol_coap_server *server, struct sol_coap_packet *pkt,
     const struct sol_network_link_addr *cliaddr,
-    int (*reply_cb)(struct sol_coap_packet *req,
-    const struct sol_network_link_addr *cliaddr, void *data),
-    void *data);
+    int (*reply_cb)(struct sol_coap_server *server,
+    struct sol_coap_packet *req, const struct sol_network_link_addr *cliaddr,
+    void *data), void *data);
 
 int sol_coap_packet_send_notification(struct sol_coap_server *server,
     struct sol_coap_resource *resource, struct sol_coap_packet *pkt);

--- a/src/lib/comms/include/sol-oic-client.h
+++ b/src/lib/comms/include/sol-oic-client.h
@@ -72,6 +72,7 @@ struct sol_oic_client {
     uint16_t api_version;
     int : 0; /* save possible hole for a future field */
     struct sol_coap_server *server;
+    struct sol_coap_server *dtls_server;
 };
 
 struct sol_oic_resource {

--- a/src/lib/comms/include/sol-oic-server.h
+++ b/src/lib/comms/include/sol-oic-server.h
@@ -93,7 +93,7 @@ struct sol_oic_resource_type {
     } get, put, post, delete;
 };
 
-int sol_oic_server_init(int port);
+int sol_oic_server_init(void);
 void sol_oic_server_release(void);
 
 struct sol_oic_server_resource *sol_oic_server_add_resource(

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -587,10 +587,11 @@ create_coap_resource(struct sol_oic_server_resource *resource)
 static char *
 create_endpoint(void)
 {
+    static unsigned int id = 0;
     char *buffer = NULL;
     int r;
 
-    r = asprintf(&buffer, "/sol/%x", oic_server.resources.len);
+    r = asprintf(&buffer, "/sol/%x", id++);
     return r < 0 ? NULL : buffer;
 }
 

--- a/src/lib/comms/sol-socket-dtls-impl-tinydtls.c
+++ b/src/lib/comms/sol-socket-dtls-impl-tinydtls.c
@@ -1,0 +1,822 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <netinet/in.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "sol-log.h"
+#include "sol-mainloop.h"
+#include "sol-network.h"
+#include "sol-util.h"
+
+#include "sol-socket.h"
+#include "sol-socket-impl.h"
+
+#include "dtls.h"
+
+#define DTLS_PSK_ID_LEN 16
+#define DTLS_PSK_KEY_LEN 16
+
+struct sol_socket *sol_socket_dtls_wrap_socket(struct sol_socket *to_wrap);
+
+struct queue_item {
+    struct sol_buffer buffer;
+    struct sol_network_link_addr addr;
+};
+
+struct sol_socket_dtls {
+    struct sol_socket base;
+    struct sol_socket *wrapped;
+    struct sol_timeout *retransmit_timeout;
+    dtls_context_t *context;
+
+    struct {
+        bool (*cb)(void *data, struct sol_socket *s);
+        const void *data;
+        struct sol_vector queue;
+    } read, write;
+
+    bool server;
+};
+
+struct cred_item {
+    char *id;
+    char *psk;
+};
+
+struct creds {
+    struct sol_vector items;
+    char *id;
+};
+
+static int
+from_sockaddr(const struct sockaddr *sockaddr, socklen_t socklen,
+    struct sol_network_link_addr *addr)
+{
+    SOL_NULL_CHECK(sockaddr, -EINVAL);
+    SOL_NULL_CHECK(addr, -EINVAL);
+
+    addr->family = sockaddr->sa_family;
+
+    if (sockaddr->sa_family == AF_INET) {
+        struct sockaddr_in *sock4 = (struct sockaddr_in *)sockaddr;
+        if (socklen < sizeof(struct sockaddr_in))
+            return -EINVAL;
+
+        addr->port = ntohs(sock4->sin_port);
+        memcpy(&addr->addr.in, &sock4->sin_addr, sizeof(sock4->sin_addr));
+    } else if (sockaddr->sa_family == AF_INET6) {
+        struct sockaddr_in6 *sock6 = (struct sockaddr_in6 *)sockaddr;
+        if (socklen < sizeof(struct sockaddr_in6))
+            return -EINVAL;
+
+        addr->port = ntohs(sock6->sin6_port);
+        memcpy(&addr->addr.in6, &sock6->sin6_addr, sizeof(sock6->sin6_addr));
+    } else {
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+static int
+to_sockaddr(const struct sol_network_link_addr *addr, struct sockaddr *sockaddr, socklen_t *socklen)
+{
+    SOL_NULL_CHECK(addr, -EINVAL);
+    SOL_NULL_CHECK(sockaddr, -EINVAL);
+    SOL_NULL_CHECK(socklen, -EINVAL);
+
+    if (addr->family == AF_INET) {
+        struct sockaddr_in *sock4 = (struct sockaddr_in *)sockaddr;
+        if (*socklen < sizeof(struct sockaddr_in))
+            return -EINVAL;
+
+        memcpy(&sock4->sin_addr, addr->addr.in, sizeof(addr->addr.in));
+        sock4->sin_port = htons(addr->port);
+        sock4->sin_family = AF_INET;
+        *socklen = sizeof(*sock4);
+    } else if (addr->family == AF_INET6) {
+        struct sockaddr_in6 *sock6 = (struct sockaddr_in6 *)sockaddr;
+        if (*socklen < sizeof(struct sockaddr_in6))
+            return -EINVAL;
+
+        memcpy(&sock6->sin6_addr, addr->addr.in6, sizeof(addr->addr.in6));
+        sock6->sin6_port = htons(addr->port);
+        sock6->sin6_family = AF_INET6;
+        *socklen = sizeof(*sock6);
+    } else {
+        return -EINVAL;
+    }
+
+    return *socklen;
+}
+
+static bool
+session_from_linkaddr(const struct sol_network_link_addr *addr,
+    session_t *session)
+{
+    memset(session, 0, sizeof(*session));
+    session->size = sizeof(session->addr);
+
+    return to_sockaddr(addr, &session->addr.sa, &session->size) >= 0;
+}
+
+static void
+clear_queue(struct sol_vector *vec)
+{
+    struct queue_item *item;
+    uint16_t idx;
+
+    SOL_VECTOR_FOREACH_IDX (vec, item, idx) {
+        sol_util_secure_clear_memory(item->buffer.data, item->buffer.capacity);
+        sol_buffer_fini(&item->buffer);
+        sol_util_secure_clear_memory(item, sizeof(*item));
+    }
+
+    sol_vector_clear(vec);
+    sol_util_secure_clear_memory(vec, sizeof(*vec));
+}
+
+static void
+sol_socket_dtls_del(struct sol_socket *socket)
+{
+    struct sol_socket_dtls *s = (struct sol_socket_dtls *)socket;
+
+    sol_socket_del(s->wrapped);
+
+    clear_queue(&s->read.queue);
+    clear_queue(&s->write.queue);
+
+    if (s->retransmit_timeout)
+        sol_timeout_del(s->retransmit_timeout);
+
+    dtls_free_context(s->context);
+
+    sol_util_secure_clear_memory(s, sizeof(*s));
+    free(s);
+}
+
+static int
+sol_socket_dtls_recvmsg(struct sol_socket *socket, void *buf, size_t len, struct sol_network_link_addr *cliaddr)
+{
+    struct sol_socket_dtls *s = (struct sol_socket_dtls *)socket;
+    struct queue_item *item;
+
+    if (s->read.queue.len == 0) {
+        SOL_DBG("Receive queue empty, returning 0");
+        return -1;
+    }
+
+    item = sol_vector_get(&s->read.queue, 0);
+    if (!item) {
+        SOL_DBG("Could not get first item in queue");
+        return -1;
+    }
+
+    memcpy(cliaddr, &item->addr, sizeof(*cliaddr));
+
+    if (item->buffer.used <= len) {
+        int used = (int)item->buffer.used;
+
+        memcpy(buf, item->buffer.data, item->buffer.used);
+
+        sol_util_secure_clear_memory(item->buffer.data, item->buffer.capacity);
+        sol_buffer_fini(&item->buffer);
+
+        sol_util_secure_clear_memory(item, sizeof(*item));
+        sol_vector_del(&s->read.queue, 0);
+
+        return used;
+    }
+
+    memcpy(buf, item->buffer.data, len);
+    item->buffer.data = (char *)item->buffer.data + len;
+    item->buffer.used -= len;
+
+    return (int)len;
+}
+
+static bool encrypt_payload(void *data, struct sol_socket *wrapped);
+
+static int
+sol_socket_dtls_sendmsg(struct sol_socket *socket, const void *buf, size_t len,
+    const struct sol_network_link_addr *cliaddr)
+{
+    struct sol_socket_dtls *s = (struct sol_socket_dtls *)socket;
+    struct queue_item *item;
+    void *buf_copy;
+
+    if (s->write.queue.len > 4) {
+        SOL_WRN("Transmission queue too long");
+        return -ENOMEM;
+    }
+
+    buf_copy = sol_util_memdup(buf, len);
+    SOL_NULL_CHECK(buf_copy, -ENOMEM);
+
+    item = sol_vector_append(&s->write.queue);
+    SOL_NULL_CHECK(item, -ENOMEM);
+
+    item->addr = *cliaddr;
+    sol_buffer_init_flags(&item->buffer, buf_copy, len, SOL_BUFFER_FLAGS_FIXED_CAPACITY | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+    item->buffer.used = len;
+
+    encrypt_payload(s, s->wrapped);
+
+    return (int)len;
+}
+
+static int
+sol_socket_dtls_join_group(struct sol_socket *socket, int ifindex, const struct sol_network_link_addr *group)
+{
+    /* DTLS servers are unicast only */
+    return 0;
+}
+
+static int
+sol_socket_dtls_bind(struct sol_socket *socket, const struct sol_network_link_addr *addr)
+{
+    struct sol_socket_dtls *s = (struct sol_socket_dtls *)socket;
+    int r;
+
+    r = sol_socket_bind(s->wrapped, addr);
+    if (r == 0) {
+        if (addr->port == 0)
+            s->server = false;
+        else
+            s->server = true;
+        SOL_DBG("Bound as a %s", s->server ? "server" : "client");
+    }
+
+    return r;
+}
+
+static void
+init_dtls_if_needed(void)
+{
+    static bool initialized = false;
+
+    if (!initialized) {
+        dtls_init();
+        initialized = true;
+        SOL_DBG("TinyDTLS initialized");
+    }
+}
+
+/* Called whenever the wrapped socket can be read. This receives a packet
+ * from that socket, and passes to TinyDTLS. When it's done decrypting
+ * the payload, dtls_handle_message() will call sol_dtls_read(), which
+ * in turn will call the user callback with the decrypted data. */
+static bool
+read_encrypted(void *data, struct sol_socket *wrapped)
+{
+    struct sol_socket_dtls *socket = data;
+    struct sol_network_link_addr cliaddr;
+    session_t session = { 0 };
+    uint8_t buf[DTLS_MAX_BUF];
+    int len;
+
+    SOL_DBG("Reading encrypted data from wrapped socket");
+
+    len = sol_socket_recvmsg(socket->wrapped, buf, sizeof(buf), &cliaddr);
+    SOL_INT_CHECK(len, < 0, false);
+
+    session.size = sizeof(session.addr);
+    if (to_sockaddr(&cliaddr, &session.addr.sa, &session.size) < 0)
+        return false;
+
+    return dtls_handle_message(socket->context, &session, buf, len) == 0;
+}
+
+static int
+call_user_read_cb(struct dtls_context_t *ctx, session_t *session, uint8_t *buf, size_t len)
+{
+    struct sol_socket_dtls *socket = dtls_get_app_data(ctx);
+    struct sol_network_link_addr addr;
+    struct queue_item *item;
+    void *buf_copy;
+
+    if (socket->read.queue.len > 4) {
+        SOL_WRN("Read queue too long, dropping packet");
+        return -ENOMEM;
+    }
+
+    if (from_sockaddr(&session->addr.sa, session->size, &addr) < 0) {
+        SOL_DBG("Could not get link address from session");
+        return -EINVAL;
+    }
+
+    buf_copy = sol_util_memdup(buf, len);
+    sol_util_secure_clear_memory(buf, len);
+    SOL_NULL_CHECK(buf_copy, -EINVAL);
+
+    item = sol_vector_append(&socket->read.queue);
+    SOL_NULL_CHECK_GOTO(item, no_item);
+
+    item->addr = addr;
+    sol_buffer_init_flags(&item->buffer, buf_copy, len,
+        SOL_BUFFER_FLAGS_FIXED_CAPACITY | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+    item->buffer.used = len;
+
+    if (!socket->read.cb) {
+        /* No need to free buf_copy/item, cb might be set later */
+        return -EINVAL;
+    }
+
+    if (socket->read.cb(socket->read.data, socket))
+        return len;
+
+    return -EINVAL;
+
+no_item:
+    sol_util_secure_clear_memory(buf_copy, len);
+    free(buf_copy);
+    return -ENOMEM;
+}
+
+/* Called whenever the wrapped socket can be written to. This gets the
+ * unencrypted data previously set with sol_socket_sendmsg() and cached in
+ * the sol_socket_dtls struct, passes through TinyDTLS, and when it's done
+ * encrypting the payload, it calls sol_socket_sendmsg() to finally pass it
+ * to the wire.  */
+static bool
+encrypt_payload(void *data, struct sol_socket *wrapped)
+{
+    struct sol_socket_dtls *socket = data;
+    struct queue_item *item;
+    session_t session;
+    int r;
+
+    item = sol_vector_get(&socket->write.queue, 0);
+    if (!item) {
+        SOL_WRN("Write transmission queue empty");
+        return false;
+    }
+
+    if (!session_from_linkaddr(&item->addr, &session)) {
+        SOL_DBG("Could not create create session from link address");
+        return false;
+    }
+
+    r = dtls_write(socket->context, &session, item->buffer.data, item->buffer.used);
+    if (r == 0) {
+        SOL_DBG("Peer state is not connected, keeping buffer in memory to try again");
+        return true;
+    }
+    if (r < 0) {
+        SOL_WRN("Could not send data through the secure channel, will try again");
+        return true;
+    }
+
+    if (r < (int)item->buffer.used)
+        SOL_WRN("Could not send all of the enqueued data, will discard");
+    else
+        SOL_DBG("Sent everything, will remove from queue");
+
+    sol_util_secure_clear_memory(item->buffer.data, item->buffer.capacity);
+    sol_buffer_fini(&item->buffer);
+    sol_util_secure_clear_memory(item, sizeof(*item));
+    sol_vector_del(&socket->write.queue, 0);
+
+    return true;
+}
+
+static int
+write_encrypted(struct dtls_context_t *ctx, session_t *session, uint8_t *buf, size_t len)
+{
+    struct sol_socket_dtls *socket = dtls_get_app_data(ctx);
+    struct sol_network_link_addr addr;
+    int r;
+
+    if (from_sockaddr(&session->addr.sa, session->size, &addr) < 0) {
+        SOL_DBG("Could not get link address from session");
+        return -EINVAL;
+    }
+
+    r = sol_socket_sendmsg(socket->wrapped, buf, len, &addr);
+    SOL_INT_CHECK(r, < 0, r);
+
+    return len;
+}
+
+static bool
+call_user_write_cb(void *data, struct sol_socket *wrapped)
+{
+    struct sol_socket_dtls *socket = data;
+
+    if (!socket->write.cb) {
+        SOL_DBG("No wrapped write callback");
+        return false;
+    }
+
+    if (socket->write.cb(socket->write.data, socket)) {
+        SOL_DBG("User func@%p returned success, encrypting payload",
+            socket->write.cb);
+
+        if (encrypt_payload(data, wrapped)) {
+            SOL_DBG("Data encrypted, should have been passed to the "
+                "wrapped socket");
+            return true;
+        } else {
+            SOL_DBG("Could not encrypt payload");
+        }
+    }
+
+    return false;
+}
+
+static void
+retransmit_timer_disable(struct sol_socket_dtls *s)
+{
+    if (s->retransmit_timeout) {
+        SOL_DBG("Disabling DTLS retransmit timer");
+
+        sol_timeout_del(s->retransmit_timeout);
+        s->retransmit_timeout = NULL;
+    }
+}
+
+static bool
+retransmit_timer_cb(void *data)
+{
+    struct sol_socket_dtls *socket = data;
+
+    SOL_DBG("Retransmitting DTLS packets");
+    dtls_check_retransmit(socket->context, NULL);
+    socket->retransmit_timeout = NULL;
+
+    return false;
+}
+
+static void
+retransmit_timer_enable(struct sol_socket_dtls *s, clock_time_t next)
+{
+    SOL_DBG("Next DTLS retransmission will happen in %u seconds", next);
+
+    if (s->retransmit_timeout) {
+        sol_timeout_del(s->retransmit_timeout);
+        s->retransmit_timeout = NULL;
+    }
+
+    s->retransmit_timeout = sol_timeout_add(next * 1000, retransmit_timer_cb,
+        socket);
+}
+
+static void
+retransmit_timer_check(struct sol_socket_dtls *s)
+{
+    clock_time_t next_retransmit = 0;
+
+    dtls_check_retransmit(s->context, &next_retransmit);
+    if (next_retransmit == 0)
+        retransmit_timer_disable(s);
+    else
+        retransmit_timer_enable(s, next_retransmit);
+}
+
+static int
+handle_dtls_event(struct dtls_context_t *ctx, session_t *session,
+    dtls_alert_level_t level, unsigned short code)
+{
+    struct sol_socket_dtls *socket = dtls_get_app_data(ctx);
+    const char *msg;
+
+    if (code == DTLS_EVENT_CONNECT)
+        msg = "handshake_init";
+    else if (code == DTLS_EVENT_CONNECTED)
+        msg = "handshake_or_renegotiation_done";
+    else if (code == DTLS_EVENT_RENEGOTIATE)
+        msg = "renegotiation_started";
+    else if (code == DTLS_ALERT_CLOSE_NOTIFY)
+        msg = "close_notify";
+    else if (code == DTLS_ALERT_UNEXPECTED_MESSAGE)
+        msg = "unexpected_message";
+    else if (code == DTLS_ALERT_BAD_RECORD_MAC)
+        msg = "bad_record_mac";
+    else if (code == DTLS_ALERT_RECORD_OVERFLOW)
+        msg = "record_overflow";
+    else if (code == DTLS_ALERT_DECOMPRESSION_FAILURE)
+        msg = "decompression_failure";
+    else if (code == DTLS_ALERT_HANDSHAKE_FAILURE)
+        msg = "handshake_failure";
+    else if (code == DTLS_ALERT_BAD_CERTIFICATE)
+        msg = "bad_certificate";
+    else if (code == DTLS_ALERT_UNSUPPORTED_CERTIFICATE)
+        msg = "unsupported_certificate";
+    else if (code == DTLS_ALERT_CERTIFICATE_REVOKED)
+        msg = "certificate_revoked";
+    else if (code == DTLS_ALERT_CERTIFICATE_EXPIRED)
+        msg = "certificate_expired";
+    else if (code == DTLS_ALERT_CERTIFICATE_UNKNOWN)
+        msg = "certificate_unknown";
+    else if (code == DTLS_ALERT_ILLEGAL_PARAMETER)
+        msg = "illegal_parameter";
+    else if (code == DTLS_ALERT_UNKNOWN_CA)
+        msg = "unknown_ca";
+    else if (code == DTLS_ALERT_ACCESS_DENIED)
+        msg = "access_denied";
+    else if (code == DTLS_ALERT_DECODE_ERROR)
+        msg = "decode_error";
+    else if (code == DTLS_ALERT_DECRYPT_ERROR)
+        msg = "decrypt_error";
+    else if (code == DTLS_ALERT_PROTOCOL_VERSION)
+        msg = "protocol_version";
+    else if (code == DTLS_ALERT_INSUFFICIENT_SECURITY)
+        msg = "insufficient_security";
+    else if (code == DTLS_ALERT_INTERNAL_ERROR)
+        msg = "internal_error";
+    else if (code == DTLS_ALERT_USER_CANCELED)
+        msg = "user_canceled";
+    else if (code == DTLS_ALERT_NO_RENEGOTIATION)
+        msg = "no_renegotiation";
+    else if (code == DTLS_ALERT_UNSUPPORTED_EXTENSION)
+        msg = "unsupported_extension";
+    else
+        msg = "unknown_event";
+
+    if (level == DTLS_ALERT_LEVEL_WARNING) {
+        SOL_WRN("\n\nDTLS warning for socket %p: %s\n\n", socket, msg);
+    } else if (level == DTLS_ALERT_LEVEL_FATAL) {
+        /* FIXME: What to do here? Destroy the wrapped socket? Renegotiate? */
+        SOL_ERR("\n\nDTLS fatal error for socket %p: %s\n\n", socket, msg);
+    } else {
+        SOL_DBG("\n\nTLS session changed for socket %p: %s\n\n", socket, msg);
+        if (code == DTLS_EVENT_CONNECTED) {
+            struct queue_item *item;
+            uint16_t idx;
+
+            SOL_DBG("Sending %d enqueued packets in write queue", socket->write.queue.len);
+            SOL_VECTOR_FOREACH_IDX (&socket->write.queue, item, idx) {
+                session_t session;
+
+                if (!session_from_linkaddr(&item->addr, &session))
+                    continue;
+
+                (void)dtls_write(socket->context, &session, item->buffer.data, item->buffer.used);
+            }
+            sol_vector_clear(&socket->write.queue);
+        }
+    }
+
+    retransmit_timer_check(socket);
+
+    return 0;
+}
+
+static int
+sol_socket_dtls_set_on_read(struct sol_socket *socket, bool (*cb)(void *data, struct sol_socket *s), void *data)
+{
+    struct sol_socket_dtls *s = (struct sol_socket_dtls *)socket;
+
+    s->read.cb = cb;
+    s->read.data = data;
+
+    SOL_DBG("setting onread of socket %p to %p<%p>", socket, cb, data);
+
+    return sol_socket_set_on_read(s->wrapped, read_encrypted, socket);
+}
+
+static int
+sol_socket_dtls_set_on_write(struct sol_socket *socket, bool (*cb)(void *data, struct sol_socket *s), void *data)
+{
+    struct sol_socket_dtls *s = (struct sol_socket_dtls *)socket;
+
+    s->write.cb = cb;
+    s->write.data = data;
+
+    SOL_DBG("setting onwrite of socket %p to %p<%p>", socket, cb, data);
+
+    return sol_socket_set_on_write(s->wrapped, call_user_write_cb, socket);
+}
+
+static const char *
+creds_find_psk(const struct creds *creds, const char *desc, size_t desc_len)
+{
+    struct cred_item *iter;
+    uint16_t idx;
+
+    SOL_DBG("Looking for PSK with ID=%.*s", (int)desc_len, desc);
+
+    SOL_VECTOR_FOREACH_IDX (&creds->items, iter, idx) {
+        if (!memcmp(desc, iter->id, desc_len)) /* timingsafe_bcmp()? */
+            return iter->psk;
+    }
+
+    return NULL;
+}
+
+static bool
+creds_add(struct creds *creds, const char *id, size_t id_len,
+    const char *psk, size_t psk_len)
+{
+    struct cred_item *item;
+    char *psk_stored;
+
+    psk_stored = creds_find_psk(creds, id, id_len);
+    if (psk_stored) {
+        if (!memcmp(psk_stored, psk, psk_len))
+            return true;
+
+        SOL_WRN("Attempting to add PSK for ID=%.*s, it's already registered "
+            " and different from the supplied key", (int)id_len, id);
+        return false;
+    }
+
+    item = sol_vector_append(&creds->items);
+    SOL_NULL_CHECK(item, false);
+
+    item->id = strndup(id, id_len);
+    SOL_NULL_CHECK_GOTO(item->id, no_id);
+
+    item->psk = strndup(psk, psk_len);
+    SOL_NULL_CHECK_GOTO(item->psk, no_psk);
+
+    return true;
+
+no_psk:
+    sol_util_secure_clear_memory(item->id, strlen(id));
+    free(item->id);
+no_id:
+    sol_util_secure_clear_memory(item, sizeof(*item));
+    sol_vector_del(&creds->items, creds->items.len);
+
+    return false;
+}
+
+static void
+creds_clear(struct creds *creds)
+{
+    struct cred_item *iter;
+    uint16_t idx;
+
+    SOL_VECTOR_FOREACH_IDX (&creds->items, iter, idx) {
+        sol_util_secure_clear_memory(iter->id, DTLS_PSK_ID_LEN);
+        sol_util_secure_clear_memory(iter->psk, DTLS_PSK_KEY_LEN);
+
+        free(iter->id);
+        free(iter->psk);
+    }
+    sol_vector_clear(&creds->items);
+
+    sol_util_secure_clear_memory(creds->id, strlen(creds->id));
+    free(creds->id);
+
+    sol_util_secure_clear_memory(creds, sizeof(*creds));
+}
+
+static bool
+creds_init(struct creds *creds)
+{
+    creds->id = strdup("1111111111111111");
+    if (!creds->id)
+        return false;
+
+    sol_vector_init(&creds->items, sizeof(struct cred_item));
+
+    /* FIXME: Load this information from a secure storage area somehow. */
+    if (!creds_add(creds, "1111111111111111", DTLS_PSK_ID_LEN, "AAAAAAAAAAAAAAAA", DTLS_PSK_KEY_LEN)) {
+        creds_clear(creds);
+        return false;
+    }
+
+    return true;
+}
+
+static int
+get_psk_info(struct dtls_context_t *ctx, const session_t *session,
+    dtls_credentials_type_t type, const char *desc, size_t desc_len,
+    char *result, size_t result_len)
+{
+    struct creds creds;
+    const char *psk;
+    int r = -1;
+
+    SOL_NULL_CHECK(result, dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR));
+
+    if (!creds_init(&creds)) {
+        SOL_WRN("Could not obtain PSK credentials");
+
+        return dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR);
+    }
+
+    if (type == DTLS_PSK_IDENTITY || type == DTLS_PSK_HINT) {
+        SOL_DBG("Server asked for PSK %s with %zu bytes, have %d",
+            type == DTLS_PSK_IDENTITY ? "identity" : "hint",
+            result_len, DTLS_PSK_ID_LEN);
+
+        if (result_len >= DTLS_PSK_ID_LEN) {
+            memcpy(result, creds.id, DTLS_PSK_ID_LEN);
+            r = DTLS_PSK_ID_LEN;
+        } else {
+            SOL_DBG("Not enough space to write PSK");
+            r = dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR);
+        }
+
+        goto out;
+    }
+
+    if (type != DTLS_PSK_KEY) {
+        SOL_WRN("Expecting request for PSK, got something else instead (got %d, expected %d)",
+            type, DTLS_PSK_KEY);
+        r = dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR);
+
+        goto out;
+    }
+    if (desc_len < DTLS_PSK_KEY_LEN) {
+        SOL_WRN("Expecting PSK key but no space to write it (got %zu, have %d)",
+            desc_len, DTLS_PSK_KEY_LEN);
+        r = dtls_alert_fatal_create(DTLS_ALERT_ILLEGAL_PARAMETER);
+
+        goto out;
+    }
+    SOL_NULL_CHECK_GOTO(desc, out);
+
+    psk = creds_find_psk(&creds, desc, desc_len);
+    if (psk) {
+        memcpy(result, psk, DTLS_PSK_KEY_LEN);
+        r = DTLS_PSK_KEY_LEN;
+    }
+
+out:
+    creds_clear(&creds);
+    return r;
+}
+
+struct sol_socket *
+sol_socket_dtls_wrap_socket(struct sol_socket *to_wrap)
+{
+    static const struct sol_socket_impl impl = {
+        .bind = sol_socket_dtls_bind,
+        .join_group = sol_socket_dtls_join_group,
+        .sendmsg = sol_socket_dtls_sendmsg,
+        .recvmsg = sol_socket_dtls_recvmsg,
+        .set_on_write = sol_socket_dtls_set_on_write,
+        .set_on_read = sol_socket_dtls_set_on_read,
+        .del = sol_socket_dtls_del,
+        .new = NULL,
+    };
+    static const dtls_handler_t dtls_handler = {
+        .write = write_encrypted,
+        .read = call_user_read_cb,
+        .event = handle_dtls_event,
+        .get_psk_info = get_psk_info
+    };
+    struct sol_socket_dtls *socket;
+
+    init_dtls_if_needed();
+
+    socket = malloc(sizeof(*socket));
+    SOL_NULL_CHECK(socket, NULL);
+
+    socket->context = dtls_new_context(socket);
+    if (!socket->context) {
+        SOL_WRN("Could not create DTLS context");
+        free(socket);
+        return NULL;
+    }
+
+    dtls_set_handler(socket->context, &dtls_handler);
+
+    socket->read.cb = NULL;
+    socket->write.cb = NULL;
+    socket->retransmit_timeout = NULL;
+    socket->wrapped = to_wrap;
+    socket->base.impl = &impl;
+    socket->server = false;
+
+    sol_vector_init(&socket->write.queue, sizeof(struct queue_item));
+    sol_vector_init(&socket->read.queue, sizeof(struct queue_item));
+
+    return &socket->base;
+}

--- a/src/lib/comms/sol-socket-impl-linux.c
+++ b/src/lib/comms/sol-socket-impl-linux.c
@@ -122,10 +122,7 @@ to_sockaddr(const struct sol_network_link_addr *addr, struct sockaddr *sockaddr,
     SOL_NULL_CHECK(sockaddr, -EINVAL);
     SOL_NULL_CHECK(socklen, -EINVAL);
 
-    if (addr->family != AF_INET && addr->family != AF_INET6)
-        return -EINVAL;
-
-    if (addr->family == AF_INET ) {
+    if (addr->family == AF_INET) {
         struct sockaddr_in *sock4 = (struct sockaddr_in *)sockaddr;
         if (*socklen < sizeof(struct sockaddr_in))
             return -EINVAL;
@@ -134,7 +131,7 @@ to_sockaddr(const struct sol_network_link_addr *addr, struct sockaddr *sockaddr,
         sock4->sin_port = htons(addr->port);
         sock4->sin_family = AF_INET;
         *socklen = sizeof(*sock4);
-    } else {
+    } else if (addr->family == AF_INET6) {
         struct sockaddr_in6 *sock6 = (struct sockaddr_in6 *)sockaddr;
         if (*socklen < sizeof(struct sockaddr_in6))
             return -EINVAL;
@@ -143,6 +140,8 @@ to_sockaddr(const struct sol_network_link_addr *addr, struct sockaddr *sockaddr,
         sock6->sin6_port = htons(addr->port);
         sock6->sin6_family = AF_INET6;
         *socklen = sizeof(*sock6);
+    } else {
+        return -EINVAL;
     }
 
     return *socklen;

--- a/src/lib/comms/sol-socket-impl-linux.c
+++ b/src/lib/comms/sol-socket-impl-linux.c
@@ -236,7 +236,7 @@ sol_socket_recvmsg(struct sol_socket *s, void *buf, size_t len, struct sol_netwo
         .msg_iov = &iov,
         .msg_iovlen = 1
     };
-    int r;
+    ssize_t r;
 
     SOL_NULL_CHECK(s, -EINVAL);
 
@@ -248,7 +248,10 @@ sol_socket_recvmsg(struct sol_socket *s, void *buf, size_t len, struct sol_netwo
     if (from_sockaddr((struct sockaddr *)sockaddr, sizeof(sockaddr), cliaddr) < 0)
         return -EINVAL;
 
-    return r;
+    if ((ssize_t)(int)r != r)
+        return -EOVERFLOW;
+
+    return (int)r;
 }
 
 static bool

--- a/src/lib/comms/sol-socket-impl.h
+++ b/src/lib/comms/sol-socket-impl.h
@@ -33,28 +33,27 @@
 #pragma once
 
 #include "sol-network.h"
+#include "sol-socket.h"
 
-struct sol_socket_impl;
+struct sol_socket_impl {
+    struct sol_socket *(*new)(int domain, enum sol_socket_type type, int protocol);
+    void (*del)(struct sol_socket *s);
 
-struct sol_socket {
-    const struct sol_socket_impl *impl;
+    int (*set_on_read)(struct sol_socket *s, bool (*cb)(void *data, struct sol_socket *s), void *data);
+    int (*set_on_write)(struct sol_socket *s, bool (*cb)(void *data, struct sol_socket *s), void *data);
+
+    int (*recvmsg)(struct sol_socket *s, void *buf, size_t len, struct sol_network_link_addr *cliaddr);
+
+    int (*sendmsg)(struct sol_socket *s, const void *buf, size_t len,
+        const struct sol_network_link_addr *cliaddr);
+
+    int (*join_group)(struct sol_socket *s, int ifindex, const struct sol_network_link_addr *group);
+
+    int (*bind)(struct sol_socket *s, const struct sol_network_link_addr *addr);
 };
 
-enum sol_socket_type {
-    SOL_SOCKET_UDP
-};
-
-struct sol_socket *sol_socket_new(int domain, enum sol_socket_type type, int protocol);
-void sol_socket_del(struct sol_socket *s);
-
-int sol_socket_set_on_read(struct sol_socket *s, bool (*cb)(void *data, struct sol_socket *s), void *data);
-int sol_socket_set_on_write(struct sol_socket *s, bool (*cb)(void *data, struct sol_socket *s), void *data);
-
-int sol_socket_recvmsg(struct sol_socket *s, void *buf, size_t len, struct sol_network_link_addr *cliaddr);
-
-int sol_socket_sendmsg(struct sol_socket *s, const void *buf, size_t len,
-    const struct sol_network_link_addr *cliaddr);
-
-int sol_socket_join_group(struct sol_socket *s, int ifindex, const struct sol_network_link_addr *group);
-
-int sol_socket_bind(struct sol_socket *s, const struct sol_network_link_addr *addr);
+#ifdef SOL_PLATFORM_LINUX
+const struct sol_socket_impl *sol_socket_linux_get_impl(void);
+#elif SOL_PLATFORM_RIOT
+const struct sol_socket_impl *sol_socket_riot_get_impl(void);
+#endif

--- a/src/lib/comms/sol-socket.c
+++ b/src/lib/comms/sol-socket.c
@@ -1,0 +1,126 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sol-socket.h"
+
+#include "sol-common-buildopts.h"
+#include "sol-log-internal.h"
+#include "sol-macros.h"
+#include "sol-network.h"
+#include "sol-socket-impl.h"
+
+#include <errno.h>
+
+SOL_API struct sol_socket *
+sol_socket_new(int domain, enum sol_socket_type type, int protocol)
+{
+    const struct sol_socket_impl *impl = NULL;
+    struct sol_socket *socket;
+
+#ifdef SOL_PLATFORM_LINUX
+    impl = sol_socket_linux_get_impl();
+#elif SOL_PLATFORM_RIOT
+    impl = sol_socket_riot_get_impl();
+#endif
+
+    SOL_NULL_CHECK(impl, NULL);
+
+    socket = impl->new(domain, type, protocol);
+    if (socket)
+        socket->impl = impl;
+
+    return socket;
+}
+
+SOL_API void
+sol_socket_del(struct sol_socket *s)
+{
+    SOL_NULL_CHECK(s);
+    SOL_NULL_CHECK(s->impl->del);
+
+    s->impl->del(s);
+}
+
+SOL_API int
+sol_socket_set_on_read(struct sol_socket *s, bool (*cb)(void *data, struct sol_socket *s), void *data)
+{
+    SOL_NULL_CHECK(s, -EINVAL);
+    SOL_NULL_CHECK(s->impl->set_on_read, -ENOSYS);
+
+    return s->impl->set_on_read(s, cb, data);
+}
+
+SOL_API int
+sol_socket_set_on_write(struct sol_socket *s, bool (*cb)(void *data, struct sol_socket *s), void *data)
+{
+    SOL_NULL_CHECK(s, -EINVAL);
+    SOL_NULL_CHECK(s->impl->set_on_write, -ENOSYS);
+
+    return s->impl->set_on_write(s, cb, data);
+}
+
+SOL_API int
+sol_socket_recvmsg(struct sol_socket *s, void *buf, size_t len, struct sol_network_link_addr *cliaddr)
+{
+    SOL_NULL_CHECK(s, -EINVAL);
+    SOL_NULL_CHECK(s->impl->recvmsg, -ENOSYS);
+
+    return s->impl->recvmsg(s, buf, len, cliaddr);
+}
+
+SOL_API int
+sol_socket_sendmsg(struct sol_socket *s, const void *buf, size_t len,
+    const struct sol_network_link_addr *cliaddr)
+{
+    SOL_NULL_CHECK(s, -EINVAL);
+    SOL_NULL_CHECK(s->impl->sendmsg, -ENOSYS);
+
+    return s->impl->sendmsg(s, buf, len, cliaddr);
+}
+
+SOL_API int
+sol_socket_join_group(struct sol_socket *s, int ifindex, const struct sol_network_link_addr *group)
+{
+    SOL_NULL_CHECK(s, -EINVAL);
+    SOL_NULL_CHECK(s->impl->join_group, -ENOSYS);
+
+    return s->impl->join_group(s, ifindex, group);
+}
+
+SOL_API int
+sol_socket_bind(struct sol_socket *s, const struct sol_network_link_addr *addr)
+{
+    SOL_NULL_CHECK(s, -EINVAL);
+    SOL_NULL_CHECK(s->impl->bind, -ENOSYS);
+
+    return s->impl->bind(s, addr);
+}

--- a/src/lib/comms/sol-socket.h
+++ b/src/lib/comms/sol-socket.h
@@ -41,7 +41,10 @@ struct sol_socket {
 };
 
 enum sol_socket_type {
-    SOL_SOCKET_UDP
+    SOL_SOCKET_UDP,
+#ifdef DTLS
+    SOL_SOCKET_DTLS,
+#endif
 };
 
 struct sol_socket *sol_socket_new(int domain, enum sol_socket_type type, int protocol);

--- a/src/lib/comms/tinydtls.h
+++ b/src/lib/comms/tinydtls.h
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+/* This file is required to build TinyDLS, and uses the constants defined
+ * by Soletta's build system to create one that TinyDTLS will be happy
+ * with, without actually running or generating its configure script. */
+
+#include "dtls_config.h"

--- a/src/samples/coap/oic-client.c
+++ b/src/samples/coap/oic-client.c
@@ -156,6 +156,9 @@ main(int argc, char *argv[])
     }
 
     client.server = sol_coap_server_new(0);
+    client.dtls_server = sol_coap_secure_server_new(0);
+
+    printf("DTLS support %s\n", client.dtls_server ? "available" : "unavailable");
 
     if (argc < 2) {
         printf("No rt filter specified, assuming everything\n");

--- a/src/samples/coap/oic-server.c
+++ b/src/samples/coap/oic-server.c
@@ -50,9 +50,6 @@
 #include "sol-coap.h"
 #include "sol-oic-server.h"
 
-
-#define DEFAULT_UDP_PORT 5683
-
 static int console_fd;
 static bool led_state;
 
@@ -165,7 +162,7 @@ main(int argc, char *argv[])
 
     sol_init();
 
-    if (sol_oic_server_init(DEFAULT_UDP_PORT) != 0) {
+    if (sol_oic_server_init() != 0) {
         SOL_WRN("Could not create OIC server.");
         return -1;
     }

--- a/src/samples/coap/simple-server.c
+++ b/src/samples/coap/simple-server.c
@@ -123,10 +123,10 @@ light_resource_to_rep(const struct sol_coap_resource *resource,
 }
 
 static int
-light_method_put(const struct sol_coap_resource *resource, struct sol_coap_packet *req,
+light_method_put(struct sol_coap_server *server,
+    const struct sol_coap_resource *resource, struct sol_coap_packet *req,
     const struct sol_network_link_addr *cliaddr, void *data)
 {
-    struct sol_coap_server *server = (void *)data;
     struct sol_coap_packet *resp;
     char *sub = NULL;
     uint8_t *p;
@@ -186,10 +186,10 @@ update_light(void *data)
 }
 
 static int
-light_method_get(const struct sol_coap_resource *resource, struct sol_coap_packet *req,
+light_method_get(struct sol_coap_server *server,
+    const struct sol_coap_resource *resource, struct sol_coap_packet *req,
     const struct sol_network_link_addr *cliaddr, void *data)
 {
-    struct sol_coap_server *server = (void *)data;
     struct sol_coap_packet *resp;
     uint8_t *payload;
     uint16_t len;
@@ -238,7 +238,7 @@ main(int argc, char *argv[])
         return -1;
     }
 
-    if (!sol_coap_server_register_resource(server, &light, server)) {
+    if (!sol_coap_server_register_resource(server, &light, NULL)) {
         SOL_WRN("Could not register resource for the light");
         return -1;
     }

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -569,3 +569,13 @@ sol_util_base16_calculate_decoded_len(const struct sol_str_slice slice)
 {
     return slice.len / 2;
 }
+
+static inline void
+sol_util_secure_clear_memory(void *buf, size_t len)
+{
+    memset(buf, 0, len);
+
+    /* Clobber memory pointed to by `buf` to prevent the optimizer from
+     * eliding the memset() call.  */
+    asm volatile ("" : : "g" (buf) : "memory");
+}

--- a/src/thirdparty/README
+++ b/src/thirdparty/README
@@ -15,3 +15,11 @@ Thirdparty
       - CBOR is the "Concise Binary Object Representation", and is the
         format used by OIC to encode network payload. TinyCBOR is a library
         to encode and decode data in CBOR.
+
+- TinyDTLS
+      - Repository: http://sourceforge.net/projects/tinydtls/
+      - License: MIT
+      - "Provides a very simple datagram server with DTLS support. It is
+        designed to support session multiplexing in single-threaded
+        applications and thus targets specifically on embedded systems."
+        (copied as is from its documentation)


### PR DESCRIPTION
This series adds a DTLS (Datagram Transport Layer Security) layer on top of sol_socket. The idea is that, regardless of the underlying socket implementation (be it standard POSIX sockets, RIOT, etc.), DTLS will be available for Soletta users without we having to implement it for each and every supported platform.

I chose the TinyDTLS library for the implementation simply because it's small and used by IoTivity, which we keep a close eye on due to the need to be compatible with their OIC implementation, and also for the fact that it's indeed a tiny library, as far as a DTLS implementation goes, which fits Soletta use cases very well.

To accomplish this, sol_socket has been virtualized. The standard implementation merely forwards calls to the system's socket APIs, while the DTLS version does its magic in TinyDTLS, which in turn sends and receives encrypted data using the native socket implementation.

The CoAP implementation had to be slightly changed as well, to pass a pointer to the server struct to the handler callbacks. This was required by the changes in the OIC server implementation in order to respond requests with the right channel.

OIC servers and clients were changed, and now they're aware of DTLS. Changes at the OIC API level should be (sans very small details) transparent. The OIC implementation for provisioning, transfer methods, and whatnot are still not compatible with IoTivity, but work on that will soon follow.

Many thanks to (in no particular order) @vcgomes, @rchiossi and @otaviobp for the help in debugging this contraption.