### PR TITLE
Don't use api_version stuff on static builds

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -22,7 +22,12 @@ config SHARED_LIBRARY
 
 config STATIC_LIBRARY
 	bool "Static"
+	select NO_API_VERSION_NEEDED
 endchoice
+
+config NO_API_VERSION_NEEDED
+    bool
+    default n
 
 # backward compatibility with autotools vars
 config ENABLE_DYNAMIC_MODULES

--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -507,8 +507,8 @@ struct %(name_c)s_options {
         outfile.write("""
 #define %(NAME_C)s_OPTIONS_DEFAULTS(...) { \\
     .base = { \\
-        .api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION, \\
-        .sub_api = %(NAME_C)s_OPTIONS_API_VERSION \\
+        SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION, ) \\
+        SOL_SET_API_VERSION(.sub_api = %(NAME_C)s_OPTIONS_API_VERSION) \\
     }, \\
 """ % {
     "name_c": data["name_c"],
@@ -737,7 +737,7 @@ def generate_code_entry(outfile, data):
             process = port_methods.get("process", "NULL")
             outfile.write("""
 static struct sol_flow_port_type_in %(type_c)s = {
-    .api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION, )
     .process = %(process)s,
     .connect = %(connect)s,
     .disconnect = %(disconnect)s,
@@ -774,7 +774,7 @@ static struct sol_flow_port_type_in %(type_c)s = {
             disconnect = port_methods.get("disconnect", "NULL")
             outfile.write("""
 static struct sol_flow_port_type_out %(type_c)s = {
-    .api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION, )
     .connect = %(connect)s,
     .disconnect = %(disconnect)s,
 };
@@ -855,7 +855,7 @@ static const struct %(name_c)s_options %(name_c)s_options_defaults = %(NAME_C)s_
     outfile.write("""
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
 static const struct sol_flow_node_type_description %(name_c)s_description = {
-    .api_version = SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION, )
     .name = %(name)s,
     .category = %(category)s,
     .symbol = %(symbol)s,
@@ -980,7 +980,7 @@ static const struct sol_flow_node_type_description %(name_c)s_description = {
         outfile.write("""\
     .options = &((const struct sol_flow_node_options_description){
         .data_size = sizeof(struct %(name_c)s_options),
-        .sub_api = %(NAME_C)s_OPTIONS_API_VERSION,
+        SOL_SET_API_VERSION(.sub_api = %(NAME_C)s_OPTIONS_API_VERSION, )
         .required = %(required)s,
         .members = (const struct sol_flow_node_options_member_description[]){
             %(member_options)s
@@ -1026,7 +1026,7 @@ static const struct sol_flow_node_type_description %(name_c)s_description = {
 
     outfile.write("""\
 static const %(node_type)s %(name_c)s = {%(node_base_type_access_open)s
-    .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_API_VERSION, )
     .data_size = %(data_size)s,
     .options_size = %(options_size)s,
     .default_options = %(default_options)s,

--- a/data/scripts/sol-flow-node-type-stub-gen.py
+++ b/data/scripts/sol-flow-node-type-stub-gen.py
@@ -275,7 +275,7 @@ static int
 #define %(NAME)s_PACKET_TYPE_API_VERSION (1)
 
 static const struct sol_flow_packet_type _%(NAME)s = {
-    .api_version = %(NAME)s_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = %(NAME)s_PACKET_TYPE_API_VERSION, )
     .name = "%(NAME)s",
     .data_size = sizeof(struct %(name_data)s),
     .init = %(name)s_packet_init,

--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -1211,7 +1211,7 @@ server_resource_init(struct server_resource *resource, struct sol_flow_node *nod
     resource->funcs = funcs;
 
     resource->type = (struct sol_oic_resource_type) {
-        .api_version = SOL_OIC_RESOURCE_TYPE_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_OIC_RESOURCE_TYPE_API_VERSION, )
         .resource_type = resource_type,
         .interface = SOL_STR_SLICE_LITERAL("oc.mi.def"),
         .get = { .handle = server_handle_get },
@@ -1282,7 +1282,7 @@ client_resource_init(struct sol_flow_node *node, struct client_resource *resourc
     if (!device_id || strlen(device_id) != 32)
         return -EINVAL;
 
-    resource->client.api_version = SOL_OIC_CLIENT_API_VERSION;
+    SOL_SET_API_VERSION(resource->client.api_version = SOL_OIC_CLIENT_API_VERSION; )
     resource->client.server = sol_coap_server_new(0);
     SOL_NULL_CHECK(resource->client.server, -ENOMEM);
 

--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -1059,8 +1059,8 @@ generate_fbp_node_options(struct fbp_data *data)
     out("};\n\n");
     out("#define GENERATED_%s_OPTIONS_DEFAULT(...) { \\\n"
         "    .base = { \\\n"
-        "        .api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION, \\\n"
-        "        .sub_api = OPTIONS_%s_API_VERSION \\\n"
+        "        SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION, ) \\\n"
+        "        SOL_SET_API_VERSION(.sub_api = OPTIONS_%s_API_VERSION) \\\n"
         "    }, \\\n"
         "    __VA_ARGS__ \\\n"
         "}\n\n", data->exported_options_symbol, data->exported_options_symbol);
@@ -1147,7 +1147,7 @@ generate_create_type_function(struct fbp_data *data)
 
     out("\n"
         "    struct sol_flow_static_spec spec = {\n"
-        "        .api_version = SOL_FLOW_STATIC_API_VERSION,\n"
+        "        SOL_SET_API_VERSION(.api_version = SOL_FLOW_STATIC_API_VERSION, )\n"
         "        .nodes = nodes,\n"
         "        .conns = conns,\n"
         "        .exported_in = %s,\n"

--- a/src/bin/sol-fbp-runner/inspector.c
+++ b/src/bin/sol-fbp-runner/inspector.c
@@ -412,7 +412,7 @@ inspector_will_deliver_packet(const struct sol_flow_inspector *inspector, const 
 }
 
 static const struct sol_flow_inspector inspector = {
-    .api_version = SOL_FLOW_INSPECTOR_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_INSPECTOR_API_VERSION, )
     .did_open_node = inspector_did_open_node,
     .will_close_node = inspector_will_close_node,
     .did_connect_port = inspector_did_connect_port,

--- a/src/bin/sol-fbp-runner/runner.c
+++ b/src/bin/sol-fbp-runner/runner.c
@@ -392,7 +392,7 @@ runner_new_from_file(
     sol_ptr_vector_init(&r->file_readers);
     r->fbp_paths = fbps;
 
-    r->parser_client.api_version = SOL_FLOW_PARSER_CLIENT_API_VERSION;
+    SOL_SET_API_VERSION(r->parser_client.api_version = SOL_FLOW_PARSER_CLIENT_API_VERSION; )
     r->parser_client.data = r;
     r->parser_client.read_file = read_file;
 

--- a/src/lib/common/include/sol-glib-integration.h
+++ b/src/lib/common/include/sol-glib-integration.h
@@ -388,7 +388,9 @@ _sol_glib_integration_source_dispose(void *data)
 }
 
 static const struct sol_mainloop_source_type _sol_glib_integration_source_type = {
+#ifndef SOL_NO_API_VERSION
     .api_version = SOL_MAINLOOP_SOURCE_TYPE_API_VERSION,
+#endif
     .prepare = _sol_glib_integration_source_prepare,
     .get_next_timeout = _sol_glib_integration_source_get_next_timeout,
     .check = _sol_glib_integration_source_check,

--- a/src/lib/common/include/sol-mainloop.h
+++ b/src/lib/common/include/sol-mainloop.h
@@ -154,12 +154,13 @@ bool sol_child_watch_del(struct sol_child_watch *handle);
 #endif
 
 struct sol_mainloop_source_type {
+#ifndef SOL_NO_API_VERSION
 #define SOL_MAINLOOP_SOURCE_TYPE_API_VERSION (1)  /**< compile time API version to be checked during runtime */
     /**
      * must match #SOL_MAINLOOP_SOURCE_TYPE_API_VERSION at runtime.
      */
     uint16_t api_version;
-
+#endif
     /**
      * Function to be called to prepare to check for events.
      *
@@ -322,8 +323,10 @@ char **sol_argv(void);
 void sol_args_set(int argc, char *argv[]);
 
 struct sol_main_callbacks {
+#ifndef SOL_NO_API_VERSION
 #define SOL_MAIN_CALLBACKS_API_VERSION (1)
     uint16_t api_version;
+#endif
     uint16_t flags;
     void (*startup)(void);
     void (*shutdown)(void);
@@ -349,33 +352,26 @@ struct sol_main_callbacks {
         sol_shutdown();                                   \
         PROCESS_END();                                    \
     }
-#elif defined(SOL_PLATFORM_RIOT)
+#else
+#ifdef SOL_PLATFORM_RIOT
 #define SOL_MAIN(CALLBACKS) \
     int main(void) { \
         return sol_mainloop_default_main(&(CALLBACKS), 0, NULL); \
     }
-
-#define SOL_MAIN_DEFAULT(STARTUP, SHUTDOWN) \
-    static const struct sol_main_callbacks sol_main_callbacks_instance = { \
-        .api_version = SOL_MAIN_CALLBACKS_API_VERSION, \
-        .startup = (STARTUP), \
-        .shutdown = (SHUTDOWN), \
-    }; \
-    SOL_MAIN(sol_main_callbacks_instance)
 #else
 #define SOL_MAIN(CALLBACKS)                                          \
     int main(int argc, char *argv[]) {                              \
         return sol_mainloop_default_main(&(CALLBACKS), argc, argv);  \
     }
-
+#endif /* SOL_PLATFORM_RIOT */
 #define SOL_MAIN_DEFAULT(STARTUP, SHUTDOWN)                              \
     static const struct sol_main_callbacks sol_main_callbacks_instance = { \
-        .api_version = SOL_MAIN_CALLBACKS_API_VERSION,                   \
+        SOL_SET_API_VERSION(.api_version = SOL_MAIN_CALLBACKS_API_VERSION, ) \
         .startup = (STARTUP),                                           \
         .shutdown = (SHUTDOWN),                                         \
     };                                                                  \
     SOL_MAIN(sol_main_callbacks_instance)
-#endif
+#endif /* SOL_PLATFORM_CONTIKI */
 
 /* Internal. */
 int sol_mainloop_default_main(const struct sol_main_callbacks *callbacks, int argc, char *argv[]);

--- a/src/lib/common/include/sol-pin-mux-modules.h
+++ b/src/lib/common/include/sol-pin-mux-modules.h
@@ -34,6 +34,7 @@
 
 #include <stdarg.h>
 
+#include "sol-common-buildopts.h"
 #include "sol-gpio.h"
 #include "sol-pin-mux.h"
 
@@ -45,9 +46,11 @@ extern "C" {
  * Structure containing the recipes (lists of rules) that should be used
  * to multiplex the pins of a given platform
  */
-#define SOL_PIN_MUX_API_VERSION (2UL)
 struct sol_pin_mux {
+#ifndef SOL_NO_API_VERSION
+#define SOL_PIN_MUX_API_VERSION (2UL)
     unsigned long int api_version; /**< API version */
+#endif
     const char *plat_name; /**< Name this multiplexer target platform */
 
     int (*init)(void);
@@ -64,10 +67,16 @@ struct sol_pin_mux {
 
 #ifdef SOL_PIN_MUX_MODULE_EXTERNAL
 #define SOL_PIN_MUX_DECLARE(_NAME, decl ...) \
-    SOL_API const struct sol_pin_mux SOL_PIN_MUX = { SOL_PIN_MUX_API_VERSION, decl }
+    SOL_API const struct sol_pin_mux SOL_PIN_MUX = { \
+        SOL_SET_API_VERSION(SOL_PIN_MUX_API_VERSION, ) \
+        decl \
+    }
 #else
 #define SOL_PIN_MUX_DECLARE(_NAME, decl ...) \
-    SOL_API const struct sol_pin_mux SOL_PIN_MUX_ ## _NAME = { SOL_PIN_MUX_API_VERSION, decl }
+    SOL_API const struct sol_pin_mux SOL_PIN_MUX_ ## _NAME = { \
+        SOL_SET_API_VERSION(SOL_PIN_MUX_API_VERSION, ) \
+        decl \
+    }
 #endif
 
 #ifdef __cplusplus

--- a/src/lib/common/include/sol-types.h
+++ b/src/lib/common/include/sol-types.h
@@ -36,6 +36,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <float.h>
+#include <sol-common-buildopts.h>
 #include <sol-vector.h>
 
 #ifdef __cplusplus
@@ -249,9 +250,11 @@ struct sol_blob {
 };
 
 struct sol_blob_type {
+#ifndef SOL_NO_API_VERSION
 #define SOL_BLOB_TYPE_API_VERSION (1)
     uint16_t api_version;
     uint16_t sub_api;
+#endif
     void (*free)(struct sol_blob *blob);
 };
 

--- a/src/lib/common/include/sol-worker-thread.h
+++ b/src/lib/common/include/sol-worker-thread.h
@@ -35,6 +35,8 @@
 #include <stdbool.h>
 #include <inttypes.h>
 
+#include "sol-common-buildopts.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,11 +49,13 @@ struct sol_worker_thread;
  * @brief Worker thread functions and context data specification.
  */
 struct sol_worker_thread_spec {
+#ifndef SOL_NO_API_VERSION
 #define SOL_WORKER_THREAD_SPEC_API_VERSION (1)
     /** must match SOL_WORKER_THREAD_SPEC_API_VERSION in runtime */
     uint16_t api_version;
     /* hole reserved for future use */
     int : 0;
+#endif
     /** the context data to give to all functions. */
     const void *data;
     /**

--- a/src/lib/common/sol-bus.c
+++ b/src/lib/common/sol-bus.c
@@ -103,7 +103,7 @@ source_dispose(void *data)
 }
 
 static const struct sol_mainloop_source_type source_type = {
-    .api_version = SOL_MAINLOOP_SOURCE_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_MAINLOOP_SOURCE_TYPE_API_VERSION, )
     .prepare = source_prepare,
     .check = source_check,
     .dispatch = source_dispatch,

--- a/src/lib/common/sol-common-buildopts.h.in
+++ b/src/lib/common/sol-common-buildopts.h.in
@@ -40,6 +40,7 @@ st.on_value("PLATFORM_CONTIKI", "y", "#define SOL_PLATFORM_CONTIKI 1", "")
 
 {{
 st.on_value("LOG", "y", "#define SOL_LOG_ENABLED 1", "")
+st.on_value("NO_API_VERSION_NEEDED", "y", "#define SOL_NO_API_VERSION 1", "")
 }}
 
 {{
@@ -49,4 +50,10 @@ st.on_value("MODULES", "y", "#define SOL_DYNAMIC_MODULES 1", "")
 #ifdef SOL_PLATFORM_LINUX
 #define SOL_MAINLOOP_FD_ENABLED 1
 #define SOL_MAINLOOP_FORK_WATCH_ENABLED 1
+#endif
+
+#ifdef SOL_NO_API_VERSION
+#define SOL_SET_API_VERSION(...)
+#else
+#define SOL_SET_API_VERSION(...) __VA_ARGS__
 #endif

--- a/src/lib/common/sol-mainloop.c
+++ b/src/lib/common/sol-mainloop.c
@@ -324,6 +324,7 @@ sol_mainloop_source_new(const struct sol_mainloop_source_type *type, const void 
 {
     SOL_NULL_CHECK(type, NULL);
 
+#ifndef SOL_NO_API_VERSION
     if (type->api_version != SOL_MAINLOOP_SOURCE_TYPE_API_VERSION) {
         SOL_WRN("type(%p)->api_version(%hu) != "
             "SOL_MAINLOOP_SOURCE_TYPE_API_VERSION(%hu)",
@@ -331,6 +332,7 @@ sol_mainloop_source_new(const struct sol_mainloop_source_type *type, const void 
             SOL_MAINLOOP_SOURCE_TYPE_API_VERSION);
         return NULL;
     }
+#endif
 
     SOL_NULL_CHECK(type->check, NULL);
     SOL_NULL_CHECK(type->dispatch, NULL);

--- a/src/lib/common/sol-pin-mux.c
+++ b/src/lib/common/sol-pin-mux.c
@@ -85,11 +85,13 @@ _load_mux(const char *name)
         goto error;
     }
 
+#ifndef SOL_NO_API_VERSION
     if (p_sym->api_version != SOL_PIN_MUX_API_VERSION) {
         SOL_WRN("Mux '%s' has incorrect api_version: %lu expected %lu", path, p_sym->api_version,
             SOL_PIN_MUX_API_VERSION);
         goto error;
     }
+#endif
 
     if (dl_handle)
         dlclose(dl_handle);

--- a/src/lib/common/sol-platform-impl-linux-micro.c
+++ b/src/lib/common/sol-platform-impl-linux-micro.c
@@ -170,11 +170,13 @@ new_external_service_module(const char *name)
             path, dlerror());
         goto error;
     }
+#ifndef SOL_NO_API_VERSION
     if ((*p_sym)->api_version != SOL_PLATFORM_LINUX_MICRO_MODULE_API_VERSION) {
         SOL_WRN("module '%s' has incorrect api_version: %lu expected %lu",
             path, (*p_sym)->api_version, SOL_PLATFORM_LINUX_MICRO_MODULE_API_VERSION);
         goto error;
     }
+#endif
 
     mod = sol_vector_append(&service_modules);
     SOL_NULL_CHECK_GOTO(mod, error);

--- a/src/lib/common/sol-platform-linux-micro.h
+++ b/src/lib/common/sol-platform-linux-micro.h
@@ -32,6 +32,7 @@
 
 #pragma once
 
+#include "sol-common-buildopts.h"
 #include "sol-platform.h"
 #include "sol-platform-linux.h"
 #include <stdbool.h>
@@ -43,8 +44,10 @@ extern "C" {
 #endif
 
 struct sol_platform_linux_micro_module {
+#ifndef SOL_NO_API_VERSION
     unsigned long int api_version;
 #define SOL_PLATFORM_LINUX_MICRO_MODULE_API_VERSION (1UL)
+#endif
     const char *name;
     int (*init)(const struct sol_platform_linux_micro_module *module, const char *service);
     void (*shutdown)(const struct sol_platform_linux_micro_module *module, const char *service);
@@ -59,10 +62,16 @@ void sol_platform_linux_micro_inform_service_state(const char *service, enum sol
 
 #ifdef SOL_PLATFORM_LINUX_MICRO_MODULE_EXTERNAL
 #define SOL_PLATFORM_LINUX_MICRO_MODULE(_NAME, decl ...)                  \
-    SOL_API const struct sol_platform_linux_micro_module *SOL_PLATFORM_LINUX_MICRO_MODULE = &((const struct sol_platform_linux_micro_module){.api_version = SOL_PLATFORM_LINUX_MICRO_MODULE_API_VERSION, decl })
+    SOL_API const struct sol_platform_linux_micro_module *SOL_PLATFORM_LINUX_MICRO_MODULE = &((const struct sol_platform_linux_micro_module) { \
+            SOL_SET_API_VERSION(.api_version = SOL_PLATFORM_LINUX_MICRO_MODULE_API_VERSION, ) \
+            decl \
+        })
 #else
 #define SOL_PLATFORM_LINUX_MICRO_MODULE(_NAME, decl ...)                    \
-    const struct sol_platform_linux_micro_module SOL_PLATFORM_LINUX_MICRO_MODULE_ ## _NAME = { .api_version = SOL_PLATFORM_LINUX_MICRO_MODULE_API_VERSION, decl }
+    const struct sol_platform_linux_micro_module SOL_PLATFORM_LINUX_MICRO_MODULE_ ## _NAME = { \
+        SOL_SET_API_VERSION(.api_version = SOL_PLATFORM_LINUX_MICRO_MODULE_API_VERSION, ) \
+        decl \
+    }
 #endif
 
 #ifdef __cplusplus

--- a/src/lib/common/sol-worker-thread.c
+++ b/src/lib/common/sol-worker-thread.c
@@ -46,12 +46,14 @@ sol_worker_thread_new(const struct sol_worker_thread_spec *spec)
     SOL_NULL_CHECK(spec, NULL);
     SOL_NULL_CHECK(spec->iterate, NULL);
 
+#ifndef SOL_NO_API_VERSION
     if (unlikely(spec->api_version != SOL_WORKER_THREAD_SPEC_API_VERSION)) {
         SOL_WRN("Couldn't create worker thread with unsupported version '%u', "
             "expected version is '%u'",
             spec->api_version, SOL_WORKER_THREAD_SPEC_API_VERSION);
         return NULL;
     }
+#endif
 
     return sol_worker_thread_impl_new(spec);
 }

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -152,9 +152,11 @@ struct sol_coap_packet;
 struct sol_coap_server;
 
 struct sol_coap_resource {
+#ifndef SOL_NO_API_VERSION
 #define SOL_COAP_RESOURCE_API_VERSION (1)
     uint16_t api_version;
     uint16_t reserved; /* save this hole for a future field */
+#endif
     /*
      * handlers for the CoAP defined methods.
      */

--- a/src/lib/comms/include/sol-mqtt.h
+++ b/src/lib/comms/include/sol-mqtt.h
@@ -33,6 +33,7 @@
 #pragma once
 
 #include <sol-buffer.h>
+#include <sol-common-buildopts.h>
 #include <stdbool.h>
 #include <stdlib.h>
 
@@ -151,11 +152,13 @@ struct sol_mqtt;
  * publishing and receiving data to/from the broker.
  */
 struct sol_mqtt_message {
+#ifndef SOL_NO_API_VERSION
 #define SOL_MQTT_MESSAGE_API_VERSION (1)
     /**
      * Should always be set to SOL_MQTT_MESSAGE_API_VERSION
      */
     uint16_t api_version;
+#endif
 
     /**
      * The topic which the message was/will be posted to
@@ -189,11 +192,13 @@ struct sol_mqtt_message {
  * @brief MQTT callback handlers
  */
 struct sol_mqtt_handlers {
+#ifndef SOL_NO_API_VERSION
 #define SOL_MQTT_HANDLERS_API_VERSION (1)
     /**
      * Should always be set to SOL_MQTT_HANDLERS_API_VERSION
      */
     uint16_t api_version;
+#endif
 
     /**
      * @brief On connect callback
@@ -281,11 +286,13 @@ struct sol_mqtt_handlers {
  * @brief Server Configuration
  */
 struct sol_mqtt_config {
+#ifndef SOL_NO_API_VERSION
 #define SOL_MQTT_CONFIG_API_VERSION (1)
     /**
      * Should always be set to SOL_MQTT_CONFIG_API_VERSION
      */
     uint16_t api_version;
+#endif
 
     /**
      * If set, the broker will drop all messages and subscriptions when

--- a/src/lib/comms/include/sol-network.h
+++ b/src/lib/comms/include/sol-network.h
@@ -35,6 +35,7 @@
 #include <stdbool.h>
 #include <sys/socket.h>
 
+#include <sol-common-buildopts.h>
 #include <sol-vector.h>
 
 #ifdef __cplusplus
@@ -91,9 +92,11 @@ struct sol_network_link_addr {
 };
 
 struct sol_network_link {
+#ifndef SOL_NO_API_VERSION
 #define SOL_NETWORK_LINK_API_VERSION (1)
     uint16_t api_version;
     int : 0; /* save possible hole for a future field */
+#endif
     int index;
     enum sol_network_link_flags flags;
     struct sol_vector addrs;       /* struct sol_network_link_addr */

--- a/src/lib/comms/include/sol-oic-client.h
+++ b/src/lib/comms/include/sol-oic-client.h
@@ -68,16 +68,20 @@ extern "C" {
  */
 
 struct sol_oic_client {
+#ifndef SOL_NO_API_VERSION
 #define SOL_OIC_CLIENT_API_VERSION (1)
     uint16_t api_version;
     int : 0; /* save possible hole for a future field */
+#endif
     struct sol_coap_server *server;
 };
 
 struct sol_oic_resource {
+#ifndef SOL_NO_API_VERSION
 #define SOL_OIC_RESOURCE_API_VERSION (1)
     uint16_t api_version;
     int : 0; /* save possible hole for a future field */
+#endif
     struct sol_network_link_addr addr;
     struct sol_str_slice href;
     struct sol_str_slice device_id;

--- a/src/lib/comms/include/sol-oic-common.h
+++ b/src/lib/comms/include/sol-oic-common.h
@@ -32,6 +32,7 @@
 
 #pragma once
 
+#include <sol-common-buildopts.h>
 #include <sol-vector.h>
 
 #ifdef __cplusplus
@@ -39,9 +40,11 @@ extern "C" {
 #endif
 
 struct sol_oic_server_information {
+#ifndef SOL_NO_API_VERSION
 #define SOL_OIC_SERVER_INFORMATION_API_VERSION (1)
     uint16_t api_version;
     int : 0; /* save possible hole for a future field */
+#endif
 
     /* All fields are required by the spec.  Some of the fields are
      * obtained in runtime (such as system time, OS version), and are

--- a/src/lib/comms/include/sol-oic-server.h
+++ b/src/lib/comms/include/sol-oic-server.h
@@ -80,9 +80,11 @@ extern "C" {
 struct sol_oic_server_resource;
 
 struct sol_oic_resource_type {
+#ifndef SOL_NO_API_VERSION
 #define SOL_OIC_RESOURCE_TYPE_API_VERSION (1)
     uint16_t api_version;
     int : 0; /* save possible hole for a future field */
+#endif
 
     struct sol_str_slice resource_type;
     struct sol_str_slice interface;

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -66,6 +66,7 @@ SOL_LOG_INTERNAL_DECLARE(_sol_coap_log_domain, "coap");
 #define ACK_TIMEOUT_MS 2345
 #define MAX_RETRANSMIT 4
 
+#ifndef SOL_NO_API_VERSION
 #define COAP_RESOURCE_CHECK_API(...) \
     do { \
         if (unlikely(resource->api_version != \
@@ -76,6 +77,9 @@ SOL_LOG_INTERNAL_DECLARE(_sol_coap_log_domain, "coap");
             return __VA_ARGS__; \
         } \
     } while (0)
+#else
+#define COAP_RESOURCE_CHECK_API(...)
+#endif
 
 struct sol_coap_server {
     struct sol_vector contexts;

--- a/src/lib/comms/sol-http-client-impl-curl.c
+++ b/src/lib/comms/sol-http-client-impl-curl.c
@@ -153,7 +153,7 @@ call_connection_finish_cb(struct sol_http_client_connection *connection)
 
     buffer = sol_buffer_steal(&connection->buffer, &size);
     response = &(struct sol_http_response) {
-        .api_version = SOL_HTTP_RESPONSE_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_HTTP_RESPONSE_API_VERSION, )
         .content = SOL_BUFFER_INIT_DATA(buffer, size)
     };
 
@@ -822,11 +822,13 @@ set_post_data_from_params(CURL *curl, struct sol_arena *arena,
 static bool
 check_param_api_version(const struct sol_http_param *params)
 {
+#ifndef SOL_NO_API_VERSION
     if (unlikely(params->api_version != SOL_HTTP_PARAM_API_VERSION)) {
         SOL_ERR("Parameter has an invalid API version. Expected %u, got %u",
             SOL_HTTP_PARAM_API_VERSION, params->api_version);
         return false;
     }
+#endif
 
     return true;
 }

--- a/src/lib/comms/sol-http-common.c
+++ b/src/lib/comms/sol-http-common.c
@@ -47,11 +47,13 @@ sol_http_param_add(struct sol_http_param *params,
 
     SOL_NULL_CHECK(params, -EINVAL);
 
+#ifndef SOL_NO_API_VERSION
     if (params->api_version != SOL_HTTP_PARAM_API_VERSION) {
         SOL_ERR("API version mistmatch; expected %u, got %u",
             SOL_HTTP_PARAM_API_VERSION, params->api_version);
         return false;
     }
+#endif
 
     ptr = sol_vector_append(&params->params);
     if (!ptr) {
@@ -68,11 +70,13 @@ sol_http_param_free(struct sol_http_param *params)
 {
     SOL_NULL_CHECK(params);
 
+#ifndef SOL_NO_API_VERSION
     if (params->api_version != SOL_HTTP_PARAM_API_VERSION) {
         SOL_ERR("API version mistmatch; expected %u, got %u",
             SOL_HTTP_PARAM_API_VERSION, params->api_version);
         return;
     }
+#endif
     sol_vector_clear(&params->params);
 }
 

--- a/src/lib/comms/sol-mqtt-impl-mosquitto.c
+++ b/src/lib/comms/sol-mqtt-impl-mosquitto.c
@@ -52,6 +52,7 @@ static int init_ref;
         } \
     } while (0)
 
+#ifndef SOL_NO_API_VERSION
 #define MQTT_CHECK_API(ptr, ...) \
     do {                                        \
         if (unlikely(ptr->api_version != \
@@ -62,6 +63,9 @@ static int init_ref;
             return __VA_ARGS__; \
         } \
     } while (0)
+#else
+#define MQTT_CHECK_API(ptr, ...)
+#endif
 
 struct sol_mqtt {
     struct mosquitto *mosq;

--- a/src/lib/comms/sol-network-impl-linux.c
+++ b/src/lib/comms/sol-network-impl-linux.c
@@ -110,7 +110,7 @@ _get_link(int index)
     link = sol_vector_append(&network->links);
     SOL_NULL_CHECK(link, NULL);
 
-    link->api_version = SOL_NETWORK_LINK_API_VERSION;
+    SOL_SET_API_VERSION(link->api_version = SOL_NETWORK_LINK_API_VERSION; )
     link->flags = 0;
     sol_vector_init(&link->addrs, sizeof(struct sol_network_link_addr));
     link->index = index;
@@ -454,12 +454,14 @@ sol_network_link_get_name(const struct sol_network_link *link)
 
     SOL_NULL_CHECK(link, NULL);
 
+#ifndef SOL_NO_API_VERSION
     if (unlikely(link->api_version != SOL_NETWORK_LINK_API_VERSION)) {
         SOL_WRN("Couldn't link that has unsupported version '%u', "
             "expected version is '%u'",
             link->api_version, SOL_NETWORK_LINK_API_VERSION);
         return NULL;
     }
+#endif
 
     if (if_indextoname(link->index, name))
         return strdup(name);

--- a/src/lib/comms/sol-network-impl-riot.c
+++ b/src/lib/comms/sol-network-impl-riot.c
@@ -94,7 +94,7 @@ add_ip6_link(int idx, gnrc_ipv6_netif_t *if_ip6)
 
     sol_vector_init(&link->addrs, sizeof(struct sol_network_link_addr));
 
-    link->api_version = SOL_NETWORK_LINK_API_VERSION;
+    SOL_SET_API_VERSION(link->api_version = SOL_NETWORK_LINK_API_VERSION; )
     link->index = idx;
     link->flags = 0;
 

--- a/src/lib/comms/sol-oic-client.c
+++ b/src/lib/comms/sol-oic-client.c
@@ -55,6 +55,7 @@
 #define POLL_OBSERVE_TIMEOUT_MS 10000
 #define DISCOVERY_RESPONSE_TIMEOUT_MS 10000
 
+#ifndef SOL_NO_API_VERSION
 #define OIC_RESOURCE_CHECK_API(ptr, ...) \
     do {                                        \
         if (unlikely(ptr->api_version != \
@@ -75,6 +76,10 @@
             return __VA_ARGS__; \
         } \
     } while (0)
+#else
+#define OIC_RESOURCE_CHECK_API(ptr, ...)
+#define OIC_CLIENT_CHECK_API(ptr, ...)
+#endif
 
 struct find_resource_ctx {
     struct sol_oic_client *client;
@@ -328,7 +333,7 @@ _server_info_reply_cb(struct sol_coap_packet *req, const struct sol_network_link
     }
 
     if (_parse_server_info_payload(&info, payload, payload_len)) {
-        info.api_version = SOL_OIC_SERVER_INFORMATION_API_VERSION;
+        SOL_SET_API_VERSION(info.api_version = SOL_OIC_SERVER_INFORMATION_API_VERSION; )
         ctx->cb(ctx->client, &info, ctx->data);
     } else {
         SOL_WRN("Could not parse payload");
@@ -448,7 +453,7 @@ _new_resource(void)
 
     res->refcnt = 1;
 
-    res->api_version = SOL_OIC_RESOURCE_API_VERSION;
+    SOL_SET_API_VERSION(res->api_version = SOL_OIC_RESOURCE_API_VERSION; )
 
     return res;
 }

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -179,7 +179,7 @@ out:
 }
 
 static const struct sol_coap_resource oic_d_coap_resource = {
-    .api_version = SOL_COAP_RESOURCE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_COAP_RESOURCE_API_VERSION, )
     .path = {
         SOL_STR_SLICE_LITERAL("oic"),
         SOL_STR_SLICE_LITERAL("d"),
@@ -346,7 +346,7 @@ _sol_oic_server_res(const struct sol_coap_resource *resource, struct sol_coap_pa
 }
 
 static const struct sol_coap_resource oic_res_coap_resource = {
-    .api_version = SOL_COAP_RESOURCE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_COAP_RESOURCE_API_VERSION, )
     .path = {
         SOL_STR_SLICE_LITERAL("oic"),
         SOL_STR_SLICE_LITERAL("res"),
@@ -560,7 +560,7 @@ create_coap_resource(struct sol_oic_server_resource *resource)
     res = calloc(1, sizeof(struct sol_coap_resource) + (count + 1) * sizeof(struct sol_str_slice));
     SOL_NULL_CHECK(res, NULL);
 
-    res->api_version = SOL_COAP_RESOURCE_API_VERSION;
+    SOL_SET_API_VERSION(res->api_version = SOL_COAP_RESOURCE_API_VERSION; )
 
     res->path[0].data = &endpoint.data[1];
     for (i = 1, current = 0; i < endpoint.len; i++) {
@@ -603,12 +603,14 @@ sol_oic_server_add_resource(const struct sol_oic_resource_type *rt,
     OIC_SERVER_CHECK(NULL);
     SOL_NULL_CHECK(rt, NULL);
 
+#ifndef SOL_NO_API_VERSION
     if (unlikely(rt->api_version != SOL_OIC_RESOURCE_TYPE_API_VERSION)) {
         SOL_WRN("Couldn't add resource_type with "
             "version '%u'. Expected version '%u'.",
             rt->api_version, SOL_OIC_RESOURCE_TYPE_API_VERSION);
         return NULL;
     }
+#endif
 
     res = sol_vector_append(&oic_server.resources);
     SOL_NULL_CHECK(res, NULL);

--- a/src/lib/crypto/include/sol-message-digest.h
+++ b/src/lib/crypto/include/sol-message-digest.h
@@ -34,6 +34,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <sol-common-buildopts.h>
 #include <sol-types.h>
 #include <sol-str-slice.h>
 
@@ -87,12 +88,14 @@ struct sol_message_digest;
  * @see sol_message_digest_new()
  */
 struct sol_message_digest_config {
+#ifndef SOL_NO_API_VERSION
 #define SOL_MESSAGE_DIGEST_CONFIG_API_VERSION (1)
     /**
      * api_version must match SOL_MESSAGE_DIGEST_CONFIG_API_VERSION
      * at runtime.
      */
     uint16_t api_version;
+#endif
     /**
      * Algorithm name.
      *

--- a/src/lib/crypto/sol-message-digest-common.c
+++ b/src/lib/crypto/sol-message-digest-common.c
@@ -688,7 +688,7 @@ _sol_message_digest_thread_start(struct sol_message_digest *handle)
 {
 #ifdef MESSAGE_DIGEST_USE_THREAD
     struct sol_worker_thread_spec spec = {
-        .api_version = SOL_WORKER_THREAD_SPEC_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_WORKER_THREAD_SPEC_API_VERSION, )
         .data = handle,
         .iterate = _sol_message_digest_thread_iterate,
         .finished = _sol_message_digest_thread_finished,

--- a/src/lib/crypto/sol-message-digest-impl-linux-kcapi.c
+++ b/src/lib/crypto/sol-message-digest-impl-linux-kcapi.c
@@ -318,12 +318,14 @@ sol_message_digest_new(const struct sol_message_digest_config *config)
     SOL_NULL_CHECK(config->on_digest_ready, NULL);
     SOL_NULL_CHECK(config->algorithm, NULL);
 
+#ifndef SOL_NO_API_VERSION
     if (config->api_version != SOL_MESSAGE_DIGEST_CONFIG_API_VERSION) {
         SOL_WRN("sol_message_digest_config->api_version=%hu, "
             "expected version is %hu.",
             config->api_version, SOL_MESSAGE_DIGEST_CONFIG_API_VERSION);
         return NULL;
     }
+#endif
 
     if (strlen(config->algorithm) + 1 >= sizeof(sa.salg_name)) {
         SOL_WRN("algorithm \"%s\" is too long\n", config->algorithm);

--- a/src/lib/crypto/sol-message-digest-impl-none.c
+++ b/src/lib/crypto/sol-message-digest-impl-none.c
@@ -60,12 +60,14 @@ sol_message_digest_new(const struct sol_message_digest_config *config)
     SOL_NULL_CHECK(config->on_digest_ready, NULL);
     SOL_NULL_CHECK(config->algorithm, NULL);
 
+#ifndef SOL_NO_API_VERSION
     if (config->api_version != SOL_MESSAGE_DIGEST_CONFIG_API_VERSION) {
         SOL_WRN("sol_message_digest_config->api_version=%hu, "
             "expected version is %hu.",
             config->api_version, SOL_MESSAGE_DIGEST_CONFIG_API_VERSION);
         return NULL;
     }
+#endif
 
     SOL_WRN("not implemented.");
     errno = ENOTSUP;

--- a/src/lib/crypto/sol-message-digest-impl-openssl.c
+++ b/src/lib/crypto/sol-message-digest-impl-openssl.c
@@ -168,12 +168,14 @@ sol_message_digest_new(const struct sol_message_digest_config *config)
     SOL_NULL_CHECK(config->on_digest_ready, NULL);
     SOL_NULL_CHECK(config->algorithm, NULL);
 
+#ifndef SOL_NO_API_VERSION
     if (config->api_version != SOL_MESSAGE_DIGEST_CONFIG_API_VERSION) {
         SOL_WRN("sol_message_digest_config->api_version=%hu, "
             "expected version is %hu.",
             config->api_version, SOL_MESSAGE_DIGEST_CONFIG_API_VERSION);
         return NULL;
     }
+#endif
 
     if (!did_openssl_load_digests) {
         OpenSSL_add_all_digests();

--- a/src/lib/crypto/sol-message-digest-impl-riot.c
+++ b/src/lib/crypto/sol-message-digest-impl-riot.c
@@ -166,12 +166,14 @@ sol_message_digest_new(const struct sol_message_digest_config *config)
     SOL_NULL_CHECK(config->on_digest_ready, NULL);
     SOL_NULL_CHECK(config->algorithm, NULL);
 
+#ifndef SOL_NO_API_VERSION
     if (config->api_version != SOL_MESSAGE_DIGEST_CONFIG_API_VERSION) {
         SOL_WRN("sol_message_digest_config->api_version=%hu, "
             "expected version is %hu.",
             config->api_version, SOL_MESSAGE_DIGEST_CONFIG_API_VERSION);
         return NULL;
     }
+#endif
 
     algorithm = sol_str_slice_from_str(config->algorithm);
     if (!sol_str_table_ptr_lookup(_available_digests, algorithm, &dinfo)) {

--- a/src/lib/flow/include/sol-flow-inspector.h
+++ b/src/lib/flow/include/sol-flow-inspector.h
@@ -52,8 +52,10 @@ extern "C" {
  */
 
 struct sol_flow_inspector {
+#ifndef SOL_NO_API_VERSION
     unsigned long api_version;
 #define SOL_FLOW_INSPECTOR_API_VERSION (1UL)
+#endif
     void (*did_open_node)(const struct sol_flow_inspector *inspector, const struct sol_flow_node *node, const struct sol_flow_node_options *options);
     void (*will_close_node)(const struct sol_flow_inspector *inspector, const struct sol_flow_node *node);
     void (*did_connect_port)(const struct sol_flow_inspector *inspector, const struct sol_flow_node *src_node, uint16_t src_port, uint16_t src_conn_id, const struct sol_flow_node *dst_node, uint16_t dst_port, uint16_t dst_conn_id);

--- a/src/lib/flow/include/sol-flow-metatype.h
+++ b/src/lib/flow/include/sol-flow-metatype.h
@@ -83,7 +83,9 @@ sol_flow_metatype_ports_description_func sol_flow_metatype_get_ports_description
 #define SOL_FLOW_METATYPE_API_VERSION (1)
 
 struct sol_flow_metatype {
+#ifndef SOL_NO_API_VERSION
     uint16_t api_version;
+#endif
 
     const char *name;
 
@@ -98,13 +100,13 @@ struct sol_flow_metatype {
 #define SOL_FLOW_METATYPE(_NAME, decl ...) \
     SOL_API const struct sol_flow_metatype *SOL_FLOW_METATYPE = \
         &((const struct sol_flow_metatype) { \
-            .api_version = SOL_FLOW_METATYPE_API_VERSION, \
+            SOL_SET_API_VERSION(.api_version = SOL_FLOW_METATYPE_API_VERSION, ) \
             decl \
         })
 #else
 #define SOL_FLOW_METATYPE(_NAME, decl ...) \
     const struct sol_flow_metatype SOL_FLOW_METATYPE_ ## _NAME = { \
-        .api_version = SOL_FLOW_METATYPE_API_VERSION, \
+        SOL_SET_API_VERSION(.api_version = SOL_FLOW_METATYPE_API_VERSION, ) \
         decl \
     }
 #endif

--- a/src/lib/flow/include/sol-flow-packet.h
+++ b/src/lib/flow/include/sol-flow-packet.h
@@ -36,6 +36,7 @@
 #include <stddef.h>
 #include <time.h>
 
+#include "sol-common-buildopts.h"
 #include "sol-str-slice.h"
 #include "sol-types.h"
 
@@ -64,8 +65,10 @@ extern "C" {
 struct sol_flow_packet;
 
 struct sol_flow_packet_type {
+#ifndef SOL_NO_API_VERSION
 #define SOL_FLOW_PACKET_TYPE_API_VERSION (1)
     uint16_t api_version;
+#endif
     uint16_t data_size;
     const char *name;
 

--- a/src/lib/flow/include/sol-flow-parser.h
+++ b/src/lib/flow/include/sol-flow-parser.h
@@ -64,8 +64,10 @@ extern "C" {
 struct sol_flow_parser;
 
 struct sol_flow_parser_client {
+#ifndef SOL_NO_API_VERSION
 #define SOL_FLOW_PARSER_CLIENT_API_VERSION (1UL)
     unsigned long api_version;
+#endif
     void *data;
 
     /* Called by parser to load declared types, buf should be valid

--- a/src/lib/flow/include/sol-flow-resolver.h
+++ b/src/lib/flow/include/sol-flow-resolver.h
@@ -63,8 +63,10 @@ extern "C" {
  */
 
 struct sol_flow_resolver {
+#ifndef SOL_NO_API_VERSION
 #define SOL_FLOW_RESOLVER_API_VERSION (1UL)
     unsigned long api_version;
+#endif
     const char *name;
     void *data;
 

--- a/src/lib/flow/include/sol-flow-static.h
+++ b/src/lib/flow/include/sol-flow-static.h
@@ -76,13 +76,15 @@ struct sol_flow_static_port_spec {
 #define SOL_FLOW_STATIC_CONN_SPEC_GUARD { .src = UINT16_MAX }
 #define SOL_FLOW_STATIC_PORT_SPEC_GUARD { .node = UINT16_MAX }
 
-#define SOL_FLOW_STATIC_API_VERSION (1)
 
 /** Specification of how a static flow should work. Note that the
  * arrays and functions provided are assumed to be available and valid
  * while the static flow type created from it is being used. */
 struct sol_flow_static_spec {
+#ifndef SOL_NO_API_VERSION
+#define SOL_FLOW_STATIC_API_VERSION (1)
     uint16_t api_version;
+#endif
     uint16_t flags;
 
     /** Array specifying the node types that are used by the static

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -206,9 +206,11 @@ int sol_flow_send_http_response_packet(struct sol_flow_node *src, uint16_t src_p
 const struct sol_flow_node_type *sol_flow_node_get_type(const struct sol_flow_node *node);
 
 struct sol_flow_node_options {
+#ifndef SOL_NO_API_VERSION
 #define SOL_FLOW_NODE_OPTIONS_API_VERSION (1) /**< compile time API version to be checked during runtime */
     uint16_t api_version; /**< must match SOL_FLOW_NODE_OPTIONS_API_VERSION at runtime */
     uint16_t sub_api; /**< to version each subclass */
+#endif
 };
 
 enum sol_flow_node_options_member_type {
@@ -318,11 +320,14 @@ struct sol_flow_node_options_member_description {
 struct sol_flow_node_options_description {
     const struct sol_flow_node_options_member_description *members; /** @c NULL terminated */
     uint16_t data_size; /**< size of the whole sol_flow_node_options derivate */
+#ifndef SOL_NO_API_VERSION
     uint16_t sub_api; /**< what goes in sol_flow_node_options::sub_api */
+#endif
     bool required; /**< if true then options must be given for the node (if not, the node has no parameters) */
 };
 
 struct sol_flow_node_type_description {
+#ifndef SOL_NO_API_VERSION
     /* both sol_flow_node_type_description, sol_flow_port_description
      * and sol_flow_node_options_description are subject to
      * SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION, then whenever one of
@@ -331,6 +336,7 @@ struct sol_flow_node_type_description {
      */
 #define SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION (1)
     unsigned long api_version;
+#endif
     const char *name; /**< mandatory, the user-visible name */
     const char *category; /**< mandatory, convention is: category/subcategory/..., such as input/hw/sensor for a pressure sensor or input/sw/oic/switch for an OIC compliant on/off switch */
     const char *symbol; /**< the symbol that exports this type, useful to code that generates C code.  */
@@ -356,8 +362,10 @@ enum sol_flow_node_type_flags {
 
 struct sol_flow_node_type {
 #define SOL_FLOW_NODE_PORT_ERROR (UINT16_MAX - 1) /**< built-in output port's number, common to every node, meant to output error packets */
+#ifndef SOL_NO_API_VERSION
 #define SOL_FLOW_NODE_TYPE_API_VERSION (1) /**< compile time API version to be checked during runtime */
     uint16_t api_version; /**< must match SOL_FLOW_NODE_TYPE_API_VERSION at runtime */
+#endif
     uint16_t data_size; /**< size of the whole sol_flow_node_type derivate */
     uint16_t options_size;
     uint16_t flags; /**< @see #sol_flow_node_type_flags */
@@ -460,8 +468,10 @@ struct sol_flow_node_container_type {
 };
 
 struct sol_flow_port_type_out {
+#ifndef SOL_NO_API_VERSION
 #define SOL_FLOW_PORT_TYPE_OUT_API_VERSION (1) /**< compile time API version to be checked during runtime */
     uint16_t api_version; /**< must match SOL_FLOW_PORT_TYPE_OUT_API_VERSION at runtime */
+#endif
     const struct sol_flow_packet_type *packet_type; /**< the packet type that the port will deliver */
 
     int (*connect)(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id); /**< member function issued everytime a new connection is made to the port */
@@ -469,8 +479,10 @@ struct sol_flow_port_type_out {
 };
 
 struct sol_flow_port_type_in {
+#ifndef SOL_NO_API_VERSION
 #define SOL_FLOW_PORT_TYPE_IN_API_VERSION (1) /**< compile time API version to be checked during runtime */
     uint16_t api_version; /**< must match SOL_FLOW_PORT_TYPE_OUT_API_VERSION at runtime */
+#endif
     const struct sol_flow_packet_type *packet_type; /**< the packet type that the port will receive */
 
     int (*process)(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet); /**< member function issued everytime a new packet arrives to the port */

--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -116,7 +116,9 @@ sol_flow_builder_init(struct sol_flow_builder *builder)
 static int
 sol_flow_builder_init_type_data(struct sol_flow_builder *builder)
 {
+#ifndef SOL_NO_API_VERSION
     struct sol_flow_node_options *default_opts;
+#endif
     int r;
 
     builder->type_data = calloc(1, sizeof(struct builder_type_data));
@@ -130,12 +132,14 @@ sol_flow_builder_init_type_data(struct sol_flow_builder *builder)
     r = sol_buffer_ensure(&builder->type_data->default_opts_buf, builder->type_data->options_size);
     if (r < 0)
         goto error_default_opts;
+#ifndef SOL_NO_API_VERSION
     default_opts = builder->type_data->default_opts_buf.data;
     default_opts->api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION;
     default_opts->sub_api = SOL_FLOW_BUILDER_OPTIONS_API_VERSION;
 
     builder->type_data->spec.api_version = SOL_FLOW_STATIC_API_VERSION;
     builder->type_data->desc.api_version = SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION;
+#endif
 
     return 0;
 
@@ -743,7 +747,7 @@ fill_options_description(struct sol_flow_builder *builder,
     struct sol_flow_node_options_member_description *member;
     bool required = false;
 
-    opts->sub_api = SOL_FLOW_BUILDER_OPTIONS_API_VERSION;
+    SOL_SET_API_VERSION(opts->sub_api = SOL_FLOW_BUILDER_OPTIONS_API_VERSION; )
 
     for (member = builder->options_description.data; member->name; member++) {
         if (member->required) {

--- a/src/lib/flow/sol-flow-composed.c
+++ b/src/lib/flow/sol-flow-composed.c
@@ -339,12 +339,11 @@ setup_simple_ports(struct sol_vector *in_ports, const struct sol_str_slice conte
         }
 
         if (is_input) {
-            port_type->type.in.api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION;
+            SOL_SET_API_VERSION(port_type->type.in.api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION; )
             port_type->type.in.packet_type = packet_type;
             port_type->type.in.process = simple_port_process;
         } else {
-            port_type->type.out.api_version =
-                SOL_FLOW_PORT_TYPE_OUT_API_VERSION;
+            SOL_SET_API_VERSION(port_type->type.out.api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION; )
             port_type->type.out.packet_type = packet_type;
         }
 
@@ -384,12 +383,11 @@ setup_composed_port(struct sol_vector *simple_ports,
     if (is_splitter) {
         composed_port->name = strdup(INPUT_PORT_NAME);
         composed_port->type.in.process = composed_port_process;
-        composed_port->type.in.api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION;
+        SOL_SET_API_VERSION(composed_port->type.in.api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION; )
         composed_port->type.in.packet_type = composed_type;
     } else {
         composed_port->name = strdup(OUTPUT_PORT_NAME);
-        composed_port->type.out.api_version =
-            SOL_FLOW_PORT_TYPE_OUT_API_VERSION;
+        SOL_SET_API_VERSION(composed_port->type.out.api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION; )
         composed_port->type.out.packet_type = composed_type;
     }
 
@@ -421,7 +419,7 @@ composed_get_port_out(const struct sol_flow_node_type *type, uint16_t port)
 
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
 static const struct sol_flow_node_type_description sol_flow_node_type_composed_description = {
-    .api_version = SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION, )
     .name = "composed",
     .category = "composed",
     .symbol = "SOL_FLOW_NODE_TYPE_COMPOSED",
@@ -518,7 +516,7 @@ create_type(const struct sol_flow_metatype_context *ctx,
     SOL_NULL_CHECK(self, -ENOMEM);
 
     self->base = (struct sol_flow_node_type) {
-        .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_API_VERSION, )
         .data_size = is_splitter ? 0 : sizeof(struct composed_node_data),
         .dispose_type = composed_node_type_dispose,
         .get_port_in = composed_get_port_in,
@@ -751,7 +749,7 @@ generate_metatype_port(struct sol_buffer *out,
 
     return sol_buffer_append_printf(out,
         "static struct sol_flow_port_type_%s metatype_composed_%.*s_%s_port = {\n"
-        "   .api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION,\n"
+        "   SOL_SET_API_VERSION(.api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION, )\n"
         "   .connect = NULL,\n"
         "   %s"
         "   .disconnect = NULL\n"
@@ -961,7 +959,7 @@ composed_metatype_generate_type_code(struct sol_buffer *out,
 
     r = sol_buffer_append_printf(out,
         "static const struct sol_flow_node_type %.*s = {\n"
-        "   .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,\n"
+        "   SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_API_VERSION, )\n"
         "   .options_size = sizeof(struct sol_flow_node_options),\n"
         "   .data_size = %s,\n"
         "   .ports_out_count = %u,\n"

--- a/src/lib/flow/sol-flow-internal.h
+++ b/src/lib/flow/sol-flow-internal.h
@@ -194,6 +194,7 @@ extern const struct sol_flow_node_options sol_flow_node_options_empty;
         }                                                               \
     } while (0)
 
+#ifndef SOL_NO_API_VERSION
 #define SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, expected, ...)      \
     do {                                                                \
         SOL_NULL_CHECK(options, __VA_ARGS__);                            \
@@ -284,6 +285,15 @@ extern const struct sol_flow_node_options sol_flow_node_options_empty;
             return __VA_ARGS__;                                         \
         }                                                               \
     } while (0)
+#else
+#define SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, expected, ...)
+#define SOL_FLOW_NODE_OPTIONS_API_CHECK(options, expected, ...)
+#define SOL_FLOW_NODE_TYPE_DESCRIPTION_API_CHECK(description, expected, ...)
+#define SOL_FLOW_NODE_TYPE_API_CHECK(type, expected, ...)
+#define SOL_FLOW_PORT_TYPE_OUT_API_CHECK(out, expected, ...)
+#define SOL_FLOW_PORT_TYPE_IN_API_CHECK(in, expected, ...)
+#define SOL_FLOW_RESOLVER_API_CHECK(resolver, expected, ...)
+#endif
 
 struct sol_flow_builder;
 int sol_flow_builder_add_node_taking_options(

--- a/src/lib/flow/sol-flow-node-options.c
+++ b/src/lib/flow/sol-flow-node-options.c
@@ -822,7 +822,9 @@ sol_flow_node_options_new(
     SOL_NULL_CHECK(type, -EINVAL);
     SOL_NULL_CHECK(named_opts, -EINVAL);
     SOL_FLOW_NODE_TYPE_API_CHECK(type, SOL_FLOW_NODE_TYPE_API_VERSION, -EINVAL);
+#ifndef SOL_NO_API_VERSION
     SOL_INT_CHECK(type->options_size, < sizeof(struct sol_flow_node_options), -EINVAL);
+#endif
 
     if (type->init_type)
         type->init_type();

--- a/src/lib/flow/sol-flow-packet.c
+++ b/src/lib/flow/sol-flow-packet.c
@@ -143,11 +143,13 @@ sol_flow_packet_new(const struct sol_flow_packet_type *type, const void *value)
         return NULL;
     }
 
+#ifndef SOL_NO_API_VERSION
     if (unlikely(type->api_version != SOL_FLOW_PACKET_TYPE_API_VERSION)) {
         SOL_WRN("Couldn't create packet with type '%s' that has unsupported version '%u', expected version is '%u'",
             type->name ? : "", type->api_version, SOL_FLOW_PACKET_TYPE_API_VERSION);
         return NULL;
     }
+#endif
 
     if (type->get_constant)
         return type->get_constant(type, value);
@@ -226,7 +228,7 @@ packet_empty_get_constant(const struct sol_flow_packet_type *packet_type, const 
 }
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_EMPTY = {
-    .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION, )
     .name = "empty",
     .get = packet_empty_get,
     .get_constant = packet_empty_get_constant,
@@ -264,7 +266,7 @@ packet_boolean_get_constant(const struct sol_flow_packet_type *packet_type, cons
 }
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_BOOLEAN = {
-    .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION, )
     .name = "boolean",
     .data_size = sizeof(bool),
     .get_constant = packet_boolean_get_constant,
@@ -285,7 +287,7 @@ sol_flow_packet_get_boolean(const struct sol_flow_packet *packet, bool *boolean)
 }
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_IRANGE = {
-    .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION, )
     .name = "int",
     .data_size = sizeof(struct sol_irange),
 };
@@ -352,7 +354,7 @@ string_packet_dispose(const struct sol_flow_packet_type *packet_type, void *mem)
 }
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_STRING = {
-    .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION, )
     .name = "string",
     .data_size = sizeof(char *),
     .init = string_packet_init,
@@ -452,7 +454,7 @@ blob_packet_dispose(const struct sol_flow_packet_type *packet_type, void *mem)
 }
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_BLOB = {
-    .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION, )
     .name = "blob",
     .data_size = sizeof(struct sol_blob *),
     .init = blob_packet_init,
@@ -476,7 +478,7 @@ sol_flow_packet_get_blob(const struct sol_flow_packet *packet, struct sol_blob *
 }
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_JSON_OBJECT  = {
-    .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION, )
     .name = "json-object",
     .data_size = sizeof(struct sol_blob *),
     .init = blob_packet_init,
@@ -500,7 +502,7 @@ sol_flow_packet_get_json_object(const struct sol_flow_packet *packet, struct sol
 }
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_JSON_ARRAY  = {
-    .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION, )
     .name = "json-array",
     .data_size = sizeof(struct sol_blob *),
     .init = blob_packet_init,
@@ -524,7 +526,7 @@ sol_flow_packet_get_json_array(const struct sol_flow_packet *packet, struct sol_
 }
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_DRANGE = {
-    .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION, )
     .name = "float",
     .data_size = sizeof(struct sol_drange),
 };
@@ -570,7 +572,7 @@ sol_flow_packet_get_drange_value(const struct sol_flow_packet *packet, double *v
 }
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_BYTE = {
-    .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION, )
     .name = "byte",
     .data_size = sizeof(unsigned char),
 };
@@ -590,7 +592,7 @@ sol_flow_packet_get_byte(const struct sol_flow_packet *packet, unsigned char *by
 }
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_RGB = {
-    .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION, )
     .name = "rgb",
     .data_size = sizeof(struct sol_rgb),
 };
@@ -642,7 +644,7 @@ sol_flow_packet_get_rgb_components(const struct sol_flow_packet *packet, uint32_
 }
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_DIRECTION_VECTOR = {
-    .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION, )
     .name = "direction-vector",
     .data_size = sizeof(struct sol_direction_vector),
 };
@@ -693,7 +695,7 @@ sol_flow_packet_get_direction_vector_components(const struct sol_flow_packet *pa
 }
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_LOCATION = {
-    .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION, )
     .name = "location",
     .data_size = sizeof(struct sol_location),
 };
@@ -713,7 +715,7 @@ sol_flow_packet_get_location(const struct sol_flow_packet *packet, struct sol_lo
 }
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_TIMESTAMP = {
-    .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION, )
     .name = "timestamp",
     .data_size = sizeof(struct timespec),
 };
@@ -733,7 +735,7 @@ sol_flow_packet_get_timestamp(const struct sol_flow_packet *packet, struct times
 }
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_ANY = {
-    .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION, )
     .name = "any",
     .data_size = sizeof(void *)
 };
@@ -765,7 +767,7 @@ error_packet_init(const struct sol_flow_packet_type *packet_type, void *mem, con
 }
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_ERROR = {
-    .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION, )
     .name = "error",
     .data_size = sizeof(struct error_data),
     .init = error_packet_init,
@@ -959,7 +961,7 @@ sol_flow_packet_get_http_response(const struct sol_flow_packet *packet,
 }
 
 static const struct sol_flow_packet_type _SOL_FLOW_PACKET_TYPE_HTTP_RESPONSE = {
-    .api_version = SOL_FLOW_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION, )
     .name = "http-response",
     .data_size = sizeof(struct http_response),
     .init = http_response_type_init,
@@ -1055,7 +1057,7 @@ sol_flow_packet_type_composed_new(const struct sol_flow_packet_type **types)
         SOL_INT_CHECK_GOTO(r, < 0, err_buf);
     }
 
-    ctype->self.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION;
+    SOL_SET_API_VERSION(ctype->self.api_version = SOL_FLOW_PACKET_TYPE_API_VERSION; )
     ctype->self.name = sol_buffer_steal(&buf, NULL);
     ctype->self.data_size = sizeof(struct sol_flow_packet **);
     ctype->self.init = composed_type_init;

--- a/src/lib/flow/sol-flow-parser-dynamic.c
+++ b/src/lib/flow/sol-flow-parser-dynamic.c
@@ -49,11 +49,13 @@ check_metatype(const char *path, const char *symbol_name, void *symbol)
         return false;
     }
 
+#ifndef SOL_NO_API_VERSION
     if (metatype->api_version != SOL_FLOW_METATYPE_API_VERSION) {
         SOL_WRN("Module '%s' has incorrect api_version: %u expected %u",
             path, metatype->api_version, SOL_FLOW_METATYPE_API_VERSION);
         return false;
     }
+#endif
 
     return true;
 }

--- a/src/lib/flow/sol-flow-parser.c
+++ b/src/lib/flow/sol-flow-parser.c
@@ -47,6 +47,7 @@
 
 #include "sol-flow-metatype-builtins-gen.h"
 
+#ifndef SOL_NO_API_VERSION
 #define SOL_FLOW_PARSER_CLIENT_API_CHECK(client, expected, ...)          \
     do {                                                                \
         if ((client)->api_version != (expected)) {                      \
@@ -56,6 +57,9 @@
             return __VA_ARGS__;                                         \
         }                                                               \
     } while (0)
+#else
+#define SOL_FLOW_PARSER_CLIENT_API_CHECK(client, expected, ...)
+#endif
 
 struct sol_flow_parser {
     const struct sol_flow_resolver *resolver;
@@ -130,7 +134,7 @@ parse_state_init_resolver(struct parse_state *state)
 {
     struct sol_flow_resolver *r = &state->resolver;
 
-    r->api_version = SOL_FLOW_RESOLVER_API_VERSION;
+    SOL_SET_API_VERSION(r->api_version = SOL_FLOW_RESOLVER_API_VERSION; )
     r->name = "parse-state-resolver-with-declares";
     r->data = state;
     r->resolve = parse_state_resolve;

--- a/src/lib/flow/sol-flow-parser.c
+++ b/src/lib/flow/sol-flow-parser.c
@@ -552,8 +552,6 @@ get_metatype_by_name(const struct sol_str_slice name)
 static sol_flow_metatype_create_type_func
 get_create_type_func(const struct sol_str_slice name)
 {
-    const struct sol_flow_metatype *metatype;
-
     if (sol_str_slice_str_eq(name, "fbp"))
         return create_fbp_type;
 
@@ -564,115 +562,137 @@ get_create_type_func(const struct sol_str_slice name)
         return create_composed_constructor_type;
 
 #if (SOL_FLOW_METATYPE_BUILTINS_COUNT > 0)
-    metatype = get_metatype_by_name(name);
-    if (metatype)
-        return metatype->create_type;
+    {
+        const struct sol_flow_metatype *metatype;
+
+        metatype = get_metatype_by_name(name);
+        if (metatype)
+            return metatype->create_type;
+    }
 #endif
 
 #ifdef ENABLE_DYNAMIC_MODULES
-    metatype = get_dynamic_metatype(name);
-    if (metatype)
-        return metatype->create_type;
-    return NULL;
-#else
-    return NULL;
+    {
+        const struct sol_flow_metatype *metatype;
+
+        metatype = get_dynamic_metatype(name);
+        if (metatype)
+            return metatype->create_type;
+    }
 #endif
+    return NULL;
 }
 
 SOL_API sol_flow_metatype_generate_code_func
 sol_flow_metatype_get_generate_code_start_func(const struct sol_str_slice name)
 {
-    const struct sol_flow_metatype *metatype;
-
     if (sol_str_slice_str_eq(name, "composed-split"))
         return composed_metatype_splitter_generate_code_start;
     if (sol_str_slice_str_eq(name, "composed-new"))
         return composed_metatype_constructor_generate_code_start;
 #if (SOL_FLOW_METATYPE_BUILTINS_COUNT > 0)
-    metatype = get_metatype_by_name(name);
-    if (metatype)
-        return metatype->generate_type_start;
+    {
+        const struct sol_flow_metatype *metatype;
+
+        metatype = get_metatype_by_name(name);
+        if (metatype)
+            return metatype->generate_type_start;
+    }
 #endif
 #ifdef ENABLE_DYNAMIC_MODULES
-    metatype = get_dynamic_metatype(name);
-    if (metatype)
-        return metatype->generate_type_start;
-    return NULL;
-#else
-    return NULL;
+    {
+        const struct sol_flow_metatype *metatype;
+
+        metatype = get_dynamic_metatype(name);
+        if (metatype)
+            return metatype->generate_type_start;
+    }
 #endif
+    return NULL;
 }
 
 SOL_API sol_flow_metatype_generate_code_func
 sol_flow_metatype_get_generate_code_type_func(const struct sol_str_slice name)
 {
-    const struct sol_flow_metatype *metatype;
-
     if (sol_str_slice_str_eq(name, "composed-split"))
         return composed_metatype_splitter_generate_code_type;
     if (sol_str_slice_str_eq(name, "composed-new"))
         return composed_metatype_constructor_generate_code_type;
 #if (SOL_FLOW_METATYPE_BUILTINS_COUNT > 0)
-    metatype = get_metatype_by_name(name);
-    if (metatype)
-        return metatype->generate_type_body;
+    {
+        const struct sol_flow_metatype *metatype;
+
+        metatype = get_metatype_by_name(name);
+        if (metatype)
+            return metatype->generate_type_body;
+    }
 #endif
 #ifdef ENABLE_DYNAMIC_MODULES
-    metatype = get_dynamic_metatype(name);
-    if (metatype)
-        return metatype->generate_type_body;
-    return NULL;
-#else
-    return NULL;
+    {
+        const struct sol_flow_metatype *metatype;
+
+        metatype = get_dynamic_metatype(name);
+        if (metatype)
+            return metatype->generate_type_body;
+    }
 #endif
+    return NULL;
 }
 
 SOL_API sol_flow_metatype_generate_code_func
 sol_flow_metatype_get_generate_code_end_func(const struct sol_str_slice name)
 {
-    const struct sol_flow_metatype *metatype;
-
     if (sol_str_slice_str_eq(name, "composed-split"))
         return composed_metatype_splitter_generate_code_end;
     if (sol_str_slice_str_eq(name, "composed-new"))
         return composed_metatype_constructor_generate_code_end;
 #if (SOL_FLOW_METATYPE_BUILTINS_COUNT > 0)
-    metatype = get_metatype_by_name(name);
-    if (metatype)
-        return metatype->generate_type_end;
+    {
+        const struct sol_flow_metatype *metatype;
+
+        metatype = get_metatype_by_name(name);
+        if (metatype)
+            return metatype->generate_type_end;
+    }
 #endif
 #ifdef ENABLE_DYNAMIC_MODULES
-    metatype = get_dynamic_metatype(name);
-    if (metatype)
-        return metatype->generate_type_end;
-    return NULL;
-#else
-    return NULL;
+    {
+        const struct sol_flow_metatype *metatype;
+
+        metatype = get_dynamic_metatype(name);
+        if (metatype)
+            return metatype->generate_type_end;
+    }
 #endif
+    return NULL;
 }
 
 SOL_API sol_flow_metatype_ports_description_func
 sol_flow_metatype_get_ports_description_func(const struct sol_str_slice name)
 {
-    const struct sol_flow_metatype *metatype;
-
     if (sol_str_slice_str_eq(name, "composed-split"))
         return composed_metatype_splitter_get_ports_description;
     if (sol_str_slice_str_eq(name, "composed-new"))
         return composed_metatype_constructor_get_ports_description;
 #if (SOL_FLOW_METATYPE_BUILTINS_COUNT > 0)
-    metatype = get_metatype_by_name(name);
-    if (metatype)
-        return metatype->ports_description;
+    {
+        const struct sol_flow_metatype *metatype;
+
+        metatype = get_metatype_by_name(name);
+        if (metatype)
+            return metatype->ports_description;
+    }
 #endif
 #ifdef ENABLE_DYNAMIC_MODULES
-    metatype = get_dynamic_metatype(name);
-    if (metatype)
-        return metatype->ports_description;
-    return NULL;
-#else
-    return NULL;
+    {
+        const struct sol_flow_metatype *metatype;
+
+        metatype = get_dynamic_metatype(name);
+        if (metatype)
+            return metatype->ports_description;
+    }
 #endif
+    return NULL;
 }
 
 static int

--- a/src/lib/flow/sol-flow-resolver-conffile.c
+++ b/src/lib/flow/sol-flow-resolver-conffile.c
@@ -309,7 +309,7 @@ resolver_conffile_resolve(void *data, const char *id,
 }
 
 static const struct sol_flow_resolver _resolver_conffile = {
-    .api_version = SOL_FLOW_RESOLVER_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_RESOLVER_API_VERSION, )
     .name = "conffile",
     .resolve = resolver_conffile_resolve,
 };

--- a/src/lib/flow/sol-flow-resolver.c
+++ b/src/lib/flow/sol-flow-resolver.c
@@ -70,7 +70,7 @@ builtins_resolve(void *data, const char *id, struct sol_flow_node_type const **t
 }
 
 static const struct sol_flow_resolver builtins_resolver = {
-    .api_version = SOL_FLOW_RESOLVER_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_RESOLVER_API_VERSION, )
     .name = "builtins_resolver",
     .resolve = builtins_resolve,
 };

--- a/src/lib/flow/sol-flow-simplectype.c
+++ b/src/lib/flow/sol-flow-simplectype.c
@@ -132,7 +132,7 @@ simplectype_create_description(struct sol_flow_node_type *type, const char *name
     type->description = desc = calloc(1, sizeof(*desc));
     SOL_NULL_CHECK(type->description, false);
 
-    desc->api_version = SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION;
+    SOL_SET_API_VERSION(desc->api_version = SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION; )
 
     desc->name = strdup(name);
     SOL_NULL_CHECK_GOTO(desc->name, error);
@@ -346,8 +346,10 @@ simplectype_new_full_inner(const char *name, size_t private_data_size, uint16_t 
         int direction = va_arg(args, int);
 
         SOL_NULL_CHECK_GOTO(pt, error);
+#ifndef SOL_NO_API_VERSION
         SOL_INT_CHECK_GOTO(pt->api_version,
             != SOL_FLOW_PACKET_TYPE_API_VERSION, error);
+#endif
 
         if (direction == SOL_FLOW_SIMPLECTYPE_PORT_TYPE_IN) {
             port_in = sol_vector_append(&ports_in);
@@ -356,7 +358,7 @@ simplectype_new_full_inner(const char *name, size_t private_data_size, uint16_t 
             port_in->name = strdup(port_name);
             SOL_NULL_CHECK_GOTO(port_in->name, error);
 
-            port_in->base.api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION;
+            SOL_SET_API_VERSION(port_in->base.api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION; )
             port_in->base.packet_type = pt;
             port_in->base.connect = simplectype_port_in_connect;
             port_in->base.disconnect = simplectype_port_in_disconnect;
@@ -368,7 +370,7 @@ simplectype_new_full_inner(const char *name, size_t private_data_size, uint16_t 
             port_out->name = strdup(port_name);
             SOL_NULL_CHECK_GOTO(port_out->name, error);
 
-            port_out->base.api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION;
+            SOL_SET_API_VERSION(port_out->base.api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION; )
             port_out->base.packet_type = pt;
             port_out->base.connect = simplectype_port_out_connect;
             port_out->base.disconnect = simplectype_port_out_disconnect;
@@ -392,7 +394,7 @@ simplectype_new_full_inner(const char *name, size_t private_data_size, uint16_t 
     type = calloc(1, sizeof(*type));
     SOL_NULL_CHECK_GOTO(type, error);
 
-    type->api_version = SOL_FLOW_NODE_TYPE_API_VERSION;
+    SOL_SET_API_VERSION(type->api_version = SOL_FLOW_NODE_TYPE_API_VERSION; )
     type->data_size = private_data_size;
 
     type->type_data = type_data = calloc(1, sizeof(*type_data));
@@ -443,7 +445,9 @@ sol_flow_simplectype_new_full(const char *name, size_t private_data_size, uint16
     va_list ap;
 
     SOL_NULL_CHECK(func, NULL);
+#ifndef SOL_NO_API_VERSION
     SOL_INT_CHECK(options_size, < sizeof(struct sol_flow_node_options), NULL);
+#endif
 
     va_start(ap, func);
     type = simplectype_new_full_inner(name, private_data_size, options_size, func, ap);

--- a/src/lib/flow/sol-flow-static.c
+++ b/src/lib/flow/sol-flow-static.c
@@ -435,7 +435,9 @@ flow_node_open(struct sol_flow_node *node, void *data, const struct sol_flow_nod
 
         if (type->child_opts_set) {
             uint16_t options_size = spec->type->options_size;
+#ifndef SOL_NO_API_VERSION
             SOL_INT_CHECK_GOTO(options_size, < sizeof(struct sol_flow_node_options), error_nodes);
+#endif
 
             r = sol_buffer_ensure(&opts_buf, options_size);
             if (r < 0) {
@@ -971,7 +973,7 @@ setup_exported_ports_specs(struct flow_static_type *type)
             node = type->exported_in_specs[u].node;
             port = type->exported_in_specs[u].port;
             port_type = &type->ports_in[u];
-            port_type->api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION;
+            SOL_SET_API_VERSION(port_type->api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION; )
             port_type->packet_type = sol_flow_node_type_get_port_in(type->node_specs[node].type, port)->packet_type;
             port_type->process = flow_exported_port_process;
             port_type->connect = flow_exported_port_in_connect;
@@ -991,7 +993,7 @@ setup_exported_ports_specs(struct flow_static_type *type)
             node = type->exported_out_specs[u].node;
             port = type->exported_out_specs[u].port;
             port_type = &type->ports_out[u];
-            port_type->api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION;
+            SOL_SET_API_VERSION(port_type->api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION; )
             port_type->packet_type = sol_flow_node_type_get_port_out(type->node_specs[node].type, port)->packet_type;
             port_type->connect = flow_exported_port_out_connect;
             port_type->disconnect = flow_exported_port_out_disconnect;
@@ -1027,7 +1029,7 @@ flow_static_type_init(
     *type = (const struct flow_static_type) {
         .base = {
             .base = {
-                .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
+                SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_API_VERSION, )
                 .data_size = sizeof(struct flow_static_data),
                 .flags = SOL_FLOW_NODE_TYPE_FLAGS_CONTAINER,
                 .open = flow_node_open,
@@ -1083,7 +1085,7 @@ sol_flow_static_new(struct sol_flow_node *parent, const struct sol_flow_static_n
     struct flow_static_type *type;
 
     struct sol_flow_static_spec spec = {
-        .api_version = SOL_FLOW_STATIC_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_FLOW_STATIC_API_VERSION, )
         .nodes = nodes,
         .conns = conns,
     };
@@ -1149,12 +1151,14 @@ sol_flow_static_new_type(
 
     SOL_NULL_CHECK(spec, NULL);
 
+#ifndef SOL_NO_API_VERSION
     if (spec->api_version != SOL_FLOW_STATIC_API_VERSION) {
         SOL_WRN("spec(%p)->api_version(%u) != "
             "SOL_FLOW_STATIC_API_VERSION(%u)",
             spec, spec->api_version, SOL_FLOW_STATIC_API_VERSION);
         return NULL;
     }
+#endif
 
     type = calloc(1, sizeof(*type));
     if (!type)

--- a/src/lib/flow/sol-flow.c
+++ b/src/lib/flow/sol-flow.c
@@ -66,6 +66,7 @@ SOL_API bool
 sol_flow_set_inspector(const struct sol_flow_inspector *inspector)
 {
     if (inspector) {
+#ifndef SOL_NO_API_VERSION
         if (inspector->api_version != SOL_FLOW_INSPECTOR_API_VERSION) {
             SOL_WRN("inspector(%p)->api_version(%lu) != "
                 "SOL_FLOW_INSPECTOR_API_VERSION(%lu)",
@@ -73,6 +74,7 @@ sol_flow_set_inspector(const struct sol_flow_inspector *inspector)
                 SOL_FLOW_INSPECTOR_API_VERSION);
             return false;
         }
+#endif
     }
     _sol_flow_inspector = inspector;
     return true;
@@ -150,8 +152,10 @@ sol_flow_node_init(struct sol_flow_node *node, struct sol_flow_node *parent, con
 }
 
 const struct sol_flow_node_options sol_flow_node_options_empty = {
+#ifndef SOL_NO_API_VERSION
     .api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION,
     .sub_api = 0,
+#endif
 };
 
 SOL_API struct sol_flow_node *
@@ -466,7 +470,7 @@ sol_flow_send_error_packet_str(struct sol_flow_node *src, int code, const char *
 }
 
 static struct sol_flow_port_type_out port_error = {
-    .api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION, )
 };
 
 /* If this function or parameters change, update data/gdb/libsoletta-gdb.py. */

--- a/src/lib/io/include/sol-gpio.h
+++ b/src/lib/io/include/sol-gpio.h
@@ -34,6 +34,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <sol-common-buildopts.h>
 #include <sol-macros.h>
 
 #ifdef __cplusplus
@@ -84,8 +85,10 @@ enum sol_gpio_drive {
 };
 
 struct sol_gpio_config {
+#ifndef SOL_NO_API_VERSION
 #define SOL_GPIO_CONFIG_API_VERSION (1)
     uint16_t api_version;
+#endif
     enum sol_gpio_direction dir;
     bool active_low;
     enum sol_gpio_drive drive_mode;

--- a/src/lib/io/include/sol-iio.h
+++ b/src/lib/io/include/sol-iio.h
@@ -33,6 +33,7 @@
 #pragma once
 
 #include <sol-buffer.h>
+#include <sol-common-buildopts.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,8 +57,10 @@ struct sol_iio_device;
 struct sol_iio_channel;
 
 struct sol_iio_config {
+#ifndef SOL_NO_API_VERSION
 #define SOL_IIO_CONFIG_API_VERSION (1)
     uint16_t api_version;
+#endif
     const char *trigger_name; /**< Name of IIO trigger to be used on this device. If NULL or empty, will try to use device current trigger. If device has no current trigger, will create a 'sysfs_trigger' and use it. */
     void (*sol_iio_reader_cb)(void *data, struct sol_iio_device *device); /**< Callback to be called when get new device readings on buffer */
     const void *data; /**< User defined data to be sent to sol_iio_reader_cb */
@@ -66,14 +69,18 @@ struct sol_iio_config {
 };
 
 struct sol_iio_channel_config {
+#ifndef SOL_NO_API_VERSION
 #define SOL_IIO_CHANNEL_CONFIG_API_VERSION (1)
     uint16_t api_version;
+#endif
     double scale; /**< Channel scale, to be applied to raw readings. -1 uses device default. Some devices share scale among all channels, so changing one will change all. If, in this case, different channels set different scales the result is unknown. */
     int offset; /**< Channel offset, to be added to raw readings. Some devices share offset among all channels, so changing one will change all. If, in this case, different channels set different offsets the result is unknown. */
     bool use_custom_offset; /**< If true, will use user defined offset on member #offset of this struct */
 };
 
-#define SOL_IIO_CHANNEL_CONFIG_INIT { .api_version = SOL_IIO_CHANNEL_CONFIG_API_VERSION, .scale = -1.0, .use_custom_offset = false }
+#define SOL_IIO_CHANNEL_CONFIG_INIT { \
+        SOL_SET_API_VERSION(.api_version = SOL_IIO_CHANNEL_CONFIG_API_VERSION, ) \
+        .scale = -1.0, .use_custom_offset = false }
 
 /**
  * Open an IIO device

--- a/src/lib/io/include/sol-pwm.h
+++ b/src/lib/io/include/sol-pwm.h
@@ -35,6 +35,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include <sol-common-buildopts.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -69,8 +71,10 @@ enum sol_pwm_polarity {
 };
 
 struct sol_pwm_config {
+#ifndef SOL_NO_API_VERSION
 #define SOL_PWM_CONFIG_API_VERSION (1)
     uint16_t api_version;
+#endif
     int32_t period_ns; /* if == -1, won't set */
     int32_t duty_cycle_ns; /* if == -1, won't set, but if period is set, duty cycle is zeroed */
     enum sol_pwm_alignment alignment;

--- a/src/lib/io/include/sol-spi.h
+++ b/src/lib/io/include/sol-spi.h
@@ -35,6 +35,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include <sol-common-buildopts.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -65,8 +67,10 @@ enum sol_spi_mode {
 #define SOL_SPI_DATA_BITS_DEFAULT 8
 
 struct sol_spi_config {
+#ifndef SOL_NO_API_VERSION
 #define SOL_SPI_CONFIG_API_VERSION (1)
     uint16_t api_version;
+#endif
     unsigned int chip_select; /** Also know as slave select */
     enum sol_spi_mode mode;
     uint32_t frequency; /** Clock frequency in Hz */

--- a/src/lib/io/include/sol-uart.h
+++ b/src/lib/io/include/sol-uart.h
@@ -35,6 +35,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include <sol-common-buildopts.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -82,8 +84,10 @@ enum sol_uart_stop_bits {
 };
 
 struct sol_uart_config {
+#ifndef SOL_NO_API_VERSION
 #define SOL_UART_CONFIG_API_VERSION (1)
     uint16_t api_version;
+#endif
     enum sol_uart_baud_rate baud_rate;
     enum sol_uart_data_bits data_bits;
     enum sol_uart_parity parity;

--- a/src/lib/io/sol-gpio-impl-linux.c
+++ b/src/lib/io/sol-gpio-impl-linux.c
@@ -299,12 +299,14 @@ sol_gpio_open_raw(int pin, const struct sol_gpio_config *config)
 
     SOL_LOG_INTERNAL_INIT_ONCE;
 
+#ifndef SOL_NO_API_VERSION
     if (unlikely(config->api_version != SOL_GPIO_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open gpio that has unsupported version '%u', "
             "expected version is '%u'",
             config->api_version, SOL_GPIO_CONFIG_API_VERSION);
         return NULL;
     }
+#endif
 
     gpio = calloc(1, sizeof(*gpio));
     if (!gpio) {

--- a/src/lib/io/sol-gpio-impl-riot.c
+++ b/src/lib/io/sol-gpio-impl-riot.c
@@ -76,12 +76,14 @@ sol_gpio_open_raw(int pin, const struct sol_gpio_config *config)
 
     SOL_LOG_INTERNAL_INIT_ONCE;
 
+#ifndef SOL_NO_API_VERSION
     if (unlikely(config->api_version != SOL_GPIO_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open gpio that has unsupported version '%u', "
             "expected version is '%u'",
             config->api_version, SOL_GPIO_CONFIG_API_VERSION);
         return NULL;
     }
+#endif
 
     gpio = malloc(sizeof(struct sol_gpio));
     SOL_NULL_CHECK(gpio, NULL);

--- a/src/lib/io/sol-i2c-impl-linux.c
+++ b/src/lib/io/sol-i2c-impl-linux.c
@@ -274,7 +274,7 @@ sol_i2c_write_quick(struct sol_i2c *i2c, bool rw, void (*write_quick_cb)(void *c
 {
 #ifdef WORKER_THREAD
     struct sol_worker_thread_spec spec = {
-        .api_version = SOL_WORKER_THREAD_SPEC_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_WORKER_THREAD_SPEC_API_VERSION, )
         .setup = NULL,
         .cleanup = NULL,
         .iterate = i2c_write_quick_worker_thread_iterate,
@@ -397,7 +397,7 @@ sol_i2c_read(struct sol_i2c *i2c, uint8_t *values, size_t count, void (*read_cb)
 {
 #ifdef WORKER_THREAD
     struct sol_worker_thread_spec spec = {
-        .api_version = SOL_WORKER_THREAD_SPEC_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_WORKER_THREAD_SPEC_API_VERSION, )
         .setup = NULL,
         .cleanup = NULL,
         .iterate = i2c_read_worker_thread_iterate,
@@ -471,7 +471,7 @@ sol_i2c_write(struct sol_i2c *i2c, uint8_t *values, size_t count, void (*write_c
 {
 #ifdef WORKER_THREAD
     struct sol_worker_thread_spec spec = {
-        .api_version = SOL_WORKER_THREAD_SPEC_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_WORKER_THREAD_SPEC_API_VERSION, )
         .setup = NULL,
         .cleanup = NULL,
         .iterate = i2c_write_worker_thread_iterate,
@@ -623,7 +623,7 @@ sol_i2c_read_register(struct sol_i2c *i2c, uint8_t reg, uint8_t *values, size_t 
 {
 #ifdef WORKER_THREAD
     struct sol_worker_thread_spec spec = {
-        .api_version = SOL_WORKER_THREAD_SPEC_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_WORKER_THREAD_SPEC_API_VERSION, )
         .setup = NULL,
         .cleanup = NULL,
         .iterate = i2c_read_reg_worker_thread_iterate,
@@ -737,7 +737,7 @@ sol_i2c_read_register_multiple(struct sol_i2c *i2c, uint8_t reg, uint8_t *values
 {
 #ifdef WORKER_THREAD
     struct sol_worker_thread_spec spec = {
-        .api_version = SOL_WORKER_THREAD_SPEC_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_WORKER_THREAD_SPEC_API_VERSION, )
         .setup = NULL,
         .cleanup = NULL,
         .iterate = i2c_read_reg_multiple_worker_thread_iterate,
@@ -877,7 +877,7 @@ sol_i2c_write_register(struct sol_i2c *i2c, uint8_t reg, const uint8_t *values, 
 {
 #ifdef WORKER_THREAD
     struct sol_worker_thread_spec spec = {
-        .api_version = SOL_WORKER_THREAD_SPEC_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_WORKER_THREAD_SPEC_API_VERSION, )
         .setup = NULL,
         .cleanup = NULL,
         .iterate = i2c_write_reg_worker_thread_iterate,

--- a/src/lib/io/sol-iio.c
+++ b/src/lib/io/sol-iio.c
@@ -621,11 +621,13 @@ sol_iio_open(int device_id, const struct sol_iio_config *config)
     struct sol_iio_device *device = NULL;
 
     SOL_NULL_CHECK(config, NULL);
+#ifndef SOL_NO_API_VERSION
     if (unlikely(config->api_version != SOL_IIO_CONFIG_API_VERSION)) {
         SOL_WRN("IIO config version '%u' is unexpected, expected '%u'",
             config->api_version, SOL_IIO_CONFIG_API_VERSION);
         return NULL;
     }
+#endif
 
     device = calloc(1, sizeof(struct sol_iio_device));
     SOL_NULL_CHECK(device, NULL);
@@ -902,11 +904,13 @@ sol_iio_add_channel(struct sol_iio_device *device, const char *name, const struc
     SOL_NULL_CHECK(name, NULL);
     SOL_NULL_CHECK(config, NULL);
 
+#ifndef SOL_NO_API_VERSION
     if (unlikely(config->api_version != SOL_IIO_CHANNEL_CONFIG_API_VERSION)) {
         SOL_WRN("IIO channel config version '%u' is unexpected, expected '%u'",
             config->api_version, SOL_IIO_CHANNEL_CONFIG_API_VERSION);
         return NULL;
     }
+#endif
 
     if (!check_file_existence(CHANNEL_RAW_PATH, device->device_id, name)) {
         SOL_WRN("Could not find channel [%s] for device%d", name,

--- a/src/lib/io/sol-pwm-impl-linux.c
+++ b/src/lib/io/sol-pwm-impl-linux.c
@@ -270,12 +270,14 @@ sol_pwm_open_raw(int device, int channel, const struct sol_pwm_config *config)
 
     SOL_LOG_INTERNAL_INIT_ONCE;
 
+#ifndef SOL_NO_API_VERSION
     if (unlikely(config->api_version != SOL_PWM_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open pwm that has unsupported version '%u', "
             "expected version is '%u'",
             config->api_version, SOL_PWM_CONFIG_API_VERSION);
         return NULL;
     }
+#endif
 
     pwm = calloc(1, sizeof(*pwm));
     if (!pwm) {

--- a/src/lib/io/sol-pwm-impl-riot.c
+++ b/src/lib/io/sol-pwm-impl-riot.c
@@ -108,12 +108,14 @@ sol_pwm_open_raw(int device, int channel, const struct sol_pwm_config *config)
 
     SOL_LOG_INTERNAL_INIT_ONCE;
 
+#ifndef SOL_NO_API_VERSION
     if (unlikely(config->api_version != SOL_PWM_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open pwm that has unsupported version '%u', "
             "expected version is '%u'",
             config->api_version, SOL_PWM_CONFIG_API_VERSION);
         return NULL;
     }
+#endif
 
     pwm = calloc(1, sizeof(struct sol_pwm));
     SOL_NULL_CHECK(pwm, NULL);

--- a/src/lib/io/sol-spi-impl-linux.c
+++ b/src/lib/io/sol-spi-impl-linux.c
@@ -139,7 +139,7 @@ sol_spi_transfer(struct sol_spi *spi, const uint8_t *tx, uint8_t *rx, size_t siz
 {
 #ifdef WORKER_THREAD
     struct sol_worker_thread_spec spec = {
-        .api_version = SOL_WORKER_THREAD_SPEC_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_WORKER_THREAD_SPEC_API_VERSION, )
         .setup = NULL,
         .cleanup = NULL,
         .iterate = spi_worker_thread_iterate,
@@ -203,12 +203,14 @@ sol_spi_open(unsigned int bus, const struct sol_spi_config *config)
 
     SOL_LOG_INTERNAL_INIT_ONCE;
 
+#ifndef SOL_NO_API_VERSION
     if (unlikely(config->api_version != SOL_SPI_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open SPI that has unsupported version '%u', "
             "expected version is '%u'",
             config->api_version, SOL_SPI_CONFIG_API_VERSION);
         return NULL;
     }
+#endif
 
     spi = malloc(sizeof(*spi));
     if (!spi) {

--- a/src/lib/io/sol-spi-impl-riot.c
+++ b/src/lib/io/sol-spi-impl-riot.c
@@ -84,12 +84,14 @@ sol_spi_open(unsigned int bus, const struct sol_spi_config *config)
 
     SOL_LOG_INTERNAL_INIT_ONCE;
 
+#ifndef SOL_NO_API_VERSION
     if (unlikely(config->api_version != SOL_SPI_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open SPI that has unsupported version '%u', "
             "expected version is '%u'",
             config->api_version, SOL_SPI_CONFIG_API_VERSION);
         return NULL;
     }
+#endif
 
     SOL_EXP_CHECK(config->bits_per_word != 8, NULL);
 

--- a/src/lib/io/sol-uart-impl-linux.c
+++ b/src/lib/io/sol-uart-impl-linux.c
@@ -111,12 +111,14 @@ sol_uart_open(const char *port_name, const struct sol_uart_config *config)
 
     SOL_LOG_INTERNAL_INIT_ONCE;
 
+#ifndef SOL_NO_API_VERSION
     if (unlikely(config->api_version != SOL_UART_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open UART that has unsupported version '%u', "
             "expected version is '%u'",
             config->api_version, SOL_UART_CONFIG_API_VERSION);
         return NULL;
     }
+#endif
 
     SOL_NULL_CHECK(port_name, NULL);
 

--- a/src/lib/io/sol-uart-impl-riot.c
+++ b/src/lib/io/sol-uart-impl-riot.c
@@ -119,12 +119,14 @@ sol_uart_open(const char *port_name, const struct sol_uart_config *config)
 
     SOL_LOG_INTERNAL_INIT_ONCE;
 
+#ifndef SOL_NO_API_VERSION
     if (unlikely(config->api_version != SOL_UART_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open UART that has unsupported version '%u', "
             "expected version is '%u'",
             config->api_version, SOL_UART_CONFIG_API_VERSION);
         return NULL;
     }
+#endif
 
     SOL_EXP_CHECK(config->parity != SOL_UART_PARITY_NONE, NULL);
     SOL_EXP_CHECK(config->data_bits != SOL_UART_DATA_BITS_8, NULL);

--- a/src/modules/flow-metatype/js/js.c
+++ b/src/modules/flow-metatype/js/js.c
@@ -943,7 +943,7 @@ flow_js_get_port_out(const struct sol_flow_node_type *type, uint16_t port)
 
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
 static const struct sol_flow_node_type_description sol_flow_node_type_js_description = {
-    .api_version = SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION, )
     .name = "js",
     .category = "js",
     .symbol = "SOL_FLOW_NODE_TYPE_JS",
@@ -1138,7 +1138,7 @@ setup_ports_in(struct duk_context *duk_ctx, struct sol_arena *str_arena, struct 
         port_type = sol_vector_append(ports_in);
         SOL_NULL_CHECK(port_type, false);
 
-        port_type->type.api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION;
+        SOL_SET_API_VERSION(port_type->type.api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION; )
         port_type->type.packet_type = packet_type;
         port_type->type.process = flow_js_port_process;
         port_type->type.connect = flow_js_port_in_connect;
@@ -1223,7 +1223,7 @@ setup_ports_out(struct duk_context *duk_ctx, struct sol_arena *str_arena, struct
         port_type = sol_vector_append(ports_out);
         SOL_NULL_CHECK(port_type, false);
 
-        port_type->type.api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION;
+        SOL_SET_API_VERSION(port_type->type.api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION; )
         port_type->type.packet_type = packet_type;
         port_type->type.connect = flow_js_port_out_connect;
         port_type->type.disconnect = flow_js_port_out_disconnect;
@@ -1325,7 +1325,7 @@ flow_js_type_init(struct flow_js_type *type, const char *buf, size_t len)
 
     *type = (const struct flow_js_type) {
         .base = {
-            .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
+            SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_API_VERSION, )
             .data_size = sizeof(struct flow_js_data),
             .open = flow_js_open,
             .close = flow_js_close,

--- a/src/modules/flow/calamari/calamari.c
+++ b/src/modules/flow/calamari/calamari.c
@@ -268,7 +268,7 @@ calamari_7seg_new_type(const struct sol_flow_node_type **current)
     };
 
     static const struct sol_flow_static_spec spec = {
-        .api_version = SOL_FLOW_STATIC_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_FLOW_STATIC_API_VERSION, )
         .nodes = nodes,
         .conns = conns,
         .exported_in = exported_in,
@@ -352,7 +352,7 @@ calamari_led_open(struct sol_flow_node *node, void *data, const struct sol_flow_
     mdata->val.step = opts->range.step;
     mdata->node = node;
 
-    pwm_config.api_version = SOL_PWM_CONFIG_API_VERSION;
+    SOL_SET_API_VERSION(pwm_config.api_version = SOL_PWM_CONFIG_API_VERSION; )
     pwm_config.period_ns = mdata->period;
     pwm_config.duty_cycle_ns = 0;
     pwm_config.enabled = true;
@@ -476,7 +476,7 @@ calamari_lever_open(struct sol_flow_node *node, void *data, const struct sol_flo
     mdata->val.max = opts->range.max;
     mdata->val.step = opts->range.step;
     mdata->poll_interval = opts->poll_interval;
-    spi_config.api_version = SOL_SPI_CONFIG_API_VERSION;
+    SOL_SET_API_VERSION(spi_config.api_version = SOL_SPI_CONFIG_API_VERSION; )
     spi_config.chip_select = opts->chip_select;
     spi_config.mode = SOL_SPI_MODE_0;
     spi_config.frequency = 100 * 1000; //100KHz
@@ -606,7 +606,7 @@ calamari_rgb_led_new_type(const struct sol_flow_node_type **current)
     };
 
     static const struct sol_flow_static_spec spec = {
-        .api_version = SOL_FLOW_STATIC_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_FLOW_STATIC_API_VERSION, )
         .nodes = nodes,
         .conns = conns,
         .exported_in = exported_in,

--- a/src/modules/flow/file/file.c
+++ b/src/modules/flow/file/file.c
@@ -64,7 +64,7 @@ file_reader_blob_free(struct sol_blob *blob)
 }
 
 static const struct sol_blob_type file_reader_blob_type = {
-    .api_version = SOL_BLOB_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_BLOB_TYPE_API_VERSION, )
     .free = file_reader_blob_free
 };
 
@@ -351,7 +351,7 @@ static int
 file_writer_load(struct file_writer_data *mdata)
 {
     struct sol_worker_thread_spec spec = {
-        .api_version = SOL_WORKER_THREAD_SPEC_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_WORKER_THREAD_SPEC_API_VERSION, )
         .setup = file_writer_worker_thread_setup,
         .cleanup = file_writer_worker_thread_cleanup,
         .iterate = file_writer_worker_thread_iterate,

--- a/src/modules/flow/flower-power/flower-power.c
+++ b/src/modules/flow/flower-power/flower-power.c
@@ -90,7 +90,7 @@ packet_type_flower_power_packet_init(
 #define PACKET_TYPE_FLOWER_POWER_PACKET_TYPE_API_VERSION (1)
 
 static const struct sol_flow_packet_type _PACKET_TYPE_FLOWER_POWER = {
-    .api_version = PACKET_TYPE_FLOWER_POWER_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = PACKET_TYPE_FLOWER_POWER_PACKET_TYPE_API_VERSION, )
     .name = "PACKET_TYPE_FLOWER_POWER",
     .data_size = sizeof(struct sol_flower_power_data),
     .init = packet_type_flower_power_packet_init,
@@ -902,7 +902,7 @@ packet_type_flower_power_sensor_packet_init(
 #define PACKET_TYPE_FLOWER_POWER_SENSOR_PACKET_TYPE_API_VERSION (1)
 
 static const struct sol_flow_packet_type _PACKET_TYPE_FLOWER_POWER_SENSOR = {
-    .api_version = PACKET_TYPE_FLOWER_POWER_SENSOR_PACKET_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = PACKET_TYPE_FLOWER_POWER_SENSOR_PACKET_TYPE_API_VERSION, )
     .name = "PACKET_TYPE_FLOWER_POWER_SENSOR",
     .data_size = sizeof(struct sol_flower_power_sensor_data),
     .init = packet_type_flower_power_sensor_packet_init,

--- a/src/modules/flow/gpio/gpio.c
+++ b/src/modules/flow/gpio/gpio.c
@@ -84,7 +84,7 @@ gpio_reader_open(struct sol_flow_node *node, void *data, const struct sol_flow_n
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_GPIO_READER_OPTIONS_API_VERSION, -EINVAL);
 
-    gpio_conf.api_version = SOL_GPIO_CONFIG_API_VERSION;
+    SOL_SET_API_VERSION(gpio_conf.api_version = SOL_GPIO_CONFIG_API_VERSION; )
     gpio_conf.dir = SOL_GPIO_DIR_IN;
     gpio_conf.active_low = opts->active_low;
     gpio_conf.in.trigger_mode = mode_lut[opts->edge_rising + 2 * opts->edge_falling];
@@ -155,7 +155,7 @@ gpio_writer_open(struct sol_flow_node *node, void *data, const struct sol_flow_n
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_GPIO_WRITER_OPTIONS_API_VERSION, -EINVAL);
 
-    gpio_conf.api_version = SOL_GPIO_CONFIG_API_VERSION;
+    SOL_SET_API_VERSION(gpio_conf.api_version = SOL_GPIO_CONFIG_API_VERSION; )
     gpio_conf.dir = SOL_GPIO_DIR_OUT;
     gpio_conf.active_low = opts->active_low;
 

--- a/src/modules/flow/grove/grove.c
+++ b/src/modules/flow/grove/grove.c
@@ -99,7 +99,7 @@ grove_rotary_sensor_new_type(const struct sol_flow_node_type **current)
     };
 
     static const struct sol_flow_static_spec spec = {
-        .api_version = SOL_FLOW_STATIC_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_FLOW_STATIC_API_VERSION, )
         .nodes = nodes,
         .conns = conns,
         .exported_out = exported_out,
@@ -232,7 +232,7 @@ grove_light_sensor_new_type(const struct sol_flow_node_type **current)
     };
 
     static const struct sol_flow_static_spec spec = {
-        .api_version = SOL_FLOW_STATIC_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_FLOW_STATIC_API_VERSION, )
         .nodes = nodes,
         .conns = conns,
         .exported_out = exported_out,
@@ -411,7 +411,7 @@ grove_temperature_sensor_new_type(const struct sol_flow_node_type **current)
     };
 
     static const struct sol_flow_static_spec spec = {
-        .api_version = SOL_FLOW_STATIC_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_FLOW_STATIC_API_VERSION, )
         .nodes = nodes,
         .conns = conns,
         .exported_out = exported_out,

--- a/src/modules/flow/gtk/spinbutton.c
+++ b/src/modules/flow/gtk/spinbutton.c
@@ -32,6 +32,7 @@
 
 #include "spinbutton.h"
 #include "sol-flow/gtk.h"
+#include "sol-flow-internal.h"
 
 static void
 on_spinbutton_changed(GtkSpinButton *spin, gpointer data)
@@ -60,8 +61,7 @@ spinbutton_setup(struct gtk_common_data *data, const struct sol_flow_node_option
     const struct sol_flow_node_type_gtk_spinbutton_options *opts =
         (const struct sol_flow_node_type_gtk_spinbutton_options *)options;
 
-    if (options->sub_api != SOL_FLOW_NODE_TYPE_GTK_SPINBUTTON_OPTIONS_API_VERSION)
-        return -EINVAL;
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_GTK_SPINBUTTON_OPTIONS_API_VERSION, -EINVAL);
 
     range = opts->range;
     value = opts->value;

--- a/src/modules/flow/http-server/http-server.c
+++ b/src/modules/flow/http-server/http-server.c
@@ -189,7 +189,7 @@ common_response_cb(void *data, struct sol_http_request *request)
     const struct http_server_node_type *type;
     struct sol_http_param_value *value;
     struct sol_http_response response = {
-        .api_version = SOL_HTTP_RESPONSE_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_HTTP_RESPONSE_API_VERSION, )
         .content = SOL_BUFFER_INIT_EMPTY,
         .param = SOL_HTTP_REQUEST_PARAM_INIT,
         .response_code = SOL_HTTP_STATUS_OK

--- a/src/modules/flow/iio/nodes.c
+++ b/src/modules/flow/iio/nodes.c
@@ -132,7 +132,7 @@ gyroscope_open(struct sol_flow_node *node, void *data, const struct sol_flow_nod
 
     mdata->buffer_enabled = opts->buffer_size > -1;
 
-    mdata->config.api_version = SOL_IIO_CONFIG_API_VERSION;
+    SOL_SET_API_VERSION(mdata->config.api_version = SOL_IIO_CONFIG_API_VERSION; )
     mdata->config.trigger_name = opts->iio_trigger_name;
     mdata->config.buffer_size = opts->buffer_size;
     mdata->config.sampling_frequency = opts->sampling_frequency;

--- a/src/modules/flow/led-7seg/led-7seg.c
+++ b/src/modules/flow/led-7seg/led-7seg.c
@@ -142,7 +142,7 @@ led_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_opti
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
         SOL_FLOW_NODE_TYPE_LED_7SEG_LED_OPTIONS_API_VERSION, -EINVAL);
 
-    gpio_conf.api_version = SOL_GPIO_CONFIG_API_VERSION;
+    SOL_SET_API_VERSION(gpio_conf.api_version = SOL_GPIO_CONFIG_API_VERSION; )
     gpio_conf.dir = SOL_GPIO_DIR_OUT;
 
     OPEN_GPIO(0, dp);

--- a/src/modules/flow/led-strip/lpd8806.c
+++ b/src/modules/flow/led-strip/lpd8806.c
@@ -99,7 +99,7 @@ led_strip_controler_open(struct sol_flow_node *node, void *data, const struct so
     memset(mdata->pixels, 0x80, data_bytes); // Init to RGB 'off' state
     memset(&mdata->pixels[data_bytes], 0, latch_bytes); // Clear latch bytes
 
-    spi_config.api_version = SOL_SPI_CONFIG_API_VERSION;
+    SOL_SET_API_VERSION(spi_config.api_version = SOL_SPI_CONFIG_API_VERSION; )
     spi_config.chip_select = opts->chip_select;
     spi_config.mode = SOL_SPI_MODE_0;
     spi_config.frequency = 100 * 1000; //100KHz

--- a/src/modules/flow/max31855/max31855.c
+++ b/src/modules/flow/max31855/max31855.c
@@ -62,7 +62,9 @@ max31855_open(struct sol_flow_node *node, void *data, const struct sol_flow_node
 {
     struct max31855_data *mdata = data;
     struct sol_flow_node_type_max31855_temperature_options *opts;
-    struct sol_spi_config config = { .api_version = SOL_SPI_CONFIG_API_VERSION };
+    struct sol_spi_config config = {
+        SOL_SET_API_VERSION(.api_version = SOL_SPI_CONFIG_API_VERSION)
+    };
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
         SOL_FLOW_NODE_TYPE_MAX31855_TEMPERATURE_OPTIONS_API_VERSION,

--- a/src/modules/flow/piezo-speaker/piezo-speaker.c
+++ b/src/modules/flow/piezo-speaker/piezo-speaker.c
@@ -393,7 +393,7 @@ piezo_speaker_open(struct sol_flow_node *node,
         (const struct sol_flow_node_type_piezo_speaker_sound_options *)options;
     struct sol_pwm_config pwm_config = { 0 };
 
-    pwm_config.api_version = SOL_PWM_CONFIG_API_VERSION;
+    SOL_SET_API_VERSION(pwm_config.api_version = SOL_PWM_CONFIG_API_VERSION; )
     pwm_config.period_ns = -1;
     pwm_config.duty_cycle_ns = 0;
 

--- a/src/modules/flow/pwm/pwm.c
+++ b/src/modules/flow/pwm/pwm.c
@@ -113,7 +113,7 @@ pwm_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_opti
         return -EINVAL;
     }
 
-    pwm_config.api_version = SOL_PWM_CONFIG_API_VERSION;
+    SOL_SET_API_VERSION(pwm_config.api_version = SOL_PWM_CONFIG_API_VERSION; )
     pwm_config.period_ns = opts->period;
     pwm_config.duty_cycle_ns = opts->duty_cycle;
     if (opts->inversed_polarity)

--- a/src/modules/flow/servo-motor/servo-motor.c
+++ b/src/modules/flow/servo-motor/servo-motor.c
@@ -70,7 +70,7 @@ servo_motor_open(struct sol_flow_node *node, void *data, const struct sol_flow_n
     mdata->duty_cycle_diff = mdata->duty_cycle_range.max -
         mdata->duty_cycle_range.min;
 
-    pwm_config.api_version = SOL_PWM_CONFIG_API_VERSION;
+    SOL_SET_API_VERSION(pwm_config.api_version = SOL_PWM_CONFIG_API_VERSION; )
     pwm_config.period_ns = opts->period * 1000;
     pwm_config.duty_cycle_ns = 0;
 

--- a/src/modules/pin-mux/intel-common/intel-common.c
+++ b/src/modules/pin-mux/intel-common/intel-common.c
@@ -67,7 +67,7 @@ _get_gpio(int pin, enum sol_gpio_direction dir, bool val)
             return ref->gpio;
     }
 
-    gpio_config.api_version = SOL_GPIO_CONFIG_API_VERSION;
+    SOL_SET_API_VERSION(gpio_config.api_version = SOL_GPIO_CONFIG_API_VERSION; )
     gpio_config.dir = dir;
     gpio_config.out.value = val;
 

--- a/src/samples/coap/oic-client.c
+++ b/src/samples/coap/oic-client.c
@@ -143,7 +143,7 @@ int
 main(int argc, char *argv[])
 {
     struct sol_oic_client client = {
-        .api_version = SOL_OIC_CLIENT_API_VERSION
+        SOL_SET_API_VERSION(.api_version = SOL_OIC_CLIENT_API_VERSION)
     };
     struct sol_network_link_addr cliaddr = { .family = AF_INET, .port = 5683 };
     const char *resource_type;

--- a/src/samples/coap/oic-server.c
+++ b/src/samples/coap/oic-server.c
@@ -142,7 +142,7 @@ register_light_resource_type(
     /* This function will be auto-generated from the RAML definitions. */
 
     struct sol_oic_resource_type rt = {
-        .api_version = SOL_OIC_RESOURCE_TYPE_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_OIC_RESOURCE_TYPE_API_VERSION, )
         .resource_type = SOL_STR_SLICE_LITERAL("core.light"),
         .interface = SOL_STR_SLICE_LITERAL("oc.mi.def"),
         .get = {

--- a/src/samples/coap/simple-server.c
+++ b/src/samples/coap/simple-server.c
@@ -210,7 +210,7 @@ light_method_get(const struct sol_coap_resource *resource, struct sol_coap_packe
 }
 
 static struct sol_coap_resource light = {
-    .api_version = SOL_COAP_RESOURCE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_COAP_RESOURCE_API_VERSION, )
     .get = light_method_get,
     .put = light_method_put,
     .iface = SOL_STR_SLICE_LITERAL("oc.mi.def"),

--- a/src/samples/common/linux-micro-init.c
+++ b/src/samples/common/linux-micro-init.c
@@ -165,7 +165,7 @@ startup(void)
 
     if (pin >= 0) {
         struct sol_gpio_config cfg = {
-            .api_version = SOL_GPIO_CONFIG_API_VERSION,
+            SOL_SET_API_VERSION(.api_version = SOL_GPIO_CONFIG_API_VERSION, )
             .dir = SOL_GPIO_DIR_OUT,
         };
         gpio = sol_gpio_open(pin, &cfg);

--- a/src/samples/common/uart.c
+++ b/src/samples/common/uart.c
@@ -87,7 +87,7 @@ main(int argc, char *argv[])
 
     sol_init();
 
-    config.api_version = SOL_UART_CONFIG_API_VERSION;
+    SOL_SET_API_VERSION(config.api_version = SOL_UART_CONFIG_API_VERSION; )
     config.baud_rate = SOL_UART_BAUD_RATE_9600;
     config.data_bits = SOL_UART_DATA_BITS_8;
     config.parity = SOL_UART_PARITY_NONE;

--- a/src/samples/crypto/md5sum.c
+++ b/src/samples/crypto/md5sum.c
@@ -96,7 +96,7 @@ entry_new(const char *filename)
 {
     struct entry *entry;
     struct sol_message_digest_config cfg = {
-        .api_version = SOL_MESSAGE_DIGEST_CONFIG_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_MESSAGE_DIGEST_CONFIG_API_VERSION, )
         .algorithm = algorithm,
         .on_digest_ready = store_digest,
     };

--- a/src/samples/crypto/message-digest.c
+++ b/src/samples/crypto/message-digest.c
@@ -156,7 +156,7 @@ startup(void)
     for (i = 1; i < argc; i++) {
         struct feed_ctx *ctx;
         struct sol_message_digest_config cfg = {
-            .api_version = SOL_MESSAGE_DIGEST_CONFIG_API_VERSION,
+            SOL_SET_API_VERSION(.api_version = SOL_MESSAGE_DIGEST_CONFIG_API_VERSION, )
             .algorithm = algorithm,
             .on_feed_done = on_feed_done,
             .on_digest_ready = on_digest_ready,

--- a/src/samples/flow/c-api/custom-node-types.c
+++ b/src/samples/flow/c-api/custom-node-types.c
@@ -69,6 +69,7 @@
 #include <sol-util.h>
 
 /* macro to check if option's sub_api is the one we expect */
+#ifndef SOL_NO_API_VERSION
 #define SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, expected, ...)      \
     do {                                                                \
         SOL_NULL_CHECK(options, __VA_ARGS__);                            \
@@ -81,6 +82,9 @@
             return __VA_ARGS__;                                         \
         }                                                               \
     } while (0)
+#else
+#define SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, expected, ...)
+#endif
 
 
 /**

--- a/src/samples/flow/c-api/simplectype.c
+++ b/src/samples/flow/c-api/simplectype.c
@@ -141,7 +141,11 @@ mytype_func(struct sol_flow_node *node, const struct sol_flow_simplectype_event 
 
     switch (ev->type) {
     case SOL_FLOW_SIMPLECTYPE_EVENT_TYPE_OPEN: {
-        if (ev->options && ev->options->sub_api == MYTYPE_OPTIONS_SUB_API) {
+        if (ev->options
+#ifndef SOL_NO_API_VERSION
+            && ev->options->sub_api == MYTYPE_OPTIONS_SUB_API
+#endif
+            ) {
             struct mytype_options *opt = (struct mytype_options *)ev->options;
             ctx->someint = opt->someint;
             ctx->somebool = opt->somebool;
@@ -216,8 +220,10 @@ startup(void)
      */
     struct mytype_options mystuff_opts = {
         .base = {
+#ifndef SOL_NO_API_VERSION
             .api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION,
             .sub_api = MYTYPE_OPTIONS_SUB_API,
+#endif
         },
         .someint = 12,
         .somebool = true,

--- a/src/samples/mqtt/mqtt-publish.c
+++ b/src/samples/mqtt/mqtt-publish.c
@@ -97,7 +97,7 @@ on_disconnect(void *data, struct sol_mqtt *mqtt)
 }
 
 const struct sol_mqtt_config config = {
-    .api_version = SOL_MQTT_CONFIG_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_MQTT_CONFIG_API_VERSION, )
     .clean_session = true,
     .keepalive = 60,
     .handlers = {

--- a/src/samples/mqtt/mqtt-subscribe.c
+++ b/src/samples/mqtt/mqtt-subscribe.c
@@ -82,7 +82,7 @@ on_disconnect(void *data, struct sol_mqtt *mqtt)
 }
 
 const struct sol_mqtt_config config = {
-    .api_version = SOL_MQTT_CONFIG_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_MQTT_CONFIG_API_VERSION, )
     .clean_session = true,
     .keepalive = 60,
     .handlers = {

--- a/src/shared/sol-file-reader.c
+++ b/src/shared/sol-file-reader.c
@@ -40,6 +40,7 @@
 
 #include "sol-log.h"
 #include "sol-buffer.h"
+#include "sol-common-buildopts.h"
 #include "sol-util.h"
 #include "sol-file-reader.h"
 
@@ -137,8 +138,10 @@ _sol_blob_type_file_reader_close(struct sol_blob *blob)
 }
 
 static const struct sol_blob_type _SOL_BLOB_TYPE_FILE_READER = {
+#ifndef SOL_NO_API_VERSION
     .api_version = SOL_BLOB_TYPE_API_VERSION,
     .sub_api = 1,
+#endif
     .free = _sol_blob_type_file_reader_close
 };
 

--- a/src/shared/sol-modules.c
+++ b/src/shared/sol-modules.c
@@ -30,6 +30,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "sol-modules.h"
+
 #ifdef MODULES
 
 #include <dlfcn.h>
@@ -40,7 +42,6 @@
 
 #include "sol-log-internal.h"
 
-#include "sol-modules.h"
 #include "sol-util.h"
 #include "sol-vector.h"
 

--- a/src/test/test-flow-builder.c
+++ b/src/test/test-flow-builder.c
@@ -115,14 +115,14 @@ test_port_disconnect(struct sol_flow_node *node, void *data, uint16_t port, uint
 }
 
 static struct sol_flow_port_type_out test_port_out = {
-    .api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION, )
     .packet_type = NULL, /* placeholder for SOL_FLOW_PACKET_TYPE_EMTPY */
     .connect = test_port_out_connect,
     .disconnect = test_port_disconnect,
 };
 
 static struct sol_flow_port_type_in test_port_in = {
-    .api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION, )
     .packet_type = NULL, /* placeholder for SOL_FLOW_PACKET_TYPE_EMTPY */
     .connect = test_port_in_connect,
     .disconnect = test_port_disconnect,
@@ -181,7 +181,7 @@ static const struct sol_flow_node_type_description test_node_description = {
 };
 
 static const struct sol_flow_node_type test_node_type = {
-    .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_API_VERSION, )
 
     .init_type = test_node_init_type,
 
@@ -207,7 +207,7 @@ static const struct sol_flow_node_type_description test_wrong_out_node_descripti
 };
 
 static const struct sol_flow_node_type test_wrong_out_node_type = {
-    .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_API_VERSION, )
     .description = &test_wrong_out_node_description,
 };
 
@@ -223,7 +223,7 @@ static const struct sol_flow_node_type_description test_wrong_out2_node_descript
 };
 
 static const struct sol_flow_node_type test_wrong_out2_node_type = {
-    .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_API_VERSION, )
     .description = &test_wrong_out2_node_description,
 };
 
@@ -240,7 +240,7 @@ static const struct sol_flow_node_type_description test_wrong_in_node_descriptio
 };
 
 static const struct sol_flow_node_type test_wrong_in_node_type = {
-    .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_API_VERSION, )
     .description = &test_wrong_in_node_description,
 };
 
@@ -256,7 +256,7 @@ static const struct sol_flow_node_type_description test_wrong_in2_node_descripti
 };
 
 static const struct sol_flow_node_type test_wrong_in2_node_type = {
-    .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_API_VERSION, )
     .description = &test_wrong_in2_node_description,
 };
 
@@ -465,7 +465,7 @@ custom_resolve(void *data, const char *id, struct sol_flow_node_type const **typ
 }
 
 static const struct sol_flow_resolver custom_resolver = {
-    .api_version = SOL_FLOW_RESOLVER_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_RESOLVER_API_VERSION, )
     .name = "custom_resolver",
     .resolve = custom_resolve,
 };

--- a/src/test/test-flow-parser.c
+++ b/src/test/test-flow-parser.c
@@ -112,14 +112,14 @@ test_port_disconnect(struct sol_flow_node *node, void *data, uint16_t port, uint
 }
 
 static struct sol_flow_port_type_out test_port_out = {
-    .api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION, )
     .packet_type = NULL, /* placeholder for SOL_FLOW_PACKET_TYPE_EMTPY */
     .connect = test_port_out_connect,
     .disconnect = test_port_disconnect,
 };
 
 static struct sol_flow_port_type_in test_port_in = {
-    .api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION, )
     .packet_type = NULL, /* placeholder for SOL_FLOW_PACKET_TYPE_EMTPY */
     .connect = test_port_in_connect,
     .disconnect = test_port_disconnect,
@@ -182,7 +182,7 @@ static const struct sol_flow_node_type_description test_node_description = {
     },
     .options = &((const struct sol_flow_node_options_description){
             .data_size = sizeof(struct test_node_options),
-            .sub_api = 1,
+            SOL_SET_API_VERSION(.sub_api = 1, )
             .required = false,
             .members = (const struct sol_flow_node_options_member_description[]){
                 {
@@ -201,14 +201,16 @@ static const struct sol_flow_node_type_description test_node_description = {
 
 static const struct test_node_options default_opts = {
     .base = {
+#ifndef SOL_NO_API_VERSION
         .api_version = SOL_FLOW_NODE_OPTIONS_API_VERSION,
         .sub_api = 1,
+#endif
     },
     .opt = true,
 };
 
 static const struct sol_flow_node_type test_node_type = {
-    .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_API_VERSION, )
 
     .options_size = sizeof(struct test_node_options),
     .default_options = &default_opts,
@@ -236,7 +238,7 @@ static const struct sol_flow_node_type_description test_wrong_out_node_descripti
 };
 
 static const struct sol_flow_node_type test_wrong_out_node_type = {
-    .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_API_VERSION, )
     .description = &test_wrong_out_node_description,
 };
 
@@ -252,7 +254,7 @@ static const struct sol_flow_node_type_description test_wrong_out2_node_descript
 };
 
 static const struct sol_flow_node_type test_wrong_out2_node_type = {
-    .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_API_VERSION, )
     .description = &test_wrong_out2_node_description,
 };
 
@@ -269,7 +271,7 @@ static const struct sol_flow_node_type_description test_wrong_in_node_descriptio
 };
 
 static const struct sol_flow_node_type test_wrong_in_node_type = {
-    .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_API_VERSION, )
     .description = &test_wrong_in_node_description,
 };
 
@@ -285,7 +287,7 @@ static const struct sol_flow_node_type_description test_wrong_in2_node_descripti
 };
 
 static const struct sol_flow_node_type test_wrong_in2_node_type = {
-    .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_API_VERSION, )
     .description = &test_wrong_in2_node_description,
 };
 
@@ -374,7 +376,7 @@ test_resolve(void *data, const char *id,
 }
 
 static const struct sol_flow_resolver test_resolver = {
-    .api_version = SOL_FLOW_RESOLVER_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_RESOLVER_API_VERSION, )
     .name = "test_resolver",
     .resolve = test_resolve,
 };
@@ -461,7 +463,7 @@ declare_fbp_read_file(void *data, const char *name, const char **buf, size_t *si
 }
 
 struct sol_flow_parser_client declare_fbp_client = {
-    .api_version = SOL_FLOW_PARSER_CLIENT_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PARSER_CLIENT_API_VERSION, )
     .read_file = declare_fbp_read_file,
 };
 

--- a/src/test/test-flow.c
+++ b/src/test/test-flow.c
@@ -167,14 +167,14 @@ test_port_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_
 }
 
 static struct sol_flow_port_type_out test_port_out = {
-    .api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION, )
     .packet_type = NULL, /* placeholder for SOL_FLOW_PACKET_TYPE_EMTPY */
     .connect = test_port_out_connect,
     .disconnect = test_port_out_disconnect,
 };
 
 static struct sol_flow_port_type_in test_port_in = {
-    .api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION, )
     .packet_type = NULL, /* placeholder for SOL_FLOW_PACKET_TYPE_EMTPY */
     .disconnect = test_port_in_disconnect,
     .connect = test_port_in_connect,
@@ -182,7 +182,7 @@ static struct sol_flow_port_type_in test_port_in = {
 };
 
 static struct sol_flow_port_type_in test_port_match_in = {
-    .api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION, )
     .packet_type = NULL, /* placeholder for SOL_FLOW_PACKET_TYPE_EMTPY */
     .connect = test_port_in_connect,
     .disconnect = test_port_in_disconnect,
@@ -190,14 +190,14 @@ static struct sol_flow_port_type_in test_port_match_in = {
 };
 
 static struct sol_flow_port_type_out test_port_match_out = {
-    .api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION, )
     .packet_type = NULL, /* placeholder for SOL_FLOW_PACKET_TYPE_EMTPY */
     .connect = test_port_out_connect,
     .disconnect = test_port_out_disconnect,
 };
 
 static struct sol_flow_port_type_in test_port_any_in = {
-    .api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PORT_TYPE_IN_API_VERSION, )
     .packet_type = NULL, /* placeholder for SOL_FLOW_PACKET_TYPE_EMTPY */
     .connect = test_port_in_connect,
     .disconnect = test_port_in_disconnect,
@@ -205,7 +205,7 @@ static struct sol_flow_port_type_in test_port_any_in = {
 };
 
 static struct sol_flow_port_type_out test_port_any_out = {
-    .api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_PORT_TYPE_OUT_API_VERSION, )
     .packet_type = NULL, /* placeholder for SOL_FLOW_PACKET_TYPE_EMTPY */
     .connect = test_port_out_connect,
     .disconnect = test_port_out_disconnect,
@@ -251,7 +251,7 @@ test_node_get_port_out(const struct sol_flow_node_type *type, uint16_t port)
 }
 
 static const struct sol_flow_node_type test_node_type = {
-    .api_version = SOL_FLOW_NODE_TYPE_API_VERSION,
+    SOL_SET_API_VERSION(.api_version = SOL_FLOW_NODE_TYPE_API_VERSION, )
 
     /* Forces unaligned size, so the storage need to take that into account. */
     .data_size = sizeof(char),
@@ -292,7 +292,7 @@ test_flow_new_type(void)
     };
 
     static const struct sol_flow_static_spec spec = {
-        .api_version = SOL_FLOW_STATIC_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_FLOW_STATIC_API_VERSION, )
         .nodes = nodes,
         .conns = conns,
         .exported_in = exported_in,
@@ -762,7 +762,7 @@ test_other_flow_new_type(void)
     };
 
     static const struct sol_flow_static_spec spec = {
-        .api_version = SOL_FLOW_STATIC_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_FLOW_STATIC_API_VERSION, )
         .nodes = nodes,
         .conns = conns,
         .exported_in = exported_in,
@@ -1017,7 +1017,7 @@ exported_specs_must_be_ordered(void)
     };
 
     static const struct sol_flow_static_spec spec = {
-        .api_version = SOL_FLOW_STATIC_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_FLOW_STATIC_API_VERSION, )
         .nodes = nodes,
         .conns = conns,
         .exported_in = exported_in,
@@ -1392,11 +1392,15 @@ DEFINE_TEST(need_a_valid_type_to_create_packets);
 static void
 need_a_valid_type_to_create_packets(void)
 {
-    struct sol_flow_packet *packet_null, *packet_any, *packet_invalid_type;
+    struct sol_flow_packet *packet_null, *packet_any;
+
+#ifndef SOL_NO_API_VERSION
+    struct sol_flow_packet *packet_invalid_type;
 
     static const struct sol_flow_packet_type invalid_type = {
         .api_version = 0, /* Invalid API version */
     };
+#endif
 
     packet_null = sol_flow_packet_new(NULL, NULL);
     ASSERT(!packet_null);
@@ -1404,8 +1408,10 @@ need_a_valid_type_to_create_packets(void)
     packet_any = sol_flow_packet_new(SOL_FLOW_PACKET_TYPE_ANY, NULL);
     ASSERT(!packet_any);
 
+#ifndef SOL_NO_API_VERSION
     packet_invalid_type = sol_flow_packet_new(&invalid_type, NULL);
     ASSERT(!packet_invalid_type);
+#endif
 }
 
 

--- a/src/test/test-message-digest.c
+++ b/src/test/test-message-digest.c
@@ -94,7 +94,7 @@ on_timeout_do_single(void *data)
 
     for (; itr->mem != NULL; itr++) {
         struct sol_message_digest_config cfg = {
-            .api_version = SOL_MESSAGE_DIGEST_CONFIG_API_VERSION,
+            SOL_SET_API_VERSION(.api_version = SOL_MESSAGE_DIGEST_CONFIG_API_VERSION, )
             .algorithm = itr->algorithm,
             .key = itr->key,
             .on_digest_ready = on_digest_ready_simple,
@@ -213,7 +213,7 @@ on_timeout_do_chunked(void *data)
     for (; itr->mem != NULL; itr++) {
         struct chunked_ctx *ctx;
         struct sol_message_digest_config cfg = {
-            .api_version = SOL_MESSAGE_DIGEST_CONFIG_API_VERSION,
+            SOL_SET_API_VERSION(.api_version = SOL_MESSAGE_DIGEST_CONFIG_API_VERSION, )
             .algorithm = itr->algorithm,
             .key = itr->key,
             .on_digest_ready = on_digest_ready_chunked,
@@ -391,7 +391,7 @@ static bool
 on_timeout_feed_after_last(void *data)
 {
     struct sol_message_digest_config cfg = {
-        .api_version = SOL_MESSAGE_DIGEST_CONFIG_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_MESSAGE_DIGEST_CONFIG_API_VERSION, )
         .algorithm = "md5",
         .on_digest_ready = on_digest_ready_feed_after_last,
     };

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -284,18 +284,19 @@ $(sample-$(1)-out): $(SOL_LIB_OUTPUT) $(modules-out) $(sample-$(1)-srcs) $(call 
 endef
 $(foreach sample,$(samples),$(eval $(call make-sample,$(sample))))
 
-define make-test-fbp-bin
-$($(1)-out): $(SOL_LIB_OUTPUT) $($(1)-src) $(modules-out)
-	$(Q)echo "     " CC"   "$$@
-	$(Q)$(MKDIR) -p $(dir $($(1)-out))
-	$(Q)$(TARGETCC) $(SAMPLE_CFLAGS) $($(1)-src) -o $($(1)-out) $(SAMPLE_LDFLAGS)
-endef
-$(foreach test-fbp-bin,$(all-tests-fbp-bin),$(eval $(call make-test-fbp-bin,$(test-fbp-bin))))
-
 ifeq (y,$(STATIC_LIBRARY))
 use-builtin-ldflags = $(sort $(builtin-ldflags))
 use-builtin-cflags = $(sort $(builtin-cflags))
 endif
+
+define make-test-fbp-bin
+$($(1)-out): $(SOL_LIB_OUTPUT) $($(1)-src) $(modules-out)
+	$(Q)echo "     " CC"   "$$@
+	$(Q)$(MKDIR) -p $(dir $($(1)-out))
+	$(Q)$(TARGETCC) $(SAMPLE_CFLAGS) $(use-builtin-cflags) $($(1)-src) -o $($(1)-out) \
+	$(SAMPLE_LDFLAGS) $(use-builtin-ldflags)
+endef
+$(foreach test-fbp-bin,$(all-tests-fbp-bin),$(eval $(call make-test-fbp-bin,$(test-fbp-bin))))
 
 define make-test
 $(test-$(1)-out): $(SOL_LIB_OUTPUT) $(test-$(1)-srcs) $(call find-deps,$(1))


### PR DESCRIPTION
This drastically reduces the size of the binary in some cases where api_version
was heavily used, such as flows with several node types.