### PR TITLE
sol-oic-gen: add SCAN port on clients

### DIFF
--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -1445,7 +1445,8 @@ if __name__ == '__main__':
             else:
                 raise e
         except Exception as e:
-            print('Ignoring due to exception in generator. Traceback follows:')
+            print('Ignoring %s due to exception in generator. '
+                  'Traceback follows:' % path, file=sys.stderr)
             traceback.print_exc(e, file=sys.stderr)
             continue
 

--- a/src/samples/flow/oic/light-client-scan.fbp
+++ b/src/samples/flow/oic/light-client-scan.fbp
@@ -1,0 +1,46 @@
+#!/usr/bin/env sol-fbp-runner
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This will timely (every 3 seconds) trigger scan for OIC lights. This node type
+# is resolved using the light-client.json, please adjust to your network
+# configuration:
+#
+#    $ export SOL_FLOW_MODULE_RESOLVER_CONFFILE=light-client-mynet.json
+#    $ ./light-client-scan.fbp
+#
+# or save it as sol-flow.json
+
+timer(timer:interval=3000)
+light(Light)
+
+timer OUT -> IN Scanning(console)
+timer OUT -> SCAN light
+light DEVICE_ID -> IN DeviceFound(console)

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -395,8 +395,10 @@ $(eval $(call install-resource,$(GDB_AUTOLOAD_PY),$(GDB_AUTOLOAD_PY_DEST)))
 
 $(FLOW_OIC_GEN): $(FLOW_OIC_GEN_SCRIPT)
 	$(Q)echo "     "GEN"   "$(@)
-	$(Q)$(PYTHON) $(FLOW_OIC_GEN_SCRIPT) --schema-dir=$(FLOW_OIC_SPEC_DIR) --node-type-json=$(dir $(@))oic.json \
-		--node-type-impl=$(dir $(@))oic.c --node-type-gen-c=oic-gen.c --node-type-gen-h=sol-flow/oic.h &>/dev/null
+	$(Q)$(PYTHON) $(FLOW_OIC_GEN_SCRIPT) --schema-dir=$(FLOW_OIC_SPEC_DIR) \
+		--node-type-json=$(dir $(@))oic.json \
+		--node-type-impl=$(dir $(@))oic.c --node-type-gen-c=oic-gen.c \
+		--node-type-gen-h=sol-flow/oic.h >/dev/null
 
 $(KCONFIG_AUTOHEADER): $(DEPENDENCY_CACHE) $(KCONFIG_CONFIG) $(obj)/conf
 	$(Q)mkdir -p $(KCONFIG_INCLUDE)config $(KCONFIG_INCLUDE)generated


### PR DESCRIPTION
With that it's possible to request a scan for all servers
that matches the same interface of clients.

IDs will be dispatched on DEVICE_ID port, so later
they can be used to select the device which the client
will talk.

Ideally a human-friendly name should be sent on packet
as well, not only the ID string, but I didn't found
anything like that in our implementation so far.

sol_oic_client_get_server_info return some information,
but only stuff related to a model, so users wouldn't
be able to use it to differentiate devices.

Maybe manufacturer_name + model_number could be used.

TODO: ID must be converted back from binary to
hex ascii.

@otaviobp please take a look on this. I'm pushing
it this way because I'm not sure I'll be able
to work more on that today.

It requires the conversion, and accepting IDs
by port instead of only option to conclude this
task.