### PR TITLE
Improve warning about node not found in module

### DIFF
--- a/src/lib/common/include/sol-log.h
+++ b/src/lib/common/include/sol-log.h
@@ -90,6 +90,22 @@ extern "C" {
         }                                       \
     } while (0)
 
+#define SOL_NULL_CHECK_MSG(ptr, ret, fmt, ...) \
+    do { \
+        if (log_unlikely(!(ptr))) { \
+            SOL_WRN(fmt, ## __VA_ARGS__); \
+            return ret; \
+        } \
+    } while (0)
+
+#define SOL_NULL_CHECK_MSG_GOTO(ptr, label, fmt, ...) \
+    do { \
+        if (log_unlikely(!(ptr))) { \
+            SOL_WRN(fmt, ## __VA_ARGS__); \
+            goto label; \
+        } \
+    } while (0)
+
 #define _SOL_INT_CHECK_FMT(var, exp)                                     \
     __builtin_choose_expr(                                             \
     __builtin_types_compatible_p(typeof(var), int),                \

--- a/src/lib/common/sol-pin-mux.c
+++ b/src/lib/common/sol-pin-mux.c
@@ -80,10 +80,8 @@ _load_mux(const char *name)
     }
 
     p_sym = dlsym(handle, "SOL_PIN_MUX");
-    if (!p_sym) {
-        SOL_WRN("Could not find symbol SOL_PIN_MUX in module '%s': %s", path, dlerror());
-        goto error;
-    }
+    SOL_NULL_CHECK_MSG_GOTO(p_sym, error,
+        "Could not find symbol SOL_PIN_MUX in module '%s': %s", path, dlerror());
 
     if (p_sym->api_version != SOL_PIN_MUX_API_VERSION) {
         SOL_WRN("Mux '%s' has incorrect api_version: %lu expected %lu", path, p_sym->api_version,

--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -942,10 +942,7 @@ sol_flow_builder_get_node_type(struct sol_flow_builder *builder)
     spec->dispose = dispose_builder_type;
 
     builder->node_type = sol_flow_static_new_type(spec);
-    if (!builder->node_type) {
-        SOL_WRN("Failed to create new type");
-        goto error;
-    }
+    SOL_NULL_CHECK_MSG_GOTO(builder->node_type, error, "Failed to create new type");
 
     builder->node_type->options_size = builder->type_data->options_size;
     builder->node_type->default_options = builder->type_data->default_opts_buf.data;

--- a/src/lib/flow/sol-flow-packet.c
+++ b/src/lib/flow/sol-flow-packet.c
@@ -138,10 +138,7 @@ sol_flow_packet_new(const struct sol_flow_packet_type *type, const void *value)
         return NULL;
     }
 
-    if (unlikely(!type)) {
-        SOL_WRN("Couldn't create packet with NULL type");
-        return NULL;
-    }
+    SOL_NULL_CHECK_MSG(type, NULL, "Couldn't create packet with NULL type");
 
     if (unlikely(type->api_version != SOL_FLOW_PACKET_TYPE_API_VERSION)) {
         SOL_WRN("Couldn't create packet with type '%s' that has unsupported version '%u', expected version is '%u'",

--- a/src/lib/flow/sol-flow-parser-dynamic.c
+++ b/src/lib/flow/sol-flow-parser-dynamic.c
@@ -43,11 +43,9 @@ check_metatype(const char *path, const char *symbol_name, void *symbol)
     p_metatype = symbol;
     metatype = *p_metatype;
 
-    if (!metatype) {
-        SOL_WRN("Symbol '%s' in module '%s' is points to NULL instead of a valid metatype",
-            symbol_name, path);
-        return false;
-    }
+    SOL_NULL_CHECK_MSG(metatype, false,
+        "Symbol '%s' in module '%s' is points to NULL instead of a valid metatype",
+        symbol_name, path);
 
     if (metatype->api_version != SOL_FLOW_METATYPE_API_VERSION) {
         SOL_WRN("Module '%s' has incorrect api_version: %u expected %u",

--- a/src/lib/flow/sol-flow-resolver-conffile.c
+++ b/src/lib/flow/sol-flow-resolver-conffile.c
@@ -199,7 +199,7 @@ _resolver_conffile_get_module(const char *type)
 
     entry->handle = dlopen(path, RTLD_LAZY | RTLD_LOCAL | RTLD_NODELETE);
     if (!entry->handle) {
-        SOL_WRN("could not load module '%s': %s", path, dlerror());
+        SOL_WRN("Could not load module '%s':\n    %s", name, dlerror());
         goto error;
     }
     entry->foreach = dlsym(entry->handle, "sol_flow_foreach_module_node_type");

--- a/src/lib/flow/sol-flow-resolver-conffile.c
+++ b/src/lib/flow/sol-flow-resolver-conffile.c
@@ -170,7 +170,7 @@ _resolver_conffile_get_module(const char *type)
     /* the hash entry keys are the type part only */
     entry = find_entry_by_name(&resolver_conffile_dlopens, name);
     if (entry) {
-        SOL_DBG("module named '%s' previoulsy loaded", name);
+        SOL_DBG("module named '%s' previously loaded", name);
         free(name);
         goto found;
     }

--- a/src/lib/flow/sol-flow-resolver-conffile.c
+++ b/src/lib/flow/sol-flow-resolver-conffile.c
@@ -214,7 +214,7 @@ _resolver_conffile_get_module(const char *type)
 
 found:
     ret = resolve_module_type_by_component(type, entry->foreach);
-    SOL_NULL_CHECK_GOTO(ret, error);
+    SOL_NULL_CHECK_MSG_GOTO(ret, error, "Type='%s' not found.", type);
     return ret;
 
 entry_error:

--- a/src/lib/flow/sol-flow-resolver-conffile.c
+++ b/src/lib/flow/sol-flow-resolver-conffile.c
@@ -198,20 +198,16 @@ _resolver_conffile_get_module(const char *type)
     }
 
     entry->handle = dlopen(path, RTLD_LAZY | RTLD_LOCAL | RTLD_NODELETE);
-    if (!entry->handle) {
-        SOL_WRN("Could not load module '%s':\n    %s", name, dlerror());
-        goto error;
-    }
+    SOL_NULL_CHECK_MSG_GOTO(entry->handle, error,
+        "Could not load module '%s':\n    %s", name, dlerror());
+
     entry->foreach = dlsym(entry->handle, "sol_flow_foreach_module_node_type");
-    if (!entry->foreach) {
-        SOL_WRN("could not find symbol "
-            "sol_flow_foreach_module_node_type() "
-            "in module '%s': %s", path, dlerror());
-        goto error;
-    }
+
+    SOL_NULL_CHECK_MSG_GOTO(entry->foreach, error,
+        "Could not find symbol sol_flow_foreach_module_node_type() in module '%s': %s",
+        path, dlerror());
 
     SOL_DBG("module named '%s' loaded from '%s'", entry->name, path);
-
 found:
     ret = resolve_module_type_by_component(type, entry->foreach);
     SOL_NULL_CHECK_MSG_GOTO(ret, error, "Type='%s' not found.", type);

--- a/src/modules/flow-metatype/js/js.c
+++ b/src/modules/flow-metatype/js/js.c
@@ -129,10 +129,7 @@ get_in_port_name(const struct sol_flow_node *node, uint16_t port)
     const struct flow_js_port_in *p;
 
     p = sol_vector_get(&type->ports_in, port);
-    if (!p) {
-        SOL_WRN("Couldn't get input port %d name.", port);
-        return "";
-    }
+    SOL_NULL_CHECK_MSG(p, "", "Couldn't get input port %d name.", port);
 
     return p->name;
 }
@@ -144,10 +141,7 @@ get_out_port_name(const struct sol_flow_node *node, uint16_t port)
     const struct flow_js_port_out *p;
 
     p = sol_vector_get(&type->ports_out, port);
-    if (!p) {
-        SOL_WRN("Couldn't get output port %d name.", port);
-        return "";
-    }
+    SOL_NULL_CHECK_MSG(p, "", "Couldn't get output port %d name.", port);
 
     return p->name;
 }

--- a/src/modules/flow/accelerometer/adxl45.c
+++ b/src/modules/flow/accelerometer/adxl45.c
@@ -449,10 +449,7 @@ accelerometer_adxl345_open(struct sol_flow_node *node,
     SOL_NULL_CHECK(options, -EINVAL);
 
     mdata->i2c = sol_i2c_open(opts->i2c_bus, I2C_SPEED);
-    if (!mdata->i2c) {
-        SOL_WRN("Failed to open i2c bus");
-        return -EIO;
-    }
+    SOL_NULL_CHECK_MSG(mdata->i2c, -EIO, "Failed to open i2c bus");
 
     mdata->node = node;
     accel_init(mdata);

--- a/src/modules/flow/accelerometer/lsm303.c
+++ b/src/modules/flow/accelerometer/lsm303.c
@@ -183,10 +183,7 @@ accelerometer_lsm303_open(struct sol_flow_node *node, void *data, const struct s
     opts = (const struct sol_flow_node_type_accelerometer_lsm303_options *)options;
 
     mdata->i2c = sol_i2c_open(opts->i2c_bus, SOL_I2C_SPEED_10KBIT);
-    if (!mdata->i2c) {
-        SOL_WRN("Failed to open i2c bus");
-        return -EINVAL;
-    }
+    SOL_NULL_CHECK_MSG(mdata->i2c, -EINVAL, "Failed to open i2c bus");
 
     mdata->node = node;
     mdata->scale = opts->scale;

--- a/src/modules/flow/aio/aio.c
+++ b/src/modules/flow/aio/aio.c
@@ -142,11 +142,8 @@ aio_reader_open(struct sol_flow_node *node, void *data, const struct sol_flow_no
         mdata->aio = sol_aio_open_by_label(opts->pin, opts->mask);
     }
 
-    if (!mdata->aio) {
-        SOL_WRN("aio (%s): Couldn't be open. Maybe you used an invalid 'pin'=%s?",
-            opts->pin, opts->pin);
-        return -EINVAL;
-    }
+    SOL_NULL_CHECK_MSG(mdata->aio, -EINVAL,
+        "aio (%s): Couldn't be open. Maybe you used an invalid 'pin'=%s?", opts->pin, opts->pin);
 
     mdata->pin = opts->pin ? strdup(opts->pin) : NULL;
     mdata->mask = (0x01 << opts->mask) - 1;

--- a/src/modules/flow/am2315/am2315.c
+++ b/src/modules/flow/am2315/am2315.c
@@ -102,10 +102,7 @@ am2315_open(uint8_t bus, uint8_t slave)
     }
 
     i2c = sol_i2c_open(bus, SOL_I2C_SPEED_10KBIT);
-    if (!i2c) {
-        SOL_WRN("Failed to open i2c bus");
-        return NULL;
-    }
+    SOL_NULL_CHECK_MSG(i2c, NULL, "Failed to open i2c bus");
 
     device = calloc(1, sizeof(struct am2315));
     if (!device)
@@ -253,7 +250,6 @@ _read_data(void *data)
 
     if (!sol_i2c_set_slave_address(device->i2c, device->slave)) {
         SOL_WRN("Failed to set slave at address 0x%02x", device->slave);
-        device->success = false;
         goto error;
     }
 
@@ -262,15 +258,12 @@ _read_data(void *data)
      * hi/lo, 7th and 8th are CRC code to validade data. */
     device->i2c_pending = sol_i2c_read(device->i2c, device->buffer,
         sizeof(device->buffer), read_data_cb, device);
-    if (!device->i2c_pending) {
-        SOL_WRN("Could not read sensor data");
-        device->success = false;
-        goto error;
-    }
+    SOL_NULL_CHECK_MSG_GOTO(device->i2c_pending, error, "Could not read sensor data");
 
     return false;
 
 error:
+    device->success = false;
     _send_readings(device);
 
     return false;

--- a/src/modules/flow/converter/converter.c
+++ b/src/modules/flow/converter/converter.c
@@ -947,15 +947,8 @@ boolean_to_string_open(struct sol_flow_node *node, void *data, const struct sol_
 
     opts = (const struct sol_flow_node_type_converter_boolean_to_string_options *)options;
 
-    if (!opts->false_value) {
-        SOL_WRN("A valid string is required as 'false_value'");
-        return -EINVAL;
-    }
-
-    if (!opts->true_value) {
-        SOL_WRN("A valid string is required as 'true_value'");
-        return -EINVAL;
-    }
+    SOL_NULL_CHECK_MSG(opts->false_value, -EINVAL, "A valid string is required as 'false_value'");
+    SOL_NULL_CHECK_MSG(opts->true_value, -EINVAL, "A valid string is required as 'true_value'");
 
     mdata->false_value = strdup(opts->false_value);
     SOL_NULL_CHECK(mdata->false_value, -ENOMEM);
@@ -1062,8 +1055,7 @@ empty_to_string_open(struct sol_flow_node *node, void *data, const struct sol_fl
         options;
 
     mdata->string = strdup(opts->output_value);
-    if (!mdata->string)
-        return -ENOMEM;
+    SOL_NULL_CHECK(mdata->string, -ENOMEM);
 
     return 0;
 }
@@ -2150,8 +2142,7 @@ string_to_timestamp_convert(struct sol_flow_node *node, void *data, uint16_t por
     SOL_INT_CHECK(r, < 0, r);
 
     timestamp_str = strptime(in_value, mdata->string, &time_tm);
-    if (!timestamp_str)
-        goto timestamp_error;
+    SOL_NULL_CHECK_GOTO(timestamp_str, timestamp_error);
 
     out_value.tv_sec = mktime(&time_tm);
     if (out_value.tv_sec < 0)

--- a/src/modules/flow/grove/grove.c
+++ b/src/modules/flow/grove/grove.c
@@ -1090,10 +1090,7 @@ static int
 lcd_open(struct lcd_data *mdata, uint8_t bus)
 {
     mdata->i2c = sol_i2c_open(bus, SOL_I2C_SPEED_10KBIT);
-    if (!mdata->i2c) {
-        SOL_WRN("Failed to open i2c bus %d", bus);
-        return -EIO;
-    }
+    SOL_NULL_CHECK_MSG(mdata->i2c, -EIO, "Failed to open i2c bus %d", bus);
 
     sol_vector_init(&mdata->cmd_queue, sizeof(struct command));
 

--- a/src/modules/flow/gyroscope/gyroscope.c
+++ b/src/modules/flow/gyroscope/gyroscope.c
@@ -463,10 +463,7 @@ gyroscope_l3g4200d_open(struct sol_flow_node *node,
     SOL_NULL_CHECK(options, -EINVAL);
 
     mdata->i2c = sol_i2c_open(opts->i2c_bus, I2C_SPEED);
-    if (!mdata->i2c) {
-        SOL_WRN("Failed to open i2c bus");
-        return -EIO;
-    }
+    SOL_NULL_CHECK_MSG(mdata->i2c, -EIO, "Failed to open i2c bus");
 
     mdata->use_rad = opts->output_radians;
     mdata->init_sampling_cnt = 3;

--- a/src/modules/flow/location/location.c
+++ b/src/modules/flow/location/location.c
@@ -148,10 +148,7 @@ query_addr(struct freegeoip_data *mdata, const char *addr)
     connection = sol_http_client_request(SOL_HTTP_METHOD_GET, json_endpoint,
         NULL, freegeoip_query_finished, mdata);
 
-    if (!connection) {
-        SOL_WRN("Could not create HTTP request");
-        return -ENOTCONN;
-    }
+    SOL_NULL_CHECK_MSG(connection, -ENOTCONN, "Could not create HTTP request");
 
     r = sol_ptr_vector_append(&mdata->pending_conns, connection);
     if (r < 0) {
@@ -213,8 +210,7 @@ freegeoip_open(struct sol_flow_node *node, void *data, const struct sol_flow_nod
 
     mdata->node = node;
     mdata->endpoint = strdup(opts->endpoint);
-    if (!mdata->endpoint)
-        return -ENOMEM;
+    SOL_NULL_CHECK(mdata->endpoint, -ENOMEM);
 
     sol_ptr_vector_init(&mdata->pending_conns);
 

--- a/src/modules/flow/magnetometer/lsm303.c
+++ b/src/modules/flow/magnetometer/lsm303.c
@@ -191,10 +191,7 @@ magnetometer_lsm303_open(struct sol_flow_node *node, void *data, const struct so
     opts = (const struct sol_flow_node_type_magnetometer_lsm303_options *)options;
 
     mdata->i2c = sol_i2c_open(opts->i2c_bus, SOL_I2C_SPEED_10KBIT);
-    if (!mdata->i2c) {
-        SOL_WRN("Failed to open i2c bus");
-        return -EINVAL;
-    }
+    SOL_NULL_CHECK_MSG(mdata->i2c, -EINVAL, "Failed to open i2c bus");
 
     mdata->slave = opts->i2c_slave;
     mdata->scale = opts->scale;

--- a/src/modules/flow/platform/platform.c
+++ b/src/modules/flow/platform/platform.c
@@ -162,11 +162,7 @@ platform_service_open(struct sol_flow_node *node, void *data, const struct sol_f
     struct platform_service_data *mdata = data;
     const struct sol_flow_node_type_platform_service_options *opts;
 
-    if (!options) {
-        SOL_WRN("Platform Service Node: Options not found.");
-        return -1;
-    }
-
+    SOL_NULL_CHECK_MSG(options, -1, "Platform Service Node: Options not found.");
     opts = (const struct sol_flow_node_type_platform_service_options *)options;
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_PLATFORM_SERVICE_OPTIONS_API_VERSION, -EINVAL);

--- a/src/modules/flow/pwm/pwm.c
+++ b/src/modules/flow/pwm/pwm.c
@@ -137,10 +137,7 @@ pwm_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_opti
         mdata->pwm = sol_pwm_open_by_label(opts->pin, &pwm_config);
     }
 
-    if (!mdata->pwm) {
-        SOL_WRN("Could not open pwm (%s)", opts->pin);
-        return -ENXIO;
-    }
+    SOL_NULL_CHECK_MSG(mdata->pwm, -ENXIO, "Could not open pwm (%s)", opts->pin);
 
     return 0;
 }

--- a/src/modules/flow/string/string-ascii.c
+++ b/src/modules/flow/string/string-ascii.c
@@ -100,8 +100,7 @@ get_string_by_port(const struct sol_flow_packet *packet,
     free(string[port]);
 
     string[port] = strdup(in_value);
-    if (!string[port])
-        return -ENOMEM;
+    SOL_NULL_CHECK(string[port], -ENOMEM);
 
     return 0;
 }
@@ -122,10 +121,7 @@ string_concatenate_open(struct sol_flow_node *node,
 
     if (opts->separator) {
         mdata->separator = strdup(opts->separator);
-        if (!mdata->separator) {
-            SOL_WRN("Failed to duplicate separator string");
-            return -ENOMEM;
-        }
+        SOL_NULL_CHECK_MSG(mdata->separator, -ENOMEM, "Failed to duplicate separator string");
     }
 
     return 0;
@@ -319,8 +315,7 @@ string_slice_input(struct sol_flow_node *node,
 
     free(mdata->str);
     mdata->str = strdup(in_value);
-    if (!mdata->str)
-        return -ENOMEM;
+    SOL_NULL_CHECK(mdata->str, -ENOMEM);
 
     return slice_do(mdata);
 }
@@ -909,14 +904,10 @@ string_starts_with_open(struct sol_flow_node *node,
     r = prefix_suffix_open(mdata, opts->start, opts->end);
     SOL_INT_CHECK(r, < 0, r);
 
-    if (!opts->prefix) {
-        SOL_WRN("Option 'prefix' must not be NULL");
-        return -EINVAL;
-    }
+    SOL_NULL_CHECK_MSG(opts->prefix, -EINVAL, "Option 'prefix' must not be NULL");
 
     mdata->sub_str = strdup(opts->prefix);
-    if (!mdata->sub_str)
-        return -ENOMEM;
+    SOL_NULL_CHECK(mdata->sub_str, -ENOMEM);
 
     return 0;
 }
@@ -939,14 +930,10 @@ string_ends_with_open(struct sol_flow_node *node,
     r = prefix_suffix_open(mdata, opts->start, opts->end);
     SOL_INT_CHECK(r, < 0, r);
 
-    if (!opts->suffix) {
-        SOL_WRN("Option 'suffix' must not be NULL");
-        return -EINVAL;
-    }
+    SOL_NULL_CHECK_MSG(opts->suffix, -EINVAL, "Option 'suffix' must not be NULL");
 
     mdata->sub_str = strdup(opts->suffix);
-    if (!mdata->sub_str)
-        return -ENOMEM;
+    SOL_NULL_CHECK(mdata->sub_str, -ENOMEM);
 
     return 0;
 }
@@ -967,8 +954,7 @@ prefix_suffix_match_do(struct string_prefix_suffix_data *mdata,
 
     free(mdata->in_str);
     mdata->in_str = strdup(new_in_str);
-    if (!mdata->in_str)
-        return -ENOMEM;
+    SOL_NULL_CHECK(mdata->in_str, -ENOMEM);
     in_str_len = strlen(mdata->in_str);
 
 starts_with:
@@ -1030,11 +1016,9 @@ set_prefix_suffix_sub_str(struct sol_flow_node *node,
 
     free(mdata->sub_str);
     mdata->sub_str = strdup(sub_str);
-    if (!mdata->sub_str)
-        return -ENOMEM;
+    SOL_NULL_CHECK(mdata->sub_str, -ENOMEM);
 
-    if (!mdata->in_str)
-        return 0;
+    SOL_NULL_CHECK(mdata->in_str, 0);
 
     return prefix_suffix_match_do(mdata, NULL, true);
 }

--- a/src/modules/flow/string/string-icu.c
+++ b/src/modules/flow/string/string-icu.c
@@ -60,8 +60,7 @@ icu_str_from_utf8(const char *utf_str,
         return -EINVAL;
 
     *ret_icu_str = calloc(icu_sz + 1, sizeof(UChar));
-    if (!*ret_icu_str)
-        return -ENOMEM;
+    SOL_NULL_CHECK(*ret_icu_str, -ENOMEM);
 
     *ret_icu_err = U_ZERO_ERROR;
     u_strFromUTF8(*ret_icu_str, icu_sz + 1, NULL, utf_str, -1,
@@ -94,8 +93,7 @@ utf8_from_icu_str_slice(const UChar *icu_str,
         return -EINVAL;
 
     *ret_utf_str = calloc(utf_sz + 1, sizeof(char));
-    if (!*ret_utf_str)
-        return -ENOMEM;
+    SOL_NULL_CHECK(*ret_utf_str, -ENOMEM);
 
     *ret_icu_err = U_ZERO_ERROR;
     u_strToUTF8(*ret_utf_str, utf_sz + 1, NULL, icu_str, icu_str_sz,
@@ -1164,10 +1162,7 @@ string_starts_with_open(struct sol_flow_node *node,
     r = prefix_suffix_open(mdata, opts->start, opts->end);
     SOL_INT_CHECK(r, < 0, r);
 
-    if (!opts->prefix) {
-        SOL_WRN("Option 'prefix' must not be NULL");
-        return -EINVAL;
-    }
+    SOL_NULL_CHECK_MSG(opts->prefix, -EINVAL, "Option 'prefix' must not be NULL");
 
     r = icu_str_from_utf8(opts->prefix, &mdata->sub_str, &err);
     SOL_INT_CHECK(r, < 0, r);
@@ -1196,10 +1191,7 @@ string_ends_with_open(struct sol_flow_node *node,
     r = prefix_suffix_open(mdata, opts->start, opts->end);
     SOL_INT_CHECK(r, < 0, r);
 
-    if (!opts->suffix) {
-        SOL_WRN("Option 'suffix' must not be NULL");
-        return -EINVAL;
-    }
+    SOL_NULL_CHECK_MSG(opts->suffix, -EINVAL, "Option 'suffix' must not be NULL");
 
     r = icu_str_from_utf8(opts->suffix, &mdata->sub_str, &err);
     SOL_INT_CHECK(r, < 0, r);

--- a/src/modules/flow/string/string-regexp.c
+++ b/src/modules/flow/string/string-regexp.c
@@ -559,11 +559,8 @@ string_regexp_replace_open(struct sol_flow_node *node,
     }
     mdata->regexp = strdup(opts->regexp);
 
-    if (!opts->to) {
-        SOL_WRN("A non-null substitution regular expression string"
-            " must be provided");
-        return -EINVAL;
-    }
+    SOL_NULL_CHECK_MSG(opts->to, -EINVAL, "A non-null substitution regular expression string"
+        " must be provided");
     mdata->to_regexp = strdup(opts->to);
 
     return 0;

--- a/src/modules/linux-micro/hostname/hostname.c
+++ b/src/modules/linux-micro/hostname/hostname.c
@@ -51,10 +51,7 @@ hostname_start(const struct sol_platform_linux_micro_module *mod, const char *se
     int err = 0;
 
     reader = sol_file_reader_open("/etc/hostname");
-    if (!reader) {
-        SOL_WRN("could not read /etc/hostname");
-        return -errno;
-    }
+    SOL_NULL_CHECK_MSG(reader, -errno, "could not read /etc/hostname");
 
     str = sol_file_reader_get_all(reader);
     s = p = str.data;

--- a/src/modules/pin-mux/intel-common/intel-common.c
+++ b/src/modules/pin-mux/intel-common/intel-common.c
@@ -96,10 +96,7 @@ _set_gpio(int pin, enum sol_gpio_direction dir, int drive, bool val)
     const char *drive_str;
 
     gpio = _get_gpio(pin, dir, val);
-    if (!gpio) {
-        SOL_WRN("Wasn't possible to open gpio=%d", pin);
-        return -EINVAL;
-    }
+    SOL_NULL_CHECK_MSG(gpio, -EINVAL, "Wasn't possible to open gpio=%d", pin);
 
     sol_gpio_write(gpio, val);
 


### PR DESCRIPTION
Also, add a macro to make it easier to have a custom wrn msg on null checks, when apply this macro as many places I could.

Motivation was that we were slowing removing many 'SOL_NULL_CHECKS' just in order to improve our logging messages,