### PR TITLE
Fix bugs in JSON nodes and add new nodes to create JSON using JSON path - v2

### DIFF
--- a/src/modules/flow/json/json.c
+++ b/src/modules/flow/json/json.c
@@ -1008,11 +1008,46 @@ json_serialize(struct sol_buffer *buffer, struct json_element *element)
     return -EINVAL;
 }
 
+static struct json_key_element *
+json_object_get_child_element(struct json_element *element, const char *key)
+{
+    uint16_t i;
+    struct json_key_element *key_element;
+
+    SOL_VECTOR_FOREACH_IDX(&element->children, key_element, i)
+        if (streq(key, key_element->key))
+            return key_element;
+
+    return NULL;
+}
+
+static int
+json_object_add_new_element(struct json_element *base_element, const char *key, struct json_element *new_element)
+{
+    struct json_key_element *new;
+
+    new = json_object_get_child_element(base_element, key);
+    if (!new) {
+        new = sol_vector_append(&base_element->children);
+        SOL_NULL_CHECK(new, -errno);
+        new->key = strdup(key);
+        SOL_NULL_CHECK_GOTO(new->key, str_error);
+    } else
+        json_element_clear(&new->element);
+    new->element = *new_element;
+
+    return 0;
+
+str_error:
+    sol_vector_del(&base_element->children, base_element->children.len - 1);
+    return -ENOMEM;
+}
+
 static int
 json_object_in_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
 {
-    struct json_key_element *new;
     struct json_element *mdata = data;
+    struct json_element new_element;
     const char *key;
     uint16_t len;
     struct sol_flow_packet **packets;
@@ -1025,20 +1060,16 @@ json_object_in_process(struct sol_flow_node *node, void *data, uint16_t port, ui
     r = sol_flow_packet_get_string(packets[0], &key);
     SOL_INT_CHECK(r, < 0, r);
 
-    new = sol_vector_append(&mdata->children);
-    SOL_NULL_CHECK(new, -errno);
+    r = json_node_fill_element(packets[1], port, &new_element);
+    SOL_INT_CHECK(r, < 0, r);
 
-    r = json_node_fill_element(packets[1], port, &new->element);
+    r = json_object_add_new_element(mdata, key, &new_element);
     SOL_INT_CHECK_GOTO(r, < 0, error);
 
-    new->key = strdup(key);
-    SOL_NULL_CHECK_GOTO(new->key, str_error);
     return 0;
 
-str_error:
-    r = -ENOMEM;
 error:
-    sol_vector_del(&mdata->children, mdata->children.len - 1);
+    json_element_clear(&new_element);
     return r;
 }
 

--- a/src/modules/flow/json/json.c
+++ b/src/modules/flow/json/json.c
@@ -997,7 +997,7 @@ json_serialize(struct sol_buffer *buffer, struct json_element *element)
     case JSON_TYPE_FLOAT:
         return sol_json_serialize_double(buffer, element->float_value);
     case JSON_TYPE_BOOLEAN:
-        return sol_json_serialize_int32(buffer, element->bool_value);
+        return sol_json_serialize_boolean(buffer, element->bool_value);
     case JSON_TYPE_STRING:
         return sol_json_serialize_string(buffer, element->str);
     case JSON_TYPE_ARRAY_BLOB:

--- a/src/modules/flow/json/json.c
+++ b/src/modules/flow/json/json.c
@@ -405,6 +405,22 @@ json_path_is_array_key(struct sol_str_slice slice)
     for (end_reason = SOL_JSON_LOOP_REASON_OK; \
         json_path_get_next_slice(&scanner, &key_slice, &end_reason);)
 
+static int32_t
+json_array_get_key_index(struct sol_str_slice key)
+{
+    long int index_val;
+    char *endptr;
+
+    errno = 0;
+    //TODO: use safe strtol from sol-util when available
+    index_val = strtol(key.data + 1, &endptr, 10);
+    if (endptr != key.data + key.len - 1 ||
+        index_val < 0 || errno > 0 || index_val > INT32_MAX)
+        return errno > 0 ? -errno : -EINVAL;
+
+    return index_val;
+}
+
 static int
 json_object_path_process(struct sol_flow_node *node, struct sol_json_node_data *mdata)
 {
@@ -415,8 +431,7 @@ json_object_path_process(struct sol_flow_node *node, struct sol_json_node_data *
     struct sol_json_scanner json_scanner;
     struct json_path_scanner path_scanner;
     enum sol_json_loop_reason array_reason, reason;
-    char *endptr;
-    long int index_val;
+    int32_t index_val;
     bool found;
     int r;
 
@@ -451,11 +466,8 @@ json_object_path_process(struct sol_flow_node *node, struct sol_json_node_data *
             if (!json_path_is_array_key(key_slice))
                 goto error;
 
-            errno = 0;
-            index_val = strtol(key_slice.data + 1, &endptr, 10);
-            if (endptr != key_slice.data + key_slice.len - 1 ||
-                index_val < 0 || errno > 0)
-                goto error;
+            index_val = json_array_get_key_index(key_slice);
+            SOL_INT_CHECK_GOTO(index_val, < 0, error);
 
             if (!json_array_get_at_index(&json_scanner, &value, index_val,
                 &array_reason))
@@ -472,7 +484,6 @@ json_object_path_process(struct sol_flow_node *node, struct sol_json_node_data *
 
     //If path is root
     if (json_scanner.current == mdata->json_element->mem) {
-        //TODO: use send_token_packet
         type = sol_json_mem_get_type(json_scanner.current);
         if (type == SOL_JSON_TYPE_OBJECT_START)
             return sol_flow_send_json_object_packet(node,
@@ -490,8 +501,6 @@ error:
     return sol_flow_send_error_packet(node, EINVAL,
         "JSON element doesn't contain path %s", mdata->key);
 }
-
-#undef JSON_PATH_FOREACH
 
 static int
 json_node_get_key_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
@@ -740,7 +749,8 @@ json_array_get_all_elements_process(struct sol_flow_node *node, void *data, uint
 }
 
 enum json_element_type {
-    JSON_TYPE_INT = 0,
+    JSON_TYPE_UNKNOWN = 0,
+    JSON_TYPE_INT,
     JSON_TYPE_STRING,
     JSON_TYPE_BOOLEAN,
     JSON_TYPE_FLOAT,
@@ -749,11 +759,6 @@ enum json_element_type {
     JSON_TYPE_ARRAY_BLOB,
     JSON_TYPE_OBJECT_BLOB,
     JSON_TYPE_NULL,
-};
-
-struct json_node_create_type {
-    struct sol_flow_node_type base;
-    int (*send_json_packet) (struct sol_flow_node *src, uint16_t src_port, const struct sol_blob *value);
 };
 
 struct json_element {
@@ -771,6 +776,12 @@ struct json_element {
 struct json_key_element {
     char *key;
     struct json_element element;
+};
+
+struct json_node_create_type {
+    struct sol_flow_node_type base;
+    int (*send_json_packet) (struct sol_flow_node *src, uint16_t src_port, const struct sol_blob *value);
+    int (*add_new_element) (struct sol_flow_node *node, struct json_element *base_element, const char *key, struct json_element *new_element);
 };
 
 static void
@@ -805,13 +816,25 @@ json_element_clear(struct json_element *element)
     }
 }
 
+static void
+init_json_array_element(struct json_element *element)
+{
+    element->type = JSON_TYPE_ARRAY;
+    sol_vector_init(&element->children, sizeof(struct json_element));
+
+}
+
+static void
+init_json_object_element(struct json_element *element)
+{
+    element->type = JSON_TYPE_OBJECT;
+    sol_vector_init(&element->children, sizeof(struct json_key_element));
+}
+
 static int
 json_array_create_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
 {
-    struct json_element *mdata = data;
-
-    mdata->type = JSON_TYPE_ARRAY;
-    sol_vector_init(&mdata->children, sizeof(struct json_element));
+    init_json_array_element(data);
 
     return 0;
 }
@@ -819,10 +842,7 @@ json_array_create_open(struct sol_flow_node *node, void *data, const struct sol_
 static int
 json_object_create_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
 {
-    struct json_element *mdata = data;
-
-    mdata->type = JSON_TYPE_OBJECT;
-    sol_vector_init(&mdata->children, sizeof(struct json_key_element));
+    init_json_object_element(data);
 
     return 0;
 }
@@ -990,6 +1010,7 @@ json_serialize(struct sol_buffer *buffer, struct json_element *element)
             SOL_INT_CHECK(r, < 0, r);
         }
         return sol_buffer_append_char(buffer, ']');
+    case JSON_TYPE_UNKNOWN:
     case JSON_TYPE_NULL:
         return sol_json_serialize_null(buffer);
     case JSON_TYPE_INT:
@@ -1009,24 +1030,295 @@ json_serialize(struct sol_buffer *buffer, struct json_element *element)
 }
 
 static struct json_key_element *
-json_object_get_child_element(struct json_element *element, const char *key)
+json_object_get_or_create_child_element(struct json_element *element, const struct sol_str_slice key_slice)
 {
     uint16_t i;
     struct json_key_element *key_element;
 
-    SOL_VECTOR_FOREACH_IDX(&element->children, key_element, i)
-        if (streq(key, key_element->key))
+    SOL_VECTOR_FOREACH_IDX (&element->children, key_element, i)
+        if (sol_str_slice_str_eq(key_slice, key_element->key))
             return key_element;
 
+    key_element = sol_vector_append(&element->children);
+    SOL_NULL_CHECK(key_element, NULL);
+    key_element->key = sol_str_slice_to_string(key_slice);
+    SOL_NULL_CHECK_GOTO(key_element->key, str_error);
+
+    key_element->element.type = JSON_TYPE_UNKNOWN;
+
+    return key_element;
+
+str_error:
+    sol_vector_del(&element->children, element->children.len - 1);
     return NULL;
 }
 
+static struct json_element *
+json_array_get_or_create_child_element(struct json_element *element, uint16_t i)
+{
+    struct json_element *new;
+    uint16_t last_len;
+
+    if (i < element->children.len)
+        return sol_vector_get(&element->children, i);
+
+    last_len = element->children.len;
+    new = sol_vector_append_n(&element->children,
+        i - element->children.len + 1);
+    SOL_NULL_CHECK(new, NULL);
+
+    for (i = last_len; i < element->children.len; i++) {
+        new = sol_vector_get(&element->children, i);
+        SOL_NULL_CHECK(new, NULL);
+        new->type = JSON_TYPE_UNKNOWN;
+    }
+
+    return new;
+
+}
+
+static int json_element_parse(struct sol_json_token *token, struct json_element *element);
+
 static int
-json_object_add_new_element(struct json_element *base_element, const char *key, struct json_element *new_element)
+json_element_parse_array(struct sol_json_token *token, struct json_element *element)
+{
+
+    struct sol_json_scanner scanner;
+    struct sol_json_token child_token;
+    struct json_element *new;
+    enum sol_json_loop_reason reason;
+    int r;
+
+    init_json_array_element(element);
+
+    sol_json_scanner_init(&scanner, token->start, token->end - token->start);
+    SOL_JSON_SCANNER_ARRAY_LOOP_ALL(&scanner, token, reason) {
+        child_token.start = token->start;
+        if (!sol_json_scanner_skip_over(&scanner, token))
+            goto error_json;
+
+        child_token.end = token->end;
+
+        new = sol_vector_append(&element->children);
+        SOL_NULL_CHECK_GOTO(new, error_json);
+
+        r = json_element_parse(&child_token, new);
+        SOL_INT_CHECK_GOTO(r, < 0, error);
+    }
+
+    return 0;
+
+error:
+    new->type = JSON_TYPE_UNKNOWN;
+error_json:
+    json_element_clear(element);
+    return -EINVAL;
+}
+
+static int
+json_element_parse_object(struct sol_json_token *token, struct json_element *element)
+{
+    struct sol_json_scanner scanner;
+    struct sol_json_token key, value;
+    struct json_key_element *new;
+    enum sol_json_loop_reason reason;
+    int r;
+
+    init_json_object_element(element);
+
+    sol_json_scanner_init(&scanner, token->start, token->end - token->start);
+    SOL_JSON_SCANNER_OBJECT_LOOP (&scanner, token, &key, &value, reason) {
+        new = sol_vector_append(&element->children);
+        SOL_NULL_CHECK_GOTO(new, error_append);
+
+        new->key = sol_json_token_get_unescaped_string_copy(&key);
+        SOL_NULL_CHECK_GOTO(new->key, error_key);
+
+        r = json_element_parse(&value, &new->element);
+        SOL_INT_CHECK_GOTO(r, < 0, error_parse);
+    }
+
+    return 0;
+
+error_parse:
+error_key:
+    free(new->key);
+
+error_append:
+    if (r == 0)
+        r = -ENOMEM;
+    json_element_clear(element);
+
+    return r;
+}
+
+static int
+json_element_parse(struct sol_json_token *token, struct json_element *element)
+{
+    enum sol_json_type type;
+    int r;
+
+    type = sol_json_token_get_type(token);
+    switch (type) {
+    case SOL_JSON_TYPE_OBJECT_START:
+        return json_element_parse_object(token, element);
+    case SOL_JSON_TYPE_ARRAY_START:
+        return json_element_parse_array(token, element);
+    case SOL_JSON_TYPE_TRUE:
+        element->type = JSON_TYPE_BOOLEAN;
+        element->bool_value = true;
+        return 0;
+    case SOL_JSON_TYPE_FALSE:
+        element->type = JSON_TYPE_BOOLEAN;
+        element->bool_value = false;
+        return 0;
+    case SOL_JSON_TYPE_NULL:
+        element->type = JSON_TYPE_NULL;
+        return 0;
+    case SOL_JSON_TYPE_STRING:
+        element->type = JSON_TYPE_STRING;
+        element->str = sol_json_token_get_unescaped_string_copy(token);
+        SOL_NULL_CHECK(element->str, -ENOMEM);
+        return 0;
+    case SOL_JSON_TYPE_NUMBER:
+        element->type = JSON_TYPE_FLOAT;
+        r = sol_json_token_get_double(token, &element->float_value);
+        SOL_INT_CHECK(r, < 0, r);
+        return 0;
+    default:
+        return -EINVAL;
+    }
+}
+
+static int
+json_blob_element_parse(struct json_element *element)
+{
+    struct sol_json_token token;
+    struct json_element new_element;
+    int ret;
+
+    token.start = element->blob->mem;
+    token.end = token.start + element->blob->size;
+
+    ret = json_element_parse(&token, &new_element);
+    if (ret == 0) {
+        sol_blob_unref(element->blob);
+        *element = new_element;
+    }
+
+    return ret;
+}
+
+static bool
+reinit_element_if_needed(struct json_element *cur_element, struct sol_str_slice key_slice, bool is_base_element)
+{
+    if (json_path_is_array_key(key_slice)) {
+        if (cur_element->type == JSON_TYPE_ARRAY ||
+            cur_element->type == JSON_TYPE_ARRAY_BLOB)
+            return true;
+
+        if (is_base_element)
+            return false;
+
+        json_element_clear(cur_element);
+        init_json_array_element(cur_element);
+        return true;
+    }
+
+    if (cur_element->type == JSON_TYPE_OBJECT ||
+        cur_element->type == JSON_TYPE_OBJECT_BLOB)
+        return true;
+
+    if (is_base_element)
+        return false;
+
+    json_element_clear(cur_element);
+    init_json_object_element(cur_element);
+    return true;
+}
+static int
+json_path_add_new_element(struct sol_flow_node *node, struct json_element *base_element, const char *key, struct json_element *new_element)
+{
+    struct json_path_scanner path_scanner;
+    enum sol_json_loop_reason reason;
+    struct sol_str_slice key_slice = SOL_STR_SLICE_EMPTY;
+    struct json_element *cur_element;
+    struct json_key_element *key_element;
+    int32_t index_val;
+    int r;
+
+    cur_element = base_element;
+    json_path_scanner_init(&path_scanner, sol_str_slice_from_str(key));
+    JSON_PATH_FOREACH(path_scanner, key_slice, reason) {
+        if (!reinit_element_if_needed(cur_element, key_slice,
+            cur_element == base_element))
+            goto error;
+
+        switch (cur_element->type) {
+        case JSON_TYPE_OBJECT_BLOB:
+            r = json_blob_element_parse(cur_element);
+            SOL_INT_CHECK(r, == -ENOMEM, r);
+            SOL_INT_CHECK_GOTO(r, < 0, error_parse);
+
+        case JSON_TYPE_OBJECT:
+            if (json_path_is_array_key(key_slice))
+                goto error;
+
+            key_element = json_object_get_or_create_child_element(cur_element,
+                key_slice);
+            SOL_NULL_CHECK_GOTO(key_element, error);
+            cur_element = &key_element->element;
+
+            break;
+        case JSON_TYPE_ARRAY_BLOB:
+            r = json_blob_element_parse(cur_element);
+            SOL_INT_CHECK(r, == -ENOMEM, r);
+            SOL_INT_CHECK_GOTO(r, < 0, error_parse);
+
+        case JSON_TYPE_ARRAY:
+            if (!json_path_is_array_key(key_slice))
+                goto error;
+
+            index_val = json_array_get_key_index(key_slice);
+            SOL_INT_CHECK_GOTO(index_val, < 0, error);
+
+            cur_element = json_array_get_or_create_child_element(cur_element,
+                index_val);
+            SOL_NULL_CHECK_GOTO(cur_element, error);
+
+            break;
+        default:
+            goto error;
+        }
+    }
+
+    if (reason != SOL_JSON_LOOP_REASON_OK)
+        goto error;
+
+    json_element_clear(cur_element);
+    *cur_element = *new_element;
+
+    return 0;
+
+error:
+    return sol_flow_send_error_packet(node, EINVAL, "Invalid JSON path %s",
+        key);
+error_parse:
+    SOL_WRN("error parse");
+    return sol_flow_send_error_packet(node, EINVAL, "JSON element in path %s"
+        " is invalid: %.*s", key,
+        SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(cur_element->blob)));
+}
+
+#undef JSON_PATH_FOREACH
+
+static int
+json_object_add_new_element(struct sol_flow_node *node, struct json_element *base_element, const char *key, struct json_element *new_element)
 {
     struct json_key_element *new;
 
-    new = json_object_get_child_element(base_element, key);
+    new = json_object_get_or_create_child_element(base_element,
+        sol_str_slice_from_str(key));
     if (!new) {
         new = sol_vector_append(&base_element->children);
         SOL_NULL_CHECK(new, -errno);
@@ -1046,6 +1338,7 @@ str_error:
 static int
 json_object_in_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
 {
+    struct json_node_create_type *type;
     struct json_element *mdata = data;
     struct json_element new_element;
     const char *key;
@@ -1063,7 +1356,8 @@ json_object_in_process(struct sol_flow_node *node, void *data, uint16_t port, ui
     r = json_node_fill_element(packets[1], port, &new_element);
     SOL_INT_CHECK(r, < 0, r);
 
-    r = json_object_add_new_element(mdata, key, &new_element);
+    type = (struct json_node_create_type *)sol_flow_node_get_type(node);
+    r = type->add_new_element(node, mdata, key, &new_element);
     SOL_INT_CHECK_GOTO(r, < 0, error);
 
     return 0;

--- a/src/modules/flow/json/json.json
+++ b/src/modules/flow/json/json.json
@@ -322,7 +322,7 @@
           "name": "EMPTY"
         }
       ],
-      "url": "http://solettaproject.org/doc/latest/node_types/json/json-object-length.html"
+      "url": "http://solettaproject.org/doc/latest/node_types/json/json-object-get-all-keys.html"
     },
     {
       "category": "json",

--- a/src/modules/flow/json/json.json
+++ b/src/modules/flow/json/json.json
@@ -679,7 +679,8 @@
         ],
         "data_type": "struct json_node_create_type",
         "extra_methods": {
-          "send_json_packet": "sol_flow_send_json_object_packet"
+          "send_json_packet": "sol_flow_send_json_object_packet",
+          "add_new_element": "json_object_add_new_element"
         }
       },
       "out_ports": [
@@ -691,6 +692,210 @@
       ],
       "private_data_type": "json_element",
       "url": "http://solettaproject.org/doc/latest/node_types/json/json-create-object.html"
+    },
+    {
+     "category": "json",
+      "description": "Create a JSON array using data from input ports. JSON array is only created and sent to OUT port when CREATE port is triggered. Path for inputs needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+      "in_ports": [
+        {
+          "data_type": "composed:string,int",
+          "description": "A string with the JSONPath and the int number value. Path for inputs needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+          "methods": {
+            "process": "json_object_in_process"
+          },
+          "name": "INT"
+        },
+        {
+          "data_type": "composed:string,string",
+          "description": "A string with the JSONPath and the string value. Path for inputs needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+          "methods": {
+            "process": "json_object_in_process"
+          },
+          "name": "STRING"
+        },
+        {
+          "data_type": "composed:string,boolean",
+          "description": "A string with the JSONPath and the boolean value. Path for inputs needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+          "methods": {
+            "process": "json_object_in_process"
+          },
+          "name": "BOOLEAN"
+        },
+        {
+          "data_type": "composed:string,float",
+          "description": "A string with the JSONPath and the float number value. Path for inputs needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+          "methods": {
+            "process": "json_object_in_process"
+          },
+          "name": "FLOAT"
+        },
+        {
+          "data_type": "composed:string,json-object",
+          "description": "A string with the JSONPath and the JSON array value. Path for inputs needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+          "methods": {
+            "process": "json_object_in_process"
+          },
+          "name": "OBJECT"
+        },
+        {
+          "data_type": "composed:string,json-array",
+          "description": "A string with the JSONPath and the JSON object value. Path for inputs needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+          "methods": {
+            "process": "json_object_in_process"
+          },
+          "name": "ARRAY"
+        },
+        {
+          "data_type": "string",
+          "description": "A string with the JSONPath of null value. Path for inputs needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+          "methods": {
+            "process": "json_object_null_process"
+          },
+          "name": "NULL"
+        },
+        {
+          "data_type": "any",
+          "description": "Clear the JSON object",
+          "methods": {
+            "process": "json_clear_process"
+          },
+          "name": "CLEAR"
+        },
+        {
+          "data_type": "any",
+          "description": "Create a JSON object with data received in input ports and send it to OUT port.",
+          "methods": {
+            "process": "json_node_create_process"
+          },
+          "name": "CREATE"
+        }
+      ],
+      "methods": {
+        "open": "json_array_create_open",
+        "close": "json_create_close"
+      },
+      "name": "json/create-array-path",
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct json_node_create_type",
+        "extra_methods": {
+          "send_json_packet": "sol_flow_send_json_array_packet",
+          "add_new_element": "json_path_add_new_element"
+        }
+      },
+      "out_ports": [
+        {
+          "data_type": "json-array",
+          "description": "A JSON array created and sent by CREATE trigger.",
+          "name": "OUT"
+        }
+      ],
+      "private_data_type": "json_element",
+      "url": "http://solettaproject.org/doc/latest/node_types/json/json-create-array-path.html"
+    },
+    {
+      "category": "json",
+      "description": "Create a JSON object using data from input ports. JSON object is only created and sent to OUT port when CREATE port is triggered. Path for inputs needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+      "in_ports": [
+        {
+          "data_type": "composed:string,int",
+          "description": "A string with the JSONPath and the int number value. Path for inputs needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+          "methods": {
+            "process": "json_object_in_process"
+          },
+          "name": "INT"
+        },
+        {
+          "data_type": "composed:string,string",
+          "description": "A string with the JSONPath and the string value. Path for inputs needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+          "methods": {
+            "process": "json_object_in_process"
+          },
+          "name": "STRING"
+        },
+        {
+          "data_type": "composed:string,boolean",
+          "description": "A string with the JSONPath and the boolean value. Path for inputs needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+          "methods": {
+            "process": "json_object_in_process"
+          },
+          "name": "BOOLEAN"
+        },
+        {
+          "data_type": "composed:string,float",
+          "description": "A string with the JSONPath and the float number value. Path for inputs needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+          "methods": {
+            "process": "json_object_in_process"
+          },
+          "name": "FLOAT"
+        },
+        {
+          "data_type": "composed:string,json-object",
+          "description": "A string with the JSONPath and the JSON array value. Path for inputs needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+          "methods": {
+            "process": "json_object_in_process"
+          },
+          "name": "OBJECT"
+        },
+        {
+          "data_type": "composed:string,json-array",
+          "description": "A string with the JSONPath and the JSON object value. Path for inputs needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+          "methods": {
+            "process": "json_object_in_process"
+          },
+          "name": "ARRAY"
+        },
+        {
+          "data_type": "string",
+          "description": "A string with the JSONPath of null value. Path for inputs needs to be a valid JSONPath as documented in http://goessner.net/articles/JsonPath/",
+          "methods": {
+            "process": "json_object_null_process"
+          },
+          "name": "NULL"
+        },
+        {
+          "data_type": "any",
+          "description": "Clear the JSON object",
+          "methods": {
+            "process": "json_clear_process"
+          },
+          "name": "CLEAR"
+        },
+        {
+          "data_type": "any",
+          "description": "Create a JSON object with data received in input ports and send it to OUT port.",
+          "methods": {
+            "process": "json_node_create_process"
+          },
+          "name": "CREATE"
+        }
+      ],
+      "methods": {
+        "open": "json_object_create_open",
+        "close": "json_create_close"
+      },
+      "name": "json/create-object-path",
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct json_node_create_type",
+        "extra_methods": {
+          "send_json_packet": "sol_flow_send_json_object_packet",
+          "add_new_element": "json_path_add_new_element"
+        }
+      },
+      "out_ports": [
+        {
+          "data_type": "json-object",
+          "description": "A JSON object created and sent by CREATE trigger.",
+          "name": "OUT"
+        }
+      ],
+      "private_data_type": "json_element",
+      "url": "http://solettaproject.org/doc/latest/node_types/json/json-create-object-path.html"
     }
   ]
 }

--- a/src/test-fbp/json-array.fbp
+++ b/src/test-fbp/json-array.fbp
@@ -92,7 +92,7 @@ json_array_elements(converter/string-to-json-array)
 json_array_elements_str OUT -> IN json_array_elements
 json_array_elements OUT -> IN json_array_all_elements(json/array-get-all-elements)
 
-int_validator_all(test/int-validator:sequence="0 1 2 3 4")
+int_validator_all(test/int-validator:sequence="0 1 2 3 4 5")
 float_validator_all(test/float-validator:sequence="0 1 2 3 4 5.1")
 string_validator_all(test/string-validator:sequence="str1|str2")
 bool_validator_all(test/boolean-validator:sequence="FFTTTF")

--- a/src/test-fbp/json-create-path.fbp
+++ b/src/test-fbp/json-create-path.fbp
@@ -1,0 +1,156 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+DECLARE=int_pair:composed-new:KEY(string)|VALUE(int)
+DECLARE=float_pair:composed-new:KEY(string)|VALUE(float)
+DECLARE=boolean_pair:composed-new:KEY(string)|VALUE(boolean)
+DECLARE=string_pair:composed-new:KEY(string)|VALUE(string)
+DECLARE=json_array_pair:composed-new:KEY(string)|VALUE(json-array)
+DECLARE=json_object_pair:composed-new:KEY(string)|VALUE(json-object)
+
+create_obj1(json/create-object-path)
+create_obj1 OUT -> IN _(converter/json-object-to-blob) OUT -> IN _(test/blob-validator:expected="{\"val\":3}") OUT -> RESULT create_obj1_validator(test/result)
+
+_(constant/string:value="$.val") OUT -> KEY int_pair1(int_pair)
+_(constant/int:value=3) OUT -> VALUE int_pair1
+int_pair1 OUT -> INT create_obj1
+int_pair1 OUT -> CREATE create_obj1
+
+create_array1(json/create-array-path)
+create_array1 OUT -> IN _(converter/json-array-to-blob) OUT -> IN _(test/blob-validator:expected="[3]") OUT -> RESULT create_array1_validator(test/result)
+
+_(constant/string:value="$[0]") OUT -> KEY int_array_pair1(int_pair)
+_(constant/int:value=3) OUT -> VALUE int_array_pair1
+int_array_pair1 OUT -> INT create_array1
+int_array_pair1 OUT -> CREATE create_array1
+
+
+create_obj2(json/create-object-path)
+create_obj2 OUT -> IN _(converter/json-object-to-blob) OUT -> IN _(test/blob-validator:expected="{\"my_json\":[{\"json_array_value\":[3]},{\"json_object_value\":{\"val\":3}},{\"float_value\":456.789,\"string_value\":\"hello\"},{\"int_value\":123,\"boolean_value\":false}]}") OUT -> RESULT create_obj2_validator(test/result)
+
+_(constant/string:value="$.my_json[3].int_value") OUT -> KEY int_pair2(int_pair)
+_(constant/int:value=123) OUT -> VALUE int_pair2
+int_pair2 OUT -> INT create_obj2
+
+int_pair2 OUT -> IN _(converter/empty-to-string:output_value="$.my_json[2].float_value") OUT -> KEY float_pair2(float_pair)
+_(constant/float:value=456.789) OUT -> VALUE float_pair2
+float_pair2 OUT -> FLOAT create_obj2
+
+float_pair2 OUT -> IN _(converter/empty-to-string:output_value="$.my_json[3].boolean_value") OUT -> KEY boolean_pair2(boolean_pair)
+_(constant/boolean:value=false) OUT -> VALUE boolean_pair2
+boolean_pair2 OUT -> BOOLEAN create_obj2
+
+boolean_pair2 OUT -> IN _(converter/empty-to-string:output_value="$.my_json[2].string_value") OUT -> KEY string_pair2(string_pair)
+_(constant/string:value="hello") OUT -> VALUE string_pair2
+string_pair2 OUT -> STRING create_obj2
+
+string_pair2 OUT -> IN _(converter/empty-to-string:output_value="$.my_json[0].json_array_value") OUT -> KEY json_array_pair2(json_array_pair)
+create_array1 OUT -> VALUE json_array_pair2
+json_array_pair2 OUT -> ARRAY create_obj2
+
+json_array_pair2 OUT -> IN _(converter/empty-to-string:output_value="$.my_json[1].json_object_value") OUT -> KEY json_object_pair2(json_object_pair)
+create_obj1 OUT -> VALUE json_object_pair2
+json_object_pair2 OUT -> OBJECT create_obj2
+
+json_object_pair2 OUT -> CREATE create_obj2
+
+
+create_array2(json/create-array-path)
+create_array2 OUT -> IN _(converter/json-array-to-blob) OUT -> IN _(test/blob-validator:expected="[{\"json_array_value\":[3]},{\"json_object_value\":{\"val\":3}},{\"float_value\":456.789,\"string_value\":\"hello\"},{\"int_value\":123,\"boolean_value\":false}]") OUT -> RESULT create_array2_validator(test/result)
+
+_(constant/string:value="$[3].int_value") OUT -> KEY int_array_pair2(int_pair)
+_(constant/int:value=123) OUT -> VALUE int_array_pair2
+int_array_pair2 OUT -> INT create_array2
+
+int_array_pair2 OUT -> IN _(converter/empty-to-string:output_value="$[2].float_value") OUT -> KEY float_array_pair2(float_pair)
+_(constant/float:value=456.789) OUT -> VALUE float_array_pair2
+float_array_pair2 OUT -> FLOAT create_array2
+
+float_array_pair2 OUT -> IN _(converter/empty-to-string:output_value="$[3].boolean_value") OUT -> KEY boolean_array_pair2(boolean_pair)
+_(constant/boolean:value=false) OUT -> VALUE boolean_array_pair2
+boolean_array_pair2 OUT -> BOOLEAN create_array2
+
+boolean_array_pair2 OUT -> IN _(converter/empty-to-string:output_value="$[2].string_value") OUT -> KEY string_array_pair2(string_pair)
+_(constant/string:value="hello") OUT -> VALUE string_array_pair2
+string_array_pair2 OUT -> STRING create_array2
+
+string_array_pair2 OUT -> IN _(converter/empty-to-string:output_value="$[0].json_array_value") OUT -> KEY json_array_array_pair2(json_array_pair)
+create_array1 OUT -> VALUE json_array_array_pair2
+json_array_array_pair2 OUT -> ARRAY create_array2
+
+json_array_array_pair2 OUT -> IN _(converter/empty-to-string:output_value="$[1].json_object_value") OUT -> KEY json_object_array_pair2(json_object_pair)
+create_obj1 OUT -> VALUE json_object_array_pair2
+json_object_array_pair2 OUT -> OBJECT create_array2
+
+json_object_array_pair2 OUT -> CREATE create_array2
+
+#Errors
+create_obj3(json/create-object-path)
+create_obj3 ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS error1(test/result)
+
+_(constant/string:value="$[0]") OUT -> KEY int_pair3(int_pair)
+_(constant/int:value=3) OUT -> VALUE int_pair3
+int_pair3 OUT -> INT create_obj3
+int_pair3 OUT -> CREATE create_obj3
+
+create_array3(json/create-array-path)
+create_array3 ERROR -> IN _(converter/empty-to-boolean) OUT -> PASS error2(test/result)
+
+_(constant/string:value="$.a") OUT -> KEY int_array_pair3(int_pair)
+_(constant/int:value=3) OUT -> VALUE int_array_pair3
+int_array_pair3 OUT -> INT create_array3
+int_array_pair3 OUT -> CREATE create_array3
+
+#No error
+create_obj4(json/create-object-path)
+create_obj4 OUT -> IN _(converter/json-object-to-blob) OUT -> IN _(test/blob-validator:expected="{\"a\":{\"b\":5}}") OUT -> RESULT create_obj4_validator(test/result)
+
+_(constant/string:value="$.a[4]") OUT -> KEY int_pair4(int_pair)
+_(constant/int:value=4) OUT -> VALUE int_pair4
+int_pair4 OUT -> INT create_obj4
+
+_(constant/string:value="$.a.b") OUT -> KEY int_pair5(int_pair)
+_(constant/int:value=5) OUT -> VALUE int_pair5
+int_pair5 OUT -> INT create_obj4
+
+int_pair5 OUT -> CREATE create_obj4
+
+create_obj5(json/create-object-path)
+create_obj5 OUT -> IN _(converter/json-object-to-blob) OUT -> IN _(test/blob-validator:expected="{\"a\":[null,null,null,null,5]}") OUT -> RESULT create_obj5_validator(test/result)
+
+_(constant/string:value="$.a.b.c") OUT -> KEY int_pair6(int_pair)
+_(constant/int:value=4) OUT -> VALUE int_pair6
+int_pair6 OUT -> INT create_obj5
+
+_(constant/string:value="$.a[4]") OUT -> KEY int_pair7(int_pair)
+_(constant/int:value=5) OUT -> VALUE int_pair7
+int_pair7 OUT -> INT create_obj5
+
+int_pair7 OUT -> CREATE create_obj5

--- a/src/test-fbp/json-create.fbp
+++ b/src/test-fbp/json-create.fbp
@@ -51,6 +51,10 @@ create_array(json/create-array)
 null_const(constant/string:value="null_value") OUT -> NULL create_obj
 null_const OUT -> NULL create_array
 
+int_replace(int_pair) OUT -> INT create_obj
+_(constant/string:value="int_value") OUT -> KEY int_replace
+int_const_replace(constant/int:value=999) OUT -> VALUE int_replace
+
 int_val(int_pair) OUT -> INT create_obj
 _(constant/string:value="int_value") OUT -> KEY int_val
 int_const(constant/int:value=892) OUT -> VALUE int_val
@@ -65,6 +69,10 @@ float_val(float_pair) OUT -> FLOAT create_obj
 _(constant/string:value="float_value") OUT -> KEY float_val
 float_const(constant/float:value=1.23) OUT -> VALUE float_val
 float_const OUT -> FLOAT create_array
+
+string_replace(string_pair) OUT -> STRING create_obj
+_(constant/string:value="string_value") OUT -> KEY string_replace
+str_replace_const(constant/string:value="error") OUT -> VALUE string_replace
 
 string_val(string_pair) OUT -> STRING create_obj
 _(constant/string:value="string_value") OUT -> KEY string_val

--- a/src/test-fbp/json-create.fbp
+++ b/src/test-fbp/json-create.fbp
@@ -43,8 +43,8 @@ json_array(converter/string-to-json-array)
 json_object_str OUT -> IN json_object
 json_array_str OUT -> IN json_array
 
-validator_json_object(test/blob-validator:expected="{\"null_value\":null,\"int_value\":892,\"boolean_value\":1,\"float_value\":1.23,\"string_value\":\"str\",\"json_object_value\":{\"index\":3},\"json_array_value\":[1,2,3]}")
-validator_json_array(test/blob-validator:expected="[null,892,1,1.23,\"str\",{\"index\":3},[1,2,3]]")
+validator_json_object(test/blob-validator:expected="{\"null_value\":null,\"int_value\":892,\"boolean_value\":true,\"float_value\":1.23,\"string_value\":\"str\",\"json_object_value\":{\"index\":3},\"json_array_value\":[1,2,3]}")
+validator_json_array(test/blob-validator:expected="[null,892,true,1.23,\"str\",{\"index\":3},[1,2,3]]")
 create_obj(json/create-object)
 create_array(json/create-array)
 


### PR DESCRIPTION
Changelog from v1:
 - fixing issues reported in v1
 - Always replace a value when user set a new value to a key, even when types differ. For example, if $.a = [1,2,3], and user tries to set $.a.b = 2, the array will be overrided by the object.