### PR TITLE
storage headers: Do not include sol-util.h

### DIFF
--- a/src/lib/io/include/sol-efivarfs-storage.h
+++ b/src/lib/io/include/sol-efivarfs-storage.h
@@ -38,7 +38,6 @@
 #include "sol-buffer.h"
 #include "sol-log.h"
 #include "sol-types.h"
-#include "sol-util.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -85,8 +84,9 @@ int sol_efivars_read_raw(const char *name, struct sol_buffer *buffer);
 #define CREATE_BLOB(_val) \
     struct sol_blob *blob; \
     size_t _s = sizeof(*_val); \
-    void *v = sol_util_memdup(_val, _s); \
-    SOL_NULL_CHECK(v, -EINVAL); \
+    void *v = malloc(_s); \
+    SOL_NULL_CHECK(v, -ENOMEM); \
+    memcpy(v, _val, _s); \
     blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, v, _s); \
     if (!blob) { \
         free(v); \

--- a/src/lib/io/include/sol-fs-storage.h
+++ b/src/lib/io/include/sol-fs-storage.h
@@ -38,7 +38,6 @@
 #include "sol-buffer.h"
 #include "sol-log.h"
 #include "sol-types.h"
-#include "sol-util.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -89,8 +88,9 @@ int sol_fs_read_raw(const char *name, struct sol_buffer *buffer);
 #define CREATE_BLOB(_val) \
     struct sol_blob *blob; \
     size_t _s = sizeof(*_val); \
-    void *v = sol_util_memdup(_val, _s); \
-    SOL_NULL_CHECK(v, -EINVAL); \
+    void *v = malloc(_s); \
+    SOL_NULL_CHECK(v, -ENOMEM); \
+    memcpy(v, _val, _s); \
     blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, v, _s); \
     if (!blob) { \
         free(v); \

--- a/src/lib/io/include/sol-memmap-storage.h
+++ b/src/lib/io/include/sol-memmap-storage.h
@@ -39,7 +39,6 @@
 #include "sol-log.h"
 #include "sol-str-table.h"
 #include "sol-types.h"
-#include "sol-util.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -189,8 +188,9 @@ unsigned int sol_memmap_get_timeout(const struct sol_memmap_map *map);
 #define CREATE_BLOB(_val) \
     struct sol_blob *blob; \
     size_t _s = sizeof(*_val); \
-    void *v = sol_util_memdup(_val, _s); \
-    SOL_NULL_CHECK(v, -EINVAL); \
+    void *v = malloc(_s); \
+    SOL_NULL_CHECK(v, -ENOMEM); \
+    memcpy(v, _val, _s); \
     blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, v, _s); \
     if (!blob) { \
         free(v); \


### PR DESCRIPTION
CREATE_BUFFER macro as using sol_util_memdup, but as sol-util.h is not
installed, it was not possible to compile sol-fbp-generator generated
code.
Using malloc and memcpy instead.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>