### PR TITLE
build: more bad obj dependency issues fixed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,6 @@ else
 include $(top_srcdir)tools/build/Makefile.kconfig
 endif
 
-ifeq (,$(filter $(dep-avoid-targets),$(MAKECMDGOALS)))
--include ${all-objs:.o=.o.dep}
-endif
-
 ifneq (,$(NOT_FOUND))
 warning:
 	$(Q)echo -e "The following (required) dependencies were not met:\n"
@@ -58,6 +54,10 @@ endif # HAVE_KCONFIG_CONFIG
 endif # NOT_FOUND
 
 $(KCONFIG_CONFIG): $(KCONFIG_GEN)
+
+ifeq (,$(filter $(dep-avoid-targets),$(MAKECMDGOALS)))
+-include ${all-objs:.o=.o.dep}
+endif
 
 .DEFAULT_GOAL = all
 .PHONY = $(PHONY) default_target

--- a/src/lib/comms/Makefile
+++ b/src/lib/comms/Makefile
@@ -87,26 +87,26 @@ obj-networking-$(MQTT) += \
 obj-networking-$(MQTT)-extra-ldflags += \
 	$(MOSQUITTO_LDFLAGS)
 
-headers-networking-$(NETWORK) += \
+headers-$(NETWORK) += \
     include/sol-network.h
 
-headers-networking-$(COAP) += \
+headers-$(COAP) += \
     include/sol-coap.h
 
-headers-networking-$(OIC) += \
+headers-$(OIC) += \
     include/sol-oic-common.h \
     include/sol-oic-client.h \
     include/sol-oic-server.h \
     sol-oic-cbor.h
 
-headers-networking-$(HTTP) += \
+headers-$(HTTP) += \
     include/sol-http.h
 
-headers-networking-$(HTTP_CLIENT) += \
+headers-$(HTTP_CLIENT) += \
     include/sol-http-client.h
 
-headers-networking-$(HTTP_SERVER) += \
+headers-$(HTTP_SERVER) += \
     include/sol-http-server.h
 
-headers-networking-$(MQTT) += \
+headers-$(MQTT) += \
 	include/sol-mqtt.h

--- a/src/lib/comms/dtls_config.h
+++ b/src/lib/comms/dtls_config.h
@@ -33,7 +33,6 @@
 #pragma once
 
 #include "sol-common-buildopts.h"
-#include "sol_config.h"
 
 /* This file is required to build TinyDLS, and uses the constants defined
  * by Soletta's build system to create one that TinyDTLS will be happy

--- a/src/modules/flow/http-client/http-client.c
+++ b/src/modules/flow/http-client/http-client.c
@@ -45,7 +45,6 @@
 #include "sol-platform.h"
 #include "sol-util.h"
 #include "sol-vector.h"
-#include "sol_config.h"
 #include "sol-str-table.h"
 
 struct http_data {

--- a/src/modules/flow/http-server/http-server.c
+++ b/src/modules/flow/http-server/http-server.c
@@ -45,7 +45,6 @@
 #include "sol-mainloop.h"
 #include "sol-util.h"
 #include "sol-vector.h"
-#include "sol_config.h"
 
 #define HTTP_HEADER_ACCEPT "Accept"
 #define HTTP_HEADER_CONTENT_TYPE "Content-Type"

--- a/src/modules/flow/oauth/oauth.c
+++ b/src/modules/flow/oauth/oauth.c
@@ -48,8 +48,6 @@
 #include "sol-random.h"
 #include "sol-util.h"
 #include "sol-vector.h"
-#include "sol_config.h"
-
 
 struct v1_data {
     struct sol_ptr_vector pending_conns;

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -61,8 +61,6 @@ parse-common-module = \
 	$(call artifact-path,$(obj-$(1)-$(3)),$(2),artifacts) \
 	$(eval obj-$(1)-$(3) :=) \
 	$(eval all-artifacts += $(artifacts)) \
-	$(eval mod-headers  := $(addprefix $(2),$(headers-$(1)-$(3)))) \
-	$(call extra-headers,$(mod-headers)) \
 	$(eval mod-objs     := $(filter %.o,$(artifacts))) \
 	$(eval $(4)-cflags  := $(obj-$(1)-y-extra-cflags)) \
 	$(eval $(4)-cflags  += $(obj-$(1)-m-extra-cflags)) \
@@ -274,8 +272,9 @@ $(foreach curr,$(bins),$(eval $(call make-bin,$(curr))))
 sample-out = $(if $(filter %.o,$(sample-$(1)-out)), -c -o $(sample-$(1)-out),-o $(sample-$(1)-out))
 sample-src = $(filter-out %.json,$(filter-out %.h,$(sample-$(1)-srcs)))
 
+#TODO: in the future declare deps individually for samples and remove this $(modules-out) dependency here (for every module)
 define make-sample
-$(sample-$(1)-out): $(SOL_LIB_OUTPUT) $(modules-out) $(sample-$(1)-srcs) $(call find-deps,$(1)) $(addprefix $($(1)-dir),$(filter %.fbp,$($(1)-deps)))
+$(sample-$(1)-out): $(SOL_LIB_OUTPUT) $(modules-out) $(sample-$(1)-srcs) $(call find-deps,$(1)) $(addprefix $($(1)-dir),$(filter %.fbp,$($(1)-deps))) $($(filter %.json,$(sample-$(1)-srcs))-hdr)
 	$(Q)echo "     "SMP"   "$$@
 	$(Q)$(MKDIR) -p $(dir $(sample-$(1)-out))
 	$(Q)$(TARGETCC) $(SAMPLE_CFLAGS) $(sample-$(1)-cflags) $(sample-$(1)-includedir) $(sample-src) \
@@ -320,14 +319,15 @@ $(foreach curr,$(tests-internal),$(eval $(call make-test-internal,$(curr))))
 find-gen-hdrs = $(foreach gen,$($(2)-gens),$($(gen)-hdr))
 
 define make-object
-$(1): $($(1)-src) $(1).dep $(call find-deps,$(2)) $(find-gen-hdrs) $(KCONFIG_AUTOHEADER) $(HEADER_GEN) $(all-dest-hdr)
+$(1): $($(1)-src) $(1).dep
 	$(Q)echo "      "CC"   "$$@
 	$(Q)$(MKDIR) -p $(dir $(1))
 	$(Q)$(TARGETCC) $(OBJ_CFLAGS) $($(2)-gen-cflags) $(sort $($(2)-cflags)) $($(1)-src) -c -o $(1) $(3)
 
-$(1).dep: $($(1)-src) $(all-hdr) $(KCONFIG_CONFIG)
+$(1).dep: $($(1)-src) $(all-hdr) $(find-gen-hdrs) $(call find-deps,$(2)) $(all-dest-hdr) $(KCONFIG_CONFIG) $(HEADER_GEN)
 	$(Q)$(MKDIR) -p $(dir $(1))
 	$(Q)$(TARGETCC) $(OBJ_CFLAGS) $($(2)-gen-cflags) $(sort $($(2)-cflags)) -MM -MG $($(1)-src) -MT "$(1)" > $(1).dep
+
 endef
 $(foreach obj,$(sort $(all-objs)), \
 	$(eval $(call make-object,$(obj),$($(obj)-module),$($($(obj)-module)-external-flags))) \
@@ -394,7 +394,7 @@ $(eval $(call install-resource,$(NODE_TYPE_SCHEMA),$(NODE_TYPE_SCHEMA_DEST)))
 $(eval $(call install-resource,$(BOARD_DETECT),$(BOARD_DETECT_DEST)))
 $(eval $(call install-resource,$(GDB_AUTOLOAD_PY),$(GDB_AUTOLOAD_PY_DEST)))
 
-$(FLOW_OIC_GEN): $(FLOW_OIC_GEN_SCRIPT)
+$(FLOW_OIC_GEN): $(FLOW_OIC_GEN_SCRIPT) $(KCONFIG_AUTOHEADER)
 	$(Q)echo "     "GEN"   "$(@)
 	$(Q)$(PYTHON) $(FLOW_OIC_GEN_SCRIPT) --schema-dir=$(FLOW_OIC_SPEC_DIR) \
 		--node-type-json=$(dir $(@))oic.json \

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -99,7 +99,7 @@ check-stub: $(SOL_LIB_OUTPUT) $(NODE_TYPE_STUB_GEN_SCRIPT) $(NODE_TYPE_SCHEMA) $
 
 PHONY += check-stub
 
-samples: $(SOL_LIB_OUTPUT) $(samples-out)
+samples: $(SOL_LIB_OUTPUT) $(samples-out) $(PRE_GEN)
 
 PHONY += samples
 


### PR DESCRIPTION
The fixes here were mostly spotted by make -j runs of some targets (like
samples), which would sometimes reach use of some generated dependencies
before they were fully made, leading to errors that were recoverable
from a subsequent make invocation.

First of all, the inclusion of the .dep files was totally broken, so the
files listed in them were not being checked for dependencies at all! We
now moved the inclusion to a place where "all-objs" is already declared
and we're fine.

Some files were including "sol_config.h" by hand, and by fixing some
dependency declarations this will not only be unecessary but impossible
-- only the automatic compiler line inclusion will pass it forward.

"extra-headers" usage in "parse-common-module" was taken off -- it was
passing forward wrong objects and had only one user, that now users the
general "headers-$(whatever)" syntax.

Finally, "make samples" invocation right away after kconfig is working
again, though we still have samples depending on the whole library
objects set (we'll fix that later if we feel like declaring the
individual sample dependencies by hand). On the other hand, now that
.dep files *do* work, changes in headers, modules or any dependency of
another module will trigger its build again.

Thanks a lot for more help of Dorileo here :)

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>

----

Please help to test this!!