### PR TITLE
sol-fbp: Add SOL_ATTR_PRINTF() to sol_fbp_log_print()

### DIFF
--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -308,7 +308,8 @@ handle_suboption_with_explicit_fields(const struct sol_fbp_meta *meta,
 
     if (!p) {
         sol_fbp_log_print(fbp_file, meta->position.line, meta->position.column, "Wrong suboption format, ignoring"
-            " value '%s'. You cannot mix the formats, choose one 'opt1:val1|opt2:val2...' or 'val1|val2...'", option);
+            " value '%.*s'. You cannot mix the formats, choose one 'opt1:val1|opt2:val2...' or 'val1|val2...'",
+            SOL_STR_SLICE_PRINT(option));
         return false;
     }
 
@@ -380,7 +381,8 @@ check_suboption(const struct sol_str_slice option,
 {
     if (memchr(option.data, ':', option.len)) {
         sol_fbp_log_print(fbp_file, meta->position.line, meta->position.column, "Wrong suboption format, ignoring"
-            "value '%s'. You cannot mix the formats, choose one 'opt1:val1|opt2:val2...' or 'val1|val2...'", option);
+            "value '%.*s'. You cannot mix the formats, choose one 'opt1:val1|opt2:val2...' or 'val1|val2...'",
+            SOL_STR_SLICE_PRINT(option));
         return false;
     }
 
@@ -2204,7 +2206,7 @@ create_fbp_data(struct sol_vector *fbp_data_vector, struct sol_ptr_vector *file_
 
     fbp_error = sol_fbp_parse(sol_file_reader_get_all(fr), &data->graph);
     if (fbp_error) {
-        sol_fbp_log_print(filename, fbp_error->position.line, fbp_error->position.column, fbp_error->msg);
+        sol_fbp_log_print(filename, fbp_error->position.line, fbp_error->position.column, "%s", fbp_error->msg);
         sol_fbp_error_free(fbp_error);
         return NULL;
     }

--- a/src/bin/sol-fbp-to-dot/main.c
+++ b/src/bin/sol-fbp-to-dot/main.c
@@ -288,7 +288,7 @@ init_graph_from_file(struct sol_fbp_graph *g,  struct sol_file_reader *fr, const
 
     fbp_error = sol_fbp_parse(sol_file_reader_get_all(fr), g);
     if (fbp_error) {
-        sol_fbp_log_print(filename, fbp_error->position.line, fbp_error->position.column, fbp_error->msg);
+        sol_fbp_log_print(filename, fbp_error->position.line, fbp_error->position.column, "%s", fbp_error->msg);
         sol_fbp_error_free(fbp_error);
         sol_file_reader_close(fr);
         return EXIT_FAILURE;

--- a/src/lib/flow/sol-flow-parser.c
+++ b/src/lib/flow/sol-flow-parser.c
@@ -765,7 +765,7 @@ build_flow(struct parse_state *state)
 
     fbp_error = sol_fbp_parse(state->input, &state->graph);
     if (fbp_error) {
-        sol_fbp_log_print(state->filename, fbp_error->position.line, fbp_error->position.column, fbp_error->msg);
+        sol_fbp_log_print(state->filename, fbp_error->position.line, fbp_error->position.column, "%s", fbp_error->msg);
         sol_fbp_error_free(fbp_error);
         errno = -err;
         return NULL;
@@ -802,8 +802,8 @@ build_flow(struct parse_state *state)
         if (err < 0) {
             sol_fbp_log_print(state->filename, c->position.line, c->position.column,
                 "Couldn't connect '%s %s -> %s %s'",
-                state->node_names[c->src], src_port_buf.data,
-                state->node_names[c->dst], dst_port_buf.data);
+                state->node_names[c->src], (const char *)src_port_buf.data,
+                state->node_names[c->dst], (const char *)dst_port_buf.data);
             goto end;
         }
     }

--- a/src/shared/sol-fbp.h
+++ b/src/shared/sol-fbp.h
@@ -33,6 +33,7 @@
 #pragma once
 
 #include "sol-arena.h"
+#include "sol-macros.h"
 #include "sol-str-slice.h"
 #include "sol-vector.h"
 
@@ -167,5 +168,5 @@ int sol_fbp_graph_option(struct sol_fbp_graph *g,
 struct sol_fbp_error *sol_fbp_parse(struct sol_str_slice input, struct sol_fbp_graph *g);
 
 /* Print out a message of a given FBP file. */
-void sol_fbp_log_print(const char *file, unsigned int line, unsigned int column, const char *format, ...);
+void sol_fbp_log_print(const char *file, unsigned int line, unsigned int column, const char *format, ...) SOL_ATTR_PRINTF(4, 5);
 void sol_fbp_error_free(struct sol_fbp_error *e);


### PR DESCRIPTION
By declaring the prototype of this function with this attribute, the
compiler will perform a couple of checks to ensure that the varargs are
actually of the correct type for the printf-style formatting strings,
in addition to only allowing literal strings being passed to the format
string argument.

This fixes a few crashes in the generator while printing errors,
including a few call sites that passed user-controlled strings as the
formatting string.

All known places that had problems were fixed, and this attribute
will ensure these won't happen in the future.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>