### PR TITLE
allover: Disambiguate int size on public facing API

### DIFF
--- a/src/lib/common/include/sol-glib-integration.h
+++ b/src/lib/common/include/sol-glib-integration.h
@@ -102,10 +102,10 @@ struct _sol_glib_integration_source_data {
     gint max_prio;
 };
 
-static unsigned int
+static uint32_t
 _sol_glib_integration_gpoll_events_to_fd_flags(gushort gpoll_events)
 {
-    unsigned int sol_flags = 0;
+    uint32_t sol_flags = 0;
 
     if (gpoll_events & G_IO_IN) sol_flags |= SOL_FD_FLAGS_IN;
     if (gpoll_events & G_IO_OUT) sol_flags |= SOL_FD_FLAGS_OUT;
@@ -118,7 +118,7 @@ _sol_glib_integration_gpoll_events_to_fd_flags(gushort gpoll_events)
 }
 
 static gushort
-_sol_glib_integration_fd_flags_to_gpoll_events(unsigned int sol_flags)
+_sol_glib_integration_fd_flags_to_gpoll_events(uint32_t sol_flags)
 {
     gushort glib_flags = 0;
 
@@ -161,7 +161,7 @@ _sol_glib_integration_source_fd_handler_data_find(struct _sol_glib_integration_s
 }
 
 static bool
-_sol_glib_integration_on_source_fd(void *data, int fd, unsigned int active_flags)
+_sol_glib_integration_on_source_fd(void *data, int fd, uint32_t active_flags)
 {
     struct _sol_glib_integration_fd_handler *h = data;
     GPollFD *gpfd = _sol_glib_integration_source_gpollfd_find(h->mdata, fd);
@@ -197,7 +197,7 @@ _sol_glib_integration_source_fd_handlers_adjust(struct _sol_glib_integration_sou
     // 2 - create fd handlers for new or changed fds
     for (i = 0; i < (uint16_t)mdata->n_poll; i++) {
         const GPollFD *gpfd = mdata->fds + i;
-        unsigned int flags;
+        uint32_t flags;
         int r;
 
         h = _sol_glib_integration_source_fd_handler_data_find(mdata, gpfd->fd);

--- a/src/lib/common/include/sol-mainloop.h
+++ b/src/lib/common/include/sol-mainloop.h
@@ -160,7 +160,7 @@ struct sol_timeout;
  *
  * @return A handle that can be used to delete the timeout.
  */
-struct sol_timeout *sol_timeout_add(unsigned int timeout_ms, bool (*cb)(void *data), const void *data);
+struct sol_timeout *sol_timeout_add(uint32_t timeout_ms, bool (*cb)(void *data), const void *data);
 
 /**
  * Deletes the given timeout.
@@ -260,7 +260,7 @@ struct sol_fd;
  *
  * @return A handle that can be used to delete the file descriptor watcher.
  */
-struct sol_fd *sol_fd_add(int fd, unsigned int flags, bool (*cb)(void *data, int fd, unsigned int active_flags), const void *data);
+struct sol_fd *sol_fd_add(int fd, uint32_t flags, bool (*cb)(void *data, int fd, uint32_t active_flags), const void *data);
 
 /**
  * Deletes the given file descriptor watcher.
@@ -279,7 +279,7 @@ bool sol_fd_del(struct sol_fd *handle);
  *
  * @return True on success, false if the handle is invalid.
  */
-bool sol_fd_set_flags(struct sol_fd *handle, unsigned int flags);
+bool sol_fd_set_flags(struct sol_fd *handle, uint32_t flags);
 
 /**
  * Removes the given flags from those being watched.
@@ -289,7 +289,7 @@ bool sol_fd_set_flags(struct sol_fd *handle, unsigned int flags);
  *
  * @return True on success, false if the handle is invalid.
  */
-bool sol_fd_unset_flags(struct sol_fd *handle, unsigned int flags);
+bool sol_fd_unset_flags(struct sol_fd *handle, uint32_t flags);
 
 /**
  * Gets the flags being watched for the given handle.
@@ -298,7 +298,7 @@ bool sol_fd_unset_flags(struct sol_fd *handle, unsigned int flags);
  *
  * @return The flags that are currently being watched for by the handle.
  */
-unsigned int sol_fd_get_flags(const struct sol_fd *handle);
+uint32_t sol_fd_get_flags(const struct sol_fd *handle);
 #endif
 
 #ifdef SOL_MAINLOOP_FORK_WATCH_ENABLED

--- a/src/lib/common/sol-bus.c
+++ b/src/lib/common/sol-bus.c
@@ -111,7 +111,7 @@ static const struct sol_mainloop_source_type source_type = {
 };
 
 static bool
-on_sd_event_fd(void *data, int fd, unsigned int active_flags)
+on_sd_event_fd(void *data, int fd, uint32_t active_flags)
 {
     /* just used to wake up main loop */
     return true;

--- a/src/lib/common/sol-mainloop-impl-glib.c
+++ b/src/lib/common/sol-mainloop-impl-glib.c
@@ -131,17 +131,17 @@ sol_mainloop_impl_idle_del(void *handle)
 }
 
 struct sol_fd_glib {
-    bool (*cb)(void *data, int fd, unsigned int active_flags);
+    bool (*cb)(void *data, int fd, uint32_t active_flags);
     const void *data;
     int fd;
-    unsigned int flags;
+    uint32_t flags;
     gint id;
 
     int refcnt;
 };
 
 static GIOCondition
-sol_to_glib_flags(unsigned int sol_flags)
+sol_to_glib_flags(uint32_t sol_flags)
 {
     GIOCondition glib_flags = 0;
 
@@ -155,10 +155,10 @@ sol_to_glib_flags(unsigned int sol_flags)
     return glib_flags;
 }
 
-static unsigned int
+static uint32_t
 glib_to_sol_flags(GIOCondition glib_flags)
 {
-    unsigned int sol_flags = 0;
+    uint32_t sol_flags = 0;
 
     if (glib_flags & G_IO_IN) sol_flags |= SOL_FD_FLAGS_IN;
     if (glib_flags & G_IO_OUT) sol_flags |= SOL_FD_FLAGS_OUT;
@@ -192,7 +192,7 @@ unref_fd(void *data)
 }
 
 void *
-sol_mainloop_impl_fd_add(int fd, unsigned int flags, bool (*cb)(void *data, int fd, unsigned int active_flags), const void *data)
+sol_mainloop_impl_fd_add(int fd, uint32_t flags, bool (*cb)(void *data, int fd, uint32_t active_flags), const void *data)
 {
     struct sol_fd_glib *fd_handle = malloc(sizeof(*fd_handle));
 
@@ -221,7 +221,7 @@ sol_mainloop_impl_fd_del(void *handle)
 }
 
 bool
-sol_mainloop_impl_fd_set_flags(void *handle, unsigned int flags)
+sol_mainloop_impl_fd_set_flags(void *handle, uint32_t flags)
 {
     struct sol_fd_glib *fd_handle = handle;
 
@@ -246,7 +246,7 @@ sol_mainloop_impl_fd_set_flags(void *handle, unsigned int flags)
     return true;
 }
 
-unsigned int
+uint32_t
 sol_mainloop_impl_fd_get_flags(const void *handle)
 {
     const struct sol_fd_glib *fd_handle = handle;

--- a/src/lib/common/sol-mainloop-impl-posix.c
+++ b/src/lib/common/sol-mainloop-impl-posix.c
@@ -64,9 +64,9 @@ struct sol_child_watch_posix {
 
 struct sol_fd_posix {
     const void *data;
-    bool (*cb)(void *data, int fd, unsigned int active_flags);
+    bool (*cb)(void *data, int fd, uint32_t active_flags);
     int fd;
-    unsigned int flags;
+    uint32_t flags;
     bool remove_me;
     bool invalid;
 };
@@ -133,7 +133,7 @@ sol_mainloop_impl_main_thread_notify(void)
 }
 
 static inline bool
-main_thread_ack(void *data, int fd, unsigned int active_flags)
+main_thread_ack(void *data, int fd, uint32_t active_flags)
 {
     char tok;
     int r;
@@ -511,7 +511,7 @@ child_watch_process(void)
 }
 
 static short int
-fd_flags_to_poll_events(unsigned int flags)
+fd_flags_to_poll_events(uint32_t flags)
 {
     short int events = 0;
 
@@ -529,10 +529,10 @@ fd_flags_to_poll_events(unsigned int flags)
     return events;
 }
 
-static unsigned int
+static uint32_t
 poll_events_to_fd_flags(short int events)
 {
-    unsigned int flags = 0;
+    uint32_t flags = 0;
 
 #define MAP(a, b) if (events & b) flags |= a
 
@@ -676,7 +676,7 @@ fd_process(void)
 
     j = 0;
     SOL_PTR_VECTOR_FOREACH_IDX (&FD_PROCESS, handler, i) {
-        unsigned int active_flags;
+        uint32_t active_flags;
         const struct pollfd *pfd;
 
         if (!sol_mainloop_common_loop_check())
@@ -737,7 +737,7 @@ sol_mainloop_impl_iter(void)
 }
 
 void *
-sol_mainloop_impl_fd_add(int fd, unsigned int flags, bool (*cb)(void *data, int fd, unsigned int active_flags), const void *data)
+sol_mainloop_impl_fd_add(int fd, uint32_t flags, bool (*cb)(void *data, int fd, uint32_t active_flags), const void *data)
 {
     struct sol_fd_posix *handle = malloc(sizeof(struct sol_fd_posix));
     int ret;
@@ -787,7 +787,7 @@ sol_mainloop_impl_fd_del(void *handle)
 }
 
 bool
-sol_mainloop_impl_fd_set_flags(void *handle, unsigned int flags)
+sol_mainloop_impl_fd_set_flags(void *handle, uint32_t flags)
 {
     struct sol_fd_posix *fd_handle = handle;
 
@@ -803,7 +803,7 @@ sol_mainloop_impl_fd_set_flags(void *handle, unsigned int flags)
     return true;
 }
 
-unsigned int
+uint32_t
 sol_mainloop_impl_fd_get_flags(const void *handle)
 {
     const struct sol_fd_posix *fd_handle = handle;

--- a/src/lib/common/sol-mainloop-impl.h
+++ b/src/lib/common/sol-mainloop-impl.h
@@ -45,17 +45,17 @@ void sol_mainloop_impl_run(void);
 void sol_mainloop_impl_quit(void);
 void sol_mainloop_impl_shutdown(void);
 
-void *sol_mainloop_impl_timeout_add(unsigned int timeout_ms, bool (*cb)(void *data), const void *data);
+void *sol_mainloop_impl_timeout_add(uint32_t timeout_ms, bool (*cb)(void *data), const void *data);
 bool sol_mainloop_impl_timeout_del(void *handle);
 
 void *sol_mainloop_impl_idle_add(bool (*cb)(void *data), const void *data);
 bool sol_mainloop_impl_idle_del(void *handle);
 
 #ifdef SOL_MAINLOOP_FD_ENABLED
-void *sol_mainloop_impl_fd_add(int fd, unsigned int flags, bool (*cb)(void *data, int fd, unsigned int active_flags), const void *data);
+void *sol_mainloop_impl_fd_add(int fd, uint32_t flags, bool (*cb)(void *data, int fd, uint32_t active_flags), const void *data);
 bool sol_mainloop_impl_fd_del(void *handle);
-bool sol_mainloop_impl_fd_set_flags(void *handle, unsigned int flags);
-unsigned int sol_mainloop_impl_fd_get_flags(const void *handle);
+bool sol_mainloop_impl_fd_set_flags(void *handle, uint32_t flags);
+uint32_t sol_mainloop_impl_fd_get_flags(const void *handle);
 #endif
 
 #ifdef SOL_MAINLOOP_FORK_WATCH_ENABLED

--- a/src/lib/common/sol-mainloop.c
+++ b/src/lib/common/sol-mainloop.c
@@ -238,7 +238,7 @@ sol_shutdown(void)
 }
 
 SOL_API struct sol_timeout *
-sol_timeout_add(unsigned int timeout_ms, bool (*cb)(void *data), const void *data)
+sol_timeout_add(uint32_t timeout_ms, bool (*cb)(void *data), const void *data)
 {
     SOL_NULL_CHECK(cb, NULL);
     return sol_mainloop_impl_timeout_add(timeout_ms, cb, data);
@@ -267,7 +267,7 @@ sol_idle_del(struct sol_idle *handle)
 
 #ifdef SOL_MAINLOOP_FD_ENABLED
 SOL_API struct sol_fd *
-sol_fd_add(int fd, unsigned int flags, bool (*cb)(void *data, int fd, unsigned int active_flags), const void *data)
+sol_fd_add(int fd, uint32_t flags, bool (*cb)(void *data, int fd, uint32_t active_flags), const void *data)
 {
     SOL_NULL_CHECK(cb, NULL);
     return sol_mainloop_impl_fd_add(fd, flags, cb, data);
@@ -281,13 +281,13 @@ sol_fd_del(struct sol_fd *handle)
 }
 
 SOL_API bool
-sol_fd_set_flags(struct sol_fd *handle, unsigned int flags)
+sol_fd_set_flags(struct sol_fd *handle, uint32_t flags)
 {
     SOL_NULL_CHECK(handle, false);
     return sol_mainloop_impl_fd_set_flags(handle, flags);
 }
 
-SOL_API unsigned int
+SOL_API uint32_t
 sol_fd_get_flags(const struct sol_fd *handle)
 {
     SOL_NULL_CHECK(handle, false);
@@ -295,7 +295,7 @@ sol_fd_get_flags(const struct sol_fd *handle)
 }
 
 SOL_API bool
-sol_fd_unset_flags(struct sol_fd *handle, unsigned int flags)
+sol_fd_unset_flags(struct sol_fd *handle, uint32_t flags)
 {
     SOL_NULL_CHECK(handle, false);
     return sol_mainloop_impl_fd_set_flags(handle, sol_mainloop_impl_fd_get_flags(handle) & ~flags);

--- a/src/lib/common/sol-platform-linux-common.c
+++ b/src/lib/common/sol-platform-linux-common.c
@@ -633,7 +633,7 @@ next:
 }
 
 static bool
-sol_uevent_handler(void *data, int fd, unsigned int cond)
+sol_uevent_handler(void *data, int fd, uint32_t cond)
 {
     int len;
     struct uevent_context *ctx = data;

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -435,7 +435,7 @@ void sol_coap_header_set_id(struct sol_coap_packet *pkt, uint16_t id);
  *
  * @see sol_coap_secure_server_new()
  */
-struct sol_coap_server *sol_coap_server_new(int port);
+struct sol_coap_server *sol_coap_server_new(uint16_t port);
 
 /**
  * Creates a new secure CoAP server instance.
@@ -452,7 +452,7 @@ struct sol_coap_server *sol_coap_server_new(int port);
  *
  * @see sol_coap_secure_server_new()
  */
-struct sol_coap_server *sol_coap_secure_server_new(int port);
+struct sol_coap_server *sol_coap_secure_server_new(uint16_t port);
 
 /**
  * Take a reference of the given server.

--- a/src/lib/comms/include/sol-mqtt.h
+++ b/src/lib/comms/include/sol-mqtt.h
@@ -343,7 +343,7 @@ struct sol_mqtt_config {
  *
  * @return New mqtt object on sucess, NULL otherwise
  */
-struct sol_mqtt *sol_mqtt_connect(const char *host, int port, const struct sol_mqtt_config *config, void *data);
+struct sol_mqtt *sol_mqtt_connect(const char *host, uint16_t port, const struct sol_mqtt_config *config, void *data);
 
 /**
  * @brief Reestablish the connection to the MQTT broker

--- a/src/lib/comms/include/sol-network.h
+++ b/src/lib/comms/include/sol-network.h
@@ -83,7 +83,7 @@ enum sol_network_link_flags {
 };
 
 struct sol_network_link_addr {
-    unsigned short int family;
+    uint16_t family;
     union {
         uint8_t in[4];
         uint8_t in6[16];
@@ -97,7 +97,7 @@ struct sol_network_link {
     uint16_t api_version;
     int : 0; /* save possible hole for a future field */
 #endif
-    int index;
+    uint16_t index;
     enum sol_network_link_flags flags;
     struct sol_vector addrs;       /* struct sol_network_link_addr */
 };
@@ -120,7 +120,7 @@ bool sol_network_unsubscribe_events(void (*cb)(void *data, const struct sol_netw
 const struct sol_vector *sol_network_get_available_links(void);
 char *sol_network_link_get_name(const struct sol_network_link *link);
 
-bool sol_network_link_up(unsigned int link_index);
+bool sol_network_link_up(uint16_t link_index);
 
 /**
  * @}

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -1212,7 +1212,7 @@ network_event(void *data, const struct sol_network_link *link, enum sol_network_
 }
 
 static struct sol_coap_server *
-sol_coap_server_new_full(enum sol_socket_type type, int port)
+sol_coap_server_new_full(enum sol_socket_type type, uint16_t port)
 {
     struct sol_network_link_addr servaddr = { .family = AF_INET6,
                                               .port = port };
@@ -1294,13 +1294,13 @@ sol_coap_server_new_full(enum sol_socket_type type, int port)
 }
 
 SOL_API struct sol_coap_server *
-sol_coap_server_new(int port)
+sol_coap_server_new(uint16_t port)
 {
     return sol_coap_server_new_full(SOL_SOCKET_UDP, port);
 }
 
 SOL_API struct sol_coap_server *
-sol_coap_secure_server_new(int port)
+sol_coap_secure_server_new(uint16_t port)
 {
 #ifdef DTLS
     return sol_coap_server_new_full(SOL_SOCKET_DTLS, port);

--- a/src/lib/comms/sol-http-client-impl-curl.c
+++ b/src/lib/comms/sol-http-client-impl-curl.c
@@ -303,7 +303,7 @@ cleanup:
 }
 
 static bool
-connection_watch_cb(void *data, int fd, unsigned int flags)
+connection_watch_cb(void *data, int fd, uint32_t flags)
 {
     struct sol_http_client_connection *connection = data;
     int action = 0;

--- a/src/lib/comms/sol-http-server-impl-microhttpd.c
+++ b/src/lib/comms/sol-http-server-impl-microhttpd.c
@@ -497,7 +497,7 @@ end:
 }
 
 static bool
-connection_watch_cb(void *data, int fd, unsigned int flags)
+connection_watch_cb(void *data, int fd, uint32_t flags)
 {
     uint16_t i;
     fd_set rs, ws, es;

--- a/src/lib/comms/sol-mqtt-impl-mosquitto.c
+++ b/src/lib/comms/sol-mqtt-impl-mosquitto.c
@@ -154,7 +154,7 @@ sol_mqtt_shutdown(void)
 }
 
 static bool
-sol_mqtt_event_loop(void *data, int fd, unsigned int active_flags)
+sol_mqtt_event_loop(void *data, int fd, uint32_t active_flags)
 {
     struct sol_mqtt *mqtt = data;
     int r;
@@ -343,7 +343,7 @@ sol_mqtt_on_unsubscribe(struct mosquitto *mosq, void *data, int id)
 }
 
 SOL_API struct sol_mqtt *
-sol_mqtt_connect(const char *host, int port, const struct sol_mqtt_config *config, void *data)
+sol_mqtt_connect(const char *host, uint16_t port, const struct sol_mqtt_config *config, void *data)
 {
     struct sol_mqtt *mqtt;
     int r;
@@ -398,7 +398,7 @@ sol_mqtt_connect(const char *host, int port, const struct sol_mqtt_config *confi
 
     r = mosquitto_connect_async(mqtt->mosq, host, port, mqtt->keepalive);
     if (r != MOSQ_ERR_SUCCESS)
-        SOL_WRN("Unable to connect to %s:%d", host, port);
+        SOL_WRN("Unable to connect to %s:%" PRIu16, host, port);
 
     mqtt->socket_fd = mosquitto_socket(mqtt->mosq);
     if (mqtt->socket_fd == -1) {

--- a/src/lib/comms/sol-network-impl-linux.c
+++ b/src/lib/comms/sol-network-impl-linux.c
@@ -214,7 +214,7 @@ _on_addr_event(struct nlmsghdr *header)
 }
 
 static bool
-_on_event(void *data, int nl_socket, unsigned int cond)
+_on_event(void *data, int nl_socket, uint32_t cond)
 {
     int status;
     char buf[4096];
@@ -470,7 +470,7 @@ sol_network_link_get_name(const struct sol_network_link *link)
 }
 
 SOL_API bool
-sol_network_link_up(unsigned int link_index)
+sol_network_link_up(uint16_t link_index)
 {
     char buf[NLMSG_ALIGN(sizeof(struct nlmsghdr) + sizeof(struct ifinfomsg) + 512)] = { 0 };
     struct iovec iov = { buf, sizeof(buf) };

--- a/src/lib/comms/sol-network-impl-riot.c
+++ b/src/lib/comms/sol-network-impl-riot.c
@@ -83,7 +83,7 @@ sol_network_addr_from_str(struct sol_network_link_addr *addr, const char *buf)
 }
 
 static int
-add_ip6_link(int idx, gnrc_ipv6_netif_t *if_ip6)
+add_ip6_link(uint16_t idx, gnrc_ipv6_netif_t *if_ip6)
 {
 #if MODULE_GNRC_IPV6_NETIF
     int i;

--- a/src/lib/io/include/sol-gpio.h
+++ b/src/lib/io/include/sol-gpio.h
@@ -97,7 +97,7 @@ struct sol_gpio_config {
             enum sol_gpio_edge trigger_mode;
             void (*cb)(void *data, struct sol_gpio *gpio);
             const void *user_data;
-            int poll_timeout; /* Will be used if interruptions are not possible */
+            uint32_t poll_timeout; /* Will be used if interruptions are not possible */
         } in;
         struct {
             bool value;

--- a/src/lib/io/include/sol-memmap-storage.h
+++ b/src/lib/io/include/sol-memmap-storage.h
@@ -98,7 +98,7 @@ struct sol_memmap_map {
                        * @arg @a devnumber is device number on bus, like 0x50
                        * @arg @a devname is device name, the one recognized by its driver
                        */
-    unsigned int timeout; /**< Timeout, in milliseconds, of writing operations. After a write is requested, a timer will run and group all
+    uint32_t timeout; /**< Timeout, in milliseconds, of writing operations. After a write is requested, a timer will run and group all
                            * writing operations until it expires, when real writing will be performed */
     const struct sol_str_table_ptr *entries; /**< Entries on map, containing name, offset and size */ /* Memory trick in place, must be last on struct*/
 };
@@ -178,9 +178,9 @@ int sol_memmap_remove_map(const struct sol_memmap_map *map);
  * @note This change will take effect after current active timer expires.
  * Active ones will remain unchanged
  */
-bool sol_memmap_set_timeout(struct sol_memmap_map *map, unsigned int timeout);
+bool sol_memmap_set_timeout(struct sol_memmap_map *map, uint32_t timeout);
 
-unsigned int sol_memmap_get_timeout(const struct sol_memmap_map *map);
+uint32_t sol_memmap_get_timeout(const struct sol_memmap_map *map);
 
 #define CREATE_BUFFER(_val) \
     struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val, \

--- a/src/lib/io/sol-gpio-impl-linux.c
+++ b/src/lib/io/sol-gpio-impl-linux.c
@@ -145,7 +145,7 @@ _gpio_open_fd(struct sol_gpio *gpio, enum sol_gpio_direction dir)
 }
 
 static bool
-_gpio_on_event(void *userdata, int fd, unsigned int cond)
+_gpio_on_event(void *userdata, int fd, uint32_t cond)
 {
     struct sol_gpio *gpio = userdata;
 
@@ -224,8 +224,8 @@ _gpio_in_config(struct sol_gpio *gpio, const struct sol_gpio_config *config, int
     }
 
 timeout_mode:
-    if (config->in.poll_timeout <= 0) {
-        SOL_WRN("gpio #%d: Timeout value '%d' is invalid, must be a positive number of milliseconds.",
+    if (config->in.poll_timeout == 0) {
+        SOL_WRN("gpio #%d: Timeout value '%" PRIu32 "' is invalid, must be a positive number of milliseconds.",
             gpio->pin, config->in.poll_timeout);
         return -EINVAL;
     }

--- a/src/lib/io/sol-iio.c
+++ b/src/lib/io/sol-iio.c
@@ -395,7 +395,7 @@ calc_buffer_size(const struct sol_iio_device *device)
 }
 
 static bool
-device_reader_cb(void *data, int fd, unsigned int active_flags)
+device_reader_cb(void *data, int fd, uint32_t active_flags)
 {
     struct sol_iio_device *device = data;
     bool result = true;

--- a/src/lib/io/sol-memmap-storage.c
+++ b/src/lib/io/sol-memmap-storage.c
@@ -715,7 +715,7 @@ sol_memmap_remove_map(const struct sol_memmap_map *map)
 }
 
 SOL_API bool
-sol_memmap_set_timeout(struct sol_memmap_map *map, unsigned int timeout)
+sol_memmap_set_timeout(struct sol_memmap_map *map, uint32_t timeout)
 {
     struct map_internal *map_internal;
     int i;
@@ -736,7 +736,7 @@ sol_memmap_set_timeout(struct sol_memmap_map *map, unsigned int timeout)
     return false;
 }
 
-SOL_API unsigned int
+SOL_API uint32_t
 sol_memmap_get_timeout(const struct sol_memmap_map *map)
 {
     struct map_internal *map_internal;

--- a/src/lib/io/sol-uart-impl-linux.c
+++ b/src/lib/io/sol-uart-impl-linux.c
@@ -66,7 +66,7 @@ struct sol_uart {
 };
 
 static bool
-uart_rx_callback(void *data, int fd, unsigned int active_flags)
+uart_rx_callback(void *data, int fd, uint32_t active_flags)
 {
     struct sol_uart *uart = data;
 
@@ -205,7 +205,7 @@ uart_tx_dispatch(struct sol_uart *uart, int status)
 }
 
 static bool
-uart_tx_callback(void *data, int fd, unsigned int active_flags)
+uart_tx_callback(void *data, int fd, uint32_t active_flags)
 {
     struct sol_uart *uart = data;
     int ret;

--- a/src/modules/flow/accelerometer/adxl45.c
+++ b/src/modules/flow/accelerometer/adxl45.c
@@ -97,7 +97,7 @@ static bool accel_tick_do(void *data);
 
 static int
 accel_timer_resched(struct accelerometer_adxl345_data *mdata,
-    unsigned int timeout_ms,
+    uint32_t timeout_ms,
     bool (*cb)(void *data))
 {
     mdata->timer = sol_timeout_add(timeout_ms, cb, mdata);

--- a/src/modules/flow/accelerometer/lsm303.c
+++ b/src/modules/flow/accelerometer/lsm303.c
@@ -70,7 +70,7 @@ struct accelerometer_lsm303_data {
 static bool lsm303_read_data(void *data);
 
 static int
-lsm303_timer_resched(struct accelerometer_lsm303_data *mdata, unsigned int timeout_ms, bool (*cb)(void *data))
+lsm303_timer_resched(struct accelerometer_lsm303_data *mdata, uint32_t timeout_ms, bool (*cb)(void *data))
 {
     mdata->timer = sol_timeout_add(timeout_ms, cb, mdata);
     SOL_NULL_CHECK(mdata->timer, -ENOMEM);

--- a/src/modules/flow/am2315/am2315.c
+++ b/src/modules/flow/am2315/am2315.c
@@ -78,7 +78,7 @@ struct am2315 {
 static struct sol_ptr_vector devices = SOL_PTR_VECTOR_INIT;
 
 static int
-timer_sched(struct am2315 *device, unsigned int timeout_ms, bool (*cb)(void *data))
+timer_sched(struct am2315 *device, uint32_t timeout_ms, bool (*cb)(void *data))
 {
     device->timer = sol_timeout_add(timeout_ms, cb, device);
     SOL_NULL_CHECK(device->timer, -ENOMEM);

--- a/src/modules/flow/calamari/calamari.c
+++ b/src/modules/flow/calamari/calamari.c
@@ -376,7 +376,7 @@ struct calamari_lever_data {
     struct sol_flow_node *node;
     struct sol_spi *spi;
     struct sol_timeout *timer;
-    unsigned int poll_interval;
+    uint32_t poll_interval;
 
     struct sol_irange val;
 

--- a/src/modules/flow/evdev/evdev.c
+++ b/src/modules/flow/evdev/evdev.c
@@ -102,7 +102,7 @@ evdev_add_handler_check(void)
 }
 
 static bool
-evdev_fd_handler_cb(void *data, int fd, unsigned int active_flags)
+evdev_fd_handler_cb(void *data, int fd, uint32_t active_flags)
 {
     struct evdev_fd_handler *fdh = data;
     bool retval = true;

--- a/src/modules/flow/form/form.c
+++ b/src/modules/flow/form/form.c
@@ -1368,7 +1368,7 @@ struct integer_custom_data {
     struct sol_timeout *timer;
     char *chars;
     size_t cursor_row, cursor_col, value_prefix_len;
-    int blink_time;
+    uint32_t blink_time;
     uint8_t n_digits;
     bool blink_on : 1;
     bool state_changed : 1;

--- a/src/modules/flow/grove/grove.c
+++ b/src/modules/flow/grove/grove.c
@@ -725,7 +725,7 @@ timer_cb(void *data)
 
 static int
 timer_reschedule(struct lcd_data *mdata,
-    unsigned int timeout_ms,
+    uint32_t timeout_ms,
     bool delete_prev)
 {
     if (mdata->timer) {

--- a/src/modules/flow/gyroscope/gyroscope.c
+++ b/src/modules/flow/gyroscope/gyroscope.c
@@ -109,7 +109,7 @@ static bool gyro_tick_do(void *data);
 
 static int
 gyro_timer_resched(struct gyroscope_l3g4200d_data *mdata,
-    unsigned int timeout_ms,
+    uint32_t timeout_ms,
     bool (*cb)(void *data))
 {
     mdata->timer = sol_timeout_add(timeout_ms, cb, mdata);

--- a/src/modules/flow/keyboard/keyboard.c
+++ b/src/modules/flow/keyboard/keyboard.c
@@ -224,7 +224,7 @@ keyboard_irange_on_code(struct keyboard_common_data *data,
 }
 
 static bool
-keyboard_on_event(void *data, int fd, unsigned int cond)
+keyboard_on_event(void *data, int fd, uint32_t cond)
 {
     struct keyboard_common_data *mdata = data;
 

--- a/src/modules/flow/magnetometer/lsm303.c
+++ b/src/modules/flow/magnetometer/lsm303.c
@@ -65,7 +65,7 @@ struct magnetometer_lsm303_data {
 static bool magnetometer_lsm303_tick_do(void *data);
 
 static int
-timer_sched(struct magnetometer_lsm303_data *mdata, unsigned int timeout_ms, bool (*cb)(void *data))
+timer_sched(struct magnetometer_lsm303_data *mdata, uint32_t timeout_ms, bool (*cb)(void *data))
 {
     mdata->timer = sol_timeout_add(timeout_ms, cb, mdata);
     SOL_NULL_CHECK(mdata->timer, -ENOMEM);

--- a/src/modules/flow/process/output.c
+++ b/src/modules/flow/process/output.c
@@ -107,7 +107,7 @@ output_write(struct output_data *output)
 }
 
 static bool
-watch_cb(void *data, int fd, unsigned int active_flags)
+watch_cb(void *data, int fd, uint32_t active_flags)
 {
     struct output_data *output = data;
     int err = 0;

--- a/src/modules/flow/process/stdin.c
+++ b/src/modules/flow/process/stdin.c
@@ -103,7 +103,7 @@ stdin_monitor_in_use(const struct stdin_monitor *m)
 }
 
 static bool
-stdin_watch_cb(void *data, int fd, unsigned int active_flags)
+stdin_watch_cb(void *data, int fd, uint32_t active_flags)
 {
     struct stdin_monitor *m;
     struct sol_blob *blob = NULL;

--- a/src/modules/flow/process/subprocess.c
+++ b/src/modules/flow/process/subprocess.c
@@ -89,7 +89,7 @@ out_write(struct subprocess_data *mdata)
 }
 
 static bool
-on_write(void *data, int fd, unsigned int active_flags)
+on_write(void *data, int fd, uint32_t active_flags)
 {
     struct subprocess_data *mdata = data;
     int err = 0;
@@ -227,7 +227,7 @@ blob_error:
 }
 
 static bool
-on_in_read(void *data, int fd, unsigned int active_flags)
+on_in_read(void *data, int fd, uint32_t active_flags)
 {
     struct subprocess_data *mdata = data;
     struct sol_blob *blob = NULL;
@@ -253,7 +253,7 @@ on_in_read(void *data, int fd, unsigned int active_flags)
 }
 
 static bool
-on_err_read(void *data, int fd, unsigned int active_flags)
+on_err_read(void *data, int fd, uint32_t active_flags)
 {
     struct subprocess_data *mdata = data;
     struct sol_blob *blob = NULL;

--- a/src/modules/flow/thingspeak/thingspeak.c
+++ b/src/modules/flow/thingspeak/thingspeak.c
@@ -196,7 +196,7 @@ thingspeak_execute_open(struct sol_flow_node *node, void *data, const struct sol
 {
     struct thingspeak_execute_data *mdata = data;
     const struct sol_flow_node_type_thingspeak_talkback_execute_options *opts;
-    int interval;
+    uint32_t interval;
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_THINGSPEAK_TALKBACK_EXECUTE_OPTIONS_API_VERSION,
         -EINVAL);
@@ -207,7 +207,7 @@ thingspeak_execute_open(struct sol_flow_node *node, void *data, const struct sol
         return -ENOMEM;
 
     if (opts->interval < 1000) {
-        SOL_WRN("Throttling polling interval from %dms to 1000ms to not flood Thingspeak",
+        SOL_WRN("Throttling polling interval from %" PRId32 "ms to 1000ms to not flood Thingspeak",
             opts->interval);
         interval = 1000;
     } else {

--- a/src/modules/flow/udev/udev.c
+++ b/src/modules/flow/udev/udev.c
@@ -53,7 +53,7 @@ struct udev_data {
 };
 
 static bool
-_on_event(void *data, int fd, unsigned int cond)
+_on_event(void *data, int fd, uint32_t cond)
 {
     struct udev_data *mdata = data;
     struct udev_device *device;

--- a/src/modules/flow/unix-socket/unix-socket-impl.c
+++ b/src/modules/flow/unix-socket/unix-socket-impl.c
@@ -93,7 +93,7 @@ socket_write(int fd, const void *data, size_t count)
 }
 
 static bool
-on_client_data(void *data, int fd, unsigned int cond)
+on_client_data(void *data, int fd, uint32_t cond)
 {
     struct unix_socket *un_socket = data;
 
@@ -114,7 +114,7 @@ err:
 }
 
 static bool
-on_server_data(void *data, int fd, unsigned int cond)
+on_server_data(void *data, int fd, uint32_t cond)
 {
     struct unix_socket_server *server = data;
     struct client_data *c;
@@ -137,7 +137,7 @@ on_server_data(void *data, int fd, unsigned int cond)
 }
 
 static bool
-on_server_connect(void *data, int fd, unsigned int cond)
+on_server_connect(void *data, int fd, uint32_t cond)
 {
     struct unix_socket_server *server = data;
     struct client_data *c = sol_vector_append(&server->clients);

--- a/src/modules/linux-micro/watchdog/watchdog.c
+++ b/src/modules/linux-micro/watchdog/watchdog.c
@@ -140,7 +140,7 @@ watchdog_start(const struct sol_platform_linux_micro_module *mod, const char *se
 {
     int err = 0;
     int timeout = 60;
-    unsigned int timeout_ms;
+    uint32_t timeout_ms;
 
     if (watchdog_fd >= 0)
         return 0;
@@ -165,9 +165,9 @@ watchdog_start(const struct sol_platform_linux_micro_module *mod, const char *se
     }
 
     if (timeout > 5)
-        timeout_ms = (unsigned)(timeout - 5) * 1000U;
+        timeout_ms = (uint32_t)(timeout - 5) * 1000U;
     else
-        timeout_ms = (unsigned)timeout * 900U;
+        timeout_ms = (uint32_t)timeout * 900U;
 
     watchdog_timeout = sol_timeout_add(timeout_ms, watchdog_keep_alive, NULL);
     if (!watchdog_timeout) {

--- a/src/samples/crypto/md5sum.c
+++ b/src/samples/crypto/md5sum.c
@@ -139,7 +139,7 @@ check_stdin(void)
 }
 
 static bool
-on_stdin_hash(void *data, int fd, unsigned int flags)
+on_stdin_hash(void *data, int fd, uint32_t flags)
 {
     struct entry *entry = data;
     struct sol_blob *b = NULL;

--- a/src/test/test-mainloop-linux.c
+++ b/src/test/test-mainloop-linux.c
@@ -89,7 +89,7 @@ watchdog(void *data)
 }
 
 static bool
-on_fd(void *data, int fd, unsigned int active_flags)
+on_fd(void *data, int fd, uint32_t active_flags)
 {
     if (active_flags & SOL_FD_FLAGS_IN) {
         int err;

--- a/src/test/test-mainloop-threads.c
+++ b/src/test/test-mainloop-threads.c
@@ -68,7 +68,7 @@ idler_dn(void *data)
 }
 
 static bool
-fd_watch_dn(void *data, int fd, unsigned int flags)
+fd_watch_dn(void *data, int fd, uint32_t flags)
 {
     bool *val = data;
 
@@ -156,7 +156,7 @@ thr5_run(void *data)
 }
 
 static bool
-on_fd(void *data, int fd, unsigned int active_flags)
+on_fd(void *data, int fd, uint32_t active_flags)
 {
     if (active_flags & SOL_FD_FLAGS_IN) {
         int err;


### PR DESCRIPTION
In some cases, int won't necessary be the of the size the code using it
expects, so we need to make sure to specify that size where it matters.