### PR TITLE
app:argv: Not failing on open if index out of range

### DIFF
--- a/src/modules/flow/app/app.c
+++ b/src/modules/flow/app/app.c
@@ -71,7 +71,10 @@ argv_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_opt
     opts = (const struct sol_flow_node_type_app_argv_options *)options;
 
     r = check_index(node, opts->index);
-    SOL_INT_CHECK(r, < 0, r);
+    if (r < 0) {
+        SOL_WRN("Could not check the index: %d, an error packet has been sent", opts->index);
+        return 0;
+    }
 
     return sol_flow_send_string_packet(node,
         SOL_FLOW_NODE_TYPE_APP_ARGV__OUT__OUT, sol_argv()[opts->index]);


### PR DESCRIPTION
It's sending an error packet to be possible the flow treat the problem
correctly.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>