### PR TITLE
Do not enforce nul byte in sol-buffer since they are added by default.

### DIFF
--- a/src/lib/comms/sol-http-common.c
+++ b/src/lib/comms/sol-http-common.c
@@ -477,9 +477,6 @@ sol_http_create_uri(char **uri_out, const struct sol_http_url url,
         SOL_INT_CHECK_GOTO(r, < 0, exit);
     }
 
-    r = sol_buffer_ensure_nul_byte(&buf);
-    SOL_INT_CHECK_GOTO(r, < 0, exit);
-
     *uri_out = sol_buffer_steal(&buf, NULL);
 
     if (!*uri_out)
@@ -544,9 +541,6 @@ sol_http_create_simple_uri(char **uri, const struct sol_str_slice base_uri,
             SOL_INT_CHECK_GOTO(r, < 0, exit);
         }
     }
-
-    r = sol_buffer_ensure_nul_byte(&buf);
-    SOL_INT_CHECK_GOTO(r, < 0, exit);
 
     *uri = sol_buffer_steal(&buf, NULL);
 

--- a/src/lib/comms/sol-http-server-impl-microhttpd.c
+++ b/src/lib/comms/sol-http-server-impl-microhttpd.c
@@ -174,8 +174,6 @@ build_mhd_response(const struct sol_http_response *response)
             SOL_INT_CHECK_GOTO(ret, < 0, err);
             ret = sol_buffer_append_slice(&buf, value->value.key_value.value);
             SOL_INT_CHECK_GOTO(ret, < 0, err);
-            ret = sol_buffer_append_char(&buf, 0);
-            SOL_INT_CHECK_GOTO(ret, < 0, err);
             if (MHD_add_response_header(r, sol_buffer_at(&buf, 0), sol_buffer_at(&buf,
                 value->value.key_value.key.len + 1)) == MHD_NO) {
                 SOL_WRN("Could not add the header: %.*s", SOL_STR_SLICE_PRINT(value->value.key_value.key));
@@ -188,8 +186,6 @@ build_mhd_response(const struct sol_http_response *response)
             ret = sol_buffer_append_char(&buf, '=');
             SOL_INT_CHECK_GOTO(ret, < 0, err);
             ret = sol_buffer_append_slice(&buf, value->value.key_value.value);
-            SOL_INT_CHECK_GOTO(ret, < 0, err);
-            ret = sol_buffer_append_char(&buf, 0);
             SOL_INT_CHECK_GOTO(ret, < 0, err);
             if (MHD_add_response_header(r, MHD_HTTP_HEADER_SET_COOKIE, sol_buffer_at(&buf, 0)) == MHD_NO) {
                 SOL_WRN("Could not add the cookie: %.*s", SOL_STR_SLICE_PRINT(value->value.key_value.key));


### PR DESCRIPTION
There's no need to ensure nul byte in these cases, since the sol_buffer
when initialized with the default flags will already insert the nul byte
automatically.

Signed-off-by: Guilherme Iscaro <guilherme.iscaro@intel.com>