### PR TITLE
Fix undefined symbol

### DIFF
--- a/src/lib/comms/sol-socket-impl.h
+++ b/src/lib/comms/sol-socket-impl.h
@@ -54,6 +54,6 @@ struct sol_socket_impl {
 
 #ifdef SOL_PLATFORM_LINUX
 const struct sol_socket_impl *sol_socket_linux_get_impl(void);
-#elif SOL_PLATFORM_RIOT
+#elif defined(SOL_PLATFORM_RIOT)
 const struct sol_socket_impl *sol_socket_riot_get_impl(void);
 #endif

--- a/src/lib/comms/sol-socket.c
+++ b/src/lib/comms/sol-socket.c
@@ -61,7 +61,7 @@ sol_socket_new(int domain, enum sol_socket_type type, int protocol)
 
 #ifdef SOL_PLATFORM_LINUX
     impl = sol_socket_linux_get_impl();
-#elif SOL_PLATFORM_RIOT
+#elif defined(SOL_PLATFORM_RIOT)
     impl = sol_socket_riot_get_impl();
 #endif
 


### PR DESCRIPTION
./src/lib/comms/sol-socket-impl.h:57:7: warning: "SOL_PLATFORM_RIOT" is not defined [-Wundef]
 #elif SOL_PLATFORM_RIOT

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>