### PR TITLE
Some GPIO changes - V2

### DIFF
--- a/src/lib/common/include/sol-pin-mux-modules.h
+++ b/src/lib/common/include/sol-pin-mux-modules.h
@@ -59,7 +59,7 @@ struct sol_pin_mux {
     int (*pin_map)(const char *label, const enum sol_io_protocol prot, va_list args);
 
     int (*aio)(const int device, const int pin);
-    int (*gpio)(const int pin, const enum sol_gpio_direction dir);
+    int (*gpio)(const uint32_t pin, const enum sol_gpio_direction dir);
     int (*i2c)(const uint8_t bus);
     int (*pwm)(const int device, const int channel);
 

--- a/src/lib/common/include/sol-pin-mux.h
+++ b/src/lib/common/include/sol-pin-mux.h
@@ -95,7 +95,7 @@ int sol_pin_mux_setup_aio(const int device, const int pin);
  *
  * @return '0' on success, error code (always negative) otherwise.
  */
-int sol_pin_mux_setup_gpio(const int pin, const enum sol_gpio_direction dir);
+int sol_pin_mux_setup_gpio(const uint32_t pin, const enum sol_gpio_direction dir);
 
 /**
  * Setup the pins used of the given i2c bus number to operate in I2C mode.

--- a/src/lib/common/sol-interrupt_scheduler_riot.c
+++ b/src/lib/common/sol-interrupt_scheduler_riot.c
@@ -152,7 +152,7 @@ uart_rx_cb(void *data, char char_read)
 {
     msg_t m;
     struct uart_interrupt_data *int_data = data;
-    struct uart_rx_interrupt_data *rx_int_data = malloc(sizeof(struct uart_rx_interrupt_data));
+    struct uart_rx_interrupt_data *rx_int_data;
 
     rx_int_data = malloc(sizeof(struct uart_rx_interrupt_data));
     if (!rx_int_data)

--- a/src/lib/common/sol-mainloop-common.c
+++ b/src/lib/common/sol-mainloop-common.c
@@ -555,7 +555,7 @@ sol_mainloop_impl_quit(void)
 }
 
 void *
-sol_mainloop_impl_timeout_add(unsigned int timeout_ms, bool (*cb)(void *data), const void *data)
+sol_mainloop_impl_timeout_add(uint32_t timeout_ms, bool (*cb)(void *data), const void *data)
 {
     struct timespec now;
     int ret;

--- a/src/lib/common/sol-pin-mux.c
+++ b/src/lib/common/sol-pin-mux.c
@@ -201,7 +201,7 @@ sol_pin_mux_setup_aio(const int device, const int pin)
 }
 
 SOL_API int
-sol_pin_mux_setup_gpio(const int pin, const enum sol_gpio_direction dir)
+sol_pin_mux_setup_gpio(const uint32_t pin, const enum sol_gpio_direction dir)
 {
     return (mux && mux->gpio) ? mux->gpio(pin, dir) : 0;
 }

--- a/src/lib/datatypes/include/sol-str-slice.h
+++ b/src/lib/datatypes/include/sol-str-slice.h
@@ -109,17 +109,9 @@ sol_str_slice_caseeq(const struct sol_str_slice a, const struct sol_str_slice b)
     return a.len == b.len && (strncasecmp(a.data, b.data, a.len) == 0);
 }
 
-static inline bool
-sol_str_slice_contains(const struct sol_str_slice haystack, const struct sol_str_slice needle)
-{
-    return memmem(haystack.data, haystack.len, needle.data, needle.len) != NULL;
-}
+bool sol_str_slice_contains(const struct sol_str_slice haystack, const struct sol_str_slice needle);
 
-static inline bool
-sol_str_slice_str_contains(const struct sol_str_slice haystack, const char *needle)
-{
-    return memmem(haystack.data, haystack.len, needle, strlen(needle)) != NULL;
-}
+bool sol_str_slice_str_contains(const struct sol_str_slice haystack, const char *needle);
 
 static inline void
 sol_str_slice_copy(char *dst, const struct sol_str_slice src)

--- a/src/lib/datatypes/sol-str-slice.c
+++ b/src/lib/datatypes/sol-str-slice.c
@@ -61,3 +61,15 @@ sol_str_slice_to_int(const struct sol_str_slice s, int *value)
     *value = v;
     return 0;
 }
+
+SOL_API bool
+sol_str_slice_contains(const struct sol_str_slice haystack, const struct sol_str_slice needle)
+{
+    return memmem(haystack.data, haystack.len, needle.data, needle.len) != NULL;
+}
+
+SOL_API bool
+sol_str_slice_str_contains(const struct sol_str_slice haystack, const char *needle)
+{
+    return memmem(haystack.data, haystack.len, needle, strlen(needle)) != NULL;
+}

--- a/src/lib/io/include/sol-gpio.h
+++ b/src/lib/io/include/sol-gpio.h
@@ -66,7 +66,6 @@ extern "C" {
 struct sol_gpio;
 
 enum sol_gpio_direction {
-    SOL_GPIO_DIR_UNDEFINED = -1,
     SOL_GPIO_DIR_OUT = 0,
     SOL_GPIO_DIR_IN = 1
 };

--- a/src/lib/io/include/sol-gpio.h
+++ b/src/lib/io/include/sol-gpio.h
@@ -95,7 +95,7 @@ struct sol_gpio_config {
     union {
         struct {
             enum sol_gpio_edge trigger_mode;
-            void (*cb)(void *data, struct sol_gpio *gpio);
+            void (*cb)(void *data, struct sol_gpio *gpio, bool value);
             const void *user_data;
             uint32_t poll_timeout; /* Will be used if interruptions are not possible */
         } in;

--- a/src/lib/io/include/sol-gpio.h
+++ b/src/lib/io/include/sol-gpio.h
@@ -135,7 +135,7 @@ struct sol_gpio *sol_gpio_open_by_label(const char *label, const struct sol_gpio
  *
  * @return A new @c sol_gpio instance on success, @c NULL otherwise.
  */
-struct sol_gpio *sol_gpio_open(int pin, const struct sol_gpio_config *config) SOL_ATTR_WARN_UNUSED_RESULT;
+struct sol_gpio *sol_gpio_open(uint32_t pin, const struct sol_gpio_config *config) SOL_ATTR_WARN_UNUSED_RESULT;
 
 
 /**
@@ -151,7 +151,7 @@ struct sol_gpio *sol_gpio_open(int pin, const struct sol_gpio_config *config) SO
  *
  * @return A new @c sol_gpio instance on success, @c NULL otherwise.
  */
-struct sol_gpio *sol_gpio_open_raw(int pin, const struct sol_gpio_config *config) SOL_ATTR_WARN_UNUSED_RESULT;
+struct sol_gpio *sol_gpio_open_raw(uint32_t pin, const struct sol_gpio_config *config) SOL_ATTR_WARN_UNUSED_RESULT;
 
 /**
  * Closes a given GPIO pin.

--- a/src/lib/io/sol-gpio-common.c
+++ b/src/lib/io/sol-gpio-common.c
@@ -51,7 +51,7 @@ _log_init(void)
 SOL_API struct sol_gpio *
 sol_gpio_open_by_label(const char *label, const struct sol_gpio_config *config)
 {
-    int pin;
+    uint32_t pin;
 
     _log_init();
 
@@ -69,7 +69,7 @@ sol_gpio_open_by_label(const char *label, const struct sol_gpio_config *config)
 }
 
 SOL_API struct sol_gpio *
-sol_gpio_open(int pin, const struct sol_gpio_config *config)
+sol_gpio_open(uint32_t pin, const struct sol_gpio_config *config)
 {
     struct sol_gpio *gpio;
 

--- a/src/lib/io/sol-gpio-impl-contiki.c
+++ b/src/lib/io/sol-gpio-impl-contiki.c
@@ -52,7 +52,7 @@ struct sol_gpio {
     struct sensors_sensor *button_sensor;
     bool active_low;
     struct {
-        void (*cb)(void *data, struct sol_gpio *gpio);
+        void (*cb)(void *data, struct sol_gpio *gpio, bool value);
         void *data;
     } irq;
 };
@@ -61,8 +61,10 @@ static void
 event_handler_cb(void *user_data, process_event_t ev, process_data_t ev_data)
 {
     struct sol_gpio *gpio = user_data;
+    bool val;
 
-    gpio->irq.cb(gpio->irq.data, gpio);
+    val = sol_gpio_read(gpio);
+    gpio->irq.cb(gpio->irq.data, gpio, val);
 }
 
 struct sol_gpio *

--- a/src/lib/io/sol-gpio-impl-contiki.c
+++ b/src/lib/io/sol-gpio-impl-contiki.c
@@ -48,7 +48,7 @@
 static SOL_LOG_INTERNAL_DECLARE(_log_domain, "gpio");
 
 struct sol_gpio {
-    int pin;
+    uint32_t pin;
     struct sensors_sensor *button_sensor;
     bool active_low;
     struct {
@@ -68,7 +68,7 @@ event_handler_cb(void *user_data, process_event_t ev, process_data_t ev_data)
 }
 
 struct sol_gpio *
-sol_gpio_open_raw(int pin, const struct sol_gpio_config *config)
+sol_gpio_open_raw(uint32_t pin, const struct sol_gpio_config *config)
 {
     struct sol_gpio *gpio;
     struct sensors_sensor *found = NULL;
@@ -78,7 +78,7 @@ sol_gpio_open_raw(int pin, const struct sol_gpio_config *config)
     process_start(&sensors_process, NULL);
 
     if (config->drive_mode != SOL_GPIO_DRIVE_NONE) {
-        SOL_ERR("Unable to set pull resistor on pin=%d", pin);
+        SOL_ERR("Unable to set pull resistor on pin=%" PRIu32, pin);
         return NULL;
     }
 
@@ -100,12 +100,12 @@ sol_gpio_open_raw(int pin, const struct sol_gpio_config *config)
         }
 
         if (!found) {
-            SOL_ERR("GPIO pin=%d not found.", pin);
+            SOL_ERR("GPIO pin=%" PRIu32 " not found.", pin);
             return NULL;
         }
     } else {
         if (pin < 0 || pin > 7) {
-            SOL_ERR("GPIO pin=%d not found.", pin);
+            SOL_ERR("GPIO pin=%" PRIu32 " not found.", pin);
             return NULL;
         }
     }

--- a/src/lib/io/sol-gpio-impl-linux.c
+++ b/src/lib/io/sol-gpio-impl-linux.c
@@ -55,7 +55,7 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "gpio");
 #define EXPORT_STAT_RETRIES 10
 
 struct sol_gpio {
-    int pin;
+    uint32_t pin;
 
     FILE *fp;
     struct {
@@ -72,7 +72,7 @@ struct sol_gpio {
 };
 
 static bool
-_gpio_export(int gpio, bool unexport)
+_gpio_export(uint32_t gpio, bool unexport)
 {
     char gpio_dir[PATH_MAX];
     int len, retries = 0;
@@ -84,7 +84,7 @@ _gpio_export(int gpio, bool unexport)
     if (unexport)
         action = unexport_path;
 
-    if (sol_util_write_file(action, "%d", gpio) < 0) {
+    if (sol_util_write_file(action, "%u", gpio) < 0) {
         SOL_WRN("Failed writing to GPIO export file");
         return false;
     }
@@ -92,7 +92,7 @@ _gpio_export(int gpio, bool unexport)
     if (unexport)
         return true;
 
-    len = snprintf(gpio_dir, sizeof(gpio_dir), GPIO_BASE "/gpio%d", gpio);
+    len = snprintf(gpio_dir, sizeof(gpio_dir), GPIO_BASE "/gpio%u", gpio);
     if (len < 0 || len > PATH_MAX)
         return false;
 
@@ -132,7 +132,7 @@ _gpio_open_fd(struct sol_gpio *gpio, enum sol_gpio_direction dir)
         mode = "w+e";
     }
 
-    len = snprintf(path, sizeof(path), GPIO_BASE "/gpio%d/value", gpio->pin);
+    len = snprintf(path, sizeof(path), GPIO_BASE "/gpio%u/value", gpio->pin);
     if (len < 0 || len > PATH_MAX)
         return -ENAMETOOLONG;
 
@@ -199,7 +199,7 @@ _gpio_in_config(struct sol_gpio *gpio, const struct sol_gpio_config *config, int
     case SOL_GPIO_EDGE_NONE:
         return 0;
     default:
-        SOL_WRN("gpio #%d: Unsupported edge mode '%d'", gpio->pin, trig);
+        SOL_WRN("gpio #%u: Unsupported edge mode '%d'", gpio->pin, trig);
         return -EINVAL;
     }
 
@@ -208,10 +208,10 @@ _gpio_in_config(struct sol_gpio *gpio, const struct sol_gpio_config *config, int
     gpio->irq.cb = config->in.cb;
     gpio->irq.data = config->in.user_data;
 
-    snprintf(gpio_dir, sizeof(gpio_dir), GPIO_BASE "/gpio%d/edge", gpio->pin);
+    snprintf(gpio_dir, sizeof(gpio_dir), GPIO_BASE "/gpio%u/edge", gpio->pin);
     if (!stat(gpio_dir, &st)) {
         if (sol_util_write_file(gpio_dir, "%s", mode_str) < 0) {
-            SOL_WRN("gpio #%d: could not set requested edge mode, falling back to timeout mode",
+            SOL_WRN("gpio #%u: could not set requested edge mode, falling back to timeout mode",
                 gpio->pin);
             goto timeout_mode;
         }
@@ -223,7 +223,7 @@ _gpio_in_config(struct sol_gpio *gpio, const struct sol_gpio_config *config, int
 
 timeout_mode:
     if (config->in.poll_timeout == 0) {
-        SOL_WRN("gpio #%d: Timeout value '%" PRIu32 "' is invalid, must be a positive number of milliseconds.",
+        SOL_WRN("gpio #%u: Timeout value '%" PRIu32 "' is invalid, must be a positive number of milliseconds.",
             gpio->pin, config->in.poll_timeout);
         return -EINVAL;
     }
@@ -256,19 +256,19 @@ _gpio_config(struct sol_gpio *gpio, const struct sol_gpio_config *config)
      * we have no way of knowing if the requested mode will work, so we can
      * do nothing but trust the user
      */
-    snprintf(gpio_dir, sizeof(gpio_dir), GPIO_BASE "/gpio%d/direction", gpio->pin);
+    snprintf(gpio_dir, sizeof(gpio_dir), GPIO_BASE "/gpio%u/direction", gpio->pin);
     if (!stat(gpio_dir, &st)) {
         if (sol_util_write_file(gpio_dir, "%s", dir_val) < 0) {
-            SOL_WRN("gpio #%d: could not set direction to '%s'", gpio->pin, dir_val);
+            SOL_WRN("gpio #%u: could not set direction to '%s'", gpio->pin, dir_val);
             return -EIO;
         }
     } else
         no_dir = true;
 
-    snprintf(gpio_dir, sizeof(gpio_dir), GPIO_BASE "/gpio%d/active_low", gpio->pin);
+    snprintf(gpio_dir, sizeof(gpio_dir), GPIO_BASE "/gpio%u/active_low", gpio->pin);
 
     if (sol_util_write_file(gpio_dir, "%d", config->active_low) < 0) {
-        SOL_WRN("gpio #%d: could not set requested active_low", config->active_low);
+        SOL_WRN("gpio #%u: could not set requested active_low", config->active_low);
         return -EINVAL;
     }
 
@@ -289,7 +289,7 @@ _gpio_config(struct sol_gpio *gpio, const struct sol_gpio_config *config)
 }
 
 SOL_API struct sol_gpio *
-sol_gpio_open_raw(int pin, const struct sol_gpio_config *config)
+sol_gpio_open_raw(uint32_t pin, const struct sol_gpio_config *config)
 {
     struct sol_gpio *gpio;
     char gpio_dir[PATH_MAX];
@@ -308,14 +308,14 @@ sol_gpio_open_raw(int pin, const struct sol_gpio_config *config)
 
     gpio = calloc(1, sizeof(*gpio));
     if (!gpio) {
-        SOL_WRN("gpio #%d: could not allocate gpio context", pin);
+        SOL_WRN("gpio #%u: could not allocate gpio context", pin);
         return NULL;
     }
 
-    snprintf(gpio_dir, sizeof(gpio_dir), GPIO_BASE "/gpio%d", pin);
+    snprintf(gpio_dir, sizeof(gpio_dir), GPIO_BASE "/gpio%u", pin);
     if (stat(gpio_dir, &st)) {
         if (!_gpio_export(pin, false)) {
-            SOL_WRN("gpio #%d: could not export", pin);
+            SOL_WRN("gpio #%u: could not export", pin);
             goto export_error;
         }
         gpio->owned = true;
@@ -370,7 +370,7 @@ sol_gpio_read(struct sol_gpio *gpio)
 
     rewind(gpio->fp);
     if (fscanf(gpio->fp, "%d", &val) < 1) {
-        SOL_WRN("gpio #%d: could not read value", gpio->pin);
+        SOL_WRN("gpio #%u: could not read value", gpio->pin);
         return -errno;
     }
 

--- a/src/lib/io/sol-gpio-impl-riot.c
+++ b/src/lib/io/sol-gpio-impl-riot.c
@@ -46,7 +46,7 @@
 SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "gpio");
 
 struct sol_gpio {
-    int pin;
+    uint32_t pin;
     bool active_low;
     struct {
         void (*cb)(void *data, struct sol_gpio *gpio, bool value);
@@ -86,7 +86,7 @@ gpio_timeout_cb(void *data)
 }
 
 SOL_API struct sol_gpio *
-sol_gpio_open_raw(int pin, const struct sol_gpio_config *config)
+sol_gpio_open_raw(uint32_t pin, const struct sol_gpio_config *config)
 {
     struct sol_gpio *gpio;
     gpio_pp_t pull;
@@ -139,10 +139,10 @@ sol_gpio_open_raw(int pin, const struct sol_gpio_config *config)
                 gpio_process_cb, gpio, &gpio->irq.int_handler))
                 goto end;
 
-            SOL_WRN("gpio #%d: Could not set interrupt mode, falling back to polling", pin);
+            SOL_WRN("gpio #%" PRIu32 ": Could not set interrupt mode, falling back to polling", pin);
 
             if (!(poll_timeout = config->in.poll_timeout)) {
-                SOL_WRN("gpio #%d: No timeout set, cannot fallback to polling mode", pin);
+                SOL_WRN("gpio #%" PRIu32 ": No timeout set, cannot fallback to polling mode", pin);
                 goto error;
             }
         }

--- a/src/lib/io/sol-gpio-impl-riot.c
+++ b/src/lib/io/sol-gpio-impl-riot.c
@@ -126,8 +126,8 @@ sol_gpio_open_raw(uint32_t pin, const struct sol_gpio_config *config)
         if (trig != SOL_GPIO_EDGE_NONE) {
             gpio_flank_t flank;
             const unsigned int trigger_table[] = {
-                [SOL_GPIO_EDGE_RISING] = GPIO_RISING,
-                [SOL_GPIO_EDGE_FALLING] = GPIO_FALLING,
+                [SOL_GPIO_EDGE_RISING] = gpio->active_low ? GPIO_FALLING : GPIO_RISING,
+                [SOL_GPIO_EDGE_FALLING] = gpio->active_low ? GPIO_RISING : GPIO_FALLING,
                 [SOL_GPIO_EDGE_BOTH] = GPIO_BOTH
             };
 

--- a/src/lib/io/sol-gpio-impl-riot.c
+++ b/src/lib/io/sol-gpio-impl-riot.c
@@ -49,7 +49,7 @@ struct sol_gpio {
     int pin;
     bool active_low;
     struct {
-        void (*cb)(void *data, struct sol_gpio *gpio);
+        void (*cb)(void *data, struct sol_gpio *gpio, bool value);
         const void *data;
         void *int_handler;
     } irq;
@@ -59,8 +59,10 @@ static void
 gpio_process_cb(void *data)
 {
     struct sol_gpio *gpio = data;
+    bool val;
 
-    gpio->irq.cb((void *)gpio->irq.data, gpio);
+    val = sol_gpio_read(gpio);
+    gpio->irq.cb((void *)gpio->irq.data, gpio, val);
 }
 
 SOL_API struct sol_gpio *

--- a/src/modules/flow/gpio/gpio.c
+++ b/src/modules/flow/gpio/gpio.c
@@ -54,14 +54,9 @@ gpio_close(struct sol_flow_node *node, void *data)
 
 /* GPIO READER ********************************************************************/
 static void
-gpio_reader_event(void *data, struct sol_gpio *gpio)
+gpio_reader_event(void *data, struct sol_gpio *gpio, bool value)
 {
-    int value;
     struct sol_flow_node *node = data;
-    struct gpio_data *mdata = sol_flow_node_get_private_data(node);
-
-    value = sol_gpio_read(mdata->gpio);
-    SOL_INT_CHECK(value, < 0);
 
     sol_flow_send_boolean_packet(node,
         SOL_FLOW_NODE_TYPE_GPIO_READER__OUT__OUT, value);

--- a/src/modules/flow/gpio/gpio.c
+++ b/src/modules/flow/gpio/gpio.c
@@ -65,7 +65,7 @@ gpio_reader_event(void *data, struct sol_gpio *gpio, bool value)
 static int
 gpio_reader_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
 {
-    int pin;
+    uint32_t pin;
     struct gpio_data *mdata = data;
     const struct sol_flow_node_type_gpio_reader_options *opts =
         (const struct sol_flow_node_type_gpio_reader_options *)options;
@@ -105,7 +105,7 @@ gpio_reader_open(struct sol_flow_node *node, void *data, const struct sol_flow_n
     }
 
     if (opts->raw) {
-        if (!sscanf(opts->pin, "%d", &pin)) {
+        if (!sscanf(opts->pin, "%" SCNu32, &pin)) {
             SOL_WRN("gpio (%s): 'raw' option was set, but 'pin' value=%s couldn't be parsed as "
                 "integer.", opts->pin, opts->pin);
         } else {
@@ -142,7 +142,7 @@ gpio_writer_process(struct sol_flow_node *node, void *data, uint16_t port, uint1
 static int
 gpio_writer_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
 {
-    int pin;
+    uint32_t pin;
     struct gpio_data *mdata = data;
     const struct sol_flow_node_type_gpio_writer_options *opts =
         (const struct sol_flow_node_type_gpio_writer_options *)options;
@@ -161,7 +161,7 @@ gpio_writer_open(struct sol_flow_node *node, void *data, const struct sol_flow_n
     }
 
     if (opts->raw) {
-        if (!sscanf(opts->pin, "%d", &pin)) {
+        if (!sscanf(opts->pin, "%" SCNu32, &pin)) {
             SOL_WRN("gpio (%s): 'raw' option was set, but 'pin' value=%s couldn't be parsed as "
                 "integer.", opts->pin, opts->pin);
         } else {

--- a/src/modules/pin-mux/intel-common/intel-common.h
+++ b/src/modules/pin-mux/intel-common/intel-common.h
@@ -78,7 +78,7 @@ enum mux_mode {
 #define MODE_GPIO (MODE_GPIO_INPUT | MODE_GPIO_OUTPUT)
 
 struct mux_description {
-    int gpio_pin; /**< GPIO pin that controls the mux */
+    uint32_t gpio_pin; /**< GPIO pin that controls the mux */
     enum mux_pin_val val; /**< Pin value */
     enum mux_mode mode; /**< Combination of possible pin operation modes */
 }; /**< Description of a rule to be applied to setup the multiplexer of a given pin */
@@ -95,7 +95,7 @@ struct mux_controller {
 struct mux_pin_map {
     const char *label; /**< Pin label on the board */
     int cap; /**< Combination of protocols that share the pin */
-    int gpio; /**< GPIO internal value */
+    uint32_t gpio; /**< GPIO internal value */
     struct {
         int device;
         int pin;
@@ -110,8 +110,8 @@ int mux_pin_map(const struct mux_pin_map *map, const char *label, const enum sol
 int mux_set_aio(const int device, const int pin, const struct mux_controller *ctl_list,
     const int s);
 
-int mux_set_gpio(const int pin, const enum sol_gpio_direction dir,
-    struct mux_description **const desc_list, const int s);
+int mux_set_gpio(const uint32_t pin, const enum sol_gpio_direction dir,
+    struct mux_description **const desc_list, const uint32_t s);
 
 int mux_set_i2c(const uint8_t bus, struct mux_description * (*const desc_list)[2],
     const unsigned int s);

--- a/src/modules/pin-mux/intel-edison-rev-c/intel-edison-rev-c.c
+++ b/src/modules/pin-mux/intel-edison-rev-c/intel-edison-rev-c.c
@@ -413,9 +413,9 @@ _set_aio(const int device, const int pin)
 }
 
 static int
-_set_gpio(const int pin, const enum sol_gpio_direction dir)
+_set_gpio(const uint32_t pin, const enum sol_gpio_direction dir)
 {
-    return mux_set_gpio(pin, dir, gpio_dev_0, (int)ARRAY_SIZE(gpio_dev_0));
+    return mux_set_gpio(pin, dir, gpio_dev_0, (uint32_t)ARRAY_SIZE(gpio_dev_0));
 }
 
 static int

--- a/src/modules/pin-mux/intel-galileo-rev-d/intel-galileo-rev-d.c
+++ b/src/modules/pin-mux/intel-galileo-rev-d/intel-galileo-rev-d.c
@@ -180,9 +180,9 @@ _set_aio(const int device, const int pin)
 }
 
 static int
-_set_gpio(const int pin, const enum sol_gpio_direction dir)
+_set_gpio(const uint32_t pin, const enum sol_gpio_direction dir)
 {
-    return mux_set_gpio(pin, dir, gpio_dev_0, (int)ARRAY_SIZE(gpio_dev_0));
+    return mux_set_gpio(pin, dir, gpio_dev_0, (uint32_t)ARRAY_SIZE(gpio_dev_0));
 }
 
 static int

--- a/src/modules/pin-mux/intel-galileo-rev-g/intel-galileo-rev-g.c
+++ b/src/modules/pin-mux/intel-galileo-rev-g/intel-galileo-rev-g.c
@@ -351,9 +351,9 @@ _set_aio(const int device, const int pin)
 }
 
 static int
-_set_gpio(const int pin, const enum sol_gpio_direction dir)
+_set_gpio(const uint32_t pin, const enum sol_gpio_direction dir)
 {
-    return mux_set_gpio(pin, dir, gpio_dev_0, (int)ARRAY_SIZE(gpio_dev_0));
+    return mux_set_gpio(pin, dir, gpio_dev_0, (uint32_t)ARRAY_SIZE(gpio_dev_0));
 }
 
 static int


### PR DESCRIPTION
 - Pass the value on the event callback
 - On RIOT, fallback to polling if interruptions are not available
 - Extra: Fix a leak on UART interruptions (malloc there is bad enough already)

Differences since V1:
 - Added more documentation to sol-gpio.h
 - Fixed build on RIOT
 - Moved gpio::pin to uint32_t
 - Made GPIO interruptions consistent when active_low is set