### PR TITLE
flow/test: Fix use after free in boolean-generator with invalid inputs

### DIFF
--- a/src/modules/flow/test/boolean-generator.c
+++ b/src/modules/flow/test/boolean-generator.c
@@ -54,6 +54,7 @@ timer_tick(void *data)
     } else if (*mdata->it == 'F') {
         out_packet = false;
     } else {
+        mdata->timer = NULL;
         sol_flow_send_error_packet(node, ECANCELED,
             "Unknown sample: %c. Option 'sequence' must be composed by 'T' and/or 'F' chars.",
             *mdata->it);


### PR DESCRIPTION
If a timer callback returns false, the timer is destroyed
automatically.  This caused a user after free bug in
boolean_generator_close(), which would try to call sol_timeout_del() on
a previously-destroyed timer.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>