### PR TITLE
modules/timer: don't reset timer if enabled state doesn't change

### DIFF
--- a/src/modules/flow/timer/timer.c
+++ b/src/modules/flow/timer/timer.c
@@ -114,6 +114,9 @@ timer_enabled_process(struct sol_flow_node *node, void *data, uint16_t port, uin
     r = sol_flow_packet_get_boolean(packet, &val);
     SOL_INT_CHECK(r, < 0, r);
 
+    if (val == !!mdata->timer)
+        return 0;
+
     if (!val)
         return stop_timer(mdata);
     else if (!mdata->timer)


### PR DESCRIPTION
If sucessive packets are received to enable the timer, it will
reset it at each received packet. But it shouldn't.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>