### PR TITLE
Refactor RIOT's interrupt scheduler

### DIFF
--- a/src/lib/common/sol-interrupt_scheduler_riot.h
+++ b/src/lib/common/sol-interrupt_scheduler_riot.h
@@ -32,7 +32,9 @@
 
 #include "kernel_types.h"
 #include "msg.h"
+#ifdef USE_GPIO
 #include "periph/gpio.h"
+#endif
 
 #ifdef USE_UART
 #include "periph/uart.h"
@@ -45,8 +47,10 @@
 void sol_interrupt_scheduler_set_pid(kernel_pid_t pid);
 kernel_pid_t sol_interrupt_scheduler_get_pid(void);
 
+#ifdef USE_GPIO
 int sol_interrupt_scheduler_gpio_init_int(gpio_t dev, gpio_pp_t pullup, gpio_flank_t flank, gpio_cb_t cb, void *arg, void **handler);
 void sol_interrupt_scheduler_gpio_stop(gpio_t dev, void *handler);
+#endif
 
 #ifdef USE_UART
 int sol_interrupt_scheduler_uart_init_int(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, uart_tx_cb_t tx_cb, void *arg, void **handler);

--- a/src/lib/common/sol-interrupt_scheduler_riot.h
+++ b/src/lib/common/sol-interrupt_scheduler_riot.h
@@ -48,12 +48,12 @@ void sol_interrupt_scheduler_set_pid(kernel_pid_t pid);
 kernel_pid_t sol_interrupt_scheduler_get_pid(void);
 
 #ifdef USE_GPIO
-int sol_interrupt_scheduler_gpio_init_int(gpio_t dev, gpio_pp_t pullup, gpio_flank_t flank, gpio_cb_t cb, void *arg, void **handler);
+int sol_interrupt_scheduler_gpio_init_int(gpio_t dev, gpio_pp_t pullup, gpio_flank_t flank, gpio_cb_t cb, const void *arg, void **handler);
 void sol_interrupt_scheduler_gpio_stop(gpio_t dev, void *handler);
 #endif
 
 #ifdef USE_UART
-int sol_interrupt_scheduler_uart_init_int(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, uart_tx_cb_t tx_cb, void *arg, void **handler);
+int sol_interrupt_scheduler_uart_init_int(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, uart_tx_cb_t tx_cb, const void *arg, void **handler);
 void sol_interrupt_scheduler_uart_stop(uart_t uart, void *handler);
 #endif
 


### PR DESCRIPTION
Reduce the number of messages queued due to interruptions, and avoid
calling malloc from an interrupt context.