### PR TITLE
coap: changes related to canceling replies created by sol_coap_send_packet_with_reply - v3

### DIFF
--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -1129,6 +1129,11 @@ found_resource(struct sol_oic_client *oic_cli, struct sol_oic_resource *oic_res,
     struct client_resource *resource = data;
     int r;
 
+    if (!oic_res) {
+        SOL_WRN("resource discovery timeout");
+        return false;
+    }
+
     /* Some OIC device sent this node a discovery response packet but node's already set up. */
     if (resource->resource) {
         SOL_DBG("Received discovery packet when resource already set up, ignoring");
@@ -1237,6 +1242,11 @@ scan_callback(struct sol_oic_client *oic_cli, struct sol_oic_resource *oic_res, 
     char *id;
     uint16_t i;
     int r;
+
+    if (!oic_res) {
+        SOL_WRN("Scanning timeout");
+        return false;
+    }
 
     /* FIXME: Should this check move to sol-oic-client? Does it actually make sense? */
     if (resource->rt && !client_resource_implements_type(oic_res, resource->rt)) {

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -755,6 +755,29 @@ size_t sol_coap_uri_path_to_buf(const struct sol_str_slice path[],
  */
 int sol_coap_cancel_send_packet(struct sol_coap_server *server, struct sol_coap_packet *pkt, struct sol_network_link_addr *cliaddr);
 
+/*
+ * Remove observation identified by @a token from server.
+ *
+ * Send to server an unobserve packet so client identified by @a token will be
+ * removed from the server's observation list. We are suppose to stop receiving
+ * new notifications.
+ *
+ * If observation was added using sol_coap_send_packet_with_reply() function
+ * we will have no more calls to reply_cb.
+ *
+ * @param server The server through which the observation packet was sent.
+ * @param cliaddr The source address of the observation packet sent.
+ * @param token The observation token
+ * @param tkl The observation token length
+ *
+ * @return 0 on success.
+ *         -ENOENT if there is no observe packet registered with @a token and
+ *         no unobserve packet was sent.
+ *         -ENOMEM Out of memory
+ *         -EINVAL if some parameter is invalid.
+ */
+int sol_coap_unobserve_server(struct sol_coap_server *server, const struct sol_network_link_addr *cliaddr, uint8_t *token, uint8_t tkl);
+
 /**
  * @}
  */

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -651,6 +651,11 @@ int sol_coap_send_packet(struct sol_coap_server *server, struct sol_coap_packet 
  * for more responses. When the function returns @c false, the internal response
  * handler will be freed and any new replies that arrive for this request
  * will be ignored.
+ * After internal timeout is reached reply_cb will be called with @c NULL
+ * req and cliaddr. The same behavior is expected for reply_cb return, if
+ * reply_cb returns @c true, @a server will continue waiting responses until
+ * next timeout. If reply_cb returns @c false, @a server will terminate
+ * response waiting.
  *
  * @note This function will take the reference of the given @a pkt.
  *

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -650,7 +650,8 @@ int sol_coap_send_packet(struct sol_coap_server *server, struct sol_coap_packet 
  * As long as this function returns @c true, @a server will continue waiting
  * for more responses. When the function returns @c false, the internal response
  * handler will be freed and any new replies that arrive for this request
- * will be ignored.
+ * will be ignored. For unobserving packets server will also be notified using
+ * an unobserve packet.
  * After internal timeout is reached reply_cb will be called with @c NULL
  * req and cliaddr. The same behavior is expected for reply_cb return, if
  * reply_cb returns @c true, @a server will continue waiting responses until
@@ -741,15 +742,18 @@ size_t sol_coap_uri_path_to_buf(const struct sol_str_slice path[],
 /*
  * Cancel a packet sent using sol_coap_send_packet() or
  * sol_coap_send_packet_with_reply() functions.
+ * For observating packets, an unobserve packet will be sent to server and
+ * no more replies will be processed.
  *
  * @param server The server through which the packet was sent.
  * @param pkt The packet sent.
+ * @param cliaddr The source address of the sent packet.
  *
  * @return 0 on success
  *         -ENOENT if the packet was already canceled
  *         -EINVAL if some parameter is invalid.
  */
-int sol_coap_cancel_send_packet(struct sol_coap_server *server, struct sol_coap_packet *pkt);
+int sol_coap_cancel_send_packet(struct sol_coap_server *server, struct sol_coap_packet *pkt, struct sol_network_link_addr *cliaddr);
 
 /**
  * @}

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -738,6 +738,19 @@ int sol_coap_server_unregister_resource(struct sol_coap_server *server,
 int sol_coap_uri_path_to_buf(const struct sol_str_slice path[],
     uint8_t *buf, size_t buflen);
 
+/*
+ * Cancel a packet sent using sol_coap_send_packet() or
+ * sol_coap_send_packet_with_reply() functions.
+ *
+ * @param server The server through which the packet was sent.
+ * @param pkt The packet sent.
+ *
+ * @return 0 on success
+ *         -ENOENT if the packet was already canceled
+ *         -EINVAL if some parameter is invalid.
+ */
+int sol_coap_cancel_send_packet(struct sol_coap_server *server, struct sol_coap_packet *pkt);
+
 /**
  * @}
  */

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -735,7 +735,7 @@ int sol_coap_server_unregister_resource(struct sol_coap_server *server,
  *
  * @return Size written to @a buf.
  */
-int sol_coap_uri_path_to_buf(const struct sol_str_slice path[],
+size_t sol_coap_uri_path_to_buf(const struct sol_str_slice path[],
     uint8_t *buf, size_t buflen);
 
 /*

--- a/src/lib/comms/include/sol-oic-client.h
+++ b/src/lib/comms/include/sol-oic-client.h
@@ -91,12 +91,14 @@ struct sol_oic_resource {
     struct {
         struct sol_timeout *timeout;
         int clear_data;
+        int64_t token;
     } observe;
     int refcnt;
     bool observable : 1;
     bool active : 1;
     bool slow : 1;
     bool secure : 1;
+    bool is_observing : 1;
 };
 
 bool sol_oic_client_find_resource(struct sol_oic_client *client,

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -276,7 +276,7 @@ uri_path_eq(const struct sol_coap_packet *req, const struct sol_str_slice path[]
     return path[i].len == 0 && i == count;
 }
 
-SOL_API int
+SOL_API size_t
 sol_coap_uri_path_to_buf(const struct sol_str_slice path[],
     uint8_t *buf, size_t buflen)
 {
@@ -293,12 +293,11 @@ sol_coap_uri_path_to_buf(const struct sol_str_slice path[],
         buflen--;
         cur++;
 
-        if (path[i].len >= buflen)
+        if (path[i].len > buflen)
             return cur;
 
         memcpy(buf + cur, path[i].data, path[i].len);
         cur += path[i].len;
-        buflen -= path[i].len;
     }
 
     return cur;
@@ -863,7 +862,8 @@ well_known_get(struct sol_coap_server *server,
     struct resource_context *c;
     struct sol_coap_packet *resp;
     uint8_t *payload;
-    uint16_t i, size, len;
+    uint16_t i, size;
+    size_t len;
     int err;
 
     resp = sol_coap_packet_new(req);
@@ -894,7 +894,7 @@ well_known_get(struct sol_coap_server *server,
         len++;
 
         len += sol_coap_uri_path_to_buf(r->path, payload + len, size - len);
-        if (len >= size - 2)
+        if (len + 2 >= size)
             goto error;
 
         payload[len] = '>';

--- a/src/lib/comms/sol-oic-client.c
+++ b/src/lib/comms/sol-oic-client.c
@@ -333,6 +333,9 @@ _server_info_reply_cb(struct sol_coap_server *server,
     uint16_t payload_len;
     struct sol_oic_server_information info = { 0 };
 
+    if (!req || !cliaddr)
+        goto free_ctx;
+
     if (!ctx->cb) {
         SOL_WRN("No user callback provided");
         goto free_ctx;
@@ -601,6 +604,9 @@ _find_resource_reply_cb(struct sol_coap_server *server,
         return false;
     }
 
+    if (!req || !cliaddr)
+        return ctx->cb(ctx->client, NULL, ctx->data);
+
     if (!_pkt_has_same_token(req, ctx->token)) {
         SOL_WRN("Discovery packet token differs from expected");
         return false;
@@ -729,6 +735,8 @@ _resource_request_cb(struct sol_coap_server *server,
     int payload_type;
 
     if (!ctx->cb)
+        return false;
+    if (!req || !cliaddr)
         return false;
     if (!_pkt_has_same_token(req, ctx->token))
         return true;

--- a/src/lib/comms/sol-oic-client.c
+++ b/src/lib/comms/sol-oic-client.c
@@ -877,11 +877,12 @@ _resource_request(struct sol_oic_client *client, struct sol_oic_resource *res,
             server == client->dtls_server ? "secure" : "non-secure",
             addr.port);
 
-        return sol_coap_send_packet_with_reply(server, req, &addr,
-            cb, ctx) == 0;
-    }
-
-    SOL_ERR("Could not encode CBOR representation: %s", cbor_error_string(err));
+        if (sol_coap_send_packet_with_reply(server, req, &addr,
+            cb, ctx) == 0)
+            return true;
+    } else
+        SOL_ERR("Could not encode CBOR representation: %s",
+            cbor_error_string(err));
 
 out:
     sol_coap_packet_unref(req);

--- a/src/samples/coap/oic-client.c
+++ b/src/samples/coap/oic-client.c
@@ -98,6 +98,9 @@ found_resource(struct sol_oic_client *cli, struct sol_oic_resource *res, void *d
     uint16_t idx;
     char addr[SOL_INET_ADDR_STRLEN];
 
+    if (!res)
+        return false;
+
     if (!sol_network_addr_to_str(&res->addr, addr, sizeof(addr))) {
         SOL_WRN("Could not convert network address to string");
         return false;

--- a/src/samples/coap/simple-client.c
+++ b/src/samples/coap/simple-client.c
@@ -86,6 +86,9 @@ reply_cb(struct sol_coap_server *server, struct sol_coap_packet *req,
     uint8_t *payload;
     uint16_t len;
 
+    if (!req || !cliaddr) //timeout
+        return false;
+
     sol_network_addr_to_str(cliaddr, addr, sizeof(addr));
 
     SOL_INF("Got response from %s", addr);


### PR DESCRIPTION
Changelog from v2:
 - Using correct RFC to implement unobserve packets
 - fix a possible overflow
 - Fix mistake in "Fix memory leak if error" commit

Replaces #1061