### PR TITLE
oic-demo: Use default conffile name for light-client sample

### DIFF
--- a/src/samples/flow/oic/Makefile
+++ b/src/samples/flow/oic/Makefile
@@ -5,7 +5,7 @@ sample-$(FLOW_OIC_SAMPLE) += \
 sample-light-client-$(FLOW_OIC_SAMPLE) := \
 	light-client.fbp
 sample-light-client-$(FLOW_OIC_SAMPLE)-conffile := \
-	light-client.json
+	sol-flow.json
 
 sample-light-server-$(FLOW_OIC_SAMPLE) := \
 	light-server.fbp

--- a/src/samples/flow/oic/README.md
+++ b/src/samples/flow/oic/README.md
@@ -22,7 +22,6 @@ sol-fbp-runner light-server.fbp
 
  * client:
 ```sh
-export SOL_FLOW_MODULE_RESOLVER_CONFFILE=light-client.json
 sol-fbp-runner light-client.fbp
 ```
 

--- a/src/samples/flow/oic/light-client.fbp
+++ b/src/samples/flow/oic/light-client.fbp
@@ -30,16 +30,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # This will timely (every second) toggle an OIC light. This node type
-# is resolved using the light-client.json, please adjust to your network
-# configuration:
+# is resolved using the sol-flow.json, ajust it if needed, and run:
 #
-#    $ export SOL_FLOW_MODULE_RESOLVER_CONFFILE=light-client-mynet.json
 #    $ ./light-client.fbp
-#
-# or save it as sol-flow.json
 
 timer(timer:interval=1000)
-light(Light) FOUND -> ENABLED timer
+light(LightClient) FOUND -> ENABLED timer
 light FOUND -> IN _(console:prefix="Light found ")
 
 timer OUT -> IN toggle(boolean/toggle) OUT -> IN_STATE light

--- a/src/samples/flow/oic/sol-flow.json
+++ b/src/samples/flow/oic/sol-flow.json
@@ -2,7 +2,7 @@
  "$schema": "http://solettaproject.github.io/soletta/schemas/config.schema",
  "nodetypes": [
   {
-   "name": "Light",
+   "name": "LightClient",
    "options": {
     "device_id": "580a3d6a9d194a23b90a24573558d2f4"
    },


### PR DESCRIPTION
As we don't have light-server conffile anymore, we can use the default
conffile name for light-client, so now we don't need to export conffile
before running any oic flow sample.

@bdilly, can you review that, as it is related to some changes you did in this sample conffiles.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>