### PR TITLE
doc: document missing I/O API

### DIFF
--- a/src/lib/common/include/sol-power-supply.h
+++ b/src/lib/common/include/sol-power-supply.h
@@ -55,6 +55,10 @@ extern "C" {
  * @{
  */
 
+/**
+ * Type of power supply.
+ * It may be unknown, battery, mains (like ac), and usb variants.
+ */
 enum sol_power_supply_type {
     SOL_POWER_SUPPLY_TYPE_UNKNOWN,
     SOL_POWER_SUPPLY_TYPE_BATTERY,
@@ -66,6 +70,11 @@ enum sol_power_supply_type {
     SOL_POWER_SUPPLY_TYPE_USB_ACA
 };
 
+/**
+ * Power supply charging status.
+ * It doesn't apply to some types of power supplies.
+ * Batteries usually provide status.
+ */
 enum sol_power_supply_status {
     SOL_POWER_SUPPLY_STATUS_UNKNOWN,
     SOL_POWER_SUPPLY_STATUS_CHARGING,
@@ -74,6 +83,15 @@ enum sol_power_supply_status {
     SOL_POWER_SUPPLY_STATUS_FULL
 };
 
+/**
+ * Power supply capacity level.
+ *
+ * It represents capacity as provided by sol_power_supply_get_capacity()
+ * in well defined ranges.
+ *
+ * It doesn't apply to some types of power supplies.
+ * Batteries usually provide capacity level.
+ */
 enum sol_power_supply_capacity_level {
     SOL_POWER_SUPPLY_CAPACITY_LEVEL_UNKNOWN,
     SOL_POWER_SUPPLY_CAPACITY_LEVEL_CRITICAL,

--- a/src/lib/io/include/sol-efivarfs-storage.h
+++ b/src/lib/io/include/sol-efivarfs-storage.h
@@ -63,7 +63,7 @@ extern "C" {
  * Note that as writing operations are asynchronous, to check if it completely
  * succeded, one needs to register a callback that will inform writing result.
  *
- * @param name name of property. It will create a file on filesyste with
+ * @param name name of property. It will create a file on filesystem with
  * this name.
  * @param blob blob that will be written
  * @param cb callback to be called when writing finishes. It contains status
@@ -75,12 +75,29 @@ extern "C" {
 int sol_efivars_write_raw(const char *name, struct sol_blob *blob,
     void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
     const void *data);
+
+/**
+ * Read stored contents and set to buffer.
+ *
+ * @param name name of property. It will look for a file on filesystem with
+ * this name.
+ * @param buffer buffer that will be set with read contents.
+ *
+ * return 0 on success, a negative number on failure
+ */
 int sol_efivars_read_raw(const char *name, struct sol_buffer *buffer);
 
+/**
+ * Macro to create a struct @ref sol_buffer with value passed as argument
+ * and flags SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED and SOL_BUFFER_FLAGS_NO_NUL_BYTE.
+ */
 #define CREATE_BUFFER(_val) \
     struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val, \
     sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
 
+/**
+ * Macro to create a struct @ref sol_blob with value passed as argument.
+ */
 #define CREATE_BLOB(_val) \
     struct sol_blob *blob; \
     size_t _s = sizeof(*_val); \

--- a/src/lib/io/include/sol-fs-storage.h
+++ b/src/lib/io/include/sol-fs-storage.h
@@ -67,7 +67,7 @@ extern "C" {
  * Note that as writing operations are asynchronous, to check if it completely
  * succeded, one needs to register a callback that will inform writing result.
  *
- * @param name name of property. It will create a file on filesyste with
+ * @param name name of property. It will create a file on filesystem with
  * this name.
  * @param blob blob that will be written
  * @param cb callback to be called when writing finishes. It contains status
@@ -79,12 +79,29 @@ extern "C" {
 int sol_fs_write_raw(const char *name, struct sol_blob *blob,
     void (*cb)(void *data, const char *name, struct sol_blob *blob, int status),
     const void *data);
+
+/**
+ * Read stored contents and set to buffer.
+ *
+ * @param name name of property. It will look for a file on filesystem with
+ * this name.
+ * @param buffer buffer that will be set with read contents.
+ *
+ * return 0 on success, a negative number on failure
+ */
 int sol_fs_read_raw(const char *name, struct sol_buffer *buffer);
 
+/**
+ * Macro to create a struct @ref sol_buffer with value passed as argument
+ * and flags SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED and SOL_BUFFER_FLAGS_NO_NUL_BYTE.
+ */
 #define CREATE_BUFFER(_val) \
     struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val, \
     sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
 
+/**
+ * Macro to create a struct @ref sol_blob with value passed as argument.
+ */
 #define CREATE_BLOB(_val) \
     struct sol_blob *blob; \
     size_t _s = sizeof(*_val); \

--- a/src/lib/io/include/sol-gpio.h
+++ b/src/lib/io/include/sol-gpio.h
@@ -49,7 +49,7 @@ extern "C" {
 /**
  * @defgroup IO I/O
  *
- * These routines are used for general I/O access under Soletta
+ * @brief These routines are used for general I/O access under Soletta
  * (namely GPIO, PWM, SPI, UART and I2C).
  *
  */
@@ -58,7 +58,7 @@ extern "C" {
  * @defgroup GPIO GPIO
  * @ingroup IO
  *
- * GPIO (General Purpose Input/Output) API for Soletta.
+ * @brief GPIO (General Purpose Input/Output) API for Soletta.
  *
  * @{
  */
@@ -116,9 +116,26 @@ enum sol_gpio_edge {
     SOL_GPIO_EDGE_BOTH
 };
 
+/**
+ * Possible values for pull-up or pull-down resistor of a GPIO.
+ *
+ * It will avoid values to float when this pin isn't connected.
+ * It'll define output value if nothing else is defined by software.
+ */
 enum sol_gpio_drive {
+    /**
+     * Do not set any state.
+     */
     SOL_GPIO_DRIVE_NONE = 0,
+    /**
+     * When set as pull-up, resistor will be connected to VCC.
+     * Logic value of output will be @c true while unset.
+     */
     SOL_GPIO_DRIVE_PULL_UP,
+    /**
+     * When set as pull-down, resistor will be connected to ground.
+     * Logic value of output will be @c false while unset.
+     */
     SOL_GPIO_DRIVE_PULL_DOWN
 };
 
@@ -157,6 +174,12 @@ struct sol_gpio_config {
      * different hardware configurations.
      */
     bool active_low;
+    /**
+     * Pull-up or pull-down resistor state for this GPIO.
+     *
+     * One of #sol_gpio_drive. Some platforms will configure GPIO taking
+     * this in consideration, as Continki and RIOT.
+     */
     enum sol_gpio_drive drive_mode;
     union {
         /**
@@ -166,8 +189,8 @@ struct sol_gpio_config {
             /**
              * When to trigger events for this GPIO.
              *
-             * One of #sol_gpio_drive. If the value set is anything other
-             * than #SOL_GPIO_DRIVE_NONE, then the @c cb member must be set.
+             * One of #sol_gpio_edge. If the value set is anything other
+             * than #SOL_GPIO_EDGE_NONE, then the @c cb member must be set.
              */
             enum sol_gpio_edge trigger_mode;
             /**

--- a/src/lib/io/include/sol-i2c.h
+++ b/src/lib/io/include/sol-i2c.h
@@ -49,7 +49,10 @@ extern "C" {
  */
 
 /**
+ * @defgroup I2C I2C
  * @ingroup IO
+ *
+ * @brief I²C (Inter-Integrated Circuit) API for Soletta.
  *
  * @{
  */
@@ -58,12 +61,18 @@ struct sol_i2c;
 
 struct sol_i2c_pending;
 
+/**
+ * @brief Enum for I2C bus speed.
+ *
+ * Must be choosen when opening a bus with sol_i2c_open() and
+ * sol_i2c_open_raw().
+ */
 enum sol_i2c_speed {
-    SOL_I2C_SPEED_10KBIT = 0,
-    SOL_I2C_SPEED_100KBIT,
-    SOL_I2C_SPEED_400KBIT,
-    SOL_I2C_SPEED_1MBIT,
-    SOL_I2C_SPEED_3MBIT_400KBIT
+    SOL_I2C_SPEED_10KBIT = 0, /**< flag for low speed */
+    SOL_I2C_SPEED_100KBIT, /**< flag for normal speed */
+    SOL_I2C_SPEED_400KBIT, /**< flag for fast speed */
+    SOL_I2C_SPEED_1MBIT, /**< flag for fast plus speed */
+    SOL_I2C_SPEED_3MBIT_400KBIT /**< flag for high speed */
 };
 
 /**

--- a/src/lib/io/include/sol-iio.h
+++ b/src/lib/io/include/sol-iio.h
@@ -78,6 +78,11 @@ struct sol_iio_channel_config {
     bool use_custom_offset; /**< If true, will use user defined offset on member #offset of this struct */
 };
 
+/**
+ * Macro that may be used for initialized a @ref sol_iio_channel_config
+ * with default values for this struct. It'll start with scale @c -1.0 and
+ * without custom offset.
+ */
 #define SOL_IIO_CHANNEL_CONFIG_INIT { \
         SOL_SET_API_VERSION(.api_version = SOL_IIO_CHANNEL_CONFIG_API_VERSION, ) \
         .scale = -1.0, .use_custom_offset = false }
@@ -194,7 +199,7 @@ bool sol_iio_device_start_buffer(struct sol_iio_device *device);
  */
 bool sol_iio_address_device(const char *commands, void (*cb)(void *data, int device_id), const void *data);
 
-/*
+/**
  * Returns raw buffer with channel sample.
  *
  * This function is meaningful only when buffer is enabled. Useful for reading

--- a/src/lib/io/include/sol-memmap-storage.h
+++ b/src/lib/io/include/sol-memmap-storage.h
@@ -78,12 +78,25 @@ extern "C" {
 
 #define MEMMAP_VERSION_ENTRY "_version" /**< Name of property which contains stored map version */
 
+/**
+ * Macro to declare a @ref sol_memmap_entry variable setting fields
+ * with values passed by argument.
+ */
 #define SOL_MEMMAP_ENTRY_BIT_SIZE(_name, _offset, _size, _bit_offset, _bit_size) \
     static struct sol_memmap_entry _name = { .offset = (_offset), .size = (_size), .bit_offset = (_bit_offset), .bit_size = (_bit_size) }
 
+
+/**
+ * Macro to declare a @ref sol_memmap_entry variable without bit_offset
+ * and bit_size.
+ */
 #define SOL_MEMMAP_ENTRY(_name, _offset, _size) \
     SOL_MEMMAP_ENTRY_BIT_SIZE(_name, _offset, _size, 0, 0)
 
+/**
+ * Macro to declare a @ref sol_memmap_entry variable for boolean.
+ * So size and bit_size are set to @c 1.
+ */
 #define SOL_MEMMAP_BOOL_ENTRY(_name, _offset, _bit_offset) \
     SOL_MEMMAP_ENTRY_BIT_SIZE(_name, _offset, 1, _bit_offset, 1)
 
@@ -179,12 +192,28 @@ int sol_memmap_remove_map(const struct sol_memmap_map *map);
  */
 bool sol_memmap_set_timeout(struct sol_memmap_map *map, uint32_t timeout);
 
+/**
+ * Get map timeout
+ *
+ * @see sol_memmap_set_timeout() for more details.
+ *
+ * @param map map to get its timeout
+ *
+ * @return timeout in milliseconds.
+ */
 uint32_t sol_memmap_get_timeout(const struct sol_memmap_map *map);
 
+/**
+ * Macro to create a struct @ref sol_buffer with value passed as argument
+ * and flags SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED and SOL_BUFFER_FLAGS_NO_NUL_BYTE.
+ */
 #define CREATE_BUFFER(_val) \
     struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(_val, \
     sizeof(*(_val)), SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
 
+/**
+ * Macro to create a struct @ref sol_blob with value passed as argument.
+ */
 #define CREATE_BLOB(_val) \
     struct sol_blob *blob; \
     size_t _s = sizeof(*_val); \

--- a/src/lib/io/include/sol-pwm.h
+++ b/src/lib/io/include/sol-pwm.h
@@ -57,14 +57,25 @@ extern "C" {
 
 struct sol_pwm;
 
-/* No API for this on Linux, so we simply ignore it there */
+/**
+ * Alignment determines how the pulse is aligned within the PWM period.
+ *
+ * No API for this on Linux, so we simply ignore it there
+ */
 enum sol_pwm_alignment {
-    SOL_PWM_ALIGNMENT_LEFT,
-    SOL_PWM_ALIGNMENT_RIGHT,
-    SOL_PWM_ALIGNMENT_CENTER /* Also known as phase-correct */
+    SOL_PWM_ALIGNMENT_LEFT, /**< The pulse is aligned to the leading-edge (left) of the PWM period. */
+    SOL_PWM_ALIGNMENT_RIGHT, /**< The pulse is aligned to the trailing-edge (right) of the PWM period. */
+    SOL_PWM_ALIGNMENT_CENTER /**< The pulse is aligned to the center of the PWM period. Also known as phase-correct. */
 };
 
-/* This is ignored on RIOT (no API there) and not always supported on Linux */
+/**
+ * Polarity is whether the output is active-high or active-low.
+ * In the paired and complementary configurations, the polarity of the
+ * secondary PWM output is determined by the polarity of the
+ * primary PWM channel.
+ *
+ * This is ignored on RIOT (no API there) and not always supported on Linux.
+ */
 enum sol_pwm_polarity {
     SOL_PWM_POLARITY_NORMAL,
     SOL_PWM_POLARITY_INVERSED
@@ -82,17 +93,142 @@ struct sol_pwm_config {
     bool enabled;
 };
 
+/**
+ * Opens a given pin by its board label as pwm.
+ *
+ * This function only works when the board was successfully detected
+ * by Soletta and a corresponding
+ * pin multiplexer module was found.
+ *
+ * A pin should be opened just once, calling this function more than once
+ * for the same pin results in undefined behavior - per platform basis.
+ *
+ * @see sol_pwm_open_raw(), sol_pwm_close().
+ *
+ * @param label The pin to be opened.
+ * @param config Contains the pin configuration.
+ *
+ * @return A new @c sol_pwm instance on success, @c NULL otherwise.
+ */
 struct sol_pwm *sol_pwm_open_by_label(const char *label, const struct sol_pwm_config *config);
+
+/**
+ * Opens a given pin as pwm.
+ *
+ * A pin (defined by device and channel) should be opened just once,
+ * calling this function more than once
+ * for the same pin results in undefined behaviour - per platform basis.
+ *
+ * @see sol_pwm_open_raw(), sol_pwm_close().
+ *
+ * The difference between sol_pwm_open_raw() and sol_pwm_open() is that
+ * the last will setup pin mux, if enabled.
+ *
+ * @param device The device controlling the pin to be opened.
+ * @param channel The channel used to communicate with the pin to be opened.
+ * @param config Contains the pin configuration.
+ *
+ * @return A new @c sol_pwm instance on success, @c NULL otherwise.
+ */
 struct sol_pwm *sol_pwm_open(int device, int channel, const struct sol_pwm_config *config);
+
+/**
+ * Opens a given pin as pwm.
+ *
+ * A pin (defined by device and channel) should be opened just once,
+ * calling this function more than once
+ * for the same pin results in undefined behaviour - per platform basis.
+ *
+ * @see sol_pwm_open(), sol_pwm_close().
+ *
+ * @param device The device controlling the pin to be opened.
+ * @param channel The channel used to communicate with the pin to be opened.
+ * @param config Contains the pin configuration.
+ *
+ * @return A new @c sol_pwm instance on success, @c NULL otherwise.
+ */
 struct sol_pwm *sol_pwm_open_raw(int device, int channel, const struct sol_pwm_config *config);
+
+/**
+ * Closes a given PWM pin.
+ *
+ * @see sol_pwm_open(), sol_pwm_open_raw().
+ *
+ * @param pwm The open @c sol_pwm representing the pin to be closed.
+ */
 void sol_pwm_close(struct sol_pwm *pwm);
 
+/**
+ * Enable or disable a given pwm pin.
+ *
+ * @param pwm PWM pin to be modified.
+ *
+ * @param enable If @c true pwm is enabled and if @c false it's disabled.
+ *
+ * @return @c true on success or @c false on error.
+ */
 bool sol_pwm_set_enabled(struct sol_pwm *pwm, bool enable);
+
+/**
+ * Check wheter a pmw pin is enabled or disabled.
+ *
+ * @param pwm PWM pin to get property.
+ *
+ * @return @c true if enabled or @c false if disabled or on error.
+ */
 bool sol_pwm_get_enabled(const struct sol_pwm *pwm);
 
+/**
+ * @brief Set PWM period in nanoseconds.
+ *
+ * Period is the amount of time that a cycle (on / off state) takes.
+ * It's the inverse of the frequency of the waveform.
+ *
+ * @param pwm PWM pin to be modified.
+ *
+ * @param period_ns Period in nanoseconds.
+ *
+ * @return @c true on success and @c false on error.
+ */
 bool sol_pwm_set_period(struct sol_pwm *pwm, uint32_t period_ns);
+
+/**
+ * @brief Get PWM period in nanoseconds.
+ *
+ * @see sol_pwm_set_period() for more details.
+ *
+ * @param pwm PWM pin to get property.
+ *
+ * @return Period in nanoseconds. It may be a negative value on error.
+ */
 int32_t sol_pwm_get_period(const struct sol_pwm *pwm);
+
+/**
+ * @brief Set PWM duty cycle in nanoseconds.
+ *
+ * Duty cycle describes the proportion of 'on' time to the regular interval
+ * or 'period' of time.
+ *
+ * A low duty cycle corresponds to low power, because the power is off
+ * for most of the time.
+ *
+ * @param pwm PWM pin to be modified.
+ *
+ * @param duty_cycle_ns Duty cycle in nanoseconds.
+ *
+ * @return @c true on success and @c false on error.
+ */
 bool sol_pwm_set_duty_cycle(struct sol_pwm *pwm, uint32_t duty_cycle_ns);
+
+/**
+ * @brief Get PWM duty cycle in nanoseconds.
+ *
+ * @see sol_pwm_set_duty_cycle() for more details.
+ *
+ * @param pwm PWM pin to get property.
+ *
+ * @return Duty cycle in nanoseconds. It may be a negative value on error.
+ */
 int32_t sol_pwm_get_duty_cycle(const struct sol_pwm *pwm);
 
 /**

--- a/src/lib/io/include/sol-spi.h
+++ b/src/lib/io/include/sol-spi.h
@@ -57,6 +57,21 @@ extern "C" {
 
 struct sol_spi;
 
+/**
+ * @brief SPI Transfer Modes.
+ *
+ * It may enable and disable clock polarity (cpol)
+ * and clock phase (cpha) to define a clock format to be used by the SPI
+ * bus.
+ *
+ * Depending on CPOL parameter, SPI clock may be inverted or non-inverted.
+ *
+ * CPHA parameter is used to shift the sampling phase. If CPHA=0 the data
+ * are sampled on the leading (first) clock edge.
+ *
+ * If CPHA=1 the data are sampled on the trailing (second) clock edge,
+ * regardless of whether that clock edge is rising or falling.
+ */
 enum sol_spi_mode {
     SOL_SPI_MODE_0 = 0, /** CPOL = 0 and CPHA = 0 */
     SOL_SPI_MODE_1, /** CPOL = 0 and CPHA = 1 */
@@ -64,6 +79,9 @@ enum sol_spi_mode {
     SOL_SPI_MODE_3 /** CPOL = 1 and CPHA = 1 */
 };
 
+/**
+ * Default value for bits per word when using SPI
+ */
 #define SOL_SPI_DATA_BITS_DEFAULT 8
 
 struct sol_spi_config {

--- a/src/lib/io/include/sol-uart.h
+++ b/src/lib/io/include/sol-uart.h
@@ -57,6 +57,10 @@ extern "C" {
 
 struct sol_uart;
 
+/**
+ * Baud rate is the number of times the signal can switch states in one second.
+ * Need to be defined to set uart config.
+ */
 enum sol_uart_baud_rate {
     SOL_UART_BAUD_RATE_9600 = 0,
     SOL_UART_BAUD_RATE_19200,
@@ -65,6 +69,9 @@ enum sol_uart_baud_rate {
     SOL_UART_BAUD_RATE_115200
 };
 
+/**
+ * Amount of stop bits.
+ */
 enum sol_uart_data_bits {
     SOL_UART_DATA_BITS_8 = 0,
     SOL_UART_DATA_BITS_7,
@@ -72,12 +79,19 @@ enum sol_uart_data_bits {
     SOL_UART_DATA_BITS_5
 };
 
+/**
+ * The parity characteristic can be even, odd, or none and it
+ * influences last trasmitted bit.
+ */
 enum sol_uart_parity {
-    SOL_UART_PARITY_NONE = 0,
-    SOL_UART_PARITY_EVEN,
-    SOL_UART_PARITY_ODD
+    SOL_UART_PARITY_NONE = 0, /**< no parity is used. */
+    SOL_UART_PARITY_EVEN, /**< the last data bit transmitted will be a logical 1  if the data transmitted had an even amount of 0 bits. */
+    SOL_UART_PARITY_ODD /**< the last data bit transmitted will be a logical 1 if the data transmitted had an odd amount of 0 bits. */
 };
 
+/**
+ * Amount of stop bits.
+ */
 enum sol_uart_stop_bits {
     SOL_UART_STOP_BITS_ONE = 0,
     SOL_UART_STOP_BITS_TWO


### PR DESCRIPTION
Also fix some parts.

It covers all missing documentation as spotted by doxy-coverage.

Idea here is that we'll cover everything and set our bots
to guarantee no further API get in without documentation.

@mbelluzzo , @edersondisouza , could you guys please review
this? I believe you had more contact with such API.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>