### PR TITLE
build: Fix race condition about 'sol_config.h'

### DIFF
--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -325,7 +325,7 @@ $(1): $($(1)-src) $(1).dep
 	$(Q)$(MKDIR) -p $(dir $(1))
 	$(Q)$(TARGETCC) $(OBJ_CFLAGS) $($(2)-gen-cflags) $(sort $($(2)-cflags)) $($(1)-src) -c -o $(1) $(3)
 
-$(1).dep: $($(1)-src) $(all-hdr) $(find-gen-hdrs) $(call find-obj-deps,$(2)) $(all-dest-hdr) $(KCONFIG_CONFIG) $(HEADER_GEN)
+$(1).dep: $($(1)-src) $(all-hdr) $(find-gen-hdrs) $(call find-obj-deps,$(2)) $(all-dest-hdr) $(KCONFIG_CONFIG) $(HEADER_GEN) $(KCONFIG_AUTOHEADER)
 	$(Q)$(MKDIR) -p $(dir $(1))
 	$(Q)$(TARGETCC) $(OBJ_CFLAGS) $($(2)-gen-cflags) $(sort $($(2)-cflags)) -MM -MG $($(1)-src) -MT "$(1)" > $(1).dep
 endef
@@ -402,5 +402,6 @@ $(FLOW_OIC_GEN): $(FLOW_OIC_GEN_SCRIPT) $(KCONFIG_AUTOHEADER)
 		--node-type-gen-h=sol-flow/oic.h >/dev/null
 
 $(KCONFIG_AUTOHEADER): $(DEPENDENCY_CACHE) $(KCONFIG_CONFIG) $(obj)/conf
+	$(Q)echo "     "GEN"   "$@
 	$(Q)mkdir -p $(KCONFIG_INCLUDE)config $(KCONFIG_INCLUDE)generated
 	$(Q)$(obj)/conf -s --silentoldconfig Kconfig


### PR DESCRIPTION
When running make even without '-j', FLOW_OIC_GEN rule runs in parallel
with the remaining of Soletta build and was providing 'sol_config.h'
before it was needed most of the time and the build worked. But that
wasn't always the case, which was causing the build to fail for some
users.

This patch adds 'KCONFIG_AUTOHEADER' as dependency for remaining of the
build so it's always there when is needed. This also add a message when
'sol_config.h' is generated to make debug easier.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>