### PR TITLE
Buffer v2

### DIFF
--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -538,6 +538,24 @@ sol_buffer_free(struct sol_buffer *buf)
  */
 int sol_buffer_ensure_nul_byte(struct sol_buffer *buf);
 
+
+/**
+ *  Removes part of data inside the buffer rearranging the memory
+ *  properly. It's removed up to the buffer's size in case of @c size
+ *  greater than used data.
+ *
+ *  @param buf the already-initialized buffer
+ *  @param size the amount of data (in bytes) that should be removed
+ *  @param offset the position (from begin of the buffer) where
+ *  @c size bytes will be removed
+ *
+ *  @return 0 on success, -errno on failure.
+ *
+ *  @note the buffer keeps its capacity after this function, it means,
+ *  the data is not released. If that is wanted, one should call @c sol_buffer_trim()
+ */
+int sol_buffer_remove_data(struct sol_buffer *buf, size_t size, size_t offset);
+
 /**
  * @}
  */

--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -489,6 +489,25 @@ sol_buffer_trim(struct sol_buffer *buf)
 void *sol_buffer_steal(struct sol_buffer *buf, size_t *size);
 
 /**
+ *  'Steals' sol_buffer internal buffer and resets sol_buffer if the
+ *  the buffer has not set the flag @c SOL_BUFFER_FLAGS_NO_FREE, otherwise
+ *  it will return a copy of the buffer's data.
+ *
+ *  After this call, user is responsible for the memory returned.
+ *
+ *  @param buf buffer to have it's internal buffer stolen or copied
+ *  @param size if not NULL, will store memory returned size
+ *
+ *  @return @a buffer internal buffer. It's caller responsibility now
+ *  to free this memory
+ *
+ *  @note If @a buffer was allocated with @c sol_buffer_new(), it still
+ *  needs to be freed by calling @c sol_buffer_free();
+ *  @see sol_buffer_steal
+ */
+void *sol_buffer_steal_or_copy(struct sol_buffer *buf, size_t *size);
+
+/**
  *  Allocate a new sol_buffer and a new data block and copy the
  *  contents of the provided sol_buffer
  *

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -873,3 +873,30 @@ sol_buffer_append_from_base16(struct sol_buffer *buf, const struct sol_str_slice
     return 0;
 }
 
+SOL_API int
+sol_buffer_remove_data(struct sol_buffer *buf, size_t size, size_t offset)
+{
+    int r;
+    size_t total;
+
+    SOL_NULL_CHECK(buf, -EINVAL);
+    SOL_EXP_CHECK(buf->flags & SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED, -EPERM);
+
+    if ((buf->used < offset))
+        return -EINVAL;
+
+    r = sol_util_size_add(size, offset, &total);
+    SOL_INT_CHECK(r, < 0, r);
+
+    size = total <= buf->used ? size : buf->used - offset;
+    if (buf->used != total) {
+        memmove((char *)buf->data + offset,
+            (char *)buf->data + total,
+            buf->used - size - offset);
+    }
+
+    buf->used -= size;
+
+
+    return 0;
+}

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -349,6 +349,25 @@ sol_buffer_steal(struct sol_buffer *buf, size_t *size)
     return r;
 }
 
+SOL_API void *
+sol_buffer_steal_or_copy(struct sol_buffer *buf, size_t *size)
+{
+    void *r;
+
+    SOL_NULL_CHECK(buf, NULL);
+
+    r = sol_buffer_steal(buf, size);
+    if (!r) {
+        r = sol_util_memdup(buf->data, buf->used);
+        SOL_NULL_CHECK(r, NULL);
+
+        if (size)
+            *size = buf->used;
+    }
+
+    return r;
+}
+
 SOL_API struct sol_buffer *
 sol_buffer_copy(const struct sol_buffer *buf)
 {

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -50,8 +50,7 @@ sol_buffer_resize(struct sol_buffer *buf, size_t new_size)
     char *new_data;
 
     SOL_NULL_CHECK(buf, -EINVAL);
-    SOL_EXP_CHECK(buf->flags & SOL_BUFFER_FLAGS_FIXED_CAPACITY, -EPERM);
-    SOL_EXP_CHECK(buf->flags & SOL_BUFFER_FLAGS_NO_FREE, -EPERM);
+    SOL_EXP_CHECK(buf->flags & SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED, -EPERM);
 
     if (buf->capacity == new_size)
         return 0;

--- a/src/test/test-buffer.c
+++ b/src/test/test-buffer.c
@@ -708,4 +708,42 @@ test_append_from_base16(void)
 #undef B16_DECODED
 }
 
+DEFINE_TEST(test_remove_data);
+
+static void
+test_remove_data(void)
+{
+    struct sol_buffer buf;
+    struct sol_str_slice slice;
+    int err;
+
+    sol_buffer_init(&buf);
+    slice = sol_str_slice_from_str("ABCDEFGHI");
+    err = sol_buffer_append_slice(&buf, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("ABCDEFGHI"));
+    ASSERT_STR_EQ(buf.data, "ABCDEFGHI");
+
+    err = sol_buffer_remove_data(&buf, strlen("ABC"), 0);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("DEFGHI"));
+
+    err = sol_buffer_remove_data(&buf, strlen("GHI"), 3);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("DEF"));
+
+    err = sol_buffer_remove_data(&buf, strlen("DEF"), 0);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, 0);
+
+    err = sol_buffer_remove_data(&buf, 100, 0);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, 0);
+
+    err = sol_buffer_remove_data(&buf, 0, 100);
+    ASSERT_INT_EQ(err, -EINVAL);
+
+    sol_buffer_fini(&buf);
+}
+
 TEST_MAIN();


### PR DESCRIPTION
 * from v1:
 - Uses ``size_t`` instead of using ``long``
 - Check for overflow
 - Remove all data up to ``buffer->used``