### PR TITLE
Http stream v4

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -168,6 +168,7 @@ depends on FEATURE_RUNNABLE_PROGRAMS
 source "src/samples/coap/Kconfig"
 source "src/samples/common/Kconfig"
 source "src/samples/crypto/Kconfig"
+source "src/samples/http/Kconfig"
 source "src/samples/mqtt/Kconfig"
 
 config FLOW_SAMPLES

--- a/src/lib/comms/include/sol-http-client.h
+++ b/src/lib/comms/include/sol-http-client.h
@@ -56,7 +56,79 @@ extern "C" {
 struct sol_http_client_connection;
 
 /**
- * Create a request for the specified url using the given method. The result of
+ * @brief The http request interface to use when creating a new request.
+ *
+ * It allows one have more control over the request, notifying when
+ * data comes or when data should be sent.
+ *
+ * @see sol_http_client_request_with_interface()
+ */
+struct sol_http_request_interface {
+#ifndef SOL_NO_API_VERSION
+#define SOL_HTTP_REQUEST_INTERFACE_API_VERSION (1)
+    /**
+     * api_version must match SOL_HTTP_REQUEST_INTERFACE_API_VERSION
+     * at runtime.
+     */
+    uint16_t api_version;
+#endif
+    /**
+     * This callback is called whenever data comes. The number of bytes consumed (the value
+     * returned by this callback) will be removed from buffer.
+     *
+     * It should return the number of bytes taken care of in case of success, any negative
+     * value will abort the trasnfer.
+     *
+     * The parameters are:
+     *
+     * @li @c userdata the context data given in @c sol_http_client_request_with_interface
+     * @li @c connection the connection returned in @c sol_http_client_request_with_interface
+     * @li @c buffer the data received
+     *
+     * @note it is @b NOT @b ALLOWED to cancel the connection handle from
+     *       inside this callback.
+     */
+    ssize_t (*recv_cb)(void *userdata, const struct sol_http_client_connection *connection,
+        struct sol_buffer *buffer);
+    /**
+     * This callback is called data should be written, it's commonly used for @c POST.
+     * When it's used, it's @b MANDATORY either the header @c Content-Length with the correct
+     * size or the header @c Transfer-Encoding with the value @b chunked on
+     * @c sol_http_client_request_with_interface.
+     *
+     * It should return the number of bytes written into buffer on success, any negative
+     * value will abort the trasnfer.
+     *
+     *
+     * The parameters are:
+     *
+     * @li @c userdata the context data given in @c sol_http_client_request_with_interface
+     * @li @c connection the connection returned in @c sol_http_client_request_with_interface
+     * @li @c buffer the buffer where the data should be written, the buffer's capacity indicates
+     * the amount of data that should be set.
+     *
+     * @note it is @b NOT @b ALLOWED to cancel the connection handle from
+     *       inside this callback.
+     */
+    ssize_t (*send_cb)(void *userdata, const struct sol_http_client_connection *connection,
+        struct sol_buffer *buffer);
+    /**
+     * This callback is called when the request finishes, the result of request is available on
+     * @c response. @see sol_http_response
+     *
+     * @li @c userdata the context data given in @c sol_http_client_request_with_interface
+     * @li @c connection the connection returned in @c sol_http_client_request_with_interface
+     * @li @c response the result of the request
+     *
+     * @note it is @b NOT @b ALLOWED to cancel the connection handle from
+     *       inside this callback.
+     */
+    void (*response_cb)(void *userdata, const struct sol_http_client_connection *connection,
+        struct sol_http_response *response);
+};
+
+/**
+ * @brief Create a request for the specified url using the given method. The result of
  * the request is obtained in @c cb.
  *
  * One should check the response code on @c sol_http_response to check
@@ -80,6 +152,33 @@ struct sol_http_client_connection *sol_http_client_request(enum sol_http_method 
     const char *url, const struct sol_http_params *params,
     void (*cb)(void *data, const struct sol_http_client_connection *connection,
     struct sol_http_response *response),
+    const void *data) SOL_ATTR_NONNULL(2, 4) SOL_ATTR_WARN_UNUSED_RESULT;
+
+/**
+ * @brief Create a request for the specified url using the given method. The result of
+ * the request is obtained in @c cb.
+ *
+ * One should check the response code on @c sol_http_response to check
+ * if the request returned success or with some error. @see sol_http_status_code.
+ *
+ * @note It should never be called from response callback given in
+ *       sol_http_client_request().
+ *
+ * @param method a valid HTTP method, e. g. SOL_HTTP_METHOD_GET or SOL_HTTP_METHOD_POST
+ * @param url a string containing a valid URL.
+ * @param params the parameters used on this request, e. g. headers,
+ *        cookies and post fields.
+ * @param interface the interface with the callbacks used in the request. @see sol_http_request_interface
+ * @param data user data given as parameter on @c cb
+ *
+ * @return a pending connection on success, @c NULL on error.
+ *
+ * @see sol_http_client_connection_cancel
+ * @see sol_http_client_request
+ */
+struct sol_http_client_connection *sol_http_client_request_with_interface(enum sol_http_method method,
+    const char *url, const struct sol_http_params *params,
+    const struct sol_http_request_interface *interface,
     const void *data) SOL_ATTR_NONNULL(2, 4) SOL_ATTR_WARN_UNUSED_RESULT;
 
 /**

--- a/src/samples/http/.gitignore
+++ b/src/samples/http/.gitignore
@@ -1,0 +1,2 @@
+download
+

--- a/src/samples/http/Kconfig
+++ b/src/samples/http/Kconfig
@@ -1,0 +1,8 @@
+config HTTP_SAMPLES
+	bool "HTTP samples"
+	default y
+
+config DOWNLOAD_SAMPLE
+	bool "Download sample"
+	depends on COMMON_SAMPLES && HTTP_CLIENT
+	default y

--- a/src/samples/http/Makefile
+++ b/src/samples/http/Makefile
@@ -1,0 +1,3 @@
+sample-$(DOWNLOAD_SAMPLE) += download
+sample-download-$(DOWNLOAD_SAMPLE) := download.c
+

--- a/src/samples/http/download.c
+++ b/src/samples/http/download.c
@@ -1,0 +1,148 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "sol-mainloop.h"
+#include "sol-http.h"
+#include "sol-http-client.h"
+
+static FILE *fd;
+struct sol_http_client_connection *pending;
+
+static ssize_t
+recv_func(void *userdata, const struct sol_http_client_connection *connection,
+    struct sol_buffer *buffer)
+{
+    ssize_t ret;
+
+    ret = fwrite(buffer->data, buffer->used, 1, fd);
+    if (!ret || ferror(fd)) {
+        fprintf(stderr, "ERROR: Failed to write\n");
+        return -1;
+    }
+
+    return ret * buffer->used;
+}
+
+static void
+response_func(void *userdata, const struct sol_http_client_connection *connection,
+    struct sol_http_response *response)
+{
+    fclose(fd);
+    fd = NULL;
+    pending = NULL;
+
+    if (response->response_code != SOL_HTTP_STATUS_OK) {
+        fprintf(stderr, "ERROR: Finished with error, response code: %d\n", response->response_code);
+        sol_quit_with_code(EXIT_FAILURE);
+        return;
+    }
+
+    printf("Download concluded successfully\n");
+    sol_quit_with_code(EXIT_SUCCESS);
+}
+
+static const struct sol_http_request_interface iface = {
+    SOL_SET_API_VERSION(.api_version = SOL_HTTP_REQUEST_INTERFACE_API_VERSION, )
+    .recv_cb = recv_func,
+    .response_cb = response_func
+};
+
+static void
+startup(void)
+{
+    char **argv = sol_argv();
+    char *output = NULL, *url = NULL;
+    int c, opt_idx,  argc = sol_argc();
+    static const struct option opts[] = {
+        { "output", required_argument, NULL, 'o' },
+        { "help", no_argument, NULL, 'h' },
+        { 0, 0, 0, 0 }
+    };
+
+    while ((c = getopt_long(argc, argv, "o:h", opts, &opt_idx)) != -1) {
+        switch (c) {
+        case 'o':
+            output = optarg;
+            break;
+        case 'h':
+        default:
+            fprintf(stderr,
+                "Usage:\n\t%s [-o <output_file>] <url>\n", argv[0]);
+            sol_quit_with_code(EXIT_SUCCESS);
+            return;
+        }
+    }
+
+    url = argv[optind];
+    if (!url) {
+        fprintf(stderr, "ERROR: missing url.\n");
+        sol_quit_with_code(EXIT_FAILURE);
+        return;
+    }
+
+    if (output) {
+        fd = fopen(output, "w");
+        if (fd == NULL) {
+            fprintf(stderr, "ERROR: Failed to create the file: %s\n", output);
+            sol_quit_with_code(EXIT_FAILURE);
+            return;
+        }
+    } else {
+        fd = stdout;
+    }
+
+    pending = sol_http_client_request_with_interface(SOL_HTTP_METHOD_GET,
+        url, NULL, &iface, NULL);
+    if (!pending) {
+        fprintf(stderr, "ERROR: Failed to create the request\n");
+        fclose(fd);
+        sol_quit_with_code(EXIT_FAILURE);
+        return;
+    }
+}
+
+
+static void
+shutdown(void)
+{
+    if (pending)
+        sol_http_client_connection_cancel(pending);
+    if (fd)
+        fclose(fd);
+}
+
+SOL_MAIN_DEFAULT(startup, shutdown);


### PR DESCRIPTION
- from v3
 - Change interface's callbacks to return ssize_t (negative values abort connection)
 - Use getopt on sample

- from v2
 - Use fwrite/fopen/fclose on sample
 - Rename write_cb/read_cb to recv_cb/send_cb
 - Use buffer in both callbacks
 - Add api_versio (with checks)
 - Documentation
 - Interface is not a pointer anymore (avoid memory allocation)