### PR TITLE
coap: Add safety check to pending_reply_free

### DIFF
--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -483,6 +483,9 @@ timeout_cb(void *data)
 static void
 pending_reply_free(struct pending_reply *reply)
 {
+    if (!reply)
+        return;
+
     if (reply->observing)
         free(reply->path);
     free(reply);


### PR DESCRIPTION
Check if parameter is null in pending_reply_free before accessing it.

Coverity issue: 132831

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>