### PR TITLE
scripts/gen-html: escape double quotes on default values

### DIFF
--- a/data/scripts/sol-flow-node-type-gen-html.py
+++ b/data/scripts/sol-flow-node-type-gen-html.py
@@ -86,7 +86,7 @@ def print_option(outfile, option):
     "name": option["name"],
     "data_type": option["data_type"],
     "description": option["description"].replace("\"", "\\\""),
-    "default": str(option.get("default", ""))
+    "default": re.sub("\"", "\\\"", str(option.get("default", "")))
     })
 
 def print_port(outfile, port):


### PR DESCRIPTION
Otherwise it may break the generated page.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>