### PR TITLE
Cleanup and features needed by the OIC security module

### DIFF
--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -326,8 +326,6 @@ struct sol_coap_resource {
      * Bitwise OR-ed flags from #sol_coap_flags, if any is necessary.
      */
     enum sol_coap_flags flags;
-    struct sol_str_slice iface;
-    struct sol_str_slice resource_type;
     /**
      * Path representing the resource.
      *

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -610,9 +610,6 @@ create_coap_resource(struct sol_oic_server_resource *resource)
     if (oic_server.dtls_server)
         resource->flags |= SOL_OIC_FLAG_SECURE;
 
-    res->iface = sol_str_slice_from_str(resource->iface);
-    res->resource_type = sol_str_slice_from_str(resource->rt);
-
     return res;
 }
 

--- a/src/lib/comms/sol-socket-dtls.h
+++ b/src/lib/comms/sol-socket-dtls.h
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+#include "sol-buffer.h"
+#include "sol-network.h"
+#include "sol-socket.h"
+#include "sol-str-slice.h"
+
+enum sol_socket_dtls_cipher {
+    SOL_SOCKET_DTLS_CIPHER_ECDH_ANON_AES128_CBC_SHA256,
+    SOL_SOCKET_DTLS_CIPHER_PSK_AES128_CCM8,
+    SOL_SOCKET_DTLS_CIPHER_ECDHE_ECDSA_AES128_CCM8
+};
+
+struct sol_socket *sol_socket_dtls_wrap_socket(struct sol_socket *socket);
+
+int sol_socket_dtls_set_handshake_cipher(struct sol_socket *s,
+    enum sol_socket_dtls_cipher cipher);
+
+int sol_socket_dtls_set_anon_ecdh_enabled(struct sol_socket *s, bool setting);
+
+int sol_socket_dtls_prf_keyblock(struct sol_socket *s,
+    const struct sol_network_link_addr *addr, struct sol_str_slice label,
+    struct sol_str_slice random1, struct sol_str_slice random2,
+    struct sol_buffer *buffer);

--- a/src/lib/comms/sol-socket.c
+++ b/src/lib/comms/sol-socket.c
@@ -39,7 +39,7 @@
 #include "sol-socket-impl.h"
 
 #ifdef DTLS
-struct sol_socket *sol_socket_dtls_wrap_socket(struct sol_socket *socket);
+#include "sol-socket-dtls.h"
 #endif
 
 #include <errno.h>

--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -103,7 +103,12 @@ enum sol_buffer_flags {
     /**
      * do not reserve space for the NUL byte
      */
-    SOL_BUFFER_FLAGS_NO_NUL_BYTE = (1 << 2)
+    SOL_BUFFER_FLAGS_NO_NUL_BYTE = (1 << 2),
+    /**
+     * securely clear buffer data before finishing; this implies the flag
+     * SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED
+     */
+    SOL_BUFFER_FLAGS_CLEAR_MEMORY = (1 << 3) | SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED,
 };
 
 struct sol_buffer {
@@ -141,23 +146,14 @@ static inline void
 sol_buffer_init_flags(struct sol_buffer *buf, void *data, size_t data_size, enum sol_buffer_flags flags)
 {
     assert(buf);
+    assert((flags & SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED) ? !!data : 1);
     buf->data = data;
     buf->capacity = data_size;
     buf->used = 0;
     buf->flags = flags;
 }
 
-static inline void
-sol_buffer_fini(struct sol_buffer *buf)
-{
-    if (!buf)
-        return;
-    if (!(buf->flags & SOL_BUFFER_FLAGS_NO_FREE))
-        free(buf->data);
-    buf->data = NULL;
-    buf->used = 0;
-    buf->capacity = 0;
-}
+void sol_buffer_fini(struct sol_buffer *buf);
 
 static inline void *
 sol_buffer_at(const struct sol_buffer *buf, size_t pos)

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -138,6 +138,7 @@ sol_buffer_append_slice(struct sol_buffer *buf, const struct sol_str_slice slice
 {
     return sol_buffer_append_bytes(buf, (uint8_t *)slice.data, slice.len);
 }
+
 SOL_API int
 sol_buffer_set_slice_at(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice)
 {
@@ -915,6 +916,19 @@ sol_buffer_remove_data(struct sol_buffer *buf, size_t size, size_t offset)
 
     buf->used -= size;
 
-
     return 0;
+}
+
+SOL_API void
+sol_buffer_fini(struct sol_buffer *buf)
+{
+    if (!buf)
+        return;
+    if (buf->flags & SOL_BUFFER_FLAGS_CLEAR_MEMORY)
+        sol_util_secure_clear_memory(buf->data, buf->capacity);
+    if (!(buf->flags & SOL_BUFFER_FLAGS_NO_FREE))
+        free(buf->data);
+    buf->data = NULL;
+    buf->used = 0;
+    buf->capacity = 0;
 }

--- a/src/shared/sol-random.c
+++ b/src/shared/sol-random.c
@@ -222,6 +222,11 @@ engine_urandom_init(struct sol_random *generic, uint64_t seed)
 {
     struct sol_random_urandom *engine = (struct sol_random_urandom *)generic;
 
+    if (seed) {
+        SOL_WRN("Explicit seed not supported by this random implementation");
+        return false;
+    }
+
     engine->fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
     if (engine->fd < 0) {
         SOL_WRN("Could not open /dev/urandom: %s", sol_util_strerrora(errno));
@@ -259,7 +264,7 @@ engine_urandom_generate_uint32(struct sol_random *generic)
     }
 
     SOL_ERR("Could not read from /dev/urandom: %s", sol_util_strerrora(errno));
-    return 0;
+    return -errno;
 }
 
 const struct sol_random_impl *SOL_RANDOM_URANDOM =


### PR DESCRIPTION
This PR contains small patches adding features necessary to implement the OIC security module:

* Functions specific to DTLS sockets, such as changing the cipher suite, enabling anonymous ECDH handshakes, etc.
* Removing unused members from sol_coap_resource
* Ensuring sol_random with URANDOM engine won't accept a seed being passed
* Add a flag to sol_buffer to clear the memory before freeing the buffer

@otaviobp, could you please review these?