### PR TITLE
tests: avoid wrong order of packets on timeout delays

### DIFF
--- a/src/test-fbp/boolean-buffer.fbp
+++ b/src/test-fbp/boolean-buffer.fbp
@@ -76,22 +76,20 @@ nany_false_buffer OUT -> IN _(boolean/not) OUT -> RESULT t8(test/result)
 
 # Timeout tests
 
+input9(test/boolean-generator:sequence="FT", interval=40)
 buffer_timeout(boolean/buffer:timeout=100, operation=any_true)
 
-input9(test/boolean-generator:sequence="FT", interval=40)
 input9 OUT -> IN buffer_timeout OUT -> RESULT t9(test/result)
 
-buffer_timeout2(boolean/buffer:timeout=100, operation=any_true)
-
 input10(test/boolean-generator:sequence="TTF", interval=40)
+buffer_timeout2(boolean/buffer:timeout=100, operation=any_true)
 validator_timeout(test/boolean-validator:sequence="TF")
 
 input10 OUT -> IN buffer_timeout2
 buffer_timeout2 OUT -> IN validator_timeout OUT -> RESULT t10(test/result)
 
-buffer_timeout3(boolean/buffer:timeout=100, operation=any_true, circular=true)
-
 input11(test/boolean-generator:sequence="TTF", interval=60)
+buffer_timeout3(boolean/buffer:timeout=100, operation=any_true, circular=true)
 validator_timeout2(test/boolean-validator:sequence="TT")
 
 input11 OUT -> IN buffer_timeout3

--- a/src/test-fbp/irange-buffer.fbp
+++ b/src/test-fbp/irange-buffer.fbp
@@ -86,20 +86,17 @@ validator_circular OUT -> RESULT test_circular(test/result)
 
 # ----- Timeout tests ------
 
+gen5(test/int-generator:sequence="10 20", interval=40)
 timeout_buffer(int/buffer:timeout=100)
 timeout_equal(int/equal)
 timeout_result(constant/int:value=15)
 
-gen5(test/int-generator:sequence="10 20", interval=40)
 gen5 OUT -> IN timeout_buffer
-
 timeout_buffer OUT -> IN[0] timeout_equal
 timeout_result OUT -> IN[1] timeout_equal
-
 timeout_equal OUT -> RESULT test_timeout(test/result)
 
 gen6(test/int-generator:sequence="10 20 30", interval=40)
-
 timeout_buffer2(int/buffer:timeout=100)
 validator_timeout(test/int-validator:sequence="15 30")
 
@@ -107,8 +104,8 @@ gen6 OUT -> IN timeout_buffer2
 timeout_buffer2 OUT -> IN validator_timeout
 validator_timeout OUT -> RESULT test_timeout_seq(test/result)
 
-timeout_buffer3(int/buffer:timeout=100, circular=true)
 validator_timeout2(test/int-validator:sequence="15 20")
+timeout_buffer3(int/buffer:timeout=100, circular=true)
 
 gen6 OUT -> IN timeout_buffer3
 timeout_buffer3 OUT -> IN validator_timeout2


### PR DESCRIPTION
Apparently if a delay happens and sequence generator
send packets together with buffer (validator) timeout,
results diverge.

Changing order of node types declaration should
avoid this problem.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>