### PR TITLE
Docs, docs, docs

### DIFF
--- a/src/lib/common/include/sol-pin-mux-modules.h
+++ b/src/lib/common/include/sol-pin-mux-modules.h
@@ -44,30 +44,30 @@ extern "C" {
 
 /**
  * @file
- * @brief These structure is used for implementation of Pin Multiplexer modules under Soletta.
+ * @brief Defines the API that needs to be implemented by Pin Multiplexer modules under Soletta.
  */
 
 /**
  * @defgroup PinMuxModules Pin Multiplexer Modules
  * @ingroup PinMux
  *
- * @brief These structure is used for implementation of Pin Multiplexing modules under Soletta.
+ * @brief Defines the API that needs to be implemented by Pin Multiplexer modules under Soletta.
  *
  * @{
  */
 
 /**
- * Structure containing the callbacks used to setup and multiplex the pins of a given board
+ * @brief Structure defining the API of a Pin Multiplexer module
  */
 struct sol_pin_mux {
 #ifndef SOL_NO_API_VERSION
 #define SOL_PIN_MUX_API_VERSION (2UL)
-    unsigned long int api_version; /**< API version */
+    unsigned long int api_version; /**< @brief API version */
 #endif
-    const char *plat_name; /**< Name of this multiplexer target platform */
+    const char *plat_name; /**< @brief Name of this multiplexer target platform */
 
     /**
-     * Called after the module is successfully load by Soletta to allow it
+     * @brief Called after the module is successfully load by Soletta to allow it
      * to do any initialization it may require.
      *
      * @return @c 0 on success, error code (always negative) otherwise.
@@ -75,13 +75,14 @@ struct sol_pin_mux {
     int (*init)(void);
 
     /**
-     * Called before the module is unloaded.
+     * @brief Called before the module is unloaded.
+     *
      * Is an opportunity for the module to execute any clean-up tasks it may require.
      */
     void (*shutdown)(void);
 
     /**
-     * Callback to map a pin label to the parameters necessary so it works on the desired protocol.
+     * @brief Callback to map a pin label to the parameters necessary so it works on the desired protocol.
      *
      * Find if a given pin labeled @c label is capable of operate on protocol @c prot and return
      * the parameters needed to setup the protocol.
@@ -96,7 +97,7 @@ struct sol_pin_mux {
     int (*pin_map)(const char *label, const enum sol_io_protocol prot, va_list args);
 
     /**
-     * Callback to setup the given pin to operate as Analog I/O.
+     * @brief Callback to setup the given pin to operate as Analog I/O.
      *
      * Soletta will call this function so the module can execute the instructions
      * needed to configure 'device'/'pin' pair to operate as Analog I/O.
@@ -109,7 +110,7 @@ struct sol_pin_mux {
     int (*aio)(const int device, const int pin);
 
     /**
-     * Callback to setup the given pin to operate as GPIO in the given direction (in or out).
+     * @brief Callback to setup the given pin to operate as GPIO in the given direction (in or out).
      *
      * Soletta will call this function so the module can execute the instructions
      * needed to configure @c pin to operate as GPIO in direction @c dir.
@@ -122,7 +123,7 @@ struct sol_pin_mux {
     int (*gpio)(const uint32_t pin, const enum sol_gpio_direction dir);
 
     /**
-     * Callback to setup the pins used of the given i2c bus number to operate in I2C mode.
+     * @brief Callback to setup the pins used of the given i2c bus number to operate in I2C mode.
      *
      * Soletta will call this function so the module can execute the instructions
      * needed to configure the pins used by the given i2c bus to operate in I2C mode.
@@ -134,7 +135,7 @@ struct sol_pin_mux {
     int (*i2c)(const uint8_t bus);
 
     /**
-     * Callback to setup the given pin to operate as PWM.
+     * @brief Callback to setup the given pin to operate as PWM.
      *
      * Soletta will call this function so the module can execute the instructions
      * needed to configure 'device'/'channel' pair to operate as PWM.
@@ -150,7 +151,7 @@ struct sol_pin_mux {
 
 /**
  * @def SOL_PIN_MUX_DECLARE(_NAME, decl ...)
- * Helper macro to make easier to correctly declare the symbol
+ * @brief Helper macro to make easier to correctly declare the symbol
  * needed by the Pin Mux module.
  */
 #ifdef SOL_PIN_MUX_MODULE_EXTERNAL

--- a/src/lib/common/include/sol-platform.h
+++ b/src/lib/common/include/sol-platform.h
@@ -47,6 +47,7 @@ extern "C" {
 
 /**
  * @defgroup Platform Platform
+ * @brief These routines are used for Soletta platform interaction.
  *
  * @{
  */
@@ -63,12 +64,20 @@ extern "C" {
  */
 #define CHUNK_MAX_TIME_NS (20 * (NSEC_PER_MSEC))
 
+/**
+ * @brief Retrieves the name of the board on which Soletta is running.
+ *
+ * @return String containing the board name on success, @c NULL otherwise.
+ *
+ * @note: Check the Board Detection documentation for more information
+ * about how the name is found.
+ */
 const char *sol_platform_get_board_name(void);
 
 /**
- * Retrieves, in @a id, the machine-id present in the file system. The
- * returned string is assured to be a valid, 16 bytes-long (128 bits)
- * UUID.
+ * @brief Retrieves, in @a id, the machine-id present in the file system.
+ *
+ * The returned string is assured to be a valid, 16 bytes-long (128 bits) UUID.
  *
  * @note: If the environment variable SOL_MACHINE_ID is set and is
  * properly formatted as a UUID, its value is returned by this call.
@@ -79,7 +88,7 @@ const char *sol_platform_get_board_name(void);
 const char *sol_platform_get_machine_id(void);
 
 /**
- * Retrieves, in @a number, the platform's main board serial
+ * @brief Retrieves, in @a number, the platform's main board serial
  * number/identifier.
  *
  * @note: If the environment variable SOL_SERIAL_NUMBER is set, its
@@ -91,7 +100,7 @@ const char *sol_platform_get_machine_id(void);
 const char *sol_platform_get_serial_number(void);
 
 /**
- * Retrieves the version of Soletta that is running.
+ * @brief Retrieves the version of Soletta that is running.
  *
  * @return On success, it returns the version string, that must not be
  * modified. On error, it returns @c NULL.
@@ -99,7 +108,7 @@ const char *sol_platform_get_serial_number(void);
 const char *sol_platform_get_sw_version(void);
 
 /**
- * Retrieves the operating system's version that Soletta is running
+ * @brief Retrieves the operating system's version that Soletta is running
  * on top of.
  *
  * @return On success, it returns the version string. This string should
@@ -161,7 +170,7 @@ int sol_platform_restart_service(const char *service);
 int sol_platform_set_target(const char *target);
 
 /**
- * List mount points mounted by us on hotplug events
+ * @brief List mount points mounted by us on hotplug events.
  *
  * @param vector Initialized sol_vector used to store the resulting list
  *
@@ -170,7 +179,7 @@ int sol_platform_set_target(const char *target);
 int sol_platform_get_mount_points(struct sol_ptr_vector *vector);
 
 /**
- * Umount a @c mpoint
+ * @brief Umount a @c mpoint
  *
  * @param mpoint The mount point to be unmounted
  * @param cb Callback to be called when unmount operation finishes

--- a/src/lib/io/include/sol-aio.h
+++ b/src/lib/io/include/sol-aio.h
@@ -47,15 +47,15 @@ extern "C" {
  * @defgroup AIO AIO
  * @ingroup IO
  *
- * Analog I/O API for Soletta.
+ * @brief Analog I/O API for Soletta.
  *
  * @{
  */
 
-struct sol_aio; /**< Structure of the AIO handler */
+struct sol_aio; /**< @brief AIO handler structure */
 
 /**
- * @brief Open the given board 'pin' by its label to be used as Analog I/O.
+ * @brief Open the given board @c pin by its label to be used as Analog I/O.
  *
  * This function only works when the board was successfully detect by Soletta and a corresponding
  * pin multiplexer module was found.
@@ -72,7 +72,7 @@ struct sol_aio; /**< Structure of the AIO handler */
 struct sol_aio *sol_aio_open_by_label(const char *label, const unsigned int precision);
 
 /**
- * @brief Open the given Analog I/O 'pin' on 'device' to be used.
+ * @brief Open the given Analog I/O @c pin on @c device to be used.
  *
  * This function also applies any Pin Multiplexer rules needed if a multiplexer for
  * the current board was previously loaded.
@@ -87,9 +87,9 @@ struct sol_aio *sol_aio_open_by_label(const char *label, const unsigned int prec
 struct sol_aio *sol_aio_open(const int device, const int pin, const unsigned int precision);
 
 /**
- * @brief Open the given Analog I/O 'pin' on 'device' to be used.
+ * @brief Open the given Analog I/O @c pin on @c device to be used.
  *
- * 'precision' is used to filter the valid bits from the data received from hardware
+ * @c precision is used to filter the valid bits from the data received from hardware
  * (which is manufacturer dependent), therefore should not be used as a way to change
  * the output range because is applied to the least significant bits.
  *
@@ -108,10 +108,10 @@ struct sol_aio *sol_aio_open_raw(const int device, const int pin, const unsigned
 void sol_aio_close(struct sol_aio *aio);
 
 /**
- * @brief Read the value of AIO 'pin' on 'device'.
+ * @brief Read the value of AIO @c pin on @c device.
  *
- * @param aio A valid AIO handler for the desired 'device'/'pin' pair.
- * @return The value read. -1 in case of error.
+ * @param aio A valid AIO handler for the desired @c 'device/pin' pair.
+ * @return The value read. @c -1 in case of error.
  */
 int32_t sol_aio_get_value(const struct sol_aio *aio);
 


### PR DESCRIPTION
* Improve pin mux modules text a little bit (take the opportunity to add @briefs)
* Add 'get_board_name' docs that was missing from platform (and add more @briefs)
* s/''/@c/ in aio and add missing brief in group because was the only one without description in the 'Modules' list
