### PR TITLE
buffer: Only perform 'clear memory' if buffer has requested so

### DIFF
--- a/src/lib/comms/sol-http-common.c
+++ b/src/lib/comms/sol-http-common.c
@@ -158,6 +158,11 @@ sol_http_encode_slice(struct sol_buffer *buf, const struct sol_str_slice value)
     SOL_NULL_CHECK(buf, -EINVAL);
 
     sol_buffer_init(buf);
+
+    /* Empty slice. Just return an empty buffer */
+    if (!value.len)
+        return 0;
+
     last_append = 0;
     for (i = 0; i < value.len; i++) {
         unsigned char c = value.data[i];
@@ -199,6 +204,11 @@ sol_http_decode_slice(struct sol_buffer *buf,
     SOL_NULL_CHECK(buf, -EINVAL);
 
     sol_buffer_init(buf);
+
+    /* Empty slice. Just return an empty buffer */
+    if (!value.len)
+        return 0;
+
     last_append = 0;
 
     for (i = 0; i < value.len; i++) {

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -924,7 +924,7 @@ sol_buffer_fini(struct sol_buffer *buf)
 {
     if (!buf)
         return;
-    if (buf->flags & SOL_BUFFER_FLAGS_CLEAR_MEMORY)
+    if ((buf->flags & SOL_BUFFER_FLAGS_CLEAR_MEMORY) == SOL_BUFFER_FLAGS_CLEAR_MEMORY)
         sol_util_secure_clear_memory(buf->data, buf->capacity);
     if (!(buf->flags & SOL_BUFFER_FLAGS_NO_FREE))
         free(buf->data);

--- a/src/samples/coap/simple-server.c
+++ b/src/samples/coap/simple-server.c
@@ -213,8 +213,6 @@ static struct sol_coap_resource light = {
     SOL_SET_API_VERSION(.api_version = SOL_COAP_RESOURCE_API_VERSION, )
     .get = light_method_get,
     .put = light_method_put,
-    .iface = SOL_STR_SLICE_LITERAL("oc.mi.def"),
-    .resource_type = SOL_STR_SLICE_LITERAL("core.light"),
     .flags = SOL_COAP_FLAGS_WELL_KNOWN,
     .path = {
         SOL_STR_SLICE_LITERAL("a"),


### PR DESCRIPTION
A buffer shall use `sol_util_secure_clear_memory` only if
SOL_BUFFER_FLAGS_CLEAR_MEMORY flag is set.
However, current comparison had a mistake, as this flag contains
SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED bits, so it was taking not owned as
requiring secure free.

Shall fix segfaults on make samples.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>