### PR TITLE
lib/http: Fix build of library and tests

### DIFF
--- a/src/lib/comms/Kconfig
+++ b/src/lib/comms/Kconfig
@@ -62,8 +62,8 @@ config OIC
             Both client and server sides are covered by this library.
 
 config HTTP
-	bool
-	default n
+	bool "HTTP Common"
+	default y
 
 config HTTP_CLIENT
 	bool "HTTP Client"

--- a/src/test/Kconfig
+++ b/src/test/Kconfig
@@ -108,7 +108,7 @@ config TEST_PERSISTENCE_MEMMAP
 
 config TEST_HTTP
        bool "http"
-       depends on NETWORK
+       depends on HTTP
        default y
 
 config TEST_CERTIFICATE


### PR DESCRIPTION
test_http should depends on HTTP, not NETWORK

The common module of HTTP doesn't depends on any
external stuff, it could be enabled and tested
even if no dependencies are met for client or server.

Issue spotted by Lei A Yang <lei.a.yang@intel.com>

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>