### PR TITLE
oic/cbor: encode cbor to/from packets on the wire

### DIFF
--- a/src/lib/comms/Makefile
+++ b/src/lib/comms/Makefile
@@ -44,6 +44,7 @@ obj-networking-$(COAP) += \
 obj-networking-$(OIC) += \
     sol-oic-cbor.o \
     sol-oic-client.o \
+    sol-oic-common.o \
     sol-oic-server.o \
     $(TINYCBOR_SRC_PATH)/cborencoder.o \
     $(TINYCBOR_SRC_PATH)/cborerrorstrings.o \
@@ -99,8 +100,7 @@ headers-$(COAP) += \
 headers-$(OIC) += \
     include/sol-oic-common.h \
     include/sol-oic-client.h \
-    include/sol-oic-server.h \
-    sol-oic-cbor.h
+    include/sol-oic-server.h
 
 headers-$(HTTP) += \
     include/sol-http.h

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -240,7 +240,9 @@ enum sol_coap_flags {
 struct sol_coap_packet;
 
 /**
- * Opaque handler for a CoAP server.
+ * @struct sol_coap_server
+ *
+ * @brief Opaque handler for a CoAP server.
  */
 struct sol_coap_server;
 

--- a/src/lib/comms/include/sol-oic-client.h
+++ b/src/lib/comms/include/sol-oic-client.h
@@ -51,18 +51,7 @@ extern "C" {
  */
 
 /**
- * @defgroup OIC Open Interconnect Consortium
- * @ingroup Comms
- *
- * Implementation of protocol defined by Open Interconnect Consortium
- * (OIC - http://openinterconnect.org/)
- *
- * It's a common communication framework based on industry standard
- * technologies to wirelessly connect and intelligently manage
- * the flow of information among devices, regardless of form factor,
- * operating system or service provider.
- *
- * Both client and server sides are covered by this module.
+ * @ingroup OIC
  *
  * @{
  */
@@ -115,14 +104,16 @@ bool sol_oic_client_get_server_info(struct sol_oic_client *client,
     void *data);
 
 bool sol_oic_client_resource_request(struct sol_oic_client *client, struct sol_oic_resource *res,
-    sol_coap_method_t method, const struct sol_vector *reprs,
+    sol_coap_method_t method,
+    bool (*fill_repr_map)(void *data, struct sol_oic_map_writer *repr_map),
+    void *fill_repr_map_data,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_vector *reprs, void *data),
-    void *data);
+    const struct sol_str_slice *href, const struct sol_oic_map_reader *repr_vec, void *data),
+    void *callback_data);
 
 bool sol_oic_client_resource_set_observable(struct sol_oic_client *client, struct sol_oic_resource *res,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_vector *reprs, void *data),
+    const struct sol_str_slice *href, const struct sol_oic_map_reader *repr_map, void *data),
     void *data, bool observe);
 
 struct sol_oic_resource *sol_oic_resource_ref(struct sol_oic_resource *r);

--- a/src/lib/comms/include/sol-oic-server.h
+++ b/src/lib/comms/include/sol-oic-server.h
@@ -91,7 +91,7 @@ struct sol_oic_resource_type {
 
     struct {
         sol_coap_responsecode_t (*handle)(const struct sol_network_link_addr *cliaddr,
-            const void *data, const struct sol_vector *input, struct sol_vector *output);
+            const void *data, const struct sol_oic_map_reader *input, struct sol_oic_map_writer *output);
     } get, put, post, delete;
 };
 
@@ -104,7 +104,8 @@ struct sol_oic_server_resource *sol_oic_server_add_resource(
 void sol_oic_server_del_resource(struct sol_oic_server_resource *resource);
 
 bool sol_oic_notify_observers(struct sol_oic_server_resource *resource,
-    const struct sol_vector *repr);
+    bool (*fill_repr_map)(void *data, struct sol_oic_map_writer *repr_map),
+    void *data);
 
 /**
  * @}

--- a/src/lib/comms/sol-oic-cbor.h
+++ b/src/lib/comms/sol-oic-cbor.h
@@ -37,12 +37,17 @@
 #include "sol-oic-common.h"
 #include "sol-vector.h"
 
-CborError sol_oic_encode_cbor_repr(struct sol_coap_packet *pkt, const char *href, const struct sol_vector *reprs);
-
-CborError sol_oic_decode_cbor_repr(struct sol_coap_packet *pkt, struct sol_vector *reprs);
-CborError sol_oic_decode_cbor_repr_map(CborValue *map, struct sol_vector *reprs);
-
+CborError sol_oic_packet_cbor_extract_repr_map(struct sol_coap_packet *pkt, CborParser *parser, CborValue *repr_map);
+CborError sol_oic_cbor_repr_map_get_next_field(CborValue *value, struct sol_oic_repr_field *repr);
+CborError sol_oic_packet_cbor_close(struct sol_coap_packet *pkt, struct sol_oic_map_writer *encoder);
+CborError sol_oic_packet_cbor_create(struct sol_coap_packet *pkt, const char *href, struct sol_oic_map_writer *encoder);
+CborError sol_oic_packet_cbor_append(struct sol_oic_map_writer *encoder, struct sol_oic_repr_field *repr);
 bool sol_oic_pkt_has_cbor_content(const struct sol_coap_packet *pkt);
+
+struct sol_oic_map_writer {
+    CborEncoder encoder, rep_map, array, map;
+    uint8_t *payload;
+};
 
 enum sol_oic_payload_type {
     SOL_OIC_PAYLOAD_DISCOVERY = 1,

--- a/src/lib/comms/sol-oic-common.c
+++ b/src/lib/comms/sol-oic-common.c
@@ -1,0 +1,94 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sol-oic-common.h"
+#include "sol-oic-cbor.h"
+#include "sol-log.h"
+#include <assert.h>
+
+SOL_API enum sol_oic_map_loop_reason
+sol_oic_map_loop_init(const struct sol_oic_map_reader *map, struct sol_oic_map_reader *iterator, struct sol_oic_repr_field *repr)
+{
+    SOL_NULL_CHECK(map, SOL_OIC_MAP_LOOP_ERROR);
+    SOL_NULL_CHECK(iterator, SOL_OIC_MAP_LOOP_ERROR);
+    SOL_NULL_CHECK(repr, SOL_OIC_MAP_LOOP_ERROR);
+
+    static_assert(sizeof(*iterator) == sizeof(CborValue),
+        "struct sol_oic_map_reader size must be at least the same size of "
+        "CborValue struct defined in cbor.h header2");
+
+    if (!cbor_value_is_map((CborValue *)map))
+        return SOL_OIC_MAP_LOOP_ERROR;
+
+    if (cbor_value_enter_container((CborValue *)map, (CborValue *)iterator) != CborNoError)
+        return SOL_OIC_MAP_LOOP_ERROR;
+
+    /* Initialize repr with harmless data so cleanup works. */
+    repr->type = SOL_OIC_REPR_TYPE_BOOLEAN;
+    repr->key = NULL;
+    return SOL_OIC_MAP_LOOP_OK;
+}
+
+static void
+repr_field_free(struct sol_oic_repr_field *field)
+{
+    if (field->type == SOL_OIC_REPR_TYPE_TEXT_STRING ||
+        field->type == SOL_OIC_REPR_TYPE_BYTE_STRING)
+        free((char *)field->v_slice.data);
+
+    if (field)
+        free((char *)field->key);
+}
+
+SOL_API bool
+sol_oic_map_loop_next(struct sol_oic_repr_field *repr, struct sol_oic_map_reader *iterator, enum sol_oic_map_loop_reason *reason)
+{
+    CborError err;
+
+    repr_field_free(repr);
+    if (!cbor_value_is_valid((CborValue *)iterator))
+        return false;
+
+    err = sol_oic_cbor_repr_map_get_next_field((CborValue *)iterator, repr);
+    if (err != CborNoError) {
+        *reason = SOL_OIC_MAP_LOOP_ERROR;
+        return false;
+    }
+
+    return true;
+}
+
+SOL_API bool
+sol_oic_map_append(struct sol_oic_map_writer *oic_map_writer, struct sol_oic_repr_field *repr)
+{
+    return sol_oic_packet_cbor_append(oic_map_writer, repr) == CborNoError;
+}

--- a/src/samples/coap/oic-client.c
+++ b/src/samples/coap/oic-client.c
@@ -136,7 +136,7 @@ found_resource(struct sol_oic_client *cli, struct sol_oic_resource *res, void *d
         printf("\t\t%.*s\n", SOL_STR_SLICE_PRINT(*slice));
 
     printf("Issuing GET %.*s on resource...\n", SOL_STR_SLICE_PRINT(res->href));
-    sol_oic_client_resource_request(cli, res, SOL_COAP_METHOD_GET, NULL,
+    sol_oic_client_resource_request(cli, res, SOL_COAP_METHOD_GET, NULL, NULL,
         got_get_response, data);
 
     printf("\n");


### PR DESCRIPTION
Don't allocate extra sol_vector sctrucs to hold data from cbor fields
contained in oic packets. Read and write them directly from/to the
packet payload.

To read data from oic packets the user will now get a struct
sol_oic_map_reader, intead of a sol_vector and use the macro
SOL_OIC_MAP_LOOP to loop through all elements contained in the cbor map.

To write data in an oic packet the user won't need to add all elements
in a sol_vector. The user will need to create a callback that receives
a struct sol_oic_map_writer and add all elements to it using
sol_oic_map_append function. The callback strategy was used because the
used doesn't have access to the packet and the cbor element needs to be
created in the packets before adding elements to it and closed after
adding elements.

Fixes #1080