### PR TITLE
common: add macro for static checking array size

### DIFF
--- a/src/lib/common/include/sol-macros.h
+++ b/src/lib/common/include/sol-macros.h
@@ -73,6 +73,12 @@
 #define SOL_ATTR_PURE
 #endif
 
+#ifdef __cplusplus
+#define SOL_STATIC_ARRAY_SIZE(n)
+#else
+#define SOL_STATIC_ARRAY_SIZE(n) static n
+#endif
+
 /**
  * @}
  */

--- a/src/lib/common/sol-platform-impl-contiki.c
+++ b/src/lib/common/sol-platform-impl-contiki.c
@@ -97,7 +97,7 @@ sol_platform_impl_set_target(const char *target)
 }
 
 int
-sol_platform_impl_get_machine_id(char id[static 33])
+sol_platform_impl_get_machine_id(char id[SOL_STATIC_ARRAY_SIZE(33)])
 {
     SOL_WRN("Not implemented");
     return -ENOTSUP;

--- a/src/lib/common/sol-platform-impl-linux-micro.c
+++ b/src/lib/common/sol-platform-impl-linux-micro.c
@@ -933,7 +933,7 @@ sol_platform_impl_set_target(const char *target)
 }
 
 static int
-validate_machine_id(char id[static 33])
+validate_machine_id(char id[SOL_STATIC_ARRAY_SIZE(33)])
 {
     if (!sol_util_uuid_str_valid(id))
         return -EINVAL;
@@ -942,7 +942,7 @@ validate_machine_id(char id[static 33])
 }
 
 int
-sol_platform_impl_get_machine_id(char id[static 33])
+sol_platform_impl_get_machine_id(char id[SOL_STATIC_ARRAY_SIZE(33)])
 {
     static const char *etc_path = "/etc/machine-id",
     *run_path = "/run/machine-id";

--- a/src/lib/common/sol-platform-impl-riot.c
+++ b/src/lib/common/sol-platform-impl-riot.c
@@ -147,7 +147,7 @@ serial_to_string(const char *buf, size_t len, char *dst)
 #endif
 
 int
-sol_platform_impl_get_machine_id(char id[static 33])
+sol_platform_impl_get_machine_id(char id[SOL_STATIC_ARRAY_SIZE(33)])
 {
 #ifdef CPUID_ID_LEN
     char cpuid[CPUID_ID_LEN];

--- a/src/lib/common/sol-platform-impl-systemd.c
+++ b/src/lib/common/sol-platform-impl-systemd.c
@@ -156,7 +156,7 @@ fail_new_method:
 }
 
 static const char *
-sanitize_unit_name(char buf[static PATH_MAX], const char *unit,
+sanitize_unit_name(char buf[SOL_STATIC_ARRAY_SIZE(PATH_MAX)], const char *unit,
     const char *suffix, const char *action)
 {
     size_t len;
@@ -181,7 +181,7 @@ sanitize_unit_name(char buf[static PATH_MAX], const char *unit,
 }
 
 static inline const char *
-sanitize_service_name(char buf[static PATH_MAX], const char *service,
+sanitize_service_name(char buf[SOL_STATIC_ARRAY_SIZE(PATH_MAX)], const char *service,
     const char *action)
 {
     return sanitize_unit_name(buf, service, ".service", action);
@@ -443,7 +443,7 @@ sol_platform_impl_set_target(const char *target)
 }
 
 int
-sol_platform_impl_get_machine_id(char id[static 33])
+sol_platform_impl_get_machine_id(char id[SOL_STATIC_ARRAY_SIZE(33)])
 {
     int r;
 

--- a/src/lib/common/sol-platform-impl.h
+++ b/src/lib/common/sol-platform-impl.h
@@ -52,7 +52,7 @@ int sol_platform_impl_restart_service(const char *service) SOL_ATTR_NONNULL(1);
 
 int sol_platform_impl_set_target(const char *target) SOL_ATTR_NONNULL(1);
 
-int sol_platform_impl_get_machine_id(char id[static 33]);
+int sol_platform_impl_get_machine_id(char id[SOL_STATIC_ARRAY_SIZE(33)]);
 int sol_platform_impl_get_serial_number(char **number);
 int sol_platform_impl_get_os_version(char **version);
 

--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -272,7 +272,7 @@ extern const char SOL_BASE64_MAP[66];
  * @see sol_buffer_insert_from_base64()
  * @see sol_buffer_append_from_base64()
  */
-int sol_buffer_insert_as_base64(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice, const char base64_map[static 65]);
+int sol_buffer_insert_as_base64(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)]);
 
 /**
  * Append the 'slice' at the end of 'buf' encoded as base64 using the given map.
@@ -292,7 +292,7 @@ int sol_buffer_insert_as_base64(struct sol_buffer *buf, size_t pos, const struct
  * @see sol_buffer_insert_from_base64()
  * @see sol_buffer_append_from_base64()
  */
-int sol_buffer_append_as_base64(struct sol_buffer *buf, const struct sol_str_slice slice, const char base64_map[static 65]);
+int sol_buffer_append_as_base64(struct sol_buffer *buf, const struct sol_str_slice slice, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)]);
 
 /**
  * Insert the 'slice' into 'buf' at position 'pos' decoded from base64 using the given map.
@@ -314,7 +314,7 @@ int sol_buffer_append_as_base64(struct sol_buffer *buf, const struct sol_str_sli
  * @see sol_buffer_append_as_base64()
  * @see sol_buffer_append_from_base64()
  */
-int sol_buffer_insert_from_base64(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice, const char base64_map[static 65]);
+int sol_buffer_insert_from_base64(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)]);
 
 /**
  * Append the 'slice' at the end of 'buf' decoded from base64 using the given map.
@@ -334,7 +334,7 @@ int sol_buffer_insert_from_base64(struct sol_buffer *buf, size_t pos, const stru
  * @see sol_buffer_append_as_base64()
  * @see sol_buffer_insert_from_base64()
  */
-int sol_buffer_append_from_base64(struct sol_buffer *buf, const struct sol_str_slice slice, const char base64_map[static 65]);
+int sol_buffer_append_from_base64(struct sol_buffer *buf, const struct sol_str_slice slice, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)]);
 
 /**
  * Insert the 'slice' into 'buf' at position 'pos' encoded as base16 (hexadecimal).

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -469,7 +469,7 @@ sol_buffer_insert_char(struct sol_buffer *buf, size_t pos, const char c)
 SOL_API const char SOL_BASE64_MAP[66] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
 
 SOL_API int
-sol_buffer_insert_as_base64(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice, const char base64_map[static 65])
+sol_buffer_insert_as_base64(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)])
 {
     char *p;
     size_t new_size;
@@ -525,7 +525,7 @@ sol_buffer_insert_as_base64(struct sol_buffer *buf, size_t pos, const struct sol
 }
 
 SOL_API int
-sol_buffer_append_as_base64(struct sol_buffer *buf, const struct sol_str_slice slice, const char base64_map[static 65])
+sol_buffer_append_as_base64(struct sol_buffer *buf, const struct sol_str_slice slice, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)])
 {
     char *p;
     size_t new_size;
@@ -575,7 +575,7 @@ sol_buffer_append_as_base64(struct sol_buffer *buf, const struct sol_str_slice s
 }
 
 SOL_API int
-sol_buffer_insert_from_base64(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice, const char base64_map[static 65])
+sol_buffer_insert_from_base64(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)])
 {
     char *p;
     size_t new_size;
@@ -631,7 +631,7 @@ sol_buffer_insert_from_base64(struct sol_buffer *buf, size_t pos, const struct s
 }
 
 SOL_API int
-sol_buffer_append_from_base64(struct sol_buffer *buf, const struct sol_str_slice slice, const char base64_map[static 65])
+sol_buffer_append_from_base64(struct sol_buffer *buf, const struct sol_str_slice slice, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)])
 {
     char *p;
     size_t new_size;

--- a/src/modules/linux-micro/machine-id/machine-id.c
+++ b/src/modules/linux-micro/machine-id/machine-id.c
@@ -54,7 +54,7 @@ static void on_fstab_service_state_changed(void *data,
     enum sol_platform_service_state state);
 
 static int
-validate_machine_id(char id[static 33])
+validate_machine_id(char id[SOL_STATIC_ARRAY_SIZE(33)])
 {
     id[32] = '\0';
 
@@ -65,7 +65,7 @@ validate_machine_id(char id[static 33])
 }
 
 static int
-write_machine_id(const char *path, char id[static 33])
+write_machine_id(const char *path, char id[SOL_STATIC_ARRAY_SIZE(33)])
 {
     SOL_NULL_CHECK(path, -EINVAL);
 

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -267,7 +267,7 @@ uuid_gen(struct sol_uuid *ret)
 int
 sol_util_uuid_gen(bool upcase,
     bool with_hyphens,
-    char id[static 37])
+    char id[SOL_STATIC_ARRAY_SIZE(37)])
 {
     static struct sol_str_slice hyphen = SOL_STR_SLICE_LITERAL("-");
     /* hyphens on positions 8, 13, 18, 23 (from 0) */
@@ -347,7 +347,7 @@ sol_util_replace_str_from_slice_if_changed(char **str,
 }
 
 ssize_t
-sol_util_base64_encode(void *buf, size_t buflen, const struct sol_str_slice slice, const char base64_map[static 65])
+sol_util_base64_encode(void *buf, size_t buflen, const struct sol_str_slice slice, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)])
 {
     char *output;
     const uint8_t *input;
@@ -410,7 +410,7 @@ sol_util_base64_encode(void *buf, size_t buflen, const struct sol_str_slice slic
 }
 
 static inline uint8_t
-base64_index_of(char c, const char base64_map[static 65])
+base64_index_of(char c, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)])
 {
     const char *p = memchr(base64_map, c, 65);
 
@@ -420,7 +420,7 @@ base64_index_of(char c, const char base64_map[static 65])
 }
 
 ssize_t
-sol_util_base64_decode(void *buf, size_t buflen, const struct sol_str_slice slice, const char base64_map[static 65])
+sol_util_base64_decode(void *buf, size_t buflen, const struct sol_str_slice slice, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)])
 {
     uint8_t *output;
     const char *input;

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -401,7 +401,7 @@ sol_util_uint64_add(const uint64_t a, const uint64_t b, uint64_t *out)
  *
  * @return 0 on success, negative error code otherwise.
  */
-int sol_util_uuid_gen(bool upcase, bool with_hyphens, char id[static 37]);
+int sol_util_uuid_gen(bool upcase, bool with_hyphens, char id[SOL_STATIC_ARRAY_SIZE(37)]);
 
 /**
  * Checks if a given universally unique identifier (UUID), in string
@@ -473,7 +473,7 @@ int sol_util_replace_str_from_slice_if_changed(char **str, const struct sol_str_
  *
  * @return the number of bytes written or -errno if failed.
  */
-ssize_t sol_util_base64_encode(void *buf, size_t buflen, const struct sol_str_slice slice, const char base64_map[static 65]);
+ssize_t sol_util_base64_encode(void *buf, size_t buflen, const struct sol_str_slice slice, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)]);
 
 /**
  * Decode the binary slice from base64 using the given map.
@@ -494,10 +494,10 @@ ssize_t sol_util_base64_encode(void *buf, size_t buflen, const struct sol_str_sl
  *
  * @return the number of bytes written or -errno if failed.
  */
-ssize_t sol_util_base64_decode(void *buf, size_t buflen, const struct sol_str_slice slice, const char base64_map[static 65]);
+ssize_t sol_util_base64_decode(void *buf, size_t buflen, const struct sol_str_slice slice, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)]);
 
 static inline ssize_t
-sol_util_base64_calculate_encoded_len(const struct sol_str_slice slice, const char base64_map[static 65])
+sol_util_base64_calculate_encoded_len(const struct sol_str_slice slice, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)])
 {
     ssize_t req_len = slice.len / 3;
     int err;
@@ -511,7 +511,7 @@ sol_util_base64_calculate_encoded_len(const struct sol_str_slice slice, const ch
 }
 
 static inline ssize_t
-sol_util_base64_calculate_decoded_len(const struct sol_str_slice slice, const char base64_map[static 65])
+sol_util_base64_calculate_decoded_len(const struct sol_str_slice slice, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)])
 {
     size_t req_len = (slice.len / 4) * 3;
     size_t i;


### PR DESCRIPTION
In C there's a feature to improve the check of the array size being
passed to a function, by specifying 'static' before the array
size. However this feature is not supported on C++.

This patch wraps the usage into a macro to let the public headers to be
used in C++ programs.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>