### PR TITLE
build: fix make install regarding EXTRA_BINS

### DIFF
--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -103,7 +103,7 @@ samples: $(SOL_LIB_OUTPUT) $(samples-out) $(PRE_GEN)
 
 PHONY += samples
 
-PRE_INSTALL := $(PC_GEN) $(SOL_LIB_OUTPUT) $(bins-out) $(modules-out) $(all-mod-descs)
+PRE_INSTALL := $(PRE_GEN) $(SOL_LIB_OUTPUT) $(bins-out) $(modules-out) $(all-mod-descs)
 PRE_INSTALL += $(NODE_TYPE_SCHEMA_DEST) $(BOARD_DETECT_DEST) $(GDB_AUTOLOAD_PY_DEST)
 
 ifeq (y,$(RPATH))


### PR DESCRIPTION
Some scripts weren't installed for install rule,
like oic-gen or node-type-validate.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>