### PR TITLE
oic: Call callback when timeout is reached

### DIFF
--- a/src/lib/comms/sol-oic-client.c
+++ b/src/lib/comms/sol-oic-client.c
@@ -333,8 +333,10 @@ _server_info_reply_cb(struct sol_coap_server *server,
     uint16_t payload_len;
     struct sol_oic_server_information info = { 0 };
 
-    if (!req || !cliaddr)
+    if (!req || !cliaddr) {
+        ctx->cb(ctx->client, NULL, ctx->data);
         goto free_ctx;
+    }
 
     if (!ctx->cb) {
         SOL_WRN("No user callback provided");


### PR DESCRIPTION
In sol_oic_client_get_server_info, callback needs to be called when
timeout is reached, so users can perform any cleaning operation. This is
the same behavior from other equivalent methods, as
sol_oic_client_find_resource()

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>