### PR TITLE
update: 'need_update' field on `struct sol_update_info`.

### DIFF
--- a/src/lib/common/include/sol-update.h
+++ b/src/lib/common/include/sol-update.h
@@ -81,8 +81,13 @@ struct sol_update_handle;
  * @see sol_update_check
  */
 struct sol_update_info {
+#ifndef SOL_NO_API_VERSION
+#define SOL_UPDATE_INFO_API_VERSION (1)
+    uint16_t api_version;
+#endif
     const char *version; /**< @brief Current version of update file */
     uint64_t size; /**< @brief Size of update file. Useful to warn user about big downloads. */
+    bool need_update; /**< @brief If version of update is newer than current, so the update is necessary. */
 };
 
 /**

--- a/src/modules/flow/update/update.c
+++ b/src/modules/flow/update/update.c
@@ -91,10 +91,20 @@ check_cb(void *data, int status, const struct sol_update_info *response)
         goto end;
     }
 
+#ifndef SOL_NO_API_VERSION
+    if (unlikely(response->api_version != SOL_UPDATE_INFO_API_VERSION)) {
+        SOL_WRN("Update info config version '%u' is unexpected, expected '%u'",
+            response->api_version, SOL_UPDATE_INFO_API_VERSION);
+        return NULL;
+    }
+#endif
+
     sol_flow_send_string_packet(node,
         SOL_FLOW_NODE_TYPE_UPDATE_CHECK__OUT__VERSION, response->version);
     sol_flow_send_irange_value_packet(node,
         SOL_FLOW_NODE_TYPE_UPDATE_CHECK__OUT__SIZE, response->size);
+    sol_flow_send_boolean_packet(node,
+        SOL_FLOW_NODE_TYPE_UPDATE_CHECK__OUT__NEED_UPDATE, response->need_update);
 
 end:
     mdata->handle = NULL;

--- a/src/modules/flow/update/update.json
+++ b/src/modules/flow/update/update.json
@@ -62,7 +62,13 @@
           "data_type": "int",
           "description": "Current progress of task, a number between 0 and 100. An output of -1 indicates that current progress is not available",
           "name": "PROGRESS"
+        },
+        {
+          "data_type": "boolean",
+          "description": "If update version is different from current version, outputs true, false otherwise. Note that this behaviour is backend defined: if an update module also downgrades, it may output true here also.",
+          "name": "NEED_UPDATE"
         }
+
       ],
       "private_data_type": "update_data"
     },

--- a/src/modules/update/update-common/file.h
+++ b/src/modules/update/update-common/file.h
@@ -42,11 +42,11 @@ extern "C" {
  */
 
 /**
- * @struct update_check_hash_handle
+ * @struct update_get_hash_handle
  *
  * @brief Handle to cancel check hash operation
  */
-struct update_check_hash_handle;
+struct update_get_hash_handle;
 
 /**
  * @brief Check file hash
@@ -59,8 +59,8 @@ struct update_check_hash_handle;
  *
  * @return handle of operation if could start checking. NULL otherwise
  */
-struct update_check_hash_handle *check_file_hash(FILE *file, const char *hash,
-    const char *hash_algorithm, void (*cb)(void *data, int status),
+struct update_get_hash_handle *get_file_hash(FILE *file, const char *hash,
+    const char *hash_algorithm, void (*cb)(void *data, int status, const char *hash),
     const void *data);
 
 /**
@@ -68,7 +68,7 @@ struct update_check_hash_handle *check_file_hash(FILE *file, const char *hash,
  *
  * @return always true
  */
-bool cancel_check_file_hash(struct update_check_hash_handle *handle);
+bool cancel_get_file_hash(struct update_get_hash_handle *handle);
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/samples/flow/update/update.fbp
+++ b/src/samples/flow/update/update.fbp
@@ -52,6 +52,7 @@ install(update/install)
 
 fetch_progress_timer(timer:interval=10)
 fetch_progress_timer OUT -> GET_PROGRESS fetch
+_(constant/boolean:value=false) OUT -> ENABLED fetch_progress_timer
 
 check ERROR -> IN error_check(console)
 fetch ERROR -> IN error_fetch(console)
@@ -61,8 +62,9 @@ _(constant/int:value=0) OUT -> CHECK check
 
 check VERSION -> IN print_version(console)
 check SIZE -> IN print_size(console)
-check VERSION -> IN _(converter/empty-to-boolean:output_value=true) OUT -> ENABLED fetch_progress_timer
-check VERSION -> FETCH fetch
+check NEED_UPDATE -> IN print_need_update(console)
+check NEED_UPDATE -> PULSE_IF_TRUE _(converter/boolean-to-empty) OUT -> FETCH fetch
+check NEED_UPDATE -> ENABLED fetch_progress_timer
 
 fetch PROGRESS -> IN print_progress(console)
 fetch SUCCESS -> IN print_fetch_success(console)


### PR DESCRIPTION
So, update modules have a handy way to inform user that the update is
necessary.
Also introduced a versioning schema to `struct sol_update_info` because
it was proved it can change.
Update file helper method `check_file_hash` changed to `get_file_hash`,
turning caller task do the check, as Linux Micro EFI update module
checks if current file hash is different from update one to decide if
update is necessary (instead of comparing versions).
An output port NEED_UPDATE was also added to 'update/check' node, as
well as sample was updated to use it.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>