### PR TITLE
Plataform+Flow: Add support to get/set hostname. v3

### DIFF
--- a/src/lib/common/include/sol-platform.h
+++ b/src/lib/common/include/sol-platform.h
@@ -190,6 +190,52 @@ int sol_platform_get_mount_points(struct sol_ptr_vector *vector);
 int sol_platform_unmount(const char *mpoint, void (*cb)(void *data, const char *mpoint, int error), const void *data);
 
 /**
+ * @brief Gets the hostname.
+ *
+ *
+ * @return The hostname or NULL on error.
+ *
+ * @see sol_platform_set_hostname()
+ */
+const char *sol_platform_get_hostname(void);
+
+/**
+ * @brief Changes the hostname to @c name.
+ *
+ * @param name The new hostname.
+ *
+ * @return 0 on success, negative errno otherwise.
+ *
+ * @see sol_platform_get_hostname()
+ */
+int sol_platform_set_hostname(const char *name);
+
+/**
+ * @brief Adds a hostname monitor.
+ *
+ * If the hostname changes @c cb will be called.
+ *
+ * @param cb The callback that will inform the new hostname.
+ * @param data The data to the callback.
+ * @return 0 on success, negative errno otherwise.
+ *
+ * @see sol_platform_del_hostname_monitor()
+ */
+int sol_platform_add_hostname_monitor(void (*cb)(void *data, const char *hostname), const void *data);
+
+/**
+ * @brief Remove a hostname monitor.
+ *
+ * @param cb The registered callback.
+ * @param data The data to the callback.
+ * @return 0 on success, negative errno otherwise.
+ *
+ *
+ * @see sol_platform_add_hostname_monitor()
+ */
+int sol_platform_del_hostname_monitor(void (*cb)(void *data, const char *hostname), const void *data);
+
+/**
  * @}
  */
 

--- a/src/lib/common/sol-platform-impl-contiki.c
+++ b/src/lib/common/sol-platform-impl-contiki.c
@@ -135,3 +135,31 @@ sol_platform_impl_umount(const char *mpoint, void (*cb)(void *data, const char *
     SOL_WRN("Not implemented");
     return -ENOTSUP;
 }
+
+int
+sol_platform_unregister_hostname_monitor(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_register_hostname_monitor(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+const char *
+sol_platform_impl_get_hostname(void)
+{
+    SOL_WRN("Not implemented");
+    return NULL;
+}
+
+int
+sol_platform_impl_set_hostname(const char *name)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}

--- a/src/lib/common/sol-platform-impl-linux-micro.c
+++ b/src/lib/common/sol-platform-impl-linux-micro.c
@@ -33,6 +33,7 @@
 #include <ctype.h>
 #include <dlfcn.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <limits.h>
 #include <signal.h>
 #include <stdio.h>
@@ -41,6 +42,8 @@
 #include <sys/mount.h>
 #include <sys/reboot.h>
 #include <sys/stat.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -78,6 +81,13 @@ static const struct mount_table {
     { "debugfs", NULL,  "/sys/kernel/debug", NULL, 0, false },
     { "securityfs", NULL, "/sys/kernel/security", NULL, MS_NOSUID | MS_NOEXEC | MS_NODEV, false },
 };
+
+struct sol_fd_watcher_ctx {
+    struct sol_fd *watcher;
+    int fd;
+};
+
+static struct sol_fd_watcher_ctx hostname_monitor = { NULL, -1 };
 
 #ifdef ENABLE_DYNAMIC_MODULES
 struct service_module {
@@ -741,6 +751,7 @@ sol_platform_impl_shutdown(void)
 
     service_instances_cleanup();
     service_modules_cleanup();
+    sol_platform_unregister_hostname_monitor();
     builtins_cleanup();
 
     if (getpid() == 1 && getppid() == 0)
@@ -1000,4 +1011,60 @@ sol_platform_linux_micro_inform_service_state(const char *service, enum sol_plat
     inst->state = state;
 #endif
     sol_platform_inform_service_monitors(service, state);
+}
+
+int
+sol_platform_impl_set_hostname(const char *name)
+{
+    size_t len = strlen(name);
+
+    if (len > HOST_NAME_MAX) {
+        SOL_WRN("Hostname can not be bigger than %d - Hostname:%s",
+            HOST_NAME_MAX, name);
+        return -EINVAL;
+    }
+
+    if (sethostname(name, len) < 0)
+        return -errno;
+    return 0;
+}
+
+static bool
+hostname_changed(void *data, int fd, uint32_t active_flags)
+{
+    sol_platform_inform_hostname_monitors();
+    return true;
+}
+
+int
+sol_platform_register_hostname_monitor(void)
+{
+    if (hostname_monitor.watcher)
+        return 0;
+
+    hostname_monitor.fd = open("/proc/sys/kernel/hostname", O_RDONLY | O_CLOEXEC);
+
+    if (hostname_monitor.fd < 0)
+        return -errno;
+
+    hostname_monitor.watcher = sol_fd_add(hostname_monitor.fd,
+        SOL_FD_FLAGS_HUP, hostname_changed, NULL);
+    if (!hostname_monitor.watcher) {
+        close(hostname_monitor.fd);
+        return -ENOMEM;
+    }
+
+    return 0;
+}
+
+int
+sol_platform_unregister_hostname_monitor(void)
+{
+    if (!hostname_monitor.watcher)
+        return 0;
+    sol_fd_del(hostname_monitor.watcher);
+    close(hostname_monitor.fd);
+    hostname_monitor.fd = -1;
+    hostname_monitor.watcher = NULL;
+    return 0;
 }

--- a/src/lib/common/sol-platform-impl-riot.c
+++ b/src/lib/common/sol-platform-impl-riot.c
@@ -208,3 +208,31 @@ sol_platform_impl_umount(const char *mpoint, void (*cb)(void *data, const char *
     SOL_WRN("Not implemented");
     return -ENOTSUP;
 }
+
+int
+sol_platform_unregister_hostname_monitor(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_register_hostname_monitor(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+const char *
+sol_platform_impl_get_hostname(void)
+{
+    SOL_WRN("Not implemented");
+    return NULL;
+}
+
+int
+sol_platform_impl_set_hostname(const char *name)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}

--- a/src/lib/common/sol-platform-impl-systemd.c
+++ b/src/lib/common/sol-platform-impl-systemd.c
@@ -489,3 +489,56 @@ sol_platform_impl_shutdown(void)
 
     sol_bus_close();
 }
+
+int
+sol_platform_impl_set_hostname(const char *name)
+{
+    sd_bus *bus;
+    int r;
+
+    bus = sol_bus_get(NULL);
+    SOL_NULL_CHECK(bus, -ENOTCONN);
+
+    r = sd_bus_call_method_async(bus, NULL, "org.freedesktop.hostname1",
+        "/org/freedesktop/hostname1", "org.freedesktop.hostname1",
+        "SetStaticHostname", sol_bus_log_callback, NULL, "sb", name, false);
+    SOL_INT_CHECK(r, < 0, r);
+    return 0;
+}
+
+static bool
+_set_hostname(void *data, const void *value)
+{
+    return true;
+}
+
+static const struct sol_bus_properties _hostname_property = {
+    .member = "StaticHostname",
+    .type = 's',
+    .set = _set_hostname,
+};
+
+int
+sol_platform_unregister_hostname_monitor(void)
+{
+    return sol_bus_unmap_cached_properties(&_hostname_property, NULL);
+}
+
+static void
+_hostname_changed(void *data, uint64_t mask)
+{
+    sol_platform_inform_hostname_monitors();
+}
+
+int
+sol_platform_register_hostname_monitor(void)
+{
+    sd_bus *bus;
+
+    bus = sol_bus_get(NULL);
+    SOL_NULL_CHECK(bus, -ENOTCONN);
+
+    return sol_bus_map_cached_properties(bus, "org.freedesktop.hostname1",
+        "/org/freedesktop/hostname1", "org.freedesktop.hostname1",
+        &_hostname_property, _hostname_changed, NULL);
+}

--- a/src/lib/common/sol-platform-impl.h
+++ b/src/lib/common/sol-platform-impl.h
@@ -63,3 +63,11 @@ void sol_platform_inform_service_monitors(const char *service,
 
 int sol_platform_impl_get_mount_points(struct sol_ptr_vector *vector);
 int sol_platform_impl_umount(const char *mpoint, void (*cb)(void *data, const char *mpoint, int error), const void *data);
+
+int sol_platform_impl_set_hostname(const char *name);
+const char *sol_platform_impl_get_hostname(void);
+
+void sol_platform_inform_hostname_monitors(void);
+
+int sol_platform_unregister_hostname_monitor(void);
+int sol_platform_register_hostname_monitor(void);

--- a/src/lib/common/sol-platform-linux-common.c
+++ b/src/lib/common/sol-platform-linux-common.c
@@ -93,6 +93,7 @@ struct uevent_context {
     } uevent;
 };
 
+static char hostname[HOST_NAME_MAX + 1];
 static struct uevent_context uevent_ctx;
 static struct sol_ptr_vector fork_runs = SOL_PTR_VECTOR_INIT;
 
@@ -113,6 +114,14 @@ find_handle(const struct sol_platform_linux_fork_run *handle)
     }
 
     return UINT16_MAX;
+}
+
+const char *
+sol_platform_impl_get_hostname(void)
+{
+    if (gethostname(hostname, sizeof(hostname)) < 0)
+        return NULL;
+    return hostname;
 }
 
 static void

--- a/src/lib/common/sol-platform.c
+++ b/src/lib/common/sol-platform.c
@@ -63,6 +63,7 @@ struct service_monitor {
 struct ctx {
     struct sol_monitors state_monitors;
     struct sol_monitors service_monitors;
+    struct sol_monitors hostname_monitors;
 };
 
 static struct ctx _ctx;
@@ -78,6 +79,7 @@ sol_platform_init(void)
     sol_log_domain_init_level(SOL_LOG_DOMAIN);
 
     sol_monitors_init(&_ctx.state_monitors, NULL);
+    sol_monitors_init(&_ctx.hostname_monitors, NULL);
     sol_monitors_init_custom(&_ctx.service_monitors, sizeof(struct service_monitor), service_monitor_free);
 
     return sol_platform_impl_init();
@@ -91,6 +93,7 @@ sol_platform_shutdown(void)
     free(serial_number);
     sol_monitors_clear(&_ctx.state_monitors);
     sol_monitors_clear(&_ctx.service_monitors);
+    sol_monitors_clear(&_ctx.hostname_monitors);
     sol_platform_impl_shutdown();
 }
 
@@ -171,19 +174,39 @@ sol_platform_get_state(void)
     return sol_platform_impl_get_state();
 }
 
-SOL_API int
-sol_platform_add_state_monitor(void (*cb)(void *data,
-    enum sol_platform_state state),
-    const void *data)
+static int
+monitor_add(struct sol_monitors *monitors, sol_monitors_cb_t cb, const void *data)
 {
     struct sol_monitors_entry *e;
 
     SOL_NULL_CHECK(cb, -EINVAL);
 
-    e = sol_monitors_append(&_ctx.state_monitors, (sol_monitors_cb_t)cb, data);
+    e = sol_monitors_append(monitors, cb, data);
     SOL_NULL_CHECK(e, -ENOMEM);
-
     return 0;
+}
+
+static int
+monitor_del(struct sol_monitors *monitors, sol_monitors_cb_t cb, const void *data)
+{
+    int i;
+
+    SOL_NULL_CHECK(cb, -EINVAL);
+
+    i = sol_monitors_find(monitors, cb, data);
+    if (i < 0)
+        return i;
+
+    return sol_monitors_del(monitors, i);
+}
+
+SOL_API int
+sol_platform_add_state_monitor(void (*cb)(void *data,
+    enum sol_platform_state state),
+    const void *data)
+{
+
+    return monitor_add(&_ctx.state_monitors, (sol_monitors_cb_t)cb, data);
 }
 
 SOL_API int
@@ -191,15 +214,7 @@ sol_platform_del_state_monitor(void (*cb)(void *data,
     enum sol_platform_state state),
     const void *data)
 {
-    int i;
-
-    SOL_NULL_CHECK(cb, -EINVAL);
-
-    i = sol_monitors_find(&_ctx.state_monitors, (sol_monitors_cb_t)cb, data);
-    if (i < 0)
-        return i;
-
-    return sol_monitors_del(&_ctx.state_monitors, i);
+    return monitor_del(&_ctx.state_monitors, (sol_monitors_cb_t)cb, data);
 }
 
 static inline struct service_monitor *
@@ -456,4 +471,63 @@ sol_platform_unmount(const char *mpoint, void (*cb)(void *data, const char *mpoi
     SOL_NULL_CHECK(mpoint, -EINVAL);
     SOL_NULL_CHECK(cb, -EINVAL);
     return sol_platform_impl_umount(mpoint, cb, data);
+}
+
+SOL_API int
+sol_platform_set_hostname(const char *name)
+{
+    SOL_NULL_CHECK(name, -EINVAL);
+    return sol_platform_impl_set_hostname(name);
+}
+
+SOL_API const char *
+sol_platform_get_hostname(void)
+{
+    return sol_platform_impl_get_hostname();
+}
+
+void
+sol_platform_inform_hostname_monitors(void)
+{
+    const char *hostname;
+    struct sol_monitors_entry *entry;
+    uint16_t i;
+
+    hostname = sol_platform_impl_get_hostname();
+    SOL_NULL_CHECK(hostname);
+
+    SOL_MONITORS_WALK (&_ctx.hostname_monitors, entry, i)
+        ((void (*)(void *, const char *))entry->cb)((void *)entry->data, hostname);
+}
+
+SOL_API int
+sol_platform_add_hostname_monitor(void (*cb)(void *data, const char *hostname), const void *data)
+{
+    int r;
+
+    SOL_NULL_CHECK(cb, -EINVAL);
+    r = monitor_add(&_ctx.hostname_monitors, (sol_monitors_cb_t)cb, data);
+    SOL_INT_CHECK(r, < 0, r);
+    if (sol_monitors_count(&_ctx.hostname_monitors) == 1) {
+        r = sol_platform_register_hostname_monitor();
+        SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+    }
+    return 0;
+err_exit:
+    (void)monitor_del(&_ctx.hostname_monitors, (sol_monitors_cb_t)cb, data);
+    return r;
+}
+
+SOL_API int
+sol_platform_del_hostname_monitor(void (*cb)(void *data, const char *hostname), const void *data)
+{
+    int r;
+
+    SOL_NULL_CHECK(cb, -EINVAL);
+    r = monitor_del(&_ctx.hostname_monitors, (sol_monitors_cb_t)cb, data);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (sol_monitors_count(&_ctx.hostname_monitors) == 0)
+        return sol_platform_unregister_hostname_monitor();
+    return 0;
 }

--- a/src/modules/flow/platform/platform.c
+++ b/src/modules/flow/platform/platform.c
@@ -43,6 +43,10 @@ struct platform_data {
     enum sol_platform_state state;
 };
 
+struct hostname_data {
+    uint16_t connections;
+};
+
 static int
 state_dispatch_ready(struct platform_data *mdata)
 {
@@ -207,5 +211,79 @@ platform_machine_id_open(struct sol_flow_node *node,
     return sol_flow_send_string_packet(node,
         SOL_FLOW_NODE_TYPE_PLATFORM_MACHINE_ID__OUT__OUT, id);
 }
+
+static int
+hostname_send(const char *hostname, struct sol_flow_node *node)
+{
+    int r;
+
+    if (!hostname) {
+        hostname = sol_platform_get_hostname();
+        SOL_NULL_CHECK(hostname, -ECANCELED);
+    }
+
+    r = sol_flow_send_string_packet(node, 0, hostname);
+    SOL_INT_CHECK(r, < 0, r);
+    return 0;
+}
+
+static int
+hostname_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
+{
+    const struct sol_flow_node_type_platform_hostname_options *opts;
+
+    opts = (const struct sol_flow_node_type_platform_hostname_options *)options;
+
+    if (opts->send_initial_packet)
+        return hostname_send(NULL, node);
+    return 0;
+}
+
+static int
+hostname_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    int r;
+    const char *name;
+
+    r = sol_flow_packet_get_string(packet, &name);
+    SOL_INT_CHECK(r, < 0, r);
+    r = sol_platform_set_hostname(name);
+    SOL_INT_CHECK(r, < 0, r);
+    return 0;
+}
+
+static void
+hostname_changed(void *data, const char *hostname)
+{
+    hostname_send(hostname, data);
+}
+
+static int
+hostname_out_connect(struct sol_flow_node *node, void *data,
+    uint16_t port, uint16_t conn_id)
+{
+    struct hostname_data *mdata = data;
+
+    mdata->connections++;
+    if (mdata->connections == 1)
+        return sol_platform_add_hostname_monitor(hostname_changed, node);
+    return 0;
+}
+
+static int
+hostname_out_disconnect(struct sol_flow_node *node, void *data,
+    uint16_t port, uint16_t conn_id)
+{
+    struct hostname_data *mdata = data;
+
+    if (!mdata->connections)
+        return 0;
+
+    if (!--mdata->connections)
+        return sol_platform_del_hostname_monitor(hostname_changed, node);
+    return 0;
+}
+
 
 #include "platform-gen.c"

--- a/src/modules/flow/platform/platform.json
+++ b/src/modules/flow/platform/platform.json
@@ -36,6 +36,48 @@
       "url": "http://solettaproject.org/doc/latest/node_types/platform.html"
     },
     {
+      "category": "hostname",
+      "description": "This node can be used to set the machine's host name, get the current hostname or monitor for hostname changes",
+      "in_ports": [
+        {
+          "data_type": "string",
+          "description": "The new hostname",
+          "methods": {
+            "process": "hostname_process"
+          },
+          "name": "IN"
+        }
+      ],
+      "methods": {
+        "open": "hostname_open"
+      },
+      "options": {
+        "members": [
+          {
+            "data_type": "boolean",
+            "default": true,
+            "description": "An initial packet with the current hostname will be sent",
+            "name": "send_initial_packet"
+          }
+        ],
+        "version": 1
+      },
+      "name": "platform/hostname",
+      "out_ports": [
+        {
+          "data_type": "string",
+          "description": "The current hostname. When the node is created an initial packet will be sent with the current hostname, if the hostname changes a new packet will be set with the new hostname.",
+          "methods": {
+            "connect": "hostname_out_connect",
+            "disconnect": "hostname_out_disconnect"
+          },
+          "name": "OUT"
+        }
+      ],
+      "private_data_type": "hostname_data",
+      "url": "http://solettaproject.org/doc/latest/node_types/platform_hostname.html"
+    },
+    {
       "category": "input/sw",
       "description": "Platform Service State",
       "in_ports": [

--- a/src/samples/flow/misc/Makefile
+++ b/src/samples/flow/misc/Makefile
@@ -9,3 +9,6 @@ sample-random-numbers-$(FLOW_MISC_RANDOM_NUMBERS_SAMPLE) := random-numbers.fbp
 
 sample-$(FLOW_MISC_TICKETS_QUEUE_SAMPLE) += tickets-queue
 sample-tickets-queue-$(FLOW_MISC_TICKETS_QUEUE_SAMPLE) := tickets_queue.fbp
+
+sample-$(FLOW_MISC_CHANGE_HOSTNAME_SAMPLE) += chamge_hostname
+sample-tickets-queue-$(FLOW_MISC_CHANGE_HOSTNAME_SAMPLE) := change_hostname.fbp

--- a/src/samples/flow/misc/change_hostname.fbp
+++ b/src/samples/flow/misc/change_hostname.fbp
@@ -1,0 +1,39 @@
+#!/usr/bin/env sol-fbp-runner
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+# Usage: sol-fbp-runner change_hostname.fbp HOSTNAME
+# This FBP will change the hostname name of the current machine.
+# Changing the hostname may required administrator privileges
+
+_(constant/string:value="The new hostname is: ") OUT -> IN[0] text(string/concatenate)
+_(app/argv:index=1) OUT -> IN _(platform/hostname:send_initial_packet=false) OUT -> IN[1] text
+text OUT -> IN _(console)


### PR DESCRIPTION
Changes since v2:
* changed the order of the arguments in sol_platform_add/del_hostname_monitor.
* removed src/lib/common/sol-platform-linux-common.h
* moved sol_platform_impl_linux_set_hostname(const char *name) to linux micro
* renamed sol_platform_impl_linux_get_hostname(void) to sol_platform_linux_get_hostname(void) 