### PR TITLE
Platform+Flow: Add locale API and nodes V2.

### DIFF
--- a/src/lib/common/include/sol-platform.h
+++ b/src/lib/common/include/sol-platform.h
@@ -236,6 +236,95 @@ int sol_platform_add_hostname_monitor(void (*cb)(void *data, const char *hostnam
 int sol_platform_del_hostname_monitor(void (*cb)(void *data, const char *hostname), const void *data);
 
 /**
+ * @brief Set the system wide time.
+ *
+ * @param timestamp The new system_clock
+ * @return @c 0 on succes, negative errno otherwise
+ *
+ * @note The @c timestamp is relative to 1970-01-01 00:00:00 +0000 (UTC)
+ * @see sol_platform_get_system_clock()
+ */
+int sol_platform_set_system_clock(int64_t timestamp);
+
+/**
+ * @brief Get the current system time.
+ *
+ * @return the system time on success, negative errno on error
+ *
+ * @note The returned value is the number of seconds since 1970-01-01 00:00:00 +0000 (UTC)
+ *
+ * @see sol_platform_set_system_clock()
+ */
+int64_t sol_platform_get_system_clock(void);
+
+/**
+ * @brief Add a callback to monitor system clock changes.
+ *
+ * @param cb A callback to be called when the system clock changes
+ * @param data The data to @c cb
+ * @return @c 0 on success, negative errno otherwise
+ *
+ * @note The registered callback will not be called every second (a.k.a: this is not a timer!), it will only
+ * be called if the system clock is adjusted. If one needs a timer use sol_timeout_add()
+ * @see sol_platform_del_system_clock_monitor()
+ */
+int sol_platform_add_system_clock_monitor(void (*cb)(void *data, int64_t timestamp), const void *data);
+
+/**
+ * @brief Delete a register system_clock monitor.
+ *
+ * @param cb The previous registered callback
+ * @param data The data to @c cb
+ * @return @c 0 on success, negative errno otherwise
+ *
+ * @see sol_platform_add_system_clock_monitor()
+ */
+int sol_platform_del_system_clock_monitor(void (*cb)(void *data, int64_t timestamp), const void *data);
+
+/**
+ * @brief Set the system timezone.
+ *
+ * @param timezone The new timezone. (Example: America/Sao Paulo)
+ *
+ * @return @c 0 on success, negative errno on error
+ *
+ * @note The new timezone must be avaible at /usr/share/zoneinfo/
+ *
+ * @see sol_platform_get_timezone()
+ */
+int sol_platform_set_timezone(const char *timezone);
+
+/**
+ * @brief Get the current timezone.
+ *
+ * @return The timezone or @c NULL on error
+ *
+ * @see sol_platform_set_timezone()
+ */
+const char *sol_platform_get_timezone(void);
+
+/**
+ * @brief Add a timezone monitor.
+ *
+ * @param cb A callback to be called when the timezone changes
+ * @param data The data to @c cb
+ *
+ * @return @c 0 on success, negative errno otherwise
+ */
+int sol_platform_add_timezone_monitor(void (*cb)(void *data, const char *timezone), const void *data);
+
+/**
+ * @brief Remove a timezone monitor.
+ *
+ * @param cb The previous registered callback
+ * @param data The data to @c cb
+ *
+ * @return @c 0 on success, negative errno otherwise
+ */
+int sol_platform_del_timezone_monitor(void (*cb)(void *data, const char *timezone), const void *data);
+
+
+/**
  * @}
  */
 

--- a/src/lib/common/include/sol-platform.h
+++ b/src/lib/common/include/sol-platform.h
@@ -145,6 +145,26 @@ enum sol_platform_service_state {
     SOL_PLATFORM_SERVICE_STATE_UNKNOWN = -1
 };
 
+/**
+ * @brief A locale category.
+ */
+enum sol_platform_locale_category {
+    SOL_PLATFORM_LOCALE_LANGUAGE,
+    SOL_PLATFORM_LOCALE_ADDRESS,
+    SOL_PLATFORM_LOCALE_COLLATE,
+    SOL_PLATFORM_LOCALE_CTYPE,
+    SOL_PLATFORM_LOCALE_IDENTIFICATION,
+    SOL_PLATFORM_LOCALE_MEASUREMENT,
+    SOL_PLATFORM_LOCALE_MESSAGES,
+    SOL_PLATFORM_LOCALE_MONETARY,
+    SOL_PLATFORM_LOCALE_NAME,
+    SOL_PLATFORM_LOCALE_NUMERIC,
+    SOL_PLATFORM_LOCALE_PAPER,
+    SOL_PLATFORM_LOCALE_TELEPHONE,
+    SOL_PLATFORM_LOCALE_TIME,
+    SOL_PLATFORM_LOCALE_UNKNOWN = -1
+};
+
 enum sol_platform_service_state sol_platform_get_service_state(const char *service);
 
 int sol_platform_add_service_monitor(void (*cb)(void *data, const char *service,
@@ -323,6 +343,66 @@ int sol_platform_add_timezone_monitor(void (*cb)(void *data, const char *timezon
  */
 int sol_platform_del_timezone_monitor(void (*cb)(void *data, const char *timezone), const void *data);
 
+/**
+ * @brief Set locale for a category.
+ *
+ * This function will change the system wide locale for a given category.
+ * The already running proceses might not be aware that the locale has changed.
+ *
+ * @param category The category to set the new locale
+ * @param locale The locale string (Example: en_US.UTF-8)
+ *
+ * @return 0 on success, negative errno on error
+ *
+ * @note This function only saves the new locale category in the disk, in order to use it in
+ * the current process, one must call sol_platform_apply_locale() after using sol_platform_set_locale()
+ *
+ * @see sol_platform_get_locale()
+ * @see sol_platform_apply_locale()
+ */
+int sol_platform_set_locale(enum sol_platform_locale_category category, const char *locale);
+
+/**
+ * @brief Get the current locale of a given category.
+ *
+ * @param category The category which one wants to know the locale
+ * @return The locale value on success, @c NULL otherwise
+ *
+ * @see sol_platform_set_locale()
+ */
+const char *sol_platform_get_locale(enum sol_platform_locale_category category);
+
+/**
+ * @brief Add a locale monitor.
+ *
+ * @param cb A callback to be called when the locale changes
+ * @param data The data to @c cb
+ *
+ * @return 0 on success, negative errno otherwise.
+ */
+int sol_platform_add_locale_monitor(void (*cb)(void *data, enum sol_platform_locale_category category, const char *locale), const void *data);
+
+/**
+ * @brief Remove a locale monitor.
+ *
+ * @param cb The previous registered callback
+ * @param data The data to @c cb
+ *
+ * @return 0 on success, negative errno otherwise
+ */
+int sol_platform_del_locale_monitor(void (*cb)(void *data, enum sol_platform_locale_category category, const char *locale), const void *data);
+
+/**
+ * @brief Apply the locale category to the process.
+ *
+ * This function sets the current locale of the given category to the process,
+ * in order to set a new locale value to a category use sol_platform_set_locale().
+ *
+ * @param category The category to set the process locale
+ * @return 0 on success, negative errno otherwise
+ * @see sol_platform_set_locale()
+ */
+int sol_platform_apply_locale(enum sol_platform_locale_category category);
 
 /**
  * @}

--- a/src/lib/common/sol-platform-impl-contiki.c
+++ b/src/lib/common/sol-platform-impl-contiki.c
@@ -218,3 +218,52 @@ sol_platform_unregister_timezone_monitor(void)
     SOL_WRN("Not implemented");
     return -ENOTSUP;
 }
+
+int
+sol_platform_unregister_timezone_monitor(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_impl_set_locale(char **locales)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+const char *
+sol_platform_impl_get_locale(enum sol_platform_locale_category type)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_register_locale_monitor(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_unregister_locale_monitor(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_impl_apply_locale(enum sol_platform_locale_category type, const char *locale)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_impl_load_locales(char **locale_cache)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}

--- a/src/lib/common/sol-platform-impl-contiki.c
+++ b/src/lib/common/sol-platform-impl-contiki.c
@@ -163,3 +163,58 @@ sol_platform_impl_set_hostname(const char *name)
     SOL_WRN("Not implemented");
     return -ENOTSUP;
 }
+int
+sol_platform_impl_set_system_clock(int64_t timestamp)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int64_t
+sol_platform_impl_get_system_clock(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_unregister_system_clock_monitor(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_register_system_clock_monitor(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_impl_set_timezone(const char *timezone)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+const char *
+sol_platform_impl_get_timezone(void)
+{
+    SOL_WRN("Not implemented");
+    return NULL;
+}
+
+int
+sol_platform_register_timezone_monitor(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_unregister_timezone_monitor(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}

--- a/src/lib/common/sol-platform-impl-linux-micro.c
+++ b/src/lib/common/sol-platform-impl-linux-micro.c
@@ -35,6 +35,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <locale.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -54,6 +55,7 @@
 #include "sol-platform-linux-micro.h"
 #include "sol-platform-linux.h"
 #include "sol-platform.h"
+#include "sol-str-table.h"
 #include "sol-util.h"
 #include "sol-vector.h"
 
@@ -91,6 +93,7 @@ struct sol_fd_watcher_ctx {
 
 static struct sol_fd_watcher_ctx hostname_monitor = { NULL, -1 };
 static struct sol_fd_watcher_ctx timezone_monitor = { NULL, -1 };
+static struct sol_fd_watcher_ctx locale_monitor = { NULL, -1 };
 
 #ifdef ENABLE_DYNAMIC_MODULES
 struct service_module {
@@ -757,6 +760,7 @@ sol_platform_impl_shutdown(void)
     sol_platform_unregister_hostname_monitor();
     sol_platform_unregister_system_clock_monitor();
     sol_platform_unregister_timezone_monitor();
+    sol_platform_unregister_locale_monitor();
     builtins_cleanup();
 
     if (getpid() == 1 && getppid() == 0)
@@ -1150,29 +1154,30 @@ timezone_changed(void *data, int fd, uint32_t active_flags)
     return false;
 }
 
-int
-sol_platform_register_timezone_monitor(void)
+static int
+add_watch(struct sol_fd_watcher_ctx *monitor, const char *path,
+    bool (*cb)(void *data, int fd, uint32_t active_flags))
 {
     int r;
 
-    if (timezone_monitor.watcher)
+    if (monitor->watcher)
         return 0;
 
-    timezone_monitor.fd = inotify_init1(IN_CLOEXEC);
+    monitor->fd = inotify_init1(IN_CLOEXEC);
 
-    if (timezone_monitor.fd < 0) {
+    if (monitor->fd < 0) {
         return -errno;
     }
 
-    if (inotify_add_watch(timezone_monitor.fd, "/etc/localtime",
+    if (inotify_add_watch(monitor->fd, path,
         IN_MODIFY | IN_DONT_FOLLOW) < 0) {
         r = -errno;
         goto err_exit;
     }
 
-    timezone_monitor.watcher = sol_fd_add(timezone_monitor.fd,
-        SOL_FD_FLAGS_IN, timezone_changed, NULL);
-    if (!timezone_monitor.watcher) {
+    monitor->watcher = sol_fd_add(monitor->fd,
+        SOL_FD_FLAGS_IN, cb, NULL);
+    if (!monitor->watcher) {
         r = -ENOMEM;
         goto err_exit;
     }
@@ -1180,14 +1185,76 @@ sol_platform_register_timezone_monitor(void)
     return 0;
 
 err_exit:
-    close(timezone_monitor.fd);
-    timezone_monitor.fd = -1;
+    close(monitor->fd);
+    monitor->fd = -1;
     return r;
+}
+
+int
+sol_platform_register_timezone_monitor(void)
+{
+    return add_watch(&timezone_monitor, "/etc/localtime", timezone_changed);
 }
 
 int
 sol_platform_unregister_timezone_monitor(void)
 {
     close_fd_monitor(&timezone_monitor);
+    return 0;
+}
+
+int
+sol_platform_impl_set_locale(char **locales)
+{
+    enum sol_platform_locale_category i;
+    FILE *f;
+    int r;
+
+    f = fopen("/etc/locale.conf", "we");
+
+    if (!f) {
+        r = -errno;
+        if (r == -ENOENT) {
+            SOL_WRN("The locale file (/etc/locale.conf) was not found in the system.");
+            return 0;
+        } else
+            return r;
+    }
+
+    for (i = SOL_PLATFORM_LOCALE_LANGUAGE; i <= SOL_PLATFORM_LOCALE_TIME; i++) {
+        if (!locales[i])
+            continue;
+        r = fprintf(f, "%s=%s\n", sol_platform_locale_to_c_str_category(i),
+            locales[i]);
+        SOL_INT_CHECK_GOTO(r, < 0, exit);
+    }
+
+exit:
+    if (fclose(f) < 0)
+        return -errno;
+    return 0;
+}
+
+static bool
+locale_changed(void *data, int fd, uint32_t active_flags)
+{
+    char buf[4096];
+
+    sol_platform_inform_locale_changed();
+    (void)read(fd, buf, sizeof(buf));
+    return true;
+}
+
+int
+sol_platform_register_locale_monitor(void)
+{
+    return add_watch(&locale_monitor, "/etc/locale.conf",
+        locale_changed);
+}
+
+int
+sol_platform_unregister_locale_monitor(void)
+{
+    close_fd_monitor(&locale_monitor);
     return 0;
 }

--- a/src/lib/common/sol-platform-impl-riot.c
+++ b/src/lib/common/sol-platform-impl-riot.c
@@ -236,3 +236,59 @@ sol_platform_impl_set_hostname(const char *name)
     SOL_WRN("Not implemented");
     return -ENOTSUP;
 }
+
+int
+sol_platform_impl_set_system_clock(int64_t timestamp)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int64_t
+sol_platform_impl_get_system_clock(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_unregister_system_clock_monitor(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_register_system_clock_monitor(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_impl_set_timezone(const char *timezone)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+const char *
+sol_platform_impl_get_timezone(void)
+{
+    SOL_WRN("Not implemented");
+    return NULL;
+}
+
+int
+sol_platform_register_timezone_monitor(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_unregister_timezone_monitor(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}

--- a/src/lib/common/sol-platform-impl-riot.c
+++ b/src/lib/common/sol-platform-impl-riot.c
@@ -292,3 +292,45 @@ sol_platform_unregister_timezone_monitor(void)
     SOL_WRN("Not implemented");
     return -ENOTSUP;
 }
+
+int
+sol_platform_impl_set_locale(char **locales)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+const char *
+sol_platform_impl_get_locale(enum sol_platform_locale_category type)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_register_locale_monitor(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_unregister_locale_monitor(void)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_impl_apply_locale(enum sol_platform_locale_category type, const char *locale)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+int
+sol_platform_impl_load_locales(char **locale_cache)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}

--- a/src/lib/common/sol-platform-impl-systemd.c
+++ b/src/lib/common/sol-platform-impl-systemd.c
@@ -36,6 +36,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <systemd/sd-bus.h>
+#include <time.h>
 
 #include "sol-platform-impl.h"
 
@@ -494,6 +495,7 @@ sol_platform_impl_shutdown(void)
     sol_ptr_vector_clear(&_ctx.services);
 
     sol_bus_close();
+    sol_platform_unregister_system_clock_monitor();
 }
 
 int
@@ -513,7 +515,7 @@ sol_platform_impl_set_hostname(const char *name)
 }
 
 static bool
-_set_hostname(void *data, sd_bus_message *m)
+skip_prop(void *data, sd_bus_message *m)
 {
     int r;
 
@@ -524,7 +526,7 @@ _set_hostname(void *data, sd_bus_message *m)
 
 static const struct sol_bus_properties _hostname_property = {
     .member = "StaticHostname",
-    .set = _set_hostname,
+    .set = skip_prop,
 };
 
 int
@@ -550,4 +552,70 @@ sol_platform_register_hostname_monitor(void)
     return sol_bus_map_cached_properties(bus, "org.freedesktop.hostname1",
         "/org/freedesktop/hostname1", "org.freedesktop.hostname1",
         &_hostname_property, _hostname_changed, NULL);
+}
+
+int
+sol_platform_impl_set_system_clock(int64_t timestamp)
+{
+    sd_bus *bus;
+    int r;
+    int64_t timestamp_micro;
+
+    r = sol_util_int64_mul(timestamp, USEC_PER_SEC, &timestamp_micro);
+    SOL_INT_CHECK(r, < 0, r);
+
+    bus = sol_bus_get(NULL);
+    SOL_NULL_CHECK(bus, -ENOTCONN);
+
+    r = sd_bus_call_method_async(bus, NULL, "org.freedesktop.timedate1",
+        "/org/freedesktop/timedate1", "org.freedesktop.timedate1",
+        "SetTime", sol_bus_log_callback, NULL, "xbb", timestamp_micro, false, false);
+    SOL_INT_CHECK(r, < 0, r);
+    return 0;
+}
+
+int
+sol_platform_impl_set_timezone(const char *timezone)
+{
+    sd_bus *bus;
+    int r;
+
+    bus = sol_bus_get(NULL);
+    SOL_NULL_CHECK(bus, -ENOTCONN);
+
+    r = sd_bus_call_method_async(bus, NULL, "org.freedesktop.timedate1",
+        "/org/freedesktop/timedate1", "org.freedesktop.timedate1",
+        "SetTimezone", sol_bus_log_callback, NULL, "sb", timezone, false);
+    SOL_INT_CHECK(r, < 0, r);
+    return 0;
+}
+
+static const struct sol_bus_properties _timezone_property = {
+    .member = "Timezone",
+    .set = skip_prop,
+};
+
+static void
+_timezone_changed(void *data, uint64_t mask)
+{
+    sol_platform_inform_timezone_changed();
+}
+
+int
+sol_platform_register_timezone_monitor(void)
+{
+    sd_bus *bus;
+
+    bus = sol_bus_get(NULL);
+    SOL_NULL_CHECK(bus, -ENOTCONN);
+
+    return sol_bus_map_cached_properties(bus, "org.freedesktop.timedate1",
+        "/org/freedesktop/timedate1", "org.freedesktop.timedate1",
+        &_timezone_property, _timezone_changed, NULL);
+}
+
+int
+sol_platform_unregister_timezone_monitor(void)
+{
+    return sol_bus_unmap_cached_properties(&_timezone_property, NULL);
 }

--- a/src/lib/common/sol-platform-impl.h
+++ b/src/lib/common/sol-platform-impl.h
@@ -71,3 +71,19 @@ void sol_platform_inform_hostname_monitors(void);
 
 int sol_platform_unregister_hostname_monitor(void);
 int sol_platform_register_hostname_monitor(void);
+
+void sol_platform_inform_system_clock_changed(void);
+
+int sol_platform_impl_set_system_clock(int64_t timestamp);
+int64_t sol_platform_impl_get_system_clock(void);
+
+int sol_platform_unregister_system_clock_monitor(void);
+int sol_platform_register_system_clock_monitor(void);
+
+
+void sol_platform_inform_timezone_changed(void);
+
+int sol_platform_impl_set_timezone(const char *timezone);
+const char *sol_platform_impl_get_timezone(void);
+int sol_platform_register_timezone_monitor(void);
+int sol_platform_unregister_timezone_monitor(void);

--- a/src/lib/common/sol-platform-impl.h
+++ b/src/lib/common/sol-platform-impl.h
@@ -35,6 +35,8 @@
 #define SOL_LOG_DOMAIN &_sol_platform_log_domain
 #include "sol-log-internal.h"
 #include "sol-platform.h"
+#include "sol-vector.h"
+#include "sol-str-slice.h"
 
 extern struct sol_log_domain _sol_platform_log_domain;
 
@@ -80,10 +82,21 @@ int64_t sol_platform_impl_get_system_clock(void);
 int sol_platform_unregister_system_clock_monitor(void);
 int sol_platform_register_system_clock_monitor(void);
 
-
 void sol_platform_inform_timezone_changed(void);
 
 int sol_platform_impl_set_timezone(const char *timezone);
 const char *sol_platform_impl_get_timezone(void);
 int sol_platform_register_timezone_monitor(void);
 int sol_platform_unregister_timezone_monitor(void);
+
+int sol_platform_impl_set_locale(char **locales);
+const char *sol_platform_impl_get_locale(enum sol_platform_locale_category type);
+
+void sol_platform_inform_locale_changed(void);
+int sol_platform_register_locale_monitor(void);
+int sol_platform_unregister_locale_monitor(void);
+int sol_platform_impl_apply_locale(enum sol_platform_locale_category type, const char *locale);
+int sol_platform_impl_load_locales(char **locale_cache);
+
+int sol_platform_locale_to_c_category(enum sol_platform_locale_category type);
+const char *sol_platform_locale_to_c_str_category(enum sol_platform_locale_category type);

--- a/src/lib/common/sol-platform-linux-common.c
+++ b/src/lib/common/sol-platform-linux-common.c
@@ -33,6 +33,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/netlink.h>
+#include <locale.h>
 #include <mntent.h>
 #include <signal.h>
 #include <stdio.h>
@@ -52,6 +53,7 @@
 #include "sol-platform-impl.h"
 #include "sol-platform-linux.h"
 #include "sol-platform.h"
+#include "sol-str-table.h"
 #include "sol-util.h"
 #include "sol-vector.h"
 
@@ -894,4 +896,112 @@ sol_platform_impl_get_timezone(void)
     }
     memmove(timezone_str, timezone_str + offset, strlen(timezone_str) - offset + 1);
     return timezone_str;
+}
+
+const char *
+sol_platform_impl_get_locale(enum sol_platform_locale_category category)
+{
+    int ctype;
+
+    ctype = sol_platform_locale_to_c_category(category);
+    SOL_INT_CHECK(ctype, < 0, NULL);
+    return setlocale(ctype, NULL);
+}
+
+int
+sol_platform_impl_apply_locale(enum sol_platform_locale_category category, const char *locale)
+{
+    int ctype;
+    char *loc;
+
+    ctype = sol_platform_locale_to_c_category(category);
+    SOL_INT_CHECK(ctype, < 0, -EINVAL);
+    loc = setlocale(ctype, locale);
+    SOL_NULL_CHECK(loc, -EINVAL);
+    return 0;
+}
+
+static enum sol_platform_locale_category
+system_locale_to_sol_locale(const struct sol_str_slice loc)
+{
+    static const struct sol_str_table map[] = {
+        SOL_STR_TABLE_ITEM("LANG", SOL_PLATFORM_LOCALE_LANGUAGE),
+        SOL_STR_TABLE_ITEM("LC_ADDRESS", SOL_PLATFORM_LOCALE_ADDRESS),
+        SOL_STR_TABLE_ITEM("LC_COLLATE", SOL_PLATFORM_LOCALE_COLLATE),
+        SOL_STR_TABLE_ITEM("LC_CTYPE", SOL_PLATFORM_LOCALE_CTYPE),
+        SOL_STR_TABLE_ITEM("LC_IDENTIFICATION", SOL_PLATFORM_LOCALE_IDENTIFICATION),
+        SOL_STR_TABLE_ITEM("LC_MEASUREMENT", SOL_PLATFORM_LOCALE_MEASUREMENT),
+        SOL_STR_TABLE_ITEM("LC_MESSAGES", SOL_PLATFORM_LOCALE_MESSAGES),
+        SOL_STR_TABLE_ITEM("LC_MONETARY", SOL_PLATFORM_LOCALE_MONETARY),
+        SOL_STR_TABLE_ITEM("LC_NAME", SOL_PLATFORM_LOCALE_NAME),
+        SOL_STR_TABLE_ITEM("LC_NUMERIC", SOL_PLATFORM_LOCALE_NUMERIC),
+        SOL_STR_TABLE_ITEM("LC_PAPER", SOL_PLATFORM_LOCALE_PAPER),
+        SOL_STR_TABLE_ITEM("LC_TELEPHONE", SOL_PLATFORM_LOCALE_TELEPHONE),
+        SOL_STR_TABLE_ITEM("LC_TIME", SOL_PLATFORM_LOCALE_TIME),
+    };
+
+    return sol_str_table_lookup_fallback(map, loc, SOL_PLATFORM_LOCALE_UNKNOWN);
+}
+
+int
+sol_platform_impl_load_locales(char **locale_cache)
+{
+    FILE *f;
+    int r;
+    char *line, *sep;
+    struct sol_str_slice key, value;
+    enum sol_platform_locale_category category;
+
+    f = fopen("/etc/locale.conf", "re");
+
+    if (!f) {
+        r = -errno;
+        if (r == -ENOENT) {
+            SOL_WRN("The locale file (/etc/locale.conf) was not found in the system.");
+            return 0;
+        } else
+            return r;
+    }
+
+    for (category = SOL_PLATFORM_LOCALE_LANGUAGE; category <= SOL_PLATFORM_LOCALE_TIME; category++) {
+        free(locale_cache[category]);
+        locale_cache[category] = NULL;
+    }
+
+    while (fscanf(f, "%m[^\n]\n", &line) != EOF) {
+        sep = strchr(line, '=');
+        if (!sep) {
+            SOL_WRN("The locale entry: %s does not have the separator '='",
+                line);
+            r = -EINVAL;
+            free(line);
+            goto err_exit;
+        }
+
+        key.data = line;
+        value.data = sep + 1;
+        key.len = sep - key.data;
+        value.len = strlen(line) - key.len - 1;
+
+        category = system_locale_to_sol_locale(key);
+        SOL_INT_CHECK_GOTO(category, == SOL_PLATFORM_LOCALE_UNKNOWN, err_exit);
+        locale_cache[category] = sol_str_slice_to_string(value);
+        free(line);
+        line = NULL;
+        SOL_NULL_CHECK_GOTO(locale_cache[category], err_exit);
+    }
+
+    r = ferror(f);
+    if (r != 0) {
+        r = -errno;
+        goto err_exit;
+    }
+
+    fclose(f);
+    return 0;
+
+err_exit:
+    free(line);
+    fclose(f);
+    return r;
 }

--- a/src/lib/common/sol-platform-linux-common.c
+++ b/src/lib/common/sol-platform-linux-common.c
@@ -40,9 +40,11 @@
 #include <sys/mount.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <sys/timerfd.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
 #include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "sol-file-reader.h"
@@ -55,6 +57,10 @@
 
 #define SOL_MTAB_FILE P_tmpdir "/mtab.sol"
 #define LIBUDEV_ID "libudev"
+
+#ifndef TFD_TIMER_CANCELON_SET
+#define TFD_TIMER_CANCELON_SET (1 << 1)
+#endif
 
 struct sol_platform_linux_fork_run {
     pid_t pid;
@@ -93,9 +99,16 @@ struct uevent_context {
     } uevent;
 };
 
+struct timer_fd_context {
+    struct sol_fd *watcher;
+    int fd;
+};
+
 static char hostname[HOST_NAME_MAX + 1];
+static char timezone_str[PATH_MAX];
 static struct uevent_context uevent_ctx;
 static struct sol_ptr_vector fork_runs = SOL_PTR_VECTOR_INIT;
+static struct timer_fd_context timer_ctx = { NULL, -1 };
 
 static uint16_t
 find_handle(const struct sol_platform_linux_fork_run *handle)
@@ -784,4 +797,101 @@ sol_platform_linux_uevent_unsubscribe(const char *action, const char *subsystem,
         sol_uevent_cleanup(&uevent_ctx);
 
     return 0;
+}
+
+
+int64_t
+sol_platform_impl_get_system_clock(void)
+{
+    return (int64_t)time(NULL);
+}
+
+static bool
+system_clock_changed(void *data, int fd, uint32_t active_flags)
+{
+    char buf[4096];
+
+    if (read(timer_ctx.fd, buf, sizeof(buf)) >= 0)
+        return true;
+    close(timer_ctx.fd);
+    timer_ctx.fd = -1;
+    timer_ctx.watcher = NULL;
+    sol_platform_register_system_clock_monitor();
+    sol_platform_inform_system_clock_changed();
+    return false;
+}
+
+int
+sol_platform_register_system_clock_monitor(void)
+{
+    int r;
+    struct itimerspec spec;
+
+    if (timer_ctx.watcher)
+        return 0;
+
+    timer_ctx.fd = timerfd_create(CLOCK_REALTIME, TFD_CLOEXEC);
+    SOL_INT_CHECK(timer_ctx.fd, < 0, -errno);
+
+    memset(&spec, 0, sizeof(struct itimerspec));
+    /* Set a dummy value, end of time. */
+    spec.it_value.tv_sec += 0xfffffff0;
+    if (timerfd_settime(timer_ctx.fd,
+        TFD_TIMER_ABSTIME | TFD_TIMER_CANCELON_SET, &spec, NULL) < 0) {
+        r = -errno;
+        SOL_WRN("Could not register a timer to watch for system_clock changes.");
+        goto err_exit;
+    }
+
+    timer_ctx.watcher = sol_fd_add(timer_ctx.fd,
+        SOL_FD_FLAGS_IN, system_clock_changed, NULL);
+
+    if (!timer_ctx.watcher) {
+        r = -ENOMEM;
+        goto err_exit;
+    }
+
+    return 0;
+
+err_exit:
+    close(timer_ctx.fd);
+    timer_ctx.fd = -1;
+    return r;
+}
+
+int
+sol_platform_unregister_system_clock_monitor(void)
+{
+    if (!timer_ctx.watcher)
+        return 0;
+
+    sol_fd_del(timer_ctx.watcher);
+    close(timer_ctx.fd);
+    timer_ctx.watcher = NULL;
+    timer_ctx.fd = -1;
+    return 0;
+}
+
+const char *
+sol_platform_impl_get_timezone(void)
+{
+    ssize_t n;
+    size_t offset;
+
+    n = readlink("/etc/localtime", timezone_str, sizeof(timezone_str));
+    if (n < 0) {
+        SOL_WRN("Could not readlink /etc/localtime");
+        return NULL;
+    }
+    timezone_str[n] = '\0';
+    if (strstartswith(timezone_str, "../usr/share/zoneinfo/"))
+        offset = strlen("../usr/share/zoneinfo/");
+    else if (strstartswith(timezone_str, "/usr/share/zoneinfo/"))
+        offset = strlen("/usr/share/zoneinfo/");
+    else {
+        SOL_WRN("The timzone is not a link to /usr/share/zoneinfo/");
+        return NULL;
+    }
+    memmove(timezone_str, timezone_str + offset, strlen(timezone_str) - offset + 1);
+    return timezone_str;
 }

--- a/src/lib/common/sol-platform.c
+++ b/src/lib/common/sol-platform.c
@@ -64,6 +64,8 @@ struct ctx {
     struct sol_monitors state_monitors;
     struct sol_monitors service_monitors;
     struct sol_monitors hostname_monitors;
+    struct sol_monitors system_clock_monitors;
+    struct sol_monitors timezone_monitors;
 };
 
 static struct ctx _ctx;
@@ -80,6 +82,8 @@ sol_platform_init(void)
 
     sol_monitors_init(&_ctx.state_monitors, NULL);
     sol_monitors_init(&_ctx.hostname_monitors, NULL);
+    sol_monitors_init(&_ctx.system_clock_monitors, NULL);
+    sol_monitors_init(&_ctx.timezone_monitors, NULL);
     sol_monitors_init_custom(&_ctx.service_monitors, sizeof(struct service_monitor), service_monitor_free);
 
     return sol_platform_impl_init();
@@ -94,6 +98,8 @@ sol_platform_shutdown(void)
     sol_monitors_clear(&_ctx.state_monitors);
     sol_monitors_clear(&_ctx.service_monitors);
     sol_monitors_clear(&_ctx.hostname_monitors);
+    sol_monitors_clear(&_ctx.system_clock_monitors);
+    sol_monitors_clear(&_ctx.timezone_monitors);
     sol_platform_impl_shutdown();
 }
 
@@ -486,6 +492,40 @@ sol_platform_get_hostname(void)
     return sol_platform_impl_get_hostname();
 }
 
+static int
+monitor_add_and_register(struct sol_monitors *monitors, sol_monitors_cb_t cb, const void *data,
+    int (*register_cb)(void))
+{
+    int r;
+
+    SOL_NULL_CHECK(cb, -EINVAL);
+    r = monitor_add(monitors, cb, data);
+    SOL_INT_CHECK(r, < 0, r);
+    if (sol_monitors_count(monitors) == 1) {
+        r = register_cb();
+        SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+    }
+    return 0;
+err_exit:
+    (void)monitor_del(monitors, cb, data);
+    return r;
+}
+
+static int
+monitor_del_and_unregister(struct sol_monitors *monitors, sol_monitors_cb_t cb, const void *data,
+    int (*unregister_cb)(void))
+{
+    int r;
+
+    SOL_NULL_CHECK(cb, -EINVAL);
+    r = monitor_del(monitors, (sol_monitors_cb_t)cb, data);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (sol_monitors_count(monitors) == 0)
+        return unregister_cb();
+    return 0;
+}
+
 void
 sol_platform_inform_hostname_monitors(void)
 {
@@ -503,31 +543,93 @@ sol_platform_inform_hostname_monitors(void)
 SOL_API int
 sol_platform_add_hostname_monitor(void (*cb)(void *data, const char *hostname), const void *data)
 {
-    int r;
-
-    SOL_NULL_CHECK(cb, -EINVAL);
-    r = monitor_add(&_ctx.hostname_monitors, (sol_monitors_cb_t)cb, data);
-    SOL_INT_CHECK(r, < 0, r);
-    if (sol_monitors_count(&_ctx.hostname_monitors) == 1) {
-        r = sol_platform_register_hostname_monitor();
-        SOL_INT_CHECK_GOTO(r, < 0, err_exit);
-    }
-    return 0;
-err_exit:
-    (void)monitor_del(&_ctx.hostname_monitors, (sol_monitors_cb_t)cb, data);
-    return r;
+    return monitor_add_and_register(&_ctx.hostname_monitors, (sol_monitors_cb_t)cb, data,
+        sol_platform_register_hostname_monitor);
 }
 
 SOL_API int
 sol_platform_del_hostname_monitor(void (*cb)(void *data, const char *hostname), const void *data)
 {
-    int r;
+    return monitor_del_and_unregister(&_ctx.hostname_monitors, (sol_monitors_cb_t)cb, data,
+        sol_platform_unregister_hostname_monitor);
+}
 
-    SOL_NULL_CHECK(cb, -EINVAL);
-    r = monitor_del(&_ctx.hostname_monitors, (sol_monitors_cb_t)cb, data);
-    SOL_INT_CHECK(r, < 0, r);
+SOL_API int
+sol_platform_set_system_clock(int64_t timestamp)
+{
+    return sol_platform_impl_set_system_clock(timestamp);
+}
 
-    if (sol_monitors_count(&_ctx.hostname_monitors) == 0)
-        return sol_platform_unregister_hostname_monitor();
-    return 0;
+SOL_API int64_t
+sol_platform_get_system_clock(void)
+{
+    return sol_platform_impl_get_system_clock();
+}
+
+void
+sol_platform_inform_system_clock_changed(void)
+{
+    int64_t timestamp;
+    struct sol_monitors_entry *entry;
+    uint16_t i;
+
+    timestamp = sol_platform_impl_get_system_clock();
+    SOL_INT_CHECK(timestamp, < 0);
+
+    SOL_MONITORS_WALK (&_ctx.system_clock_monitors, entry, i)
+        ((void (*)(void *, int64_t))entry->cb)((void *)entry->data, timestamp);
+}
+
+SOL_API int
+sol_platform_add_system_clock_monitor(void (*cb)(void *data, int64_t timestamp), const void *data)
+{
+    return monitor_add_and_register(&_ctx.system_clock_monitors, (sol_monitors_cb_t)cb, data,
+        sol_platform_register_system_clock_monitor);
+}
+
+SOL_API int
+sol_platform_del_system_clock_monitor(void (*cb)(void *data, int64_t timestamp), const void *data)
+{
+    return monitor_del_and_unregister(&_ctx.system_clock_monitors, (sol_monitors_cb_t)cb, data,
+        sol_platform_unregister_system_clock_monitor);
+}
+
+void
+sol_platform_inform_timezone_changed(void)
+{
+    const char *timezone;
+    struct sol_monitors_entry *entry;
+    uint16_t i;
+
+    timezone = sol_platform_impl_get_timezone();
+    SOL_NULL_CHECK(timezone);
+
+    SOL_MONITORS_WALK (&_ctx.timezone_monitors, entry, i)
+        ((void (*)(void *, const char *))entry->cb)((void *)entry->data, timezone);
+}
+
+SOL_API int
+sol_platform_set_timezone(const char *timezone)
+{
+    return sol_platform_impl_set_timezone(timezone);
+}
+
+SOL_API const char *
+sol_platform_get_timezone(void)
+{
+    return sol_platform_impl_get_timezone();
+}
+
+SOL_API int
+sol_platform_add_timezone_monitor(void (*cb)(void *data, const char *timezone), const void *data)
+{
+    return monitor_add_and_register(&_ctx.timezone_monitors, (sol_monitors_cb_t)cb, data,
+        sol_platform_register_timezone_monitor);
+}
+
+SOL_API int
+sol_platform_del_timezone_monitor(void (*cb)(void *data, const char *timezone), const void *data)
+{
+    return monitor_del_and_unregister(&_ctx.timezone_monitors, (sol_monitors_cb_t)cb, data,
+        sol_platform_unregister_timezone_monitor);
 }

--- a/src/lib/common/sol-platform.c
+++ b/src/lib/common/sol-platform.c
@@ -30,10 +30,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <ctype.h>
 #include <errno.h>
+#include <locale.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <ctype.h>
 
 #include "sol-platform-impl.h"
 
@@ -44,6 +45,7 @@
 #include "sol-board-detect.h"
 #endif
 #include "sol-platform.h"
+#include "sol-mainloop.h"
 #include "sol-util.h"
 
 #define SOL_BOARD_NAME_ENVVAR "SOL_BOARD_NAME"
@@ -66,6 +68,9 @@ struct ctx {
     struct sol_monitors hostname_monitors;
     struct sol_monitors system_clock_monitors;
     struct sol_monitors timezone_monitors;
+    struct sol_monitors locale_monitors;
+    struct sol_timeout *locale_timeout;
+    char *locale_cache[SOL_PLATFORM_LOCALE_TIME + 1];
 };
 
 static struct ctx _ctx;
@@ -75,18 +80,50 @@ void sol_platform_shutdown(void);
 
 static void service_monitor_free(const struct sol_monitors *ms, const struct sol_monitors_entry *e);
 
+static void
+locale_cache_clear(void)
+{
+    enum sol_platform_locale_category i;
+
+    for (i = SOL_PLATFORM_LOCALE_LANGUAGE; i <= SOL_PLATFORM_LOCALE_TIME; i++)
+        free(_ctx.locale_cache[i]);
+}
+
 int
 sol_platform_init(void)
 {
+    int r;
+    enum sol_platform_locale_category i;
+
     sol_log_domain_init_level(SOL_LOG_DOMAIN);
 
     sol_monitors_init(&_ctx.state_monitors, NULL);
     sol_monitors_init(&_ctx.hostname_monitors, NULL);
     sol_monitors_init(&_ctx.system_clock_monitors, NULL);
     sol_monitors_init(&_ctx.timezone_monitors, NULL);
+    sol_monitors_init(&_ctx.locale_monitors, NULL);
+    for (i = SOL_PLATFORM_LOCALE_LANGUAGE; i <= SOL_PLATFORM_LOCALE_TIME; i++)
+        _ctx.locale_cache[i] = NULL;
+    r = sol_platform_impl_load_locales(_ctx.locale_cache);
+    SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+    _ctx.locale_timeout = NULL;
     sol_monitors_init_custom(&_ctx.service_monitors, sizeof(struct service_monitor), service_monitor_free);
 
     return sol_platform_impl_init();
+
+err_exit:
+    locale_cache_clear();
+    return r;
+}
+
+static void
+set_locale(void)
+{
+    int r;
+
+    r = sol_platform_impl_set_locale(_ctx.locale_cache);
+    if (r < 0)
+        SOL_WRN("Could not set the locale values!");
 }
 
 void
@@ -100,6 +137,11 @@ sol_platform_shutdown(void)
     sol_monitors_clear(&_ctx.hostname_monitors);
     sol_monitors_clear(&_ctx.system_clock_monitors);
     sol_monitors_clear(&_ctx.timezone_monitors);
+    sol_monitors_clear(&_ctx.locale_monitors);
+    set_locale();
+    locale_cache_clear();
+    if (_ctx.locale_timeout)
+        sol_timeout_del(_ctx.locale_timeout);
     sol_platform_impl_shutdown();
 }
 
@@ -632,4 +674,150 @@ sol_platform_del_timezone_monitor(void (*cb)(void *data, const char *timezone), 
 {
     return monitor_del_and_unregister(&_ctx.timezone_monitors, (sol_monitors_cb_t)cb, data,
         sol_platform_unregister_timezone_monitor);
+}
+
+void
+sol_platform_inform_locale_changed(void)
+{
+    struct sol_monitors_entry *entry;
+    uint16_t j;
+    int r;
+    enum sol_platform_locale_category i;
+
+    r = sol_platform_impl_load_locales(_ctx.locale_cache);
+    SOL_INT_CHECK(r, < 0);
+    for (i = SOL_PLATFORM_LOCALE_LANGUAGE; i <= SOL_PLATFORM_LOCALE_TIME; i++) {
+        SOL_MONITORS_WALK (&_ctx.locale_monitors, entry, j) {
+            ((void (*)(void *, enum sol_platform_locale_category, const char *))
+            entry->cb)((void *)entry->data, i, _ctx.locale_cache[i] ? : "C");
+        }
+    }
+}
+
+static bool
+locale_timeout_cb(void *data)
+{
+    _ctx.locale_timeout = NULL;
+    set_locale();
+    return false;
+}
+
+SOL_API int
+sol_platform_set_locale(enum sol_platform_locale_category category, const char *locale)
+{
+    int r;
+
+    SOL_INT_CHECK(category, == SOL_PLATFORM_LOCALE_UNKNOWN, -EINVAL);
+    SOL_NULL_CHECK(locale, -EINVAL);
+    r = sol_util_replace_str_if_changed(&_ctx.locale_cache[category], locale);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (!_ctx.locale_timeout) {
+        _ctx.locale_timeout = sol_timeout_add(1, locale_timeout_cb, NULL);
+        SOL_NULL_CHECK(_ctx.locale_timeout, -ENOMEM);
+    }
+
+    return 0;
+}
+
+SOL_API const char *
+sol_platform_get_locale(enum sol_platform_locale_category category)
+{
+    SOL_INT_CHECK(category, == SOL_PLATFORM_LOCALE_UNKNOWN, NULL);
+    if (category == SOL_PLATFORM_LOCALE_LANGUAGE)
+        return _ctx.locale_cache[category] ? : "C";
+    return sol_platform_impl_get_locale(category);
+}
+
+SOL_API int
+sol_platform_add_locale_monitor(void (*cb)(void *data,
+    enum sol_platform_locale_category category, const char *locale), const void *data)
+{
+    return monitor_add_and_register(&_ctx.locale_monitors, (sol_monitors_cb_t)cb, data,
+        sol_platform_register_locale_monitor);
+}
+
+SOL_API int
+sol_platform_del_locale_monitor(void (*cb)(void *data,
+    enum sol_platform_locale_category category, const char *locale), const void *data)
+{
+    return monitor_del_and_unregister(&_ctx.locale_monitors, (sol_monitors_cb_t)cb, data,
+        sol_platform_unregister_locale_monitor);
+}
+
+SOL_API int
+sol_platform_apply_locale(enum sol_platform_locale_category category)
+{
+    SOL_INT_CHECK(category, == SOL_PLATFORM_LOCALE_UNKNOWN, -EINVAL);
+    return sol_platform_impl_apply_locale(category, _ctx.locale_cache[category] ? : "C");
+}
+
+int
+sol_platform_locale_to_c_category(enum sol_platform_locale_category category)
+{
+    switch (category) {
+    case SOL_PLATFORM_LOCALE_LANGUAGE:
+        return LC_ALL;
+    case SOL_PLATFORM_LOCALE_ADDRESS:
+        return LC_ADDRESS;
+    case SOL_PLATFORM_LOCALE_COLLATE:
+        return LC_COLLATE;
+    case SOL_PLATFORM_LOCALE_CTYPE:
+        return LC_CTYPE;
+    case SOL_PLATFORM_LOCALE_IDENTIFICATION:
+        return LC_IDENTIFICATION;
+    case SOL_PLATFORM_LOCALE_MEASUREMENT:
+        return LC_MEASUREMENT;
+    case SOL_PLATFORM_LOCALE_MESSAGES:
+        return LC_MESSAGES;
+    case SOL_PLATFORM_LOCALE_MONETARY:
+        return LC_MONETARY;
+    case SOL_PLATFORM_LOCALE_NAME:
+        return LC_NAME;
+    case SOL_PLATFORM_LOCALE_NUMERIC:
+        return LC_NUMERIC;
+    case SOL_PLATFORM_LOCALE_PAPER:
+        return LC_PAPER;
+    case SOL_PLATFORM_LOCALE_TELEPHONE:
+        return LC_TELEPHONE;
+    case SOL_PLATFORM_LOCALE_TIME:
+        return LC_TIME;
+    default:
+        return -EINVAL;
+    }
+}
+
+const char *
+sol_platform_locale_to_c_str_category(enum sol_platform_locale_category category)
+{
+    switch (category) {
+    case SOL_PLATFORM_LOCALE_LANGUAGE:
+        return "LANG";
+    case SOL_PLATFORM_LOCALE_ADDRESS:
+        return "LC_ADDRESS";
+    case SOL_PLATFORM_LOCALE_COLLATE:
+        return "LC_COLLATE";
+    case SOL_PLATFORM_LOCALE_CTYPE:
+        return "LC_CTYPE";
+    case SOL_PLATFORM_LOCALE_IDENTIFICATION:
+        return "LC_IDENTIFICATION";
+    case SOL_PLATFORM_LOCALE_MEASUREMENT:
+        return "LC_MEASUREMENT";
+    case SOL_PLATFORM_LOCALE_MESSAGES:
+        return "LC_MESSAGES";
+    case SOL_PLATFORM_LOCALE_MONETARY:
+        return "LC_MONETARY";
+    case SOL_PLATFORM_LOCALE_NAME:
+        return "LC_NAME";
+    case SOL_PLATFORM_LOCALE_NUMERIC:
+        return "LC_NUMERIC";
+    case SOL_PLATFORM_LOCALE_PAPER:
+        return "LC_PAPER";
+    case SOL_PLATFORM_LOCALE_TELEPHONE:
+        return "LC_TELEPHONE";
+    case SOL_PLATFORM_LOCALE_TIME:
+        return "LC_TIME";
+    default:
+        return NULL;
+    }
 }

--- a/src/modules/flow/platform/platform.c
+++ b/src/modules/flow/platform/platform.c
@@ -43,8 +43,15 @@ struct platform_data {
     enum sol_platform_state state;
 };
 
-struct hostname_data {
+struct monitor_data {
     uint16_t connections;
+};
+
+struct monitor_node_type {
+    struct sol_flow_node_type base;
+    int (*send_packet)(const void *, struct sol_flow_node *);
+    int (*monitor_register)(struct sol_flow_node *);
+    int (*monitor_unregister)(struct sol_flow_node *);
 };
 
 static int
@@ -213,7 +220,7 @@ platform_machine_id_open(struct sol_flow_node *node,
 }
 
 static int
-hostname_send(const char *hostname, struct sol_flow_node *node)
+hostname_send(const void *hostname, struct sol_flow_node *node)
 {
     int r;
 
@@ -228,14 +235,33 @@ hostname_send(const char *hostname, struct sol_flow_node *node)
 }
 
 static int
-hostname_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
+system_clock_send(const void *timestamp, struct sol_flow_node *node)
+{
+    struct sol_irange irange = SOL_IRANGE_INIT();
+    int r;
+
+    if (!timestamp) {
+        irange.val = sol_platform_get_system_clock();
+        SOL_INT_CHECK(irange.val, < 0, -EINVAL);
+    } else
+        irange.val = (*((int64_t *)timestamp));
+
+    r = sol_flow_send_irange_packet(node, 0, &irange);
+    SOL_INT_CHECK(r, < 0, r);
+    return 0;
+}
+
+static int
+monitor_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
 {
     const struct sol_flow_node_type_platform_hostname_options *opts;
+    const struct monitor_node_type *monitor_type =
+        (const struct monitor_node_type *)sol_flow_node_get_type(node);
 
     opts = (const struct sol_flow_node_type_platform_hostname_options *)options;
 
     if (opts->send_initial_packet)
-        return hostname_send(NULL, node);
+        return monitor_type->send_packet(NULL, node);
     return 0;
 }
 
@@ -260,28 +286,124 @@ hostname_changed(void *data, const char *hostname)
 }
 
 static int
-hostname_out_connect(struct sol_flow_node *node, void *data,
+hostname_monitor_register(struct sol_flow_node *node)
+{
+    return sol_platform_add_hostname_monitor(hostname_changed, node);
+}
+
+static int
+hostname_monitor_unregister(struct sol_flow_node *node)
+{
+    return sol_platform_del_hostname_monitor(hostname_changed, node);
+}
+
+static void
+system_clock_changed(void *data, int64_t timestamp)
+{
+    system_clock_send(&timestamp, data);
+}
+
+static int
+system_clock_monitor_register(struct sol_flow_node *node)
+{
+    return sol_platform_add_system_clock_monitor(system_clock_changed, node);
+}
+
+static int
+system_clock_monitor_unregister(struct sol_flow_node *node)
+{
+    return sol_platform_del_system_clock_monitor(system_clock_changed, node);
+}
+
+static int
+monitor_out_connect(struct sol_flow_node *node, void *data,
     uint16_t port, uint16_t conn_id)
 {
-    struct hostname_data *mdata = data;
+    struct monitor_data *mdata = data;
+    const struct monitor_node_type *monitor_type =
+        (const struct monitor_node_type *)sol_flow_node_get_type(node);
+
 
     mdata->connections++;
     if (mdata->connections == 1)
-        return sol_platform_add_hostname_monitor(hostname_changed, node);
+        return monitor_type->monitor_register(node);
     return 0;
 }
 
 static int
-hostname_out_disconnect(struct sol_flow_node *node, void *data,
+monitor_out_disconnect(struct sol_flow_node *node, void *data,
     uint16_t port, uint16_t conn_id)
 {
-    struct hostname_data *mdata = data;
+    struct monitor_data *mdata = data;
+    const struct monitor_node_type *monitor_type =
+        (const struct monitor_node_type *)sol_flow_node_get_type(node);
 
     if (!mdata->connections)
         return 0;
 
     if (!--mdata->connections)
-        return sol_platform_del_hostname_monitor(hostname_changed, node);
+        return monitor_type->monitor_unregister(node);
+    return 0;
+}
+
+static int
+system_clock_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    struct sol_irange irange;
+    int r;
+
+    r = sol_flow_packet_get_irange(packet, &irange);
+    SOL_INT_CHECK(r, < 0, r);
+    r = sol_platform_set_system_clock(irange.val);
+    SOL_INT_CHECK(r, < 0, r);
+    return 0;
+}
+
+static int
+timezone_send(const void *timezone, struct sol_flow_node *node)
+{
+    int r;
+
+    if (!timezone) {
+        timezone = sol_platform_get_timezone();
+        SOL_NULL_CHECK(timezone, -ECANCELED);
+    }
+
+    r = sol_flow_send_string_packet(node, 0, timezone);
+    SOL_INT_CHECK(r, < 0, r);
+    return 0;
+}
+
+static void
+timezone_changed(void *data, const char *timezone)
+{
+    timezone_send(timezone, data);
+}
+
+static int
+timezone_monitor_register(struct sol_flow_node *node)
+{
+    return sol_platform_add_timezone_monitor(timezone_changed, node);
+}
+
+static int
+timezone_monitor_unregister(struct sol_flow_node *node)
+{
+    return sol_platform_del_timezone_monitor(timezone_changed, node);
+}
+
+static int
+timezone_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    int r;
+    const char *tz;
+
+    r = sol_flow_packet_get_string(packet, &tz);
+    SOL_INT_CHECK(r, < 0, r);
+    r = sol_platform_set_timezone(tz);
+    SOL_INT_CHECK(r, < 0, r);
     return 0;
 }
 

--- a/src/modules/flow/platform/platform.c
+++ b/src/modules/flow/platform/platform.c
@@ -407,5 +407,246 @@ timezone_process(struct sol_flow_node *node, void *data, uint16_t port,
     return 0;
 }
 
+static int
+locale_send(struct sol_flow_node *node, enum sol_platform_locale_category category, const char *locale)
+{
+    if (!locale) {
+        locale = sol_platform_get_locale(category);
+        SOL_NULL_CHECK(locale, -EINVAL);
+    }
+    return sol_flow_send_string_packet(node, (int)category, locale);
+}
+
+static int
+locale_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
+{
+    int r;
+    const struct sol_flow_node_type_platform_hostname_options *opts;
+    enum sol_platform_locale_category i;
+
+    opts = (const struct sol_flow_node_type_platform_hostname_options *)options;
+
+    if (!opts->send_initial_packet)
+        return 0;
+
+    for (i = SOL_PLATFORM_LOCALE_LANGUAGE; i <= SOL_PLATFORM_LOCALE_TIME; i++) {
+        r = locale_send(node, i, NULL);
+        SOL_INT_CHECK(r, < 0, r);
+    }
+    return 0;
+}
+
+static void
+locale_changed(void *data, enum sol_platform_locale_category category, const char *locale)
+{
+    locale_send(data, category, locale);
+}
+
+static int
+locale_monitor_register(struct sol_flow_node *node)
+{
+    return sol_platform_add_locale_monitor(locale_changed, node);
+}
+
+static int
+locale_monitor_unregister(struct sol_flow_node *node)
+{
+    return sol_platform_del_locale_monitor(locale_changed, node);
+}
+
+static int
+set_locale(enum sol_platform_locale_category category, const struct sol_flow_packet *packet)
+{
+    int r;
+    const char *locale;
+
+    r = sol_flow_packet_get_string(packet, &locale);
+    SOL_INT_CHECK(r, < 0, r);
+
+    r = sol_platform_set_locale(category, locale);
+    SOL_INT_CHECK(r, < 0, r);
+    return 0;
+}
+
+static int
+locale_all_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return set_locale(SOL_PLATFORM_LOCALE_LANGUAGE, packet);
+}
+
+static int
+locale_address_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return set_locale(SOL_PLATFORM_LOCALE_ADDRESS, packet);
+}
+
+static int
+locale_collate_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return set_locale(SOL_PLATFORM_LOCALE_COLLATE, packet);
+}
+
+static int
+locale_ctype_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return set_locale(SOL_PLATFORM_LOCALE_CTYPE, packet);
+}
+
+static int
+locale_identification_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return set_locale(SOL_PLATFORM_LOCALE_IDENTIFICATION, packet);
+}
+
+static int
+locale_measurement_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return set_locale(SOL_PLATFORM_LOCALE_MEASUREMENT, packet);
+}
+
+static int
+locale_messages_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return set_locale(SOL_PLATFORM_LOCALE_MESSAGES, packet);
+}
+
+static int
+locale_monetary_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return set_locale(SOL_PLATFORM_LOCALE_MONETARY, packet);
+}
+
+static int
+locale_name_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return set_locale(SOL_PLATFORM_LOCALE_NAME, packet);
+}
+
+static int
+locale_numeric_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return set_locale(SOL_PLATFORM_LOCALE_NUMERIC, packet);
+}
+
+static int
+locale_paper_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return set_locale(SOL_PLATFORM_LOCALE_PAPER, packet);
+}
+
+static int
+locale_telephone_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return set_locale(SOL_PLATFORM_LOCALE_TELEPHONE, packet);
+}
+
+static int
+locale_time_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return set_locale(SOL_PLATFORM_LOCALE_TIME, packet);
+}
+
+static int
+locale_apply_lang_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return sol_platform_apply_locale(SOL_PLATFORM_LOCALE_LANGUAGE);
+}
+
+static int
+locale_apply_address_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return sol_platform_apply_locale(SOL_PLATFORM_LOCALE_ADDRESS);
+}
+
+static int
+locale_apply_collate_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return sol_platform_apply_locale(SOL_PLATFORM_LOCALE_COLLATE);
+}
+
+static int
+locale_apply_ctype_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return sol_platform_apply_locale(SOL_PLATFORM_LOCALE_CTYPE);
+}
+static int
+locale_apply_identification_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return sol_platform_apply_locale(SOL_PLATFORM_LOCALE_IDENTIFICATION);
+}
+
+static int
+locale_apply_measurement_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return sol_platform_apply_locale(SOL_PLATFORM_LOCALE_MEASUREMENT);
+}
+
+static int
+locale_apply_messages_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return sol_platform_apply_locale(SOL_PLATFORM_LOCALE_MESSAGES);
+}
+
+static int
+locale_apply_monetary_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return sol_platform_apply_locale(SOL_PLATFORM_LOCALE_MONETARY);
+}
+
+static int
+locale_apply_name_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return sol_platform_apply_locale(SOL_PLATFORM_LOCALE_NAME);
+}
+
+static int
+locale_apply_numeric_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return sol_platform_apply_locale(SOL_PLATFORM_LOCALE_NUMERIC);
+}
+
+static int
+locale_apply_paper_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return sol_platform_apply_locale(SOL_PLATFORM_LOCALE_PAPER);
+}
+
+static int
+locale_apply_telephone_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return sol_platform_apply_locale(SOL_PLATFORM_LOCALE_TELEPHONE);
+}
+
+static int
+locale_apply_time_process(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    return sol_platform_apply_locale(SOL_PLATFORM_LOCALE_TIME);
+}
 
 #include "platform-gen.c"

--- a/src/modules/flow/platform/platform.json
+++ b/src/modules/flow/platform/platform.json
@@ -195,6 +195,366 @@
       "url": "http://solettaproject.org/doc/latest/node_types/platform_timezone.html"
     },
     {
+      "category": "locale",
+      "description": "This node can be used to set the machine's locales, get the current locales or monitor for locale changes",
+      "in_ports": [
+        {
+          "data_type": "string",
+          "description": "The new current system language",
+          "methods": {
+            "process": "locale_all_process"
+          },
+          "name": "IN_LANG"
+        },
+        {
+          "data_type": "string",
+          "description": "The new system's address locale",
+          "methods": {
+            "process": "locale_address_process"
+          },
+          "name": "IN_ADDRESS"
+        },
+        {
+          "data_type": "string",
+          "description": "The new system's collate locale",
+          "methods": {
+            "process": "locale_collate_process"
+          },
+          "name": "IN_COLLATE"
+        },
+        {
+          "data_type": "string",
+          "description": "The new system's ctype locale",
+          "methods": {
+            "process": "locale_ctype_process"
+          },
+          "name": "IN_CTYPE"
+        },
+        {
+          "data_type": "string",
+          "description": "The new system's identification locale",
+          "methods": {
+            "process": "locale_identification_process"
+          },
+          "name": "IN_IDENTIFICATION"
+        },
+        {
+          "data_type": "string",
+          "description": "The new system's measurement locale",
+          "methods": {
+            "process": "locale_measurement_process"
+          },
+          "name": "IN_MEASUREMENT"
+        },
+        {
+          "data_type": "string",
+          "description": "The new system's messages locale",
+          "methods": {
+            "process": "locale_messages_process"
+          },
+          "name": "IN_MESSAGES"
+        },
+        {
+          "data_type": "string",
+          "description": "The new system's monetary locale",
+          "methods": {
+            "process": "locale_monetary_process"
+          },
+          "name": "IN_MONETARY"
+        },
+        {
+          "data_type": "string",
+          "description": "The new system's name locale",
+          "methods": {
+            "process": "locale_name_process"
+          },
+          "name": "IN_NAME"
+        },
+        {
+          "data_type": "string",
+          "description": "The new system's numeric locale",
+          "methods": {
+            "process": "locale_numeric_process"
+          },
+          "name": "IN_NUMERIC"
+        },
+        {
+          "data_type": "string",
+          "description": "The new system's paper locale",
+          "methods": {
+            "process": "locale_paper_process"
+          },
+          "name": "IN_PAPER"
+        },
+        {
+          "data_type": "string",
+          "description": "The new system's telephone",
+          "methods": {
+            "process": "locale_telephone_process"
+          },
+          "name": "IN_TELEPHONE"
+        },
+        {
+          "data_type": "string",
+          "description": "The new system's time locale",
+          "methods": {
+            "process": "locale_time_process"
+          },
+          "name": "IN_TIME"
+        },
+        {
+          "data_type": "any",
+          "description": "Apply the current system language locale to the process",
+          "methods": {
+            "process": "locale_apply_lang_process"
+          },
+          "name": "APPLY_LANG"
+        },
+        {
+          "data_type": "any",
+          "description": "Apply the current system time locale to the process",
+          "methods": {
+            "process": "locale_apply_address_process"
+          },
+          "name": "APPLY_ADDRESS"
+        },
+        {
+          "data_type": "any",
+          "description": "Apply the current system collate locale to the process",
+          "methods": {
+            "process": "locale_apply_collate_process"
+          },
+          "name": "APPLY_COLLATE"
+        },
+        {
+          "data_type": "any",
+          "description": "Apply the current system ctype locale to the process",
+          "methods": {
+            "process": "locale_apply_ctype_process"
+          },
+          "name": "APPLY_CTYPE"
+        },
+        {
+          "data_type": "any",
+          "description": "Apply the current system identification locale to the process",
+          "methods": {
+            "process": "locale_apply_identification_process"
+          },
+          "name": "APPLY_IDENTIFICATION"
+        },
+        {
+          "data_type": "any",
+          "description": "Apply the current system measurement locale to the process",
+          "methods": {
+            "process": "locale_apply_measurement_process"
+          },
+          "name": "APPLY_MEASUREMENT"
+        },
+        {
+          "data_type": "any",
+          "description": "Apply the current system monetary locale to the process",
+          "methods": {
+            "process": "locale_apply_monetary_process"
+          },
+          "name": "APPLY_MONETARY"
+        },
+        {
+          "data_type": "any",
+          "description": "Apply the current system messages locale to the process",
+          "methods": {
+            "process": "locale_apply_messages_process"
+          },
+          "name": "APPLY_MESSAGES"
+        },
+        {
+          "data_type": "any",
+          "description": "Apply the current system name locale to the process",
+          "methods": {
+            "process": "locale_apply_name_process"
+          },
+          "name": "APPLY_NAME"
+        },
+        {
+          "data_type": "any",
+          "description": "Apply the current system numeric locale to the process",
+          "methods": {
+            "process": "locale_apply_numeric_process"
+          },
+          "name": "APPLY_NUMERIC"
+        },
+        {
+          "data_type": "any",
+          "description": "Apply the current system paper locale to the process",
+          "methods": {
+            "process": "locale_apply_paper_process"
+          },
+          "name": "APPLY_PAPER"
+        },
+        {
+          "data_type": "any",
+          "description": "Apply the current system telephone locale to the process",
+          "methods": {
+            "process": "locale_apply_telephone_process"
+          },
+          "name": "APPLY_TELEPHONE"
+        },
+        {
+          "data_type": "any",
+          "description": "Apply the current system time locale to the process",
+          "methods": {
+            "process": "locale_apply_time_process"
+          },
+          "name": "APPLY_TIME"
+        }
+      ],
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct monitor_node_type",
+        "extra_methods": {
+          "monitor_register": "locale_monitor_register",
+          "monitor_unregister": "locale_monitor_unregister"
+        }
+      },
+      "methods": {
+        "open": "locale_open"
+      },
+      "options": {
+        "members": [
+          {
+            "data_type": "boolean",
+            "default": true,
+            "description": "An initial packet with the current locales will be sent",
+            "name": "send_initial_packet"
+          }
+        ],
+        "version": 1
+      },
+      "name": "platform/locale",
+      "out_ports": [
+        {
+          "data_type": "string",
+          "description": "The current system's language locale",
+          "methods": {
+            "connect": "monitor_out_connect",
+            "disconnect": "monitor_out_disconnect"
+          },
+          "name": "OUT_LANG"
+        },
+        {
+          "data_type": "string",
+          "description": "The current system's address locale",
+          "methods": {
+            "connect": "monitor_out_connect",
+            "disconnect": "monitor_out_disconnect"
+          },
+          "name": "OUT_ADDRESS"
+        },
+        {
+          "data_type": "string",
+          "description": "The current system's collate locale",
+          "methods": {
+            "connect": "monitor_out_connect",
+            "disconnect": "monitor_out_disconnect"
+          },
+          "name": "OUT_COLLATE"
+        },
+        {
+          "data_type": "string",
+          "description": "The current system's ctype locale",
+          "methods": {
+            "connect": "monitor_out_connect",
+            "disconnect": "monitor_out_disconnect"
+          },
+          "name": "OUT_CTYPE"
+        },
+        {
+          "data_type": "string",
+          "description": "The current system's identification locale",
+          "methods": {
+            "connect": "monitor_out_connect",
+            "disconnect": "monitor_out_disconnect"
+          },
+          "name": "OUT_IDENTIFICATION"
+        },
+        {
+          "data_type": "string",
+          "description": "The current system's measurement locale",
+          "methods": {
+            "connect": "monitor_out_connect",
+            "disconnect": "monitor_out_disconnect"
+          },
+          "name": "OUT_MEASUREMENT"
+        },
+        {
+          "data_type": "string",
+          "description": "The current system's messages locale",
+          "methods": {
+            "connect": "monitor_out_connect",
+            "disconnect": "monitor_out_disconnect"
+          },
+          "name": "OUT_MESSAGES"
+        },
+        {
+          "data_type": "string",
+          "description": "The current system's monetary localle",
+          "methods": {
+            "connect": "monitor_out_connect",
+            "disconnect": "monitor_out_disconnect"
+          },
+          "name": "OUT_MONETARY"
+        },
+        {
+          "data_type": "string",
+          "description": "The current system's naming locale",
+          "methods": {
+            "connect": "monitor_out_connect",
+            "disconnect": "monitor_out_disconnect"
+          },
+          "name": "OUT_NAME"
+        },
+        {
+          "data_type": "string",
+          "description": "The current system's numeric locale",
+          "methods": {
+            "connect": "monitor_out_connect",
+            "disconnect": "monitor_out_disconnect"
+          },
+          "name": "OUT_NUMERIC"
+        },
+        {
+          "data_type": "string",
+          "description": "The current system's paper locale",
+          "methods": {
+            "connect": "monitor_out_connect",
+            "disconnect": "monitor_out_disconnect"
+          },
+          "name": "OUT_PAPER"
+        },
+        {
+          "data_type": "string",
+          "description": "The current system's telephone locale",
+          "methods": {
+            "connect": "monitor_out_connect",
+            "disconnect": "monitor_out_disconnect"
+          },
+          "name": "OUT_TELEPHONE"
+        },
+        {
+          "data_type": "string",
+          "description": "The current system's time locale",
+          "methods": {
+            "connect": "monitor_out_connect",
+            "disconnect": "monitor_out_disconnect"
+          },
+          "name": "OUT_TIME"
+        }
+      ],
+      "private_data_type": "monitor_data",
+      "url": "http://solettaproject.org/doc/latest/node_types/platform_locale.html"
+    },
+    {
       "category": "input/sw",
       "description": "Platform Service State",
       "in_ports": [

--- a/src/modules/flow/platform/platform.json
+++ b/src/modules/flow/platform/platform.json
@@ -48,8 +48,19 @@
           "name": "IN"
         }
       ],
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct monitor_node_type",
+        "extra_methods": {
+          "send_packet": "hostname_send",
+          "monitor_register": "hostname_monitor_register",
+          "monitor_unregister": "hostname_monitor_unregister"
+        }
+      },
       "methods": {
-        "open": "hostname_open"
+        "open": "monitor_open"
       },
       "options": {
         "members": [
@@ -68,14 +79,120 @@
           "data_type": "string",
           "description": "The current hostname. When the node is created an initial packet will be sent with the current hostname, if the hostname changes a new packet will be set with the new hostname.",
           "methods": {
-            "connect": "hostname_out_connect",
-            "disconnect": "hostname_out_disconnect"
+            "connect": "monitor_out_connect",
+            "disconnect": "monitor_out_disconnect"
           },
           "name": "OUT"
         }
       ],
-      "private_data_type": "hostname_data",
+      "private_data_type": "monitor_data",
       "url": "http://solettaproject.org/doc/latest/node_types/platform_hostname.html"
+    },
+    {
+      "category": "timer",
+      "description": "This node can be used to set the machine's system time, get the current system time or monitor for system time changes",
+      "in_ports": [
+        {
+          "data_type": "int",
+          "description": "The new system time in seconds relative to 1970-01-01 00:00:00 +0000 (UTC).",
+          "methods": {
+            "process": "system_clock_process"
+          },
+          "name": "IN"
+        }
+      ],
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct monitor_node_type",
+        "extra_methods": {
+          "send_packet": "system_clock_send",
+          "monitor_register": "system_clock_monitor_register",
+          "monitor_unregister": "system_clock_monitor_unregister"
+        }
+      },
+      "methods": {
+        "open": "monitor_open"
+      },
+      "options": {
+        "members": [
+          {
+            "data_type": "boolean",
+            "default": true,
+            "description": "An initial packet with the current timestamp will be sent",
+            "name": "send_initial_packet"
+          }
+        ],
+        "version": 1
+      },
+      "name": "platform/system-clock",
+      "out_ports": [
+        {
+          "data_type": "int",
+          "description": "The current system time which is expressed as the number of seconds since 1970-01-01 00:00:00 +0000 (UTC).",
+          "methods": {
+            "connect": "monitor_out_connect",
+            "disconnect": "monitor_out_disconnect"
+          },
+          "name": "OUT"
+        }
+      ],
+      "private_data_type": "monitor_data",
+      "url": "http://solettaproject.org/doc/latest/node_types/platform_system_clock.html"
+    },
+    {
+      "category": "timer",
+      "description": "This node can be used to set the machine's timezone, get the current timezone or monitor for timezone changes",
+      "in_ports": [
+        {
+          "data_type": "string",
+          "description": "Set the new timezone",
+          "methods": {
+            "process": "timezone_process"
+          },
+          "name": "IN"
+        }
+      ],
+      "node_type": {
+        "access": [
+          "base"
+        ],
+        "data_type": "struct monitor_node_type",
+        "extra_methods": {
+          "send_packet": "timezone_send",
+          "monitor_register": "timezone_monitor_register",
+          "monitor_unregister": "timezone_monitor_unregister"
+        }
+      },
+      "methods": {
+        "open": "monitor_open"
+      },
+      "options": {
+        "members": [
+          {
+            "data_type": "boolean",
+            "default": true,
+            "description": "An initial packet with the current timezone will be sent",
+            "name": "send_initial_packet"
+          }
+        ],
+        "version": 1
+      },
+      "name": "platform/timezone",
+      "out_ports": [
+        {
+          "data_type": "string",
+          "description": "The current timezone",
+          "methods": {
+            "connect": "monitor_out_connect",
+            "disconnect": "monitor_out_disconnect"
+          },
+          "name": "OUT"
+        }
+      ],
+      "private_data_type": "monitor_data",
+      "url": "http://solettaproject.org/doc/latest/node_types/platform_timezone.html"
     },
     {
       "category": "input/sw",

--- a/src/samples/flow/misc/Makefile
+++ b/src/samples/flow/misc/Makefile
@@ -12,3 +12,9 @@ sample-tickets-queue-$(FLOW_MISC_TICKETS_QUEUE_SAMPLE) := tickets_queue.fbp
 
 sample-$(FLOW_MISC_CHANGE_HOSTNAME_SAMPLE) += change_hostname
 sample-tickets-queue-$(FLOW_MISC_CHANGE_HOSTNAME_SAMPLE) := change_hostname.fbp
+
+sample-$(FLOW_MISC_CHANGE_TIMEZONE_SAMPLE) += change_timezone
+sample-tickets-queue-$(FLOW_MISC_CHANGE_TIMEZONE_SAMPLE) := change_timezone.fbp
+
+sample-$(FLOW_MISC_CHANGE_SYSTEM_CLOCK_SAMPLE) += change_system_clock
+sample-tickets-queue-$(FLOW_MISC_CHANGE_SYSTEM_CLOCK_SAMPLE) := change_system_clock.fbp

--- a/src/samples/flow/misc/Makefile
+++ b/src/samples/flow/misc/Makefile
@@ -18,3 +18,6 @@ sample-tickets-queue-$(FLOW_MISC_CHANGE_TIMEZONE_SAMPLE) := change_timezone.fbp
 
 sample-$(FLOW_MISC_CHANGE_SYSTEM_CLOCK_SAMPLE) += change_system_clock
 sample-tickets-queue-$(FLOW_MISC_CHANGE_SYSTEM_CLOCK_SAMPLE) := change_system_clock.fbp
+
+sample-$(FLOW_MISC_CHANGE_LOCALE_SAMPLE) += change_locale
+sample-tickets-queue-$(FLOW_MISC_CHANGE_LOCALE_SAMPLE) := change_locale.fbp

--- a/src/samples/flow/misc/change_locale.fbp
+++ b/src/samples/flow/misc/change_locale.fbp
@@ -1,0 +1,40 @@
+#!/usr/bin/env sol-fbp-runner
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or o]ther materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+# Usage: sol-fbp-runner change_locale.fbp locale
+# This FBP will change the locale of the current machine.
+# Changing the locale may required administrator privileges
+
+Prefix(constant/string:value="The current numeric locale is: ") OUT -> IN[0] Concat(string/concatenate)
+Locale(platform/locale) OUT_NUMERIC -> IN[1] Concat OUT -> IN Console(console)
+
+_(constant/string:value="pt_BR.UTF-8") OUT -> IN_NUMERIC Locale OUT_NUMERIC -> APPLY_NUMERIC Locale

--- a/src/samples/flow/misc/change_system_clock.fbp
+++ b/src/samples/flow/misc/change_system_clock.fbp
@@ -1,0 +1,40 @@
+#!/usr/bin/env sol-fbp-runner
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+# Usage: sol-fbp-runner change_system_clock.fbp TIMESTAMP
+# This FBP will change the system clock of the current machine.
+# Changing the system clock may required administrator privileges
+
+_(constant/string:value="The new system clock is: ") OUT -> IN[0] text(string/concatenate)
+_(app/argv:index=1) OUT -> IN _(converter/string-to-int) OUT -> IN _(platform/system-clock) OUT -> IN StrToInt(converter/int-to-string)
+StrToInt OUT -> IN[1] text
+text OUT -> IN _(console)

--- a/src/samples/flow/misc/change_timezone.fbp
+++ b/src/samples/flow/misc/change_timezone.fbp
@@ -1,0 +1,39 @@
+#!/usr/bin/env sol-fbp-runner
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+# Usage: sol-fbp-runner change_timezone.fbp TIMEZONE
+# This FBP will change the timezone of the current machine.
+# Changing the timezone may required administrator privileges
+
+_(constant/string:value="The new timezone is: ") OUT -> IN[0] text(string/concatenate)
+_(app/argv:index=1) OUT -> IN _(platform/timezone) OUT -> IN[1] text
+text OUT -> IN _(console)

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -60,6 +60,7 @@
 #define OVERFLOW_TYPE(type) ((type)1 << (sizeof(type) * 4))
 #define OVERFLOW_UINT64 OVERFLOW_TYPE(uint64_t)
 #define OVERFLOW_SIZE_T OVERFLOW_TYPE(size_t)
+#define OVERFLOW_INT64 OVERFLOW_TYPE(int64_t)
 
 /**
  * Extracted from Hacker's Delight, 2nd edition, chapter 2-13
@@ -366,6 +367,21 @@ sol_util_uint64_mul(const uint64_t a, const uint64_t b, uint64_t *out)
 #else
     if ((a >= OVERFLOW_UINT64 || b >= OVERFLOW_UINT64) &&
         a > 0 && UINT64_MAX / a < b)
+        return -EOVERFLOW;
+    *out = a * b;
+#endif
+    return 0;
+}
+
+static inline int
+sol_util_int64_mul(const int64_t a, const int64_t b, int64_t *out)
+{
+#ifdef HAVE_BUILTIN_MUL_OVERFLOW
+    if (__builtin_mul_overflow(a, b, out))
+        return -EOVERFLOW;
+#else
+    if ((a >= OVERFLOW_INT64 || b >= OVERFLOW_INT64) &&
+        a > 0 && INT64_MAX / a < b)
         return -EOVERFLOW;
     *out = a * b;
 #endif

--- a/tools/run-fbp-tests
+++ b/tools/run-fbp-tests
@@ -125,14 +125,14 @@ class FbpTest:
         return False
 
     def show_result_status(self, out, code):
-        if self.output and self.output_spec != out:
+        if self.output and self.output_spec not in out:
             orig = out.splitlines(True)
             dest = self.output_spec.splitlines(True)
             logging.warning("FAILED running %s: wrong output" % os.path.basename(self.test_file))
             for line in difflib.unified_diff(orig, dest):
                 sys.stdout.write(line)
             return "failed"
-        elif self.output_regex and not re.match(self.output_spec, out):
+        elif self.output_regex and not re.search("^" + self.output_spec, out, re.MULTILINE):
             logging.warning("FAILED running %s: wrong output" % os.path.basename(self.test_file))
             logging.warning("Expected expression:")
             logging.warning(self.output_spec)


### PR DESCRIPTION
Changes since V1:

* Do not apply locales at startup.
* Fail gracefully during the startup if /etc/locale.conf does not exist.
* The node platform/locale now have ports to apply the locale values.