### PR TITLE
coap: Fix incorrect way of accessing a string position

### DIFF
--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -344,7 +344,7 @@ packet_extract_path(const struct sol_coap_packet *req, char **path_str)
             (path, (uint8_t *)*path_str, path_len - 1, NULL);
     SOL_INT_CHECK_GOTO(r, < 0, error);
 
-    *path_str[path_len - 1] = 0;
+    (*path_str)[path_len - 1] = 0;
     return 0;
 
 error:


### PR DESCRIPTION
In commit 386ee723 function packet_extract_path was changed to receive a
pointer to a string instead of returing the result string. In this new
function, the string was incorrectly accessed when adding '\0' and
invalid memory access was occuring.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>