### PR TITLE
scripts:oicgen: Remove wrong free

### DIFF
--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -1461,7 +1461,6 @@ client_connect(struct client_resource *resource, const char *device_id)
     }
 
     SOL_ERR("Could not create timeout to find resource");
-    free(resource->device_id);
     return -ENOMEM;
 }
 


### PR DESCRIPTION
device_id is not a pointer and should not be freed.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>