### PR TITLE
comms:http:oauth: Fix signature

### DIFF
--- a/src/modules/flow/oauth/oauth.c
+++ b/src/modules/flow/oauth/oauth.c
@@ -614,8 +614,8 @@ v1_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_optio
     mdata->consumer_key = strdup(opts->consumer_key);
     SOL_NULL_CHECK_GOTO(mdata->consumer_key, consumer_err);
 
-    mdata->consumer_key_secret = strdup(opts->consumer_key_secret);
-    SOL_NULL_CHECK_GOTO(mdata->consumer_key_secret, secret_err);
+    r = asprintf(&mdata->consumer_key_secret, "%s&", opts->consumer_key_secret);
+    SOL_INT_CHECK_GOTO(r, < 0, secret_err);
 
     sol_ptr_vector_init(&mdata->pending_conns);
     sol_ptr_vector_init(&mdata->pending_digests);


### PR DESCRIPTION
The signing key for request token should be followed by an ampersand
char '&'.

As the consumer key secret is only used when request the tokens, it's
safe append '&'.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>