### PR TITLE
log: log domain variables may not be referenced.

### DIFF
--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -434,7 +434,7 @@ def generate_header_tail(outfile, data):
 
 #ifdef SOL_LOG_ENABLED
 #define SOL_LOG_INTERNAL_DECLARE(_var, _name) \
-    struct sol_log_domain _var = { \
+    SOL_ATTR_UNUSED struct sol_log_domain _var = { \
         .name = "sol-" _name, \
         .color = SOL_LOG_COLOR_MAGENTA, \
         .level = SOL_LOG_LEVEL_WARNING \

--- a/src/lib/common/sol-log-internal.h
+++ b/src/lib/common/sol-log-internal.h
@@ -36,7 +36,7 @@
 
 #ifdef SOL_LOG_ENABLED
 #define SOL_LOG_INTERNAL_DECLARE(_var, _name)    \
-    struct sol_log_domain _var = {               \
+    SOL_ATTR_UNUSED struct sol_log_domain _var = { \
         .name = "sol-" _name,                    \
         .color = SOL_LOG_COLOR_MAGENTA,          \
         .level = SOL_LOG_LEVEL_WARNING           \


### PR DESCRIPTION
At least when the log domain is set to one different than the global
one, if the user issues no log calls in the Soletta app, that variable
will have no use in the code, thus leading to unused variable warnings.
We now tell, then, to the compiler, that the log domain variable may be
unused in the SOL_LOG_INTERNAL_DECLARE() macro.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>