### PR TITLE
flow: Add helper to load packet types

### DIFF
--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -507,8 +507,26 @@ struct sol_flow_port_type_in {
 #define sol_flow_get_node_type(_mod, _type, _var) sol_flow_internal_get_node_type(_mod, #_type, _var)
 
 int sol_flow_internal_get_node_type(const char *module, const char *symbol, const struct sol_flow_node_type **type);
+
+/**
+ * Gets the specified packet type, loading the necessary module if required.
+ *
+ * Checks if the node type @a _type is built-in, if not, it loads the module
+ * @a _mod and fetches the packet's symbol there. The result is stored in @a _var.
+ *
+ * @param _mod The name of the module to load if the packet is not built-in.
+ * @param _type The packet type's symbol.
+ * @param _var Variable where to store the type.
+ *
+ * @return 0 on success, < 0 on error.
+ */
+#define sol_flow_get_packet_type(_mod, _type, _var) sol_flow_internal_get_packet_type(_mod, #_type, _var)
+
+int sol_flow_internal_get_packet_type(const char *module, const char *symbol, const struct sol_flow_packet_type **type);
+
 #else
 #define sol_flow_get_node_type(_mod, _type, _var) ({ (*(_var)) = _type; 0; })
+#define sol_flow_get_packet_type(_node, _packet_type, _var) ({ (*(_var)) = _packet_type; 0; })
 #endif /* SOL_DYNAMIC_MODULES */
 
 /**

--- a/src/lib/flow/sol-flow-modules.c
+++ b/src/lib/flow/sol-flow-modules.c
@@ -47,3 +47,16 @@ sol_flow_internal_get_node_type(const char *modname, const char *symbol, const s
     *type = *ret;
     return 0;
 }
+
+SOL_API int
+sol_flow_internal_get_packet_type(const char *modname, const char *symbol, const struct sol_flow_packet_type **type)
+{
+    const struct sol_flow_packet_type **ret;
+
+    ret = sol_modules_get_symbol("flow", modname, symbol);
+    if (!ret || !*ret)
+        return -errno;
+
+    *type = *ret;
+    return 0;
+}


### PR DESCRIPTION
Some nodes can have their own custom packets, it's necessary something
that allows one use them in different nodes even when they are not build static.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>