### PR TITLE
inspector: Invalid memory access when inpecting int and float options

### DIFF
--- a/src/bin/sol-fbp-runner/inspector.c
+++ b/src/bin/sol-fbp-runner/inspector.c
@@ -332,13 +332,19 @@ inspector_did_open_node(const struct sol_flow_inspector *inspector, const struct
                 const uint8_t *b = mem;
                 fprintf(stdout, "%#x", *b);
             } else if (streq(itr->data_type, "int")) {
-                const struct sol_irange *i = mem;
-                fprintf(stdout, "val:%d|min:%d|max:%d|step:%d",
-                    i->val, i->min, i->max, i->step);
+                const int32_t *i = mem;
+                fprintf(stdout, "%d", *i);
             } else if (streq(itr->data_type, "float")) {
-                const struct sol_drange *d = mem;
-                fprintf(stdout, "val:%g|min:%g|max:%g|step:%g",
-                    d->val, d->min, d->max, d->step);
+                const double *d = mem;
+                fprintf(stdout, "%g", *d);
+            } else if (streq(itr->data_type, "irange-spec")) {
+                const struct sol_irange_spec *i = mem;
+                fprintf(stdout, "min:%d|max:%d|step:%d",
+                    i->min, i->max, i->step);
+            } else if (streq(itr->data_type, "drange-spec")) {
+                const struct sol_drange_spec *d = mem;
+                fprintf(stdout, "min:%g|max:%g|step:%g",
+                    d->min, d->max, d->step);
             } else {
                 fputs("???", stdout);
             }

--- a/src/lib/flow/sol-flow-node-options.c
+++ b/src/lib/flow/sol-flow-node-options.c
@@ -838,7 +838,7 @@ sol_flow_node_options_new(
         return -EINVAL;
     }
 
-    tmp_opts = calloc(1, type->options_size);
+    tmp_opts = malloc(type->options_size);
     if (!tmp_opts)
         return -errno;
 


### PR DESCRIPTION
Inspector was accessing invalid memory area and printing int and float
values, because they are now a single number instead of an irange or
drange.
Also adding debug for the new option types irange-spec and drange-spec.

Error following:
=================================================================
==23290==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6030000310d4 at pc 0x00000040948a bp 0x7ffee0aa9b40 sp 0x7ffee0aa9b30
READ of size 4 at 0x6030000310d4 thread T0

0x6030000310d4 is located 0 bytes to the right of 20-byte region [0x6030000310c0,0x6030000310d4)
allocated by thread T0 here:

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>