### PR TITLE
mavlink: introduce the mavlink protocol implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "src/thirdparty/tinydtls"]
 	path = src/thirdparty/tinydtls
 	url = git://git.code.sf.net/p/tinydtls/code
+[submodule "src/thirdparty/mavlink"]
+	path = src/thirdparty/mavlink
+	url = https://github.com/mavlink/c_library.git

--- a/Kconfig
+++ b/Kconfig
@@ -170,6 +170,7 @@ source "src/samples/common/Kconfig"
 source "src/samples/crypto/Kconfig"
 source "src/samples/http/Kconfig"
 source "src/samples/mqtt/Kconfig"
+source "src/samples/mavlink/Kconfig"
 
 config FLOW_SAMPLES
 	bool "Flow samples"

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -499,6 +499,19 @@
       "ldflags": {
         "value": "-lmagic"
       }
+    },
+    {
+      "dependency": "mavlink_src",
+      "type": "filesystem",
+      "files": [
+        "mavlink_types.h",
+        "protocol.h",
+        "checksum.h"
+      ],
+      "path": {
+        "in-tree": "{TOP_SRCDIR}/src/thirdparty/mavlink",
+        "out-of-tree": "{MAVLINK_SRC}"
+      }
     }
   ]
 }

--- a/src/lib/comms/Kconfig
+++ b/src/lib/comms/Kconfig
@@ -106,3 +106,12 @@ config MQTT
 
             The Soletta implementation of MQTT depends on the mosquitto library
             (http://mosquitto.org/)
+
+config MAVLINK
+	bool "Mavlink"
+	default y
+    depends on NETWORK && HAVE_MAVLINK_SRC
+    help
+            MAVLink or Micro Air Vehicle Link is a protocol for communicating with
+            small unmanned vehicle. It is designed as a header-only message marshaling
+            library.

--- a/src/lib/comms/Makefile
+++ b/src/lib/comms/Makefile
@@ -92,6 +92,14 @@ obj-networking-$(MQTT) += \
 obj-networking-$(MQTT)-extra-ldflags += \
 	$(MOSQUITTO_LDFLAGS)
 
+obj-networking-$(MAVLINK) += \
+	sol-mavlink.o
+
+obj-networking-$(MAVLINK)-extra-cflags += \
+	-I$(MAVLINK_SRC_PATH)/common/ \
+	-I$(MAVLINK_SRC_PATH)/ardupilotmega/ \
+	-Wno-declaration-after-statement
+
 headers-$(NETWORK) += \
     include/sol-network.h
 
@@ -114,3 +122,6 @@ headers-$(HTTP_SERVER) += \
 
 headers-$(MQTT) += \
 	include/sol-mqtt.h
+
+headers-$(MAVLINK) += \
+	include/sol-mavlink.h

--- a/src/lib/comms/include/sol-mavlink.h
+++ b/src/lib/comms/include/sol-mavlink.h
@@ -1,0 +1,400 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file
+ * @brief Routines to handle Mavlink protocol.
+ *
+ * Wrapper library for Mavlink communication.
+ */
+
+/**
+ * @defgroup MAVLINK MAVLINK
+ * @ingroup Comms
+ *
+ * MAVLink or Micro Air Vehicle Link is a protocol for communicating with
+ * small unmanned vehicle. It is designed as a header-only message marshaling
+ * library.
+ *
+ * @{
+ */
+
+/**
+ * @struct sol_mavlink
+ *
+ * @brief Mavlink Object
+ *
+ * @see sol_mavlink_connect
+ *
+ * This object is the abstraction of a Mavlink connection. This is the base
+ * structure for all Mavlink operations and is obtained through the
+ * sol_mavlink_connect API.
+ */
+struct sol_mavlink;
+
+typedef enum {
+    SOL_MAVLINK_MODE_ACRO = 1,
+    SOL_MAVLINK_MODE_ALT_HOLD = 2,
+    SOL_MAVLINK_MODE_ATTITUDE = 3,
+    SOL_MAVLINK_MODE_AUTO = 4,
+    SOL_MAVLINK_MODE_AUTOTUNE = 5,
+    SOL_MAVLINK_MODE_CIRCLE = 6,
+    SOL_MAVLINK_MODE_CRUISE = 7,
+    SOL_MAVLINK_MODE_DRIFT = 8,
+    SOL_MAVLINK_MODE_EASY = 9,
+    SOL_MAVLINK_MODE_FBWA = 10,
+    SOL_MAVLINK_MODE_FBWB = 11,
+    SOL_MAVLINK_MODE_FLIP = 12,
+    SOL_MAVLINK_MODE_GUIDED = 13,
+    SOL_MAVLINK_MODE_HOLD = 14,
+    SOL_MAVLINK_MODE_INITIALISING = 15,
+    SOL_MAVLINK_MODE_LAND = 16,
+    SOL_MAVLINK_MODE_LEARNING = 17,
+    SOL_MAVLINK_MODE_LOITER = 18,
+    SOL_MAVLINK_MODE_MANUAL = 19,
+    SOL_MAVLINK_MODE_OF_LOITER = 20,
+    SOL_MAVLINK_MODE_POSHOLD = 21,
+    SOL_MAVLINK_MODE_POSITION = 22,
+    SOL_MAVLINK_MODE_RTL = 23,
+    SOL_MAVLINK_MODE_SCAN = 24,
+    SOL_MAVLINK_MODE_SPORT = 25,
+    SOL_MAVLINK_MODE_STABILIZE = 26,
+    SOL_MAVLINK_MODE_STEERING = 27,
+    SOL_MAVLINK_MODE_STOP = 28,
+    SOL_MAVLINK_MODE_TRAINING = 29,
+    SOL_MAVLINK_MODE_UNKNOWN = 30,
+} sol_mavlink_mode;
+
+/**
+ * @struct sol_mavlink_position
+ *
+ * @brief Mavlink position structure
+ */
+struct sol_mavlink_position {
+    /** Latitude in degrees */
+    float latitude;
+
+    /** Longitude in degrees */
+    float longitude;
+
+    /** Altitude in meters */
+    float altitude;
+
+    /** Local X position of this position in the local coordinate frame */
+    float x;
+
+    /** Local Y position of this position in the local coordinate frame */
+    float y;
+
+    /** Local Z position of this position in the local coordinate frame */
+    float z;
+};
+
+/**
+ * @struct sol_mavlink_handlers
+ *
+ * @brief Mavlink callback handlers
+ */
+struct sol_mavlink_handlers {
+#ifndef SOL_NO_API_VERSION
+#define SOL_MAVLINK_HANDLERS_API_VERSION (1)
+    /**
+     * Should always be set to SOL_MAVLINK_HANDLERS_API_VERSION
+     */
+    uint16_t api_version;
+#endif
+
+    /**
+     * @brief On connect callback
+     *
+     * @param data User provided data
+     * @param mavlink Mavlink Object
+     *
+     * @see sol_mavlink_connect
+     *
+     * Callback called when a connect request has been processed
+     */
+    void (*connect) (void *data, struct sol_mavlink *mavlink);
+
+    /**
+     * @brief On mode changed callback
+     *
+     * @param data User provided data
+     * @param mavlink Mavlink Object
+     *
+     * @see sol_mavlink_set_mode
+     *
+     * Callback called when a mode change has been processed
+     */
+    void (*mode_changed) (void *data, struct sol_mavlink *mavlink);
+
+    /**
+     * @brief On armed callback
+     *
+     * @param data User provided data
+     * @param mavlink Mavlink Object
+     *
+     * @see sol_mavlink_set_armed
+     * @see sol_mavlink_check_armed
+     *
+     * Callback called when the vehicle has been armed, no matter if
+     * it was armed by your application or not
+     */
+    void (*armed) (void *data, struct sol_mavlink *mavlink);
+
+    /**
+     * @brief On armed callback
+     *
+     * @param data User provided data
+     * @param mavlink Mavlink Object
+     *
+     * @see sol_mavlink_set_armed
+     * @see sol_mavlink_check_armed
+     *
+     * Callback called when the vehicle has been disarmed, no matter if
+     * it was disarmed by your application or not
+     */
+    void (*disarmed) (void *data, struct sol_mavlink *mavlink);
+
+    /**
+     * @brief On position changed callback
+     *
+     * @param data User provided data
+     * @param mavlink Mavlink Object
+     *
+     * @see sol_mavlink_takeoff
+     * @see sol_mavlink_get_curr_position
+     *
+     * Callback called when the vehicle has changed its position, no matter
+     * if it was moved by your application or not
+     */
+    void (*position_changed) (void *data, struct sol_mavlink *mavlink);
+
+    /**
+     * @brief On destination reached callback
+     *
+     * @param data User provided data
+     * @param mavlink Mavlink Object
+     *
+     * @see sol_mavlink_takeoff
+     * @see sol_mavlink_goto
+     *
+     * Callback called when the vehicle has reached the current mission's
+     * destination.
+     */
+    void (*mission_reached) (void *data, struct sol_mavlink *mavlink);
+};
+
+/**
+ * @struct sol_mavlink_config
+ *
+ * @brief Server Configuration
+ */
+struct sol_mavlink_config {
+#ifndef SOL_NO_API_VERSION
+#define SOL_MAVLINK_CONFIG_API_VERSION (1)
+    /**
+     * Should always be set to SOL_MAVLINK_CONFIG_API_VERSION
+     */
+    uint16_t api_version;
+#endif
+
+    /**
+     * Handlers to be used with this connection
+     */
+    const struct sol_mavlink_handlers *handlers;
+};
+
+/**
+ * @brief Connect to a mavlink server
+ *
+ * @param addr The target mavlink server address
+ * @param config Configuration and callbacks
+ * @param data User data provided to the callbacks
+ *
+ * @return New mavlink object on success, NULL otherwise
+ *
+ * The @b addr argument is composed of protocol:address:port where port is
+ * optional depending on protocol.
+ *
+ * Currently supported protocols are tcp and serial, valid @b addr would be:
+ *   tcp:localhost:5726
+ *   serial:/dev/ttyUSB0
+ */
+struct sol_mavlink *sol_mavlink_connect(const char *addr, const struct sol_mavlink_config *config, void *data);
+
+/**
+ * @brief Disconnect from mavlink server
+ *
+ * @param mavlink Mavlink Object;
+ *
+ * @see sol_mavlink_connect
+ *
+ * Terminate the connection with the mavlink server and free the resources
+ * associated to the mavlink object.
+ */
+void sol_mavlink_disconnect(struct sol_mavlink *mavlink);
+
+/**
+ * @brief Set the vehicle to @b armed or not
+ *
+ * @param mavlink Mavlink Object;
+ * @param armed true to set as armed, false otherwise;
+ *
+ * @see sol_mavlink_check_armed
+ *
+ * @return 0 on success, -EINVAL on invalid argument, -errno on error
+ */
+int sol_mavlink_set_armed(struct sol_mavlink *mavlink, bool armed);
+
+/**
+ * @brief Takeoff the vehicle
+ *
+ * @param mavlink Mavlink Object;
+ * @param pos The target position;
+ *
+ * @see sol_mavlink_set_armed
+ * @see sol_mavlink_check_armed
+ * @see sol_mavlink_get_mode
+ * @see SOL_MAVLINK_MODE_GUIDED
+ *
+ * @return 0 on success, -EINVAL on invalid argument, -errno on error
+ *
+ * This call will attempt to take the vehicle off, for this the vehicle must
+ * in SOL_MAVLINK_MODE_GUIDED and armed. If the vehicle has already taken off
+ * calling this function will have no effect.
+ */
+int sol_mavlink_takeoff(struct sol_mavlink *mavlink, struct sol_mavlink_position *pos);
+
+/**
+ * @brief Set the vehicle @b mode
+ *
+ * @param mavlink Mavlink Object;
+ * @param mode The mode to be set;
+ *
+ * @see sol_mavlink_get_mode
+ * @see sol_mavlink_mode
+ *
+ * @return 0 on success, -EINVAL on invalid argument, -errno on error
+ */
+int sol_mavlink_set_mode(struct sol_mavlink *mavlink, sol_mavlink_mode mode);
+
+/**
+ * @brief Get the current vehicle's mode
+ *
+ * @param mavlink Mavlink Object;
+ *
+ * @see sol_mavlink_set_mode
+ * @see sol_mavlink_mode
+ *
+ * @return The current vehicle's mode
+ */
+sol_mavlink_mode sol_mavlink_get_mode(struct sol_mavlink *mavlink);
+
+/**
+ * @brief Check if the vehicle is currently armed
+ *
+ * @param mavlink Mavlink Object;
+ *
+ * @see sol_mavlink_set_armed
+ *
+ * @return true the vehicle is currently armed, false otherwise
+ */
+bool sol_mavlink_check_armed(struct sol_mavlink *mavlink);
+
+/**
+ * @brief Get the vehicle's current position
+ *
+ * @param mavlink Mavlink Object;
+ * @param pos sol_mavlink_position pointer to set the positions values to;
+ *
+ * @return 0 on success, -EINVAL on invalid argument
+ */
+int sol_mavlink_get_curr_position(struct sol_mavlink *mavlink, struct sol_mavlink_position *pos);
+
+/**
+ * @brief Get the vehicle's home position
+ *
+ * @param mavlink Mavlink Object;
+ * @param pos sol_mavlink_position pointer to set the positions values to;
+ *
+ * @return 0 on success, -EINVAL on invalid argument
+ *
+ * Home position represents the location and altitude where the vehicle
+ * took off from.
+ */
+int sol_mavlink_get_home_position(struct sol_mavlink *mavlink, struct sol_mavlink_position *pos);
+
+/**
+ * @brief Land the vehicle's
+ *
+ * @param mavlink Mavlink Object;
+ * @param pos sol_mavlink_position The position where it should land to;
+ *
+ * @return 0 on success, -EINVAL on invalid argument, -errno on error
+ */
+int sol_mavlink_land(struct sol_mavlink *mavlink, struct sol_mavlink_position *pos);
+
+/**
+ * @brief Navigate to a given location
+ *
+ * @param mavlink Mavlink Object;
+ * @param pos sol_mavlink_position The position where the vehicle should go to;
+ *
+ * @return 0 on success, -EINVAL on invalid argument, -errno on error
+ */
+int sol_mavlink_goto(struct sol_mavlink *mavlink, struct sol_mavlink_position *pos);
+
+/**
+ * @brief Change the vehicle speed
+ *
+ * @param mavlink Mavlink Object;
+ * @param speed The desired speed in m/s;
+ * @param airspeed True if @b speed in airspeed, groundspeed is used otherwise;
+ *
+ * @return 0 on success, -EINVAL on invalid argument, -errno on error
+ */
+int sol_mavlink_change_speed(struct sol_mavlink *mavlink, float speed, bool airspeed);
+    
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/lib/comms/sol-mavlink.c
+++ b/src/lib/comms/sol-mavlink.c
@@ -1,0 +1,877 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/tcp.h>
+#include <mavlink.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#define SOL_LOG_DOMAIN &_sol_mavlink_log_domain
+#include <sol-log-internal.h>
+#include <sol-mainloop.h>
+#include <sol-str-slice.h>
+#include <sol-str-table.h>
+#include <sol-util.h>
+#include <sol-vector.h>
+
+#include "sol-mavlink.h"
+
+SOL_LOG_INTERNAL_DECLARE(_sol_mavlink_log_domain, "mavlink");
+
+#define STR_SLICE_VAL(_ptr)                     \
+    *(const struct sol_str_slice *)_ptr         \
+
+#define CHECK_HANDLER(_obj, _func)                      \
+    (_obj->config && _obj->config->handlers &&          \
+    _obj->config->handlers->_func &&                   \
+    _obj->status == SOL_MAVLINK_STATUS_READY)          \
+
+#define HANDLERS(_obj)                                 \
+    _obj->config->handlers                             \
+
+#define TYPE_MODE_MAPPING(_mode_map, _type)                             \
+    {                                                                   \
+        .mapping = (struct sol_mavlink_mode_mapping *)_mode_map,        \
+        .len = ARRAY_SIZE(_mode_map),                                   \
+        .type = _type,                                                  \
+    }                                                                   \
+
+typedef enum {
+    SOL_MAVLINK_STATUS_INITIAL_SETUP = (1 << 1),
+    SOL_MAVLINK_STATUS_GPS_SETUP     = (1 << 2),
+    SOL_MAVLINK_STATUS_GPS_HOME_POS  = (1 << 3),
+    SOL_MAVLINK_STATUS_FULL_SETUP    = (SOL_MAVLINK_STATUS_INITIAL_SETUP |
+        SOL_MAVLINK_STATUS_GPS_SETUP |
+        SOL_MAVLINK_STATUS_GPS_HOME_POS),
+    SOL_MAVLINK_STATUS_CONN_NOTIFIED = (1 << 4),
+    SOL_MAVLINK_STATUS_READY         = (SOL_MAVLINK_STATUS_FULL_SETUP |
+        SOL_MAVLINK_STATUS_CONN_NOTIFIED),
+} sol_mavlink_status;
+
+struct sol_mavlink {
+    const struct sol_mavlink_config *config;
+    void *data;
+
+    struct sol_str_slice *address;
+    int port;
+    int fd;
+    struct sol_fd *watch;
+
+    sol_mavlink_status status;
+    uint8_t sysid;
+    uint8_t compid;
+    uint8_t type;
+
+    bool custom_mode_enabled;
+    sol_mavlink_mode mode;
+    uint8_t base_mode;
+
+    struct sol_mavlink_position curr_position;
+    struct sol_mavlink_position home_position;
+};
+
+struct sol_mavlink_mode_mapping {
+    sol_mavlink_mode sol_val;
+    uint8_t mav_val;
+};
+
+struct sol_mavlink_type_mode {
+    struct sol_mavlink_mode_mapping *mapping;
+    unsigned int len;
+    MAV_TYPE type;
+};
+
+struct sol_mavlink_armed_trans {
+    uint8_t from;
+    uint8_t to;
+    bool armed;
+};
+
+static const struct sol_mavlink_armed_trans armed_transitions[] = {
+    { MAV_MODE_MANUAL_DISARMED, MAV_MODE_MANUAL_ARMED, true },
+    { MAV_MODE_MANUAL_ARMED, MAV_MODE_MANUAL_DISARMED, false },
+    { MAV_MODE_TEST_DISARMED, MAV_MODE_TEST_ARMED, true },
+    { MAV_MODE_TEST_ARMED, MAV_MODE_TEST_DISARMED, false },
+    { MAV_MODE_STABILIZE_DISARMED, MAV_MODE_STABILIZE_ARMED, true },
+    { MAV_MODE_STABILIZE_ARMED, MAV_MODE_STABILIZE_DISARMED, false },
+    { MAV_MODE_GUIDED_DISARMED, MAV_MODE_GUIDED_ARMED, true },
+    { MAV_MODE_GUIDED_ARMED, MAV_MODE_GUIDED_DISARMED, false },
+    { MAV_MODE_AUTO_DISARMED, MAV_MODE_AUTO_ARMED, true },
+    { MAV_MODE_AUTO_ARMED, MAV_MODE_AUTO_DISARMED, false },
+};
+
+static const struct sol_mavlink_mode_mapping mode_mapping_apm[] = {
+    { SOL_MAVLINK_MODE_MANUAL, 0 },
+    { SOL_MAVLINK_MODE_CIRCLE, 1 },
+    { SOL_MAVLINK_MODE_STABILIZE, 2 },
+    { SOL_MAVLINK_MODE_TRAINING, 3 },
+    { SOL_MAVLINK_MODE_ACRO, 4 },
+    { SOL_MAVLINK_MODE_FBWA, 5 },
+    { SOL_MAVLINK_MODE_FBWB, 6 },
+    { SOL_MAVLINK_MODE_CRUISE, 7 },
+    { SOL_MAVLINK_MODE_AUTOTUNE, 8 },
+    { SOL_MAVLINK_MODE_AUTO, 10 },
+    { SOL_MAVLINK_MODE_RTL, 11 },
+    { SOL_MAVLINK_MODE_LOITER, 12 },
+    { SOL_MAVLINK_MODE_LAND, 14 },
+    { SOL_MAVLINK_MODE_GUIDED, 15 },
+    { SOL_MAVLINK_MODE_INITIALISING, 16 },
+};
+
+static const struct sol_mavlink_mode_mapping mode_mapping_acm[] = {
+    { SOL_MAVLINK_MODE_STABILIZE, 0 },
+    { SOL_MAVLINK_MODE_ACRO, 1 },
+    { SOL_MAVLINK_MODE_ALT_HOLD, 2 },
+    { SOL_MAVLINK_MODE_AUTO, 3 },
+    { SOL_MAVLINK_MODE_GUIDED, 4 },
+    { SOL_MAVLINK_MODE_LOITER, 5 },
+    { SOL_MAVLINK_MODE_RTL, 6 },
+    { SOL_MAVLINK_MODE_CIRCLE, 7 },
+    { SOL_MAVLINK_MODE_POSITION, 8 },
+    { SOL_MAVLINK_MODE_LAND, 9 },
+    { SOL_MAVLINK_MODE_OF_LOITER, 10 },
+    { SOL_MAVLINK_MODE_DRIFT, 11 },
+    { SOL_MAVLINK_MODE_SPORT, 13 },
+    { SOL_MAVLINK_MODE_FLIP, 14 },
+    { SOL_MAVLINK_MODE_AUTOTUNE, 15 },
+    { SOL_MAVLINK_MODE_POSHOLD, 16 },
+};
+
+static const struct sol_mavlink_mode_mapping mode_mapping_rover[] = {
+    { SOL_MAVLINK_MODE_MANUAL, 0 },
+    { SOL_MAVLINK_MODE_LEARNING, 1 },
+    { SOL_MAVLINK_MODE_STEERING, 2 },
+    { SOL_MAVLINK_MODE_HOLD, 3 },
+    { SOL_MAVLINK_MODE_AUTO, 10 },
+    { SOL_MAVLINK_MODE_RTL, 11 },
+    { SOL_MAVLINK_MODE_GUIDED, 15 },
+    { SOL_MAVLINK_MODE_INITIALISING, 16 },
+};
+
+static const struct sol_mavlink_mode_mapping mode_mapping_tracker[] = {
+    { SOL_MAVLINK_MODE_MANUAL, 0 },
+    { SOL_MAVLINK_MODE_STOP, 1 },
+    { SOL_MAVLINK_MODE_SCAN, 2 },
+    { SOL_MAVLINK_MODE_AUTO, 10 },
+    { SOL_MAVLINK_MODE_INITIALISING, 16 },
+};
+
+static const struct sol_mavlink_mode_mapping mode_mapping_px4[] = {
+    { SOL_MAVLINK_MODE_MANUAL, 0 },
+    { SOL_MAVLINK_MODE_ATTITUDE, 1 },
+    { SOL_MAVLINK_MODE_EASY, 2 },
+    { SOL_MAVLINK_MODE_AUTO, 3 },
+};
+
+static const struct sol_mavlink_type_mode type_mode_mapping[] = {
+    TYPE_MODE_MAPPING(mode_mapping_acm, MAV_TYPE_QUADROTOR),
+    TYPE_MODE_MAPPING(mode_mapping_acm, MAV_TYPE_HELICOPTER),
+    TYPE_MODE_MAPPING(mode_mapping_acm, MAV_TYPE_HEXAROTOR),
+    TYPE_MODE_MAPPING(mode_mapping_acm, MAV_TYPE_OCTOROTOR),
+    TYPE_MODE_MAPPING(mode_mapping_acm, MAV_TYPE_TRICOPTER),
+    TYPE_MODE_MAPPING(mode_mapping_apm, MAV_TYPE_FIXED_WING),
+    TYPE_MODE_MAPPING(mode_mapping_rover, MAV_TYPE_GROUND_ROVER),
+    TYPE_MODE_MAPPING(mode_mapping_tracker, MAV_TYPE_ANTENNA_TRACKER),
+    { }
+};
+
+static inline sol_mavlink_mode
+mavlink_mode_to_sol_mode_lookup(uint8_t type, uint8_t mode)
+{
+    const struct sol_mavlink_type_mode *itr;
+
+    for (itr = type_mode_mapping; itr->mapping; itr++) {
+        struct sol_mavlink_mode_mapping *mapping = itr->mapping;
+        uint8_t i;
+
+        if (itr->type != type)
+            continue;
+
+        for (i = 0; i < itr->len; i++) {
+            if (mapping[i].mav_val == mode)
+                return mapping[i].sol_val;
+        }
+    }
+
+    return SOL_MAVLINK_MODE_UNKNOWN;
+}
+
+static inline uint8_t
+sol_mode_to_mavlink_mode_lookup(uint8_t type, sol_mavlink_mode mode)
+{
+    const struct sol_mavlink_type_mode *itr;
+
+    for (itr = type_mode_mapping; itr->mapping; itr++) {
+        struct sol_mavlink_mode_mapping *mapping = itr->mapping;
+        uint8_t i;
+
+        if (itr->type != type)
+            continue;
+
+        for (i = 0; i < itr->len; i++) {
+            if (mapping[i].sol_val == mode)
+                return mapping[i].mav_val;
+        }
+    }
+
+    return MAV_MODE_ENUM_END;
+}
+
+static inline sol_mavlink_mode
+sol_mavlink_convert_mode(uint8_t type, mavlink_message_t *msg, uint8_t *base_mode)
+{
+    uint8_t mode;
+
+    mode = mavlink_msg_heartbeat_get_base_mode(msg);
+    *base_mode = mode;
+
+    if (mode & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED) {
+        mode = mavlink_msg_heartbeat_get_custom_mode(msg);
+    }
+
+    return mavlink_mode_to_sol_mode_lookup(type, mode);
+}
+
+static void
+sol_mavlink_armed_transition(struct sol_mavlink *mavlink, uint8_t base_mode)
+{
+    uint8_t i, mask;
+
+    if (mavlink->custom_mode_enabled)
+        mask = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
+
+    for (i = 0; i < ARRAY_SIZE(armed_transitions); i++) {
+        uint8_t from, to;
+        const struct sol_mavlink_armed_trans *curr = &armed_transitions[i];
+
+        from = curr->from | mask;
+        to = curr->to | mask;
+
+        if (from != mavlink->base_mode || to != base_mode)
+            continue;
+
+        if (curr->armed) {
+            if (CHECK_HANDLER(mavlink, armed))
+                HANDLERS(mavlink)->armed(mavlink->data, mavlink);
+        } else {
+            if (CHECK_HANDLER(mavlink, disarmed))
+                HANDLERS(mavlink)->disarmed(mavlink->data, mavlink);
+        }
+
+        break;
+    }
+
+    mavlink->base_mode = base_mode;
+}
+
+static inline bool
+sol_mavlink_check_known_vehicle(uint8_t type)
+{
+    const struct sol_mavlink_type_mode *itr;
+
+    for (itr = type_mode_mapping; itr->mapping; itr++) {
+        if (itr->type == type)
+            return true;
+    }
+
+    return false;
+}
+
+static bool
+sol_mavlink_request_home_position(struct sol_mavlink *mavlink)
+{
+    mavlink_message_t msg;
+    uint8_t buf[MAVLINK_MAX_PACKET_LEN];
+    uint16_t len;
+
+    mavlink_msg_command_long_pack
+        (mavlink->sysid, mavlink->compid, &msg, 0, 0,
+        MAV_CMD_GET_HOME_POSITION, 0, 0, 0, 0, 0, 0, 0, 0);
+
+    len = mavlink_msg_to_send_buffer(buf, &msg);
+    return write(mavlink->fd, buf, len) == len;
+}
+
+static void
+sol_mavlink_initial_status(struct sol_mavlink *mavlink, mavlink_message_t *msg)
+{
+    uint8_t base_mode, type;
+    sol_mavlink_mode mode;
+
+    type = mavlink_msg_heartbeat_get_type(msg);
+    if (!sol_mavlink_check_known_vehicle(type)) {
+        SOL_INF("Unknown vehicle type, we'll retry on next heartbeat");
+        return;
+    }
+
+    mode = sol_mavlink_convert_mode(type, msg, &base_mode);
+    if (mode == SOL_MAVLINK_MODE_UNKNOWN) {
+        SOL_INF("Could not determine mode, we'll retry on next heartbeat");
+        return;
+    }
+
+    mavlink->mode = mode;
+    mavlink->sysid = msg->sysid;
+    mavlink->compid = msg->compid;
+    mavlink->type = type;
+
+    mavlink->base_mode = base_mode;
+    mavlink->custom_mode_enabled = base_mode & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
+
+    mavlink->status |= SOL_MAVLINK_STATUS_INITIAL_SETUP;
+    sol_mavlink_request_home_position(mavlink);
+}
+
+static void
+sol_mavlink_heartbeat_handler(struct sol_mavlink *mavlink, mavlink_message_t *msg)
+{
+    uint8_t base_mode;
+    sol_mavlink_mode mode;
+
+    if (!(mavlink->status & SOL_MAVLINK_STATUS_INITIAL_SETUP)) {
+        sol_mavlink_initial_status(mavlink, msg);
+        return;
+    }
+
+    if (mavlink->sysid != msg->sysid || mavlink->compid != msg->sysid)
+        return;
+
+    mode = sol_mavlink_convert_mode(mavlink->type, msg, &base_mode);
+    if (mavlink->mode != mode) {
+        mavlink->mode = mode;
+
+        if (CHECK_HANDLER(mavlink, mode_changed))
+            HANDLERS(mavlink)->mode_changed(mavlink->data, mavlink);
+    }
+
+    if (mavlink->base_mode != base_mode) {
+        sol_mavlink_armed_transition(mavlink, base_mode);
+    }
+}
+
+static void
+sol_mavlink_position_handler(struct sol_mavlink *mavlink, mavlink_message_t *msg)
+{
+    int32_t lat, longi;
+    float alt;
+    struct sol_mavlink_position *pos = &mavlink->curr_position;
+
+    lat = mavlink_msg_gps_raw_int_get_lat(msg);
+    longi = mavlink_msg_gps_raw_int_get_lon(msg);
+    alt = mavlink_msg_gps_raw_int_get_alt(msg);
+    alt = (alt - mavlink->home_position.altitude) / 1000.0f;
+
+    if (lat != pos->latitude || longi != pos->longitude || alt != pos->altitude) {
+        pos->latitude = lat / 1.0e7f;
+        pos->longitude = longi / 1.0e7f;
+        pos->altitude = alt;
+        mavlink->status |= SOL_MAVLINK_STATUS_GPS_SETUP;
+
+        if (CHECK_HANDLER(mavlink, position_changed))
+            HANDLERS(mavlink)->position_changed(mavlink->data, mavlink);
+    }
+}
+
+static void
+sol_mavlink_statustext_handler(mavlink_message_t *msg)
+{
+    char text[50];
+
+    mavlink_msg_statustext_get_text(msg, text);
+    SOL_DBG("%s", text);
+}
+
+static void
+sol_mavlink_home_position_handler(struct sol_mavlink *mavlink, mavlink_message_t *msg)
+{
+    struct sol_mavlink_position *pos = &mavlink->home_position;
+
+    pos->latitude = mavlink_msg_home_position_get_latitude(msg) / 1.0e7f;
+    pos->longitude = mavlink_msg_home_position_get_longitude(msg) / 1.0e7f;
+    pos->altitude = mavlink_msg_home_position_get_altitude(msg) * 1000.0f;
+    pos->x = mavlink_msg_home_position_get_x(msg);
+    pos->y = mavlink_msg_home_position_get_y(msg);
+    pos->z = mavlink_msg_home_position_get_z(msg);
+
+    mavlink->status |= SOL_MAVLINK_STATUS_GPS_HOME_POS;
+}
+
+static void
+sol_mavlink_mission_reached_handler(struct sol_mavlink *mavlink)
+{
+    if (CHECK_HANDLER(mavlink, mission_reached))
+        HANDLERS(mavlink)->mission_reached(mavlink->data, mavlink);
+}
+
+static bool
+sol_mavlink_fd_handler(void *data, int fd, uint32_t cond)
+{
+    struct sol_mavlink *mavlink = data;
+    mavlink_message_t msg;
+    mavlink_status_t status;
+    uint8_t buf[MAVLINK_MAX_PACKET_LEN] = { 0 };
+    int i, res;
+
+    res = recv(mavlink->fd, buf, MAVLINK_MAX_PACKET_LEN, 0);
+    if (res == -1) {
+        if (errno == EINTR) {
+            SOL_INF("Could not read socket, retrying.");
+            return true;
+        } else {
+            SOL_WRN("Could not read socket. %s",
+                    sol_util_strerrora(errno));
+            return false;
+        }
+    }
+
+    for (i = 0; i < res; ++i) {
+        if (!mavlink_parse_char(MAVLINK_COMM_0, buf[i], &msg, &status))
+            continue;
+
+        switch (msg.msgid) {
+        case MAVLINK_MSG_ID_GPS_RAW_INT:
+            sol_mavlink_position_handler(mavlink, &msg);
+            break;
+        case MAVLINK_MSG_ID_HEARTBEAT:
+            sol_mavlink_heartbeat_handler(mavlink, &msg);
+            break;
+        case MAVLINK_MSG_ID_STATUSTEXT:
+            sol_mavlink_statustext_handler(&msg);
+            break;
+        case MAVLINK_MSG_ID_HOME_POSITION:
+            sol_mavlink_home_position_handler(mavlink, &msg);
+            break;
+        case MAVLINK_MSG_ID_MISSION_ITEM_REACHED:
+            sol_mavlink_mission_reached_handler(mavlink);
+            break;
+        default:
+            SOL_INF("Unhandled event, msgid: %d", msg.msgid);
+        }
+    }
+
+    if (mavlink->status == SOL_MAVLINK_STATUS_FULL_SETUP) {
+        mavlink->status = SOL_MAVLINK_STATUS_READY;
+
+        if (CHECK_HANDLER(mavlink, connect))
+            HANDLERS(mavlink)->connect(mavlink->data, mavlink);
+    }
+
+    return true;
+}
+
+static bool
+setup_data_stream(struct sol_mavlink *mavlink)
+{
+    mavlink_message_t msg;
+    uint8_t buf[MAVLINK_MAX_PACKET_LEN];
+    uint16_t len;
+
+    SOL_NULL_CHECK(mavlink, false);
+
+    mavlink_msg_request_data_stream_pack
+        (0, 0, &msg, mavlink->sysid, mavlink->compid,
+        MAV_DATA_STREAM_ALL, 1, 1);
+
+    len = mavlink_msg_to_send_buffer(buf, &msg);
+    return write(mavlink->fd, buf, len) == len;
+}
+
+static int
+sol_mavlink_init_tcp(struct sol_mavlink *mavlink)
+{
+    struct hostent *server;
+    struct sockaddr_in serveraddr = { 0 };
+    char *hostname;
+    int err, tcp_flag = 1;
+
+    mavlink->fd = socket(PF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    if (mavlink->fd == -1) {
+        SOL_ERR("Could not create a socket to specified address - %s",
+            sol_util_strerrora(errno));
+        return -errno;
+    }
+
+    hostname = sol_str_slice_to_string(*mavlink->address);
+    if (!hostname) {
+        SOL_ERR("Could not format hostname string - %s",
+            sol_util_strerrora(errno));
+        goto err;
+    }
+
+    server = gethostbyname(hostname);
+    if (!server) {
+        SOL_ERR("No such host: %s - (%s)", hostname,
+            sol_util_strerrora(h_errno));
+        errno = h_errno;
+        goto err;
+    }
+
+    serveraddr.sin_family = PF_INET;
+    memcpy(server->h_addr, &serveraddr.sin_addr.s_addr, server->h_length);
+    serveraddr.sin_port = htons(mavlink->port);
+
+    err = setsockopt
+            (mavlink->fd, IPPROTO_TCP, TCP_NODELAY, &tcp_flag, sizeof(int));
+    if (err < 0) {
+        SOL_ERR("Could not set NODELAY option to tcp socket - (%s)",
+            sol_util_strerrora(errno));
+        goto sock_err;
+    }
+
+    err = connect(mavlink->fd, &serveraddr, sizeof(serveraddr));
+    if (err < 0) {
+        SOL_ERR("Could not stablish connection to: %s:%d - (%s)", hostname,
+            mavlink->port, sol_util_strerrora(errno));
+        goto sock_err;
+    }
+
+    mavlink->watch = sol_fd_add(mavlink->fd, SOL_FD_FLAGS_IN,
+        sol_mavlink_fd_handler, mavlink);
+    SOL_NULL_CHECK_GOTO(mavlink->watch, err);
+
+    if (!setup_data_stream(mavlink)) {
+        SOL_ERR("Could not setup data stream");
+        goto stream_err;
+    }
+    free(hostname);
+
+    return 0;
+
+stream_err:
+    sol_fd_del(mavlink->watch);
+sock_err:
+    free(hostname);
+err:
+    close(mavlink->fd);
+    return -errno;
+}
+
+static int
+sol_mavlink_init_serial(struct sol_mavlink *mavlink)
+{
+    SOL_ERR("Not implemented.");
+    return 0;
+}
+
+static const struct sol_str_table_ptr protocol_table[] = {
+    SOL_STR_TABLE_PTR_ITEM("tcp", sol_mavlink_init_tcp),
+    SOL_STR_TABLE_PTR_ITEM("serial", sol_mavlink_init_serial),
+    { }
+};
+
+static inline const void *
+sol_mavlink_parse_addr_protocol(const char *str, struct sol_str_slice *addr, int *port)
+{
+    struct sol_vector tokens;
+    struct sol_str_slice slice = sol_str_slice_from_str(str);
+    const void *init;
+
+    tokens = sol_str_slice_split(slice, ":", 0);
+    if (tokens.len <= 1) {
+        SOL_ERR("Invalid addr string, it must specify at least <prot>:<addr>");
+        return NULL;
+    }
+
+    init = sol_str_table_ptr_lookup_fallback
+            (protocol_table, STR_SLICE_VAL(sol_vector_get(&tokens, 0)),
+            sol_mavlink_init_tcp);
+    if (!init) {
+        SOL_ERR("Invalid protocol");
+        goto err;
+    }
+
+    *addr = STR_SLICE_VAL(sol_vector_get(&tokens, 1));
+
+    if (tokens.len >= 3)
+        sol_str_slice_to_int(STR_SLICE_VAL(sol_vector_get(&tokens, 2)), port);
+
+    sol_vector_clear(&tokens);
+
+    return init;
+
+err:
+    sol_vector_clear(&tokens);
+    return NULL;
+}
+
+SOL_API struct sol_mavlink *
+sol_mavlink_connect(const char *addr, const struct sol_mavlink_config *config, void *data)
+{
+    struct sol_mavlink *mavlink;
+    struct sol_str_slice address;
+    int port;
+
+    int (*init) (struct sol_mavlink *mavlink);
+
+    SOL_NULL_CHECK(addr, NULL);
+
+    init = sol_mavlink_parse_addr_protocol(addr, &address, &port);
+    SOL_NULL_CHECK(init, NULL);
+
+    mavlink = calloc(1, sizeof(*mavlink));
+    SOL_NULL_CHECK(mavlink, NULL);
+
+    mavlink->address = &address;
+    SOL_NULL_CHECK_GOTO(mavlink->address, err);
+
+    mavlink->port = port;
+    SOL_NULL_CHECK_GOTO(mavlink->port, err);
+
+    mavlink->config = config;
+    mavlink->data = data;
+
+    memset(&mavlink->curr_position, 0, sizeof(mavlink->curr_position));
+    memset(&mavlink->home_position, 0, sizeof(mavlink->home_position));
+
+    if (init(mavlink) < 0) {
+        SOL_ERR("Could not initialize mavlink connection.");
+        goto err;
+    }
+
+    return mavlink;
+
+err:
+    free(mavlink);
+    return NULL;
+}
+
+SOL_API void
+sol_mavlink_disconnect(struct sol_mavlink *mavlink)
+{
+    SOL_NULL_CHECK(mavlink);
+
+    sol_fd_del(mavlink->watch);
+    close(mavlink->fd);
+    free(mavlink);
+}
+
+SOL_API int
+sol_mavlink_set_armed(struct sol_mavlink *mavlink, bool armed)
+{
+    mavlink_message_t msg;
+    uint8_t buf[MAVLINK_MAX_PACKET_LEN];
+    uint16_t len, res;
+    bool curr;
+
+    SOL_NULL_CHECK(mavlink, -EINVAL);
+
+    curr = sol_mavlink_check_armed(mavlink);
+    SOL_EXP_CHECK(curr == !!armed, -EINVAL);
+
+    mavlink_msg_command_long_pack(mavlink->sysid, mavlink->compid,
+        &msg, 0, 0, MAV_CMD_COMPONENT_ARM_DISARM, 0,
+        !!armed, 0, 0, 0, 0, 0, 0);
+
+    len = mavlink_msg_to_send_buffer(buf, &msg);
+    res = write(mavlink->fd, buf, len);
+
+    SOL_INT_CHECK(res, < len, -errno);
+    return 0;
+}
+
+SOL_API int
+sol_mavlink_takeoff(struct sol_mavlink *mavlink, struct sol_mavlink_position *pos)
+{
+    mavlink_message_t msg;
+    uint8_t buf[MAVLINK_MAX_PACKET_LEN];
+    uint16_t len, res;
+
+    SOL_NULL_CHECK(mavlink, -EINVAL);
+    SOL_NULL_CHECK(pos, -EINVAL);
+
+    mavlink_msg_command_long_pack
+        (mavlink->sysid, mavlink->compid, &msg, 0, 0,
+        MAV_CMD_NAV_TAKEOFF, 0, pos->x, 0, 0, pos->x, pos->latitude,
+        pos->longitude, pos->altitude);
+
+    len = mavlink_msg_to_send_buffer(buf, &msg);
+    res = write(mavlink->fd, buf, len);
+
+    SOL_INT_CHECK(res, < len, -errno);
+    return 0;
+}
+
+SOL_API int
+sol_mavlink_land(struct sol_mavlink *mavlink, struct sol_mavlink_position *pos)
+{
+    mavlink_message_t msg;
+    uint8_t buf[MAVLINK_MAX_PACKET_LEN];
+    uint16_t len, res;
+
+    SOL_NULL_CHECK(mavlink, -EINVAL);
+    SOL_NULL_CHECK(pos, -EINVAL);
+
+    mavlink_msg_command_long_pack
+        (mavlink->sysid, mavlink->compid, &msg, 0, 0,
+        MAV_CMD_NAV_LAND, 0, 0, 0, 0, pos->x, pos->latitude,
+        pos->longitude, pos->altitude);
+
+    len = mavlink_msg_to_send_buffer(buf, &msg);
+    res = write(mavlink->fd, buf, len);
+
+    SOL_INT_CHECK(res, < len, -errno);
+    return 0;
+}
+
+SOL_API int
+sol_mavlink_set_mode(struct sol_mavlink *mavlink, sol_mavlink_mode mode)
+{
+    mavlink_message_t msg;
+    uint8_t buf[MAVLINK_MAX_PACKET_LEN], custom_mode;
+    uint16_t len, res;
+
+    SOL_NULL_CHECK(mavlink, -EINVAL);
+
+    custom_mode = sol_mode_to_mavlink_mode_lookup(mavlink->type, mode);
+    SOL_INT_CHECK(custom_mode, == MAV_MODE_ENUM_END, -EINVAL);
+
+    mavlink_msg_set_mode_pack
+        (0, 0, &msg, mavlink->sysid, mavlink->base_mode, custom_mode);
+
+    len = mavlink_msg_to_send_buffer(buf, &msg);
+    res = write(mavlink->fd, buf, len);
+
+    SOL_INT_CHECK(res, < len, -errno);
+    return 0;
+}
+
+SOL_API sol_mavlink_mode
+sol_mavlink_get_mode(struct sol_mavlink *mavlink)
+{
+    SOL_NULL_CHECK(mavlink, false);
+    return mavlink->mode;
+}
+
+SOL_API bool
+sol_mavlink_check_armed(struct sol_mavlink *mavlink)
+{
+    uint8_t mask, base_mode;
+
+    SOL_NULL_CHECK(mavlink, false);
+
+    if (mavlink->custom_mode_enabled)
+        mask = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
+
+    base_mode = mavlink->base_mode ^ mask;
+
+    switch (base_mode) {
+    case MAV_MODE_MANUAL_ARMED:
+    case MAV_MODE_TEST_ARMED:
+    case MAV_MODE_STABILIZE_ARMED:
+    case MAV_MODE_GUIDED_ARMED:
+    case MAV_MODE_AUTO_ARMED:
+        return true;
+    default:
+        return false;
+    }
+}
+
+SOL_API int
+sol_mavlink_get_curr_position(struct sol_mavlink *mavlink, struct sol_mavlink_position *pos)
+{
+    SOL_NULL_CHECK(mavlink, -EINVAL);
+    SOL_NULL_CHECK(pos, -EINVAL);
+
+    pos->latitude = mavlink->curr_position.latitude;
+    pos->longitude = mavlink->curr_position.longitude;
+    pos->altitude = mavlink->curr_position.altitude;
+
+    return 0;
+}
+
+SOL_API int
+sol_mavlink_get_home_position(struct sol_mavlink *mavlink, struct sol_mavlink_position *pos)
+{
+    SOL_NULL_CHECK(mavlink, -EINVAL);
+    SOL_NULL_CHECK(pos, -EINVAL);
+
+    pos->latitude = mavlink->home_position.latitude;
+    pos->longitude = mavlink->home_position.longitude;
+    pos->altitude = mavlink->home_position.altitude;
+    pos->x = mavlink->home_position.x;
+    pos->y = mavlink->home_position.y;
+    pos->z = mavlink->home_position.z;
+
+    return 0;
+}
+
+SOL_API int
+sol_mavlink_goto(struct sol_mavlink *mavlink, struct sol_mavlink_position *pos)
+{
+    mavlink_message_t msg;
+    uint8_t buf[MAVLINK_MAX_PACKET_LEN];
+    uint16_t len, res;
+
+    SOL_NULL_CHECK(mavlink, -EINVAL);
+    SOL_NULL_CHECK(pos, -EINVAL);
+
+    mavlink_msg_mission_item_pack
+        (mavlink->sysid, mavlink->compid, &msg, 0, 0, 1,
+        MAV_FRAME_GLOBAL_RELATIVE_ALT, MAV_CMD_NAV_WAYPOINT, 2, 0, 0, 0, 0, 0,
+        pos->latitude, pos->longitude, pos->altitude);
+
+    len = mavlink_msg_to_send_buffer(buf, &msg);
+    res = write(mavlink->fd, buf, len);
+
+    SOL_INT_CHECK(res, < len, -errno);
+    return 0;
+}
+
+SOL_API int
+sol_mavlink_change_speed(struct sol_mavlink *mavlink, float speed, bool airspeed)
+{
+    mavlink_message_t msg;
+    uint8_t buf[MAVLINK_MAX_PACKET_LEN];
+    uint16_t len, res;
+    float speed_type = 1.f;
+
+    SOL_NULL_CHECK(mavlink, -EINVAL);
+
+    if (airspeed)
+        speed_type = 0.f;
+
+    mavlink_msg_command_long_pack(mavlink->sysid, mavlink->compid,
+        &msg, 0, 0, MAV_CMD_DO_CHANGE_SPEED, 0,
+        speed_type, speed, 80.f, 0, 0, 0, 0);
+
+    len = mavlink_msg_to_send_buffer(buf, &msg);
+    res = write(mavlink->fd, buf, len);
+
+    SOL_INT_CHECK(res, < len, -errno);
+    return 0;
+}

--- a/src/samples/mavlink/Kconfig
+++ b/src/samples/mavlink/Kconfig
@@ -1,0 +1,14 @@
+config MAVLINK_SAMPLES
+	bool "Mavlink samples"
+	depends on MAVLINK
+	default y
+
+config MAVLINK_BASIC
+	bool "Basic mavlink sample"
+	depends on MAVLINK_SAMPLES
+	default y
+
+config MAVLINK_GOTO
+	bool "Goto location sample"
+	depends on MAVLINK_SAMPLES
+	default y

--- a/src/samples/mavlink/Makefile
+++ b/src/samples/mavlink/Makefile
@@ -1,0 +1,5 @@
+sample-$(MAVLINK_BASIC) += mavlink-basic
+sample-mavlink-basic-$(MAVLINK_BASIC) := basic.c
+
+sample-$(MAVLINK_GOTO) += mavlink-goto
+sample-mavlink-goto-$(MAVLINK_GOTO) := goto.c

--- a/src/samples/mavlink/basic.c
+++ b/src/samples/mavlink/basic.c
@@ -1,0 +1,204 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sol-log.h>
+#include <sol-mainloop.h>
+#include <sol-mavlink.h>
+#include <sol-util.h>
+#include <stdio.h>
+
+#define TAKEOFF_ALT 10
+
+static void
+takeoff(struct sol_mavlink *mavlink)
+{
+    int err;
+    struct sol_mavlink_position takeoff = { 0 };
+
+    takeoff.altitude = TAKEOFF_ALT;
+    err = sol_mavlink_takeoff(mavlink, &takeoff);
+
+    if (err < 0) {
+        SOL_ERR("Could not takeoff: %s", sol_util_strerrora(-err));
+        return;
+    }
+
+    printf(">>>> Taking off.\n");
+}
+
+static void
+mode_changed_cb(void *data, struct sol_mavlink *mavlink)
+{
+    int err;
+    sol_mavlink_mode mode = sol_mavlink_get_mode(mavlink);
+    bool armed = sol_mavlink_check_armed(mavlink);
+
+    if (mode == SOL_MAVLINK_MODE_GUIDED && !armed) {
+        err = sol_mavlink_set_armed(mavlink, true);
+        if (err < 0) {
+            SOL_ERR("Could not arm vechicle: %s", sol_util_strerrora(-err));
+        }
+    }
+}
+
+static void
+position_changed_cb(void *data, struct sol_mavlink *mavlink)
+{
+    int err;
+    struct sol_mavlink_position pos;
+
+    err = sol_mavlink_get_curr_position(mavlink, &pos);
+    if (err < 0) {
+        SOL_ERR("Could not get current position: %s", sol_util_strerrora(-err));
+        return;
+    }
+
+    if (sol_mavlink_check_armed(mavlink))
+        printf("lat: %f, long: %f, alt: %f\n", pos.latitude, pos.longitude,
+            pos.altitude);
+}
+
+static void
+armed_cb(void *data, struct sol_mavlink *mavlink)
+{
+    sol_mavlink_mode mode;
+
+    SOL_DBG("vehicle just armed");
+
+    mode = sol_mavlink_get_mode(mavlink);
+    if (mode == SOL_MAVLINK_MODE_GUIDED) {
+        takeoff(mavlink);
+    }
+}
+
+static void
+disarmed_cb(void *data, struct sol_mavlink *mavlink)
+{
+    sol_mavlink_mode mode;
+
+    mode = sol_mavlink_get_mode(mavlink);
+    if (mode == SOL_MAVLINK_MODE_LAND)
+        printf(">>>> Landed...\n");
+}
+
+static void
+mission_reached_cb(void *data, struct sol_mavlink *mavlink)
+{
+    int err;
+    sol_mavlink_mode mode;
+    struct sol_mavlink_position home;
+
+    mode = sol_mavlink_get_mode(mavlink);
+    err = sol_mavlink_get_home_position(mavlink, &home);
+    if (err < 0) {
+        SOL_ERR("Could not get home position: %s", sol_util_strerrora(-err));
+        return;
+    }
+
+    if (mode != SOL_MAVLINK_MODE_GUIDED)
+        return;
+
+    err = sol_mavlink_land(mavlink, &home);
+    if (err < 0) {
+        SOL_ERR("Could not land vehicle: %s", sol_util_strerrora(-err));
+        return;
+    }
+
+    printf(">>>> Successful takeoff, now landing.\n");
+}
+
+static void
+mavlink_connect_cb(void *data, struct sol_mavlink *mavlink)
+{
+    int err;
+    sol_mavlink_mode mode;
+
+    SOL_INF("mavlink connection stablished");
+
+    mode = sol_mavlink_get_mode(mavlink);
+    if (mode != SOL_MAVLINK_MODE_GUIDED) {
+        err = sol_mavlink_set_mode(mavlink, SOL_MAVLINK_MODE_GUIDED);
+        if (err < 0) {
+            SOL_ERR("Could not set mode: %s", sol_util_strerrora(-err));
+        }
+        return;
+    }
+
+    if (!sol_mavlink_check_armed(mavlink)) {
+        err = sol_mavlink_set_armed(mavlink, true);
+        if (err < 0) {
+            SOL_ERR("Could not arm vechicle: %s", sol_util_strerrora(-err));
+        }
+        return;
+    }
+
+    takeoff(mavlink);
+}
+
+int
+main(int argc, char *argv[])
+{
+    struct sol_mavlink *mavlink;
+    struct sol_mavlink_handlers mavlink_handlers = {
+        .connect = mavlink_connect_cb,
+        .position_changed = position_changed_cb,
+        .mode_changed = mode_changed_cb,
+        .armed = armed_cb,
+        .disarmed = disarmed_cb,
+        .mission_reached = mission_reached_cb,
+    };
+    struct sol_mavlink_config config = {
+        .handlers = &mavlink_handlers,
+    };
+
+    sol_init();
+
+    if (argc < 2) {
+        SOL_ERR("Usage: %s <address>", argv[0]);
+        goto err;
+    }
+
+    mavlink = sol_mavlink_connect(argv[1], &config, NULL);
+    if (!mavlink) {
+        SOL_ERR("Unable to stablish a Mavlink connection");
+        goto err;
+    }
+
+    sol_run();
+    sol_mavlink_disconnect(mavlink);
+    sol_shutdown();
+    return EXIT_SUCCESS;
+
+err:
+    sol_shutdown();
+    return EXIT_FAILURE;
+}

--- a/src/samples/mavlink/goto.c
+++ b/src/samples/mavlink/goto.c
@@ -1,0 +1,230 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sol-log.h>
+#include <sol-mainloop.h>
+#include <sol-mavlink.h>
+#include <sol-util.h>
+#include <stdio.h>
+
+#define TAKEOFF_ALT 10
+#define DEST_LAT -35.361354
+#define DEST_LONG 149.166218
+#define DEST_ALT 20
+
+// are we greater than altitude margin?
+#define GT_MARGIN(_lval, _rval)                 \
+    (_lval > (_rval * 0.95))                    \
+
+static void
+takeoff(struct sol_mavlink *mavlink)
+{
+    int err;
+    struct sol_mavlink_position takeoff = { 0 };
+
+    takeoff.altitude = TAKEOFF_ALT;
+    err = sol_mavlink_takeoff(mavlink, &takeoff);
+
+    if (err < 0) {
+        SOL_ERR("Could not takeoff: %s", sol_util_strerrora(-err));
+        return;
+    }
+
+    printf(">>>> Taking off.\n");
+}
+
+static void
+position_changed_cb(void *data, struct sol_mavlink *mavlink)
+{
+    int err;
+    struct sol_mavlink_position pos;
+
+    err = sol_mavlink_get_curr_position(mavlink, &pos);
+    if (err < 0) {
+        SOL_ERR("Could not get current position: %s", sol_util_strerrora(-err));
+        return;
+    }
+
+    if (sol_mavlink_check_armed(mavlink))
+        printf("lat: %f, long: %f, alt: %f\n", pos.latitude, pos.longitude,
+            pos.altitude);
+}
+
+static void
+mission_reached_cb(void *data, struct sol_mavlink *mavlink)
+{
+    int err;
+    sol_mavlink_mode mode;
+    struct sol_mavlink_position home, curr;
+    struct sol_mavlink_position dest = { DEST_LAT, DEST_LONG, DEST_ALT };
+
+    mode = sol_mavlink_get_mode(mavlink);
+    err = sol_mavlink_get_curr_position(mavlink, &curr);
+    if (err < 0) {
+        SOL_ERR("Could not get current position: %s", sol_util_strerrora(-err));
+        return;
+    }
+
+    if (mode != SOL_MAVLINK_MODE_GUIDED)
+        return;
+
+    if (GT_MARGIN(curr.altitude, DEST_ALT)) {
+        printf(">>>> Going back home.\n");
+        err = sol_mavlink_get_home_position(mavlink, &home);
+
+        if (err < 0) {
+            SOL_ERR("Could not get home position: %s", sol_util_strerrora(-err));
+            return;
+        }
+
+        err = sol_mavlink_land(mavlink, &home);
+        if (err < 0) {
+            SOL_ERR("Could not land vehicle: %s", sol_util_strerrora(-err));
+        }
+    } else if (GT_MARGIN(curr.altitude, TAKEOFF_ALT)) {
+        err = sol_mavlink_goto(mavlink, &dest);
+        if (err < 0) {
+            SOL_ERR("Could not send vehicle to: (%f, %f, %f) - %s",
+                dest.latitude, dest.longitude, dest.altitude,
+                sol_util_strerrora(-err));
+            return;
+        }
+
+        printf(">>>> Successful takeoff, starting a new mission, heading to: "
+            "(%f, %f, %f)\n", dest.latitude, dest.longitude, dest.altitude);
+    }
+}
+
+static void
+mode_changed_cb(void *data, struct sol_mavlink *mavlink)
+{
+    int err;
+    sol_mavlink_mode mode = sol_mavlink_get_mode(mavlink);
+    bool armed = sol_mavlink_check_armed(mavlink);
+
+    if (mode == SOL_MAVLINK_MODE_GUIDED && !armed) {
+        err = sol_mavlink_set_armed(mavlink, true);
+        if (err < 0) {
+            SOL_ERR("Could not arm vechicle: %s", sol_util_strerrora(-err));
+        }
+    }
+}
+
+static void
+disarmed_cb(void *data, struct sol_mavlink *mavlink)
+{
+    sol_mavlink_mode mode;
+
+    mode = sol_mavlink_get_mode(mavlink);
+    if (mode == SOL_MAVLINK_MODE_LAND)
+        printf(">>>> Landed...\n");
+}
+
+static void
+armed_cb(void *data, struct sol_mavlink *mavlink)
+{
+    sol_mavlink_mode mode;
+
+    SOL_DBG("vehicle just armed");
+
+    mode = sol_mavlink_get_mode(mavlink);
+    if (mode == SOL_MAVLINK_MODE_GUIDED) {
+        takeoff(mavlink);
+    }
+}
+
+static void
+mavlink_connect_cb(void *data, struct sol_mavlink *mavlink)
+{
+    int err;
+    sol_mavlink_mode mode;
+
+    SOL_INF("mavlink connection stablished");
+
+    mode = sol_mavlink_get_mode(mavlink);
+    if (mode != SOL_MAVLINK_MODE_GUIDED) {
+        err = sol_mavlink_set_mode(mavlink, SOL_MAVLINK_MODE_GUIDED);
+        if (err < 0) {
+            SOL_ERR("Could not set mode: %s", sol_util_strerrora(-err));
+        }
+        return;
+    }
+
+    if (!sol_mavlink_check_armed(mavlink)) {
+        err = sol_mavlink_set_armed(mavlink, true);
+        if (err < 0) {
+            SOL_ERR("Could not arm vechicle: %s", sol_util_strerrora(-err));
+        }
+        return;
+    }
+
+    takeoff(mavlink);
+}
+
+int
+main(int argc, char *argv[])
+{
+    struct sol_mavlink *mavlink;
+    struct sol_mavlink_handlers mavlink_handlers = {
+        .connect = mavlink_connect_cb,
+        .mode_changed = mode_changed_cb,
+        .armed = armed_cb,
+        .disarmed = disarmed_cb,
+        .position_changed = position_changed_cb,
+        .mission_reached = mission_reached_cb,
+    };
+    struct sol_mavlink_config config = {
+        .handlers = &mavlink_handlers,
+    };
+
+    sol_init();
+
+    if (argc < 2) {
+        SOL_ERR("Usage: %s <address>", argv[0]);
+        goto err;
+    }
+
+    mavlink = sol_mavlink_connect(argv[1], &config, NULL);
+    if (!mavlink) {
+        SOL_ERR("Unable to stablish a Mavlink connection");
+        goto err;
+    }
+
+    sol_run();
+    sol_mavlink_disconnect(mavlink);
+    sol_shutdown();
+    return EXIT_SUCCESS;
+
+err:
+    sol_shutdown();
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
### Changes
+ since #1171:
  - fixed issues pointed on #1171;
  - added new api's;
  - fixed issue with doxygen;

### Dependencies
+ the ```mission_reached``` callbacks on samples requires a patch on APM.

### Rationale
This patch introduce the basic infrastructure and API's to control MAV
(Micro Air Vehicle) communication. More API's are to come.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>