### PR TITLE
build: fix circular dependency [v2]

### DIFF
--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -78,7 +78,7 @@ parse-common-module = \
 		$(eval $(dest-obj)-src := $(subst .o,.c,$(obj))) \
 		$(eval $(4)-srcs       := $($(dest-obj)-src)) \
 	        $(eval $(4)-objs       += $(dest-obj)) \
-		$(eval $(dest-obj)-module := $(4)) \
+		$(eval $(dest-obj)-module := $(if $($(dest-obj)-module),$($(dest-obj)-module),$(4))) \
 		$(eval all-objs        += $(dest-obj)) \
 	)\
 	$(eval $(4)-deps    := $(subst .mod,,$(obj-$(1)-$(3)-deps)))


### PR DESCRIPTION
### Changes
 - since v1 (#1217):
   - change the approach and properly set module's name instead of fixing the ```find-obj-dep``` result;

### Rationale
Some circular dependency may happen between .o and .o.dep files due
inter-dependent modules.

A real current example results in string-format.o <- string-format.o.dep
circular dependency. The flow/form explicitly appends string-format.o to
its obj list, this object is part of converter module, depending on the
order of evaluation the string-format.o-module will be set to flow/form,
with that on the objects processing we'll lookup the module (now
flow/form) and find its dependencies - previously set with - say -
string-format.o since it was identified as an object provided by one
another module.

This patch makes sure we set modules name to an object only if it wasn't
previously set.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>