### PR TITLE
oic: Make api similar with the rest of project

### DIFF
--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -1355,7 +1355,7 @@ server_resource_init(struct server_resource *resource, struct sol_flow_node *nod
     if (resource->resource)
         return 0;
 
-    sol_oic_server_release();
+    sol_oic_server_shutdown();
     return -EINVAL;
 }
 
@@ -1365,7 +1365,7 @@ server_resource_close(struct server_resource *resource)
     if (resource->update_schedule_timeout)
         sol_timeout_del(resource->update_schedule_timeout);
     sol_oic_server_del_resource(resource->resource);
-    sol_oic_server_release();
+    sol_oic_server_shutdown();
 }
 
 static unsigned int

--- a/src/lib/comms/include/sol-oic-server.h
+++ b/src/lib/comms/include/sol-oic-server.h
@@ -240,7 +240,7 @@ struct sol_oic_resource_type {
  *
  * The first call of sol_oic_server_init will initialize the oic-server and any
  * other following calls will increment the oic-server reference counter.
- * After using the oic-server, @ref sol_oic_server_release() must be called to
+ * After using the oic-server, @ref sol_oic_server_shutdown() must be called to
  * decrement the reference counter and to release the resource when possible.
  *
  * This function must be called before calling any other sol-oic-server
@@ -258,7 +258,7 @@ int sol_oic_server_init(void);
  *
  * @see sol_oic_server_init()
  */
-void sol_oic_server_release(void);
+void sol_oic_server_shutdown(void);
 
 /**
  * @brief Add resource to oic-server.

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -437,7 +437,7 @@ error:
 }
 
 SOL_API void
-sol_oic_server_release(void)
+sol_oic_server_shutdown(void)
 {
     struct sol_oic_server_resource *res;
     uint16_t idx;

--- a/src/samples/coap/oic-server.c
+++ b/src/samples/coap/oic-server.c
@@ -194,7 +194,7 @@ main(int argc, char *argv[])
     sol_run();
 
     sol_oic_server_del_resource(res);
-    sol_oic_server_release();
+    sol_oic_server_shutdown();
 
     if (console_fd >= 0 && ioctl(console_fd, KDSETLED, old_led_state)) {
         SOL_ERR("Could not return the leds to the old state");


### PR DESCRIPTION
OIC server was using init/release, but over the project it's more usual
to use init/shutdown.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>