### PR TITLE
AIO: if pinmux is not built, don't access the header.

### DIFF
--- a/src/lib/io/sol-aio-common.c
+++ b/src/lib/io/sol-aio-common.c
@@ -37,7 +37,9 @@
 SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "aio");
 
 #include "sol-aio.h"
+#ifdef USE_PIN_MUX
 #include "sol-pin-mux.h"
+#endif
 
 static void
 _log_init(void)


### PR DESCRIPTION
Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>