### PR TITLE
oic: Make oic packets payload compatible with iotivity 1.0.1

### DIFF
--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -1058,16 +1058,9 @@ client_resource_implements_type(struct sol_oic_resource *oic_res, const char *re
 
 static void
 state_changed(struct sol_oic_client *oic_cli, const struct sol_network_link_addr *cliaddr,
-    const struct sol_str_slice *href, const struct sol_oic_map_reader *repr_vec, void *data)
+    const struct sol_oic_map_reader *repr_vec, void *data)
 {
     struct client_resource *resource = data;
-
-    if (!sol_str_slice_eq(*href, resource->resource->href)) {
-        SOL_WRN("Received response to href=`%%.*s`, but resource href is `%%.*s`",
-            SOL_STR_SLICE_PRINT(*href),
-            SOL_STR_SLICE_PRINT(resource->resource->href));
-        return;
-    }
 
     if (!sol_network_link_addr_eq(cliaddr, &resource->resource->addr)) {
         char resaddr[SOL_INET_ADDR_STRLEN] = {0};

--- a/src/lib/comms/include/sol-oic-client.h
+++ b/src/lib/comms/include/sol-oic-client.h
@@ -108,9 +108,17 @@ struct sol_oic_resource {
      */
     struct sol_vector types;
     /**
+     * @brief Buffer with types vector data.
+     */
+    char *types_data;
+    /**
      * @brief List of interfaces implemented by this resource.
      */
     struct sol_vector interfaces;
+    /**
+     * @brief Buffer with interfaces vector data.
+     */
+    char *interfaces_data;
     /**
      * @brief Keep internal information to handle observating clients.
      *
@@ -239,10 +247,9 @@ bool sol_oic_client_get_server_info(struct sol_oic_client *client,
  * @param fill_repr_map_data User's data to be passed to @a fill_repr_map.
  * @param callback Callback to be called when a response from this request
  *        arrives. Parameter @a cli is the @a client used to perform the
- *        request, @a addr is the address of the server, @a href is the path of
- *        the resource and repr_vec is a handler to access data from response,
- *        using @ref SOL_OIC_MAP_LOOP() macro. @a data is the user's
- *        @a callback_data.
+ *        request, @a addr is the address of the server and repr_vec is a
+ *        handler to access data from response, using @ref SOL_OIC_MAP_LOOP()
+ *        macro. @a data is the user's @a callback_data.
  * @param callback_data User's data to be passed to @a callback.
  *
  * @return True if packet was successfully sent. False otherwise.
@@ -252,7 +259,7 @@ bool sol_oic_client_resource_request(struct sol_oic_client *client, struct sol_o
     bool (*fill_repr_map)(void *data, struct sol_oic_map_writer *repr_map),
     void *fill_repr_map_data,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_oic_map_reader *repr_vec, void *data),
+    const struct sol_oic_map_reader *repr_vec, void *data),
     void *callback_data);
 
 /**
@@ -277,10 +284,9 @@ bool sol_oic_client_resource_request(struct sol_oic_client *client, struct sol_o
  * @param fill_repr_map_data User's data to be passed to @a fill_repr_map.
  * @param callback Callback to be called when a response from this request
  *        arrives. Parameter @a cli is the @a client used to perform the
- *        request, @a addr is the address of the server, @a href is the path of
- *        the resource and repr_vec is a handler to access data from response,
- *        using @ref SOL_OIC_MAP_LOOP() macro. @a data is the user's
- *        @a callback_data.
+ *        request, @a addr is the address of the server and repr_vec is a
+ *        handler to access data from response, using @ref SOL_OIC_MAP_LOOP()
+ *        macro. @a data is the user's @a callback_data.
  * @param callback_data User's data to be passed to @a callback.
  *
  * @return True if packet was successfully sent. False otherwise.
@@ -290,7 +296,7 @@ bool sol_oic_client_resource_non_confirmable_request(struct sol_oic_client *clie
     bool (*fill_repr_map)(void *data, struct sol_oic_map_writer *repr_map),
     void *fill_repr_map_data,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_oic_map_reader *repr_vec, void *data),
+    const struct sol_oic_map_reader *repr_vec, void *data),
     void *callback_data);
 
 /**
@@ -319,10 +325,9 @@ bool sol_oic_client_resource_non_confirmable_request(struct sol_oic_client *clie
  * @param res The resource that is going to be observed
  * @param callback A callback to be called when notification responses arrive.
  *        Parameter @a cli is the @a client used to perform the request, @a addr
- *        is the address of the server, @a href is the path of the resource
- *        being observed, @a repr_map is the data from the notification and @a
- *        data is a pointer to user's data. To extract data from @a repr_map use
- *        @ref SOL_OIC_MAP_LOOP() macro.
+ *        is the address of the server, @a repr_map is the data from the
+ *        notification and @a data is a pointer to user's data. To extract data
+ *        from @a repr_map use @ref SOL_OIC_MAP_LOOP() macro.
  * @param data A pointer to user's data.
  * @param observe If server will be obeserved or unobserved.
  *
@@ -330,7 +335,7 @@ bool sol_oic_client_resource_non_confirmable_request(struct sol_oic_client *clie
  */
 bool sol_oic_client_resource_set_observable(struct sol_oic_client *client, struct sol_oic_resource *res,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_oic_map_reader *repr_map, void *data),
+    const struct sol_oic_map_reader *repr_map, void *data),
     void *data, bool observe);
 
 /**
@@ -364,10 +369,9 @@ bool sol_oic_client_resource_set_observable(struct sol_oic_client *client, struc
  * @param res The resource that is going to be observed
  * @param callback A callback to be called when notification responses arrive.
  *        Parameter @a cli is the @a client used to perform the request, @a addr
- *        is the address of the server, @a href is the path of the resource
- *        being observed, @a repr_map is the data from the notification and @a
- *        data is a pointer to user's data. To extract data from @a repr_map use
- *        @ref SOL_OIC_MAP_LOOP() macro.
+ *        is the address of the server, @a repr_map is the data from the
+ *        notification and @a data is a pointer to user's data. To extract data
+ *        from @a repr_map use @ref SOL_OIC_MAP_LOOP() macro.
  * @param data A pointer to user's data.
  * @param observe If server will be obeserved or unobserved.
  *
@@ -375,7 +379,7 @@ bool sol_oic_client_resource_set_observable(struct sol_oic_client *client, struc
  */
 bool sol_oic_client_resource_set_observable_non_confirmable(struct sol_oic_client *client, struct sol_oic_resource *res,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_oic_map_reader *repr_map, void *data),
+    const struct sol_oic_map_reader *repr_map, void *data),
     void *data, bool observe);
 
 /**

--- a/src/lib/comms/sol-oic-cbor.c
+++ b/src/lib/comms/sol-oic-cbor.c
@@ -238,3 +238,121 @@ sol_oic_pkt_has_cbor_content(const struct sol_coap_packet *pkt)
 
     return ptr && len == 1 && *ptr == SOL_COAP_CONTENTTYPE_APPLICATION_CBOR;
 }
+
+bool
+sol_cbor_array_to_vector(CborValue *array, struct sol_vector *vector)
+{
+    CborError err;
+    CborValue iter;
+
+    for (err = cbor_value_enter_container(array, &iter);
+        cbor_value_is_text_string(&iter) && err == CborNoError;
+        err |= cbor_value_advance(&iter)) {
+        struct sol_str_slice *slice = sol_vector_append(vector);
+
+        if (!slice) {
+            err = CborErrorOutOfMemory;
+            break;
+        }
+
+        err |= cbor_value_dup_text_string(&iter, (char **)&slice->data, &slice->len, NULL);
+    }
+
+    return (err | cbor_value_leave_container(array, &iter)) == CborNoError;
+}
+
+bool
+sol_cbor_map_get_array(const CborValue *map, const char *key,
+    struct sol_vector *vector)
+{
+    CborValue value;
+
+    if (cbor_value_map_find_value(map, key, &value) != CborNoError)
+        return false;
+
+    if (!cbor_value_is_array(&value))
+        return false;
+
+    return sol_cbor_array_to_vector(&value, vector);
+}
+
+bool
+sol_cbor_map_get_str_value(const CborValue *map, const char *key,
+    struct sol_str_slice *slice)
+{
+    CborValue value;
+
+    if (cbor_value_map_find_value(map, key, &value) != CborNoError)
+        return false;
+
+    return cbor_value_dup_text_string(&value, (char **)&slice->data, &slice->len, NULL) == CborNoError;
+}
+
+bool
+sol_cbor_bsv_to_vector(const CborValue *value, char **data, struct sol_vector *vector)
+{
+    size_t len;
+    char *last, *p;
+
+    if (*data) {
+        free(*data);
+        *data = NULL;
+    }
+    sol_vector_clear(vector);
+    if (cbor_value_dup_text_string(value, data, &len, NULL) != CborNoError)
+        return false;
+
+    for (last = *data; last != NULL;) {
+        size_t cur_len;
+
+        p = strchr(last, ' ');
+        if (p == NULL)
+            cur_len = len;
+        else {
+            cur_len = p - last;
+            p++;
+            len--;
+        }
+
+        if (cur_len > 0) {
+            struct sol_str_slice *slice = sol_vector_append(vector);
+            if (!slice)
+                goto error;
+            *slice = SOL_STR_SLICE_STR(last, cur_len);
+        }
+        last = p;
+        len -= cur_len;
+    }
+
+    return true;
+
+error:
+    free(*data);
+    *data = NULL;
+    sol_vector_clear(vector);
+    return false;
+}
+
+bool
+sol_cbor_map_get_bsv(const CborValue *map, const char *key,
+    char **data, struct sol_vector *vector)
+{
+    CborValue value;
+
+    if (cbor_value_map_find_value(map, key, &value) != CborNoError)
+        return false;
+
+    return sol_cbor_bsv_to_vector(&value, data, vector);
+}
+
+bool
+sol_cbor_map_get_bytestr_value(const CborValue *map, const char *key,
+    struct sol_str_slice *slice)
+{
+    CborValue value;
+
+    if (cbor_value_map_find_value(map, key, &value) != CborNoError)
+        return false;
+
+    return cbor_value_dup_byte_string(&value, (uint8_t **)&slice->data, &slice->len, NULL) == CborNoError;
+}

--- a/src/lib/comms/sol-oic-cbor.h
+++ b/src/lib/comms/sol-oic-cbor.h
@@ -53,7 +53,7 @@ bool sol_cbor_array_to_vector(CborValue *array, struct sol_vector *vector);
 bool sol_cbor_bsv_to_vector(const CborValue *value, char **data, struct sol_vector *vector);
 
 struct sol_oic_map_writer {
-    CborEncoder encoder, rep_map, array, map;
+    CborEncoder encoder, rep_map;
     uint8_t *payload;
     bool has_data;
 };
@@ -77,10 +77,10 @@ enum sol_oic_payload_type {
 #define SOL_OIC_KEY_FIRMWARE_VER "mnfv"
 #define SOL_OIC_KEY_SUPPORT_URL "mnsl"
 #define SOL_OIC_KEY_SYSTEM_TIME "st"
-#define SOL_OIC_KEY_DEVICE_ID "sid"
+#define SOL_OIC_KEY_DEVICE_ID "di"
+#define SOL_OIC_KEY_RESOURCE_LINKS "links"
 #define SOL_OIC_KEY_PROPERTIES "prop"
 #define SOL_OIC_KEY_RESOURCE_TYPES "rt"
 #define SOL_OIC_KEY_INTERFACES "if"
 #define SOL_OIC_KEY_POLICY "p"
 #define SOL_OIC_KEY_BITMAP "bm"
-

--- a/src/lib/comms/sol-oic-cbor.h
+++ b/src/lib/comms/sol-oic-cbor.h
@@ -43,6 +43,14 @@ CborError sol_oic_packet_cbor_close(struct sol_coap_packet *pkt, struct sol_oic_
 CborError sol_oic_packet_cbor_create(struct sol_coap_packet *pkt, const char *href, struct sol_oic_map_writer *encoder);
 CborError sol_oic_packet_cbor_append(struct sol_oic_map_writer *encoder, struct sol_oic_repr_field *repr);
 bool sol_oic_pkt_has_cbor_content(const struct sol_coap_packet *pkt);
+bool sol_cbor_map_get_bytestr_value(const CborValue *map, const char *key, struct sol_str_slice *slice);
+/* BSV is a blank separated string, as defined in oic documentation. It is a
+ * string with list of values, separated by a blank space. */
+bool sol_cbor_map_get_bsv(const CborValue *map, const char *key, char **data, struct sol_vector *vector);
+bool sol_cbor_map_get_str_value(const CborValue *map, const char *key, struct sol_str_slice *slice);
+bool sol_cbor_map_get_array(const CborValue *map, const char *key, struct sol_vector *vector);
+bool sol_cbor_array_to_vector(CborValue *array, struct sol_vector *vector);
+bool sol_cbor_bsv_to_vector(const CborValue *value, char **data, struct sol_vector *vector);
 
 struct sol_oic_map_writer {
     CborEncoder encoder, rep_map, array, map;

--- a/src/lib/comms/sol-oic-client.c
+++ b/src/lib/comms/sol-oic-client.c
@@ -102,7 +102,7 @@ struct resource_request_ctx {
     struct sol_oic_client *client;
     struct sol_oic_resource *res;
     void (*cb)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-        const struct sol_str_slice *href, const struct sol_oic_map_reader *repr_vec, void *data);
+        const struct sol_oic_map_reader *repr_vec, void *data);
     void *data;
     int64_t token;
 };
@@ -194,19 +194,14 @@ sol_oic_resource_unref(struct sol_oic_resource *r)
 
     r->refcnt--;
     if (!r->refcnt) {
-        struct sol_str_slice *slice;
-        uint16_t idx;
-
         free((char *)r->href.data);
         free((char *)r->device_id.data);
 
-        SOL_VECTOR_FOREACH_IDX (&r->types, slice, idx)
-            free((char *)slice->data);
         sol_vector_clear(&r->types);
+        free(r->types_data);
 
-        SOL_VECTOR_FOREACH_IDX (&r->interfaces, slice, idx)
-            free((char *)slice->data);
         sol_vector_clear(&r->interfaces);
+        free(r->interfaces_data);
 
         free(r);
     }
@@ -248,27 +243,27 @@ _parse_server_info_payload(struct sol_oic_server_information *info,
     if (err != CborNoError)
         return false;
 
-    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_PLATFORM_ID, &info->platform_id))
+    if (!sol_cbor_map_get_str_value(&value, SOL_OIC_KEY_PLATFORM_ID, &info->platform_id))
         return false;
-    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_MANUF_NAME, &info->manufacturer_name))
+    if (!sol_cbor_map_get_str_value(&value, SOL_OIC_KEY_MANUF_NAME, &info->manufacturer_name))
         return false;
-    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_MANUF_URL, &info->manufacturer_url))
+    if (!sol_cbor_map_get_str_value(&value, SOL_OIC_KEY_MANUF_URL, &info->manufacturer_url))
         return false;
-    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_MODEL_NUM, &info->model_number))
+    if (!sol_cbor_map_get_str_value(&value, SOL_OIC_KEY_MODEL_NUM, &info->model_number))
         return false;
-    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_MANUF_DATE, &info->manufacture_date))
+    if (!sol_cbor_map_get_str_value(&value, SOL_OIC_KEY_MANUF_DATE, &info->manufacture_date))
         return false;
-    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_PLATFORM_VER, &info->platform_version))
+    if (!sol_cbor_map_get_str_value(&value, SOL_OIC_KEY_PLATFORM_VER, &info->platform_version))
         return false;
-    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_OS_VER, &info->os_version))
+    if (!sol_cbor_map_get_str_value(&value, SOL_OIC_KEY_OS_VER, &info->os_version))
         return false;
-    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_HW_VER, &info->hardware_version))
+    if (!sol_cbor_map_get_str_value(&value, SOL_OIC_KEY_HW_VER, &info->hardware_version))
         return false;
-    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_FIRMWARE_VER, &info->firmware_version))
+    if (!sol_cbor_map_get_str_value(&value, SOL_OIC_KEY_FIRMWARE_VER, &info->firmware_version))
         return false;
-    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_SUPPORT_URL, &info->support_url))
+    if (!sol_cbor_map_get_str_value(&value, SOL_OIC_KEY_SUPPORT_URL, &info->support_url))
         return false;
-    if (!_cbor_map_get_str_value(&value, SOL_OIC_KEY_SYSTEM_TIME, &info->system_time))
+    if (!sol_cbor_map_get_str_value(&value, SOL_OIC_KEY_SYSTEM_TIME, &info->system_time))
         return false;
 
     return err == CborNoError;
@@ -406,7 +401,9 @@ _new_resource(void)
     res->href = SOL_STR_SLICE_STR(NULL, 0);
     res->device_id = SOL_STR_SLICE_STR(NULL, 0);
     sol_vector_init(&res->types, sizeof(struct sol_str_slice));
+    res->types_data = NULL;
     sol_vector_init(&res->interfaces, sizeof(struct sol_str_slice));
+    res->interfaces_data = NULL;
 
     res->observe.timeout = NULL;
     res->observe.clear_data = 0;
@@ -431,10 +428,14 @@ _iterate_over_resource_reply_payload(struct sol_coap_packet *req,
 {
     CborParser parser;
     CborError err;
-    CborValue root, array, value, map;
-    int payload_type;
+    CborValue root, devices_array, resources_array, value, map;
     uint8_t *payload;
     uint16_t payload_len;
+    struct sol_str_slice device_id;
+    struct sol_oic_resource *res = NULL;
+    CborValue bitmap_value;
+    uint64_t bitmap;
+
 
     *cb_return  = true;
 
@@ -444,70 +445,83 @@ _iterate_over_resource_reply_payload(struct sol_coap_packet *req,
     }
 
     err = cbor_parser_init(payload, payload_len, 0, &parser, &root);
-    if (err != CborNoError)
-        return false;
+    SOL_INT_CHECK(err, != CborNoError, false);
     if (!cbor_value_is_array(&root))
         return false;
 
-    err |= cbor_value_enter_container(&root, &array);
+    err = cbor_value_enter_container(&root, &devices_array);
+    SOL_INT_CHECK(err, != CborNoError, false);
 
-    err |= cbor_value_get_int(&array, &payload_type);
-    err |= cbor_value_advance_fixed(&array);
-    if (err != CborNoError)
-        return false;
-    if (payload_type != SOL_OIC_PAYLOAD_DISCOVERY)
-        return false;
-
-    for (; cbor_value_is_map(&array) && err == CborNoError;
-        err |= cbor_value_advance(&array)) {
-        struct sol_oic_resource *res = _new_resource();
-
-        SOL_NULL_CHECK(res, false);
-
-        if (!_cbor_map_get_str_value(&array, SOL_OIC_KEY_HREF, &res->href))
-            return false;
-        if (!_cbor_map_get_bytestr_value(&array, SOL_OIC_KEY_DEVICE_ID, &res->device_id))
+    for (; cbor_value_is_map(&devices_array) && err == CborNoError;
+        err = cbor_value_advance(&devices_array)) {
+        SOL_INT_CHECK(err, != CborNoError, false);
+        if (!sol_cbor_map_get_bytestr_value(&devices_array, SOL_OIC_KEY_DEVICE_ID,
+            &device_id))
             return false;
 
-        err |= cbor_value_map_find_value(&array, SOL_OIC_KEY_PROPERTIES, &value);
-        if (!cbor_value_is_map(&value))
-            return false;
+        err  = cbor_value_map_find_value(&devices_array,
+            SOL_OIC_KEY_RESOURCE_LINKS, &value);
+        if (err != CborNoError || !cbor_value_is_array(&value))
+            goto error;
 
-        if (!_cbor_map_get_array(&value, SOL_OIC_KEY_RESOURCE_TYPES, &res->types))
-            return false;
-        if (!_cbor_map_get_array(&value, SOL_OIC_KEY_INTERFACES, &res->interfaces))
-            return false;
+        err = cbor_value_enter_container(&value, &resources_array);
+        SOL_INT_CHECK_GOTO(err, != CborNoError, error);
+        for (; cbor_value_is_map(&resources_array) && err == CborNoError;
+            err = cbor_value_advance(&resources_array)) {
+            res = _new_resource();
+            SOL_NULL_CHECK_GOTO(res, error);
 
-        err |= cbor_value_map_find_value(&value, SOL_OIC_KEY_POLICY, &map);
-        if (!cbor_value_is_map(&map)) {
-            err = CborErrorUnknownType;
-        } else {
-            CborValue bitmap_value;
-            uint64_t bitmap = 0;
+            if (!sol_cbor_map_get_str_value(&resources_array, SOL_OIC_KEY_HREF,
+                &res->href))
+                goto error;
 
-            err |= cbor_value_map_find_value(&map, SOL_OIC_KEY_BITMAP, &bitmap_value);
-            err |= cbor_value_get_uint64(&bitmap_value, &bitmap);
+            if (!sol_cbor_map_get_bsv(&resources_array,
+                SOL_OIC_KEY_RESOURCE_TYPES, &res->types_data, &res->types))
+                goto error;
+            if (!sol_cbor_map_get_bsv(&resources_array,
+                SOL_OIC_KEY_INTERFACES, &res->interfaces_data,
+                &res->interfaces))
+                goto error;
+
+            err = cbor_value_map_find_value(&resources_array,
+                SOL_OIC_KEY_POLICY, &map);
+            if (err != CborNoError || !cbor_value_is_map(&map))
+                goto error;
+            err = cbor_value_map_find_value(&map, SOL_OIC_KEY_BITMAP,
+                &bitmap_value);
+            SOL_INT_CHECK(err, != CborNoError, false);
+            err = cbor_value_get_uint64(&bitmap_value, &bitmap);
+            SOL_INT_CHECK(err, != CborNoError, false);
 
             res->observable = (bitmap & SOL_OIC_FLAG_OBSERVABLE);
             res->active = (bitmap & SOL_OIC_FLAG_ACTIVE);
             res->slow = (bitmap & SOL_OIC_FLAG_SLOW);
             res->secure = (bitmap & SOL_OIC_FLAG_SECURE);
-        }
-
-        if (err == CborNoError) {
             res->observable = res->observable || _has_observable_option(req);
             res->addr = *cliaddr;
+            res->device_id.data = sol_util_memdup(device_id.data,
+                device_id.len);
+            if (!res->device_id.data)
+                goto error;
+            res->device_id.len = device_id.len;
             if (!ctx->cb(ctx->client, res, ctx->data)) {
                 sol_oic_resource_unref(res);
+                free((char *)device_id.data);
                 *cb_return  = false;
                 return true;
             }
-        }
 
-        sol_oic_resource_unref(res);
+            sol_oic_resource_unref(res);
+        }
+        free((char *)device_id.data);
     }
 
-    return (err | cbor_value_leave_container(&root, &array)) == CborNoError;
+    return true;
+
+error:
+    sol_oic_resource_unref(res);
+    free((char *)device_id.data);
+    return false;
 }
 
 static bool
@@ -670,11 +684,10 @@ _resource_request_cb(struct sol_coap_server *server,
 {
     struct resource_request_ctx *ctx = data;
     CborParser parser;
-    CborValue root, array;
+    CborValue root;
     CborError err;
     uint8_t *payload;
     uint16_t payload_len;
-    int payload_type;
 
     if (!ctx->cb)
         return false;
@@ -692,47 +705,14 @@ _resource_request_cb(struct sol_coap_server *server,
         return true;
 
     err = cbor_parser_init(payload, payload_len, 0, &parser, &root);
-    if (err != CborNoError)
+    if (err != CborNoError || !cbor_value_is_map(&root)) {
+        SOL_ERR("Error while parsing CBOR repr packet: %s",
+            cbor_error_string(err));
         return true;
-
-    if (!cbor_value_is_array(&root))
-        return true;
-
-    err |= cbor_value_enter_container(&root, &array);
-
-    err |= cbor_value_get_int(&array, &payload_type);
-    err |= cbor_value_advance_fixed(&array);
-    if (err != CborNoError)
-        return true;
-    if (payload_type != SOL_OIC_PAYLOAD_REPRESENTATION)
-        return true;
-
-    while (cbor_value_is_map(&array) && err == CborNoError) {
-        CborValue value;
-        char *href;
-        size_t len;
-
-        err |= cbor_value_map_find_value(&array, SOL_OIC_KEY_HREF, &value);
-        err |= cbor_value_dup_text_string(&value, &href, &len, NULL);
-
-        err |= cbor_value_map_find_value(&array, SOL_OIC_KEY_REPRESENTATION, &value);
-
-        if (cbor_value_is_map(&value)) {
-            struct sol_str_slice href_slice = sol_str_slice_from_str(href);
-            ctx->cb(ctx->client, cliaddr, &href_slice, (struct sol_oic_map_reader *)&value, ctx->data);
-        }
-
-        free(href);
-
-        err |= cbor_value_advance(&array);
     }
 
-    err |= cbor_value_leave_container(&root, &array);
+    ctx->cb(ctx->client, cliaddr, (struct sol_oic_map_reader *)&root, ctx->data);
 
-    if (err == CborNoError)
-        return true;
-
-    SOL_ERR("Error while parsing CBOR repr packet: %s", cbor_error_string(err));
     return true;
 }
 
@@ -769,7 +749,7 @@ _resource_request(struct sol_oic_client *client, struct sol_oic_resource *res,
     bool (*fill_repr_map)(void *data, struct sol_oic_map_writer *repr_map),
     void *fill_repr_map_data,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_oic_map_reader *repr_vec, void *data),
+    const struct sol_oic_map_reader *repr_vec, void *data),
     void *data, bool observe)
 {
     const uint8_t format_cbor = SOL_COAP_CONTENTTYPE_APPLICATION_CBOR;
@@ -853,7 +833,7 @@ sol_oic_client_resource_request(struct sol_oic_client *client, struct sol_oic_re
     bool (*fill_repr_map)(void *data, struct sol_oic_map_writer *repr_map),
     void *fill_repr_map_data,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_oic_map_reader *repr_vec, void *data),
+    const struct sol_oic_map_reader *repr_vec, void *data),
     void *callback_data)
 {
     SOL_NULL_CHECK(client, false);
@@ -872,7 +852,7 @@ sol_oic_client_resource_non_confirmable_request(struct sol_oic_client *client, s
     bool (*fill_repr_map)(void *data, struct sol_oic_map_writer *repr_map),
     void *fill_repr_map_data,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_oic_map_reader *repr_vec, void *data),
+    const struct sol_oic_map_reader *repr_vec, void *data),
     void *callback_data)
 {
     SOL_NULL_CHECK(client, false);
@@ -908,7 +888,7 @@ _poll_resource(void *data)
 static bool
 _observe_with_polling(struct sol_oic_client *client, struct sol_oic_resource *res,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_oic_map_reader *repr_vec, void *data),
+    const struct sol_oic_map_reader *repr_vec, void *data),
     void *data)
 {
     struct resource_request_ctx *ctx = sol_util_memdup(&(struct resource_request_ctx) {
@@ -949,7 +929,7 @@ _stop_observing_with_polling(struct sol_oic_resource *res)
 static bool
 client_resource_set_observable(struct sol_oic_client *client, struct sol_oic_resource *res,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_oic_map_reader *repr_vec, void *data),
+    const struct sol_oic_map_reader *repr_vec, void *data),
     void *data, bool observe, bool non_confirmable)
 {
     SOL_NULL_CHECK(client, false);
@@ -989,7 +969,7 @@ client_resource_set_observable(struct sol_oic_client *client, struct sol_oic_res
 SOL_API bool
 sol_oic_client_resource_set_observable(struct sol_oic_client *client, struct sol_oic_resource *res,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_oic_map_reader *repr_vec, void *data),
+    const struct sol_oic_map_reader *repr_vec, void *data),
     void *data, bool observe)
 {
     return client_resource_set_observable(client, res, callback, data,
@@ -999,7 +979,7 @@ sol_oic_client_resource_set_observable(struct sol_oic_client *client, struct sol
 SOL_API bool
 sol_oic_client_resource_set_observable_non_confirmable(struct sol_oic_client *client, struct sol_oic_resource *res,
     void (*callback)(struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_str_slice *href, const struct sol_oic_map_reader *repr_vec, void *data),
+    const struct sol_oic_map_reader *repr_vec, void *data),
     void *data, bool observe)
 {
     return client_resource_set_observable(client, res, callback, data,

--- a/src/samples/coap/oic-client.c
+++ b/src/samples/coap/oic-client.c
@@ -39,8 +39,7 @@
 #include "sol-oic-client.h"
 
 static void
-got_get_response(struct sol_oic_client *cli, const struct sol_network_link_addr *cliaddr,
-    const struct sol_str_slice *href, const struct sol_oic_map_reader *map_reader, void *data)
+got_get_response(struct sol_oic_client *cli, const struct sol_network_link_addr *cliaddr, const struct sol_oic_map_reader *map_reader, void *data)
 {
     struct sol_oic_repr_field field;
     enum sol_oic_map_loop_reason end_reason;


### PR DESCRIPTION
Oic reference and iotivity implementation has changed since the oic
library was implemented in soletta and during this time the packets
payload reference has changed.

Soletta oic playload is now compatible with iotivity 1.0.1 for non
secure connections.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>