### PR TITLE
oic: Fix /oic/d and /oic/p url behavior

### DIFF
--- a/src/lib/comms/include/sol-oic-client.h
+++ b/src/lib/comms/include/sol-oic-client.h
@@ -194,10 +194,66 @@ bool sol_oic_client_find_resource(struct sol_oic_client *client,
     void *data);
 
 /**
+ * @brief Retrieve platform information.
+ *
+ * Sends a packet to @a resource's server asking for platform information
+ * defined at @ref sol_oic_platform_information.
+ *
+ * When a response is received, the function @a info_received_cb will be
+ * called.
+ * After internal timeout is reached @a info_received_cb will be called with
+ * @c NULL @a info and any clean up can be performed.
+ *
+ * @param client An oic client instance.
+ * @param resource The resource that is going to receive the request.
+ * @param info_received_cb Callback to be called when response is received or
+ *        when timeout is reached. Parameter cli is the sol_oic_client used to
+ *        perform the request, info is the @ref sol_oic_platform_information
+ *        structure with server info data, data is a pointer to user's data
+ *        parameter.
+ * @param data A pointer to user's data.
+ *
+ * @return True if packet was successfully sent. False otherwise.
+ */
+bool sol_oic_client_get_platform_info(struct sol_oic_client *client,
+    struct sol_oic_resource *resource,
+    void (*info_received_cb)(struct sol_oic_client *cli,
+    const struct sol_oic_platform_information *info, void *data),
+    void *data);
+
+/**
+ * @brief Retrieve platform information from @a cliaddr.
+ *
+ * Sends a packet to server identified by @a cliaddr asking for platform
+ * information defined at @ref sol_oic_platform_information.
+ *
+ * When a response is received, the function @a info_received_cb will be
+ * called.
+ * After internal timeout is reached @a info_received_cb will be called with
+ * @c NULL @a info and any clean up can be performed.
+ *
+ * @param client An oic client instance.
+ * @param resource The resource that is going to receive the request.
+ * @param info_received_cb Callback to be called when response is received or
+ *        when timeout is reached. Parameter cli is the sol_oic_client used to
+ *        perform the request, info is the @ref sol_oic_platform_information
+ *        structure with server info data, data is a pointer to user's data
+ *        parameter.
+ * @param data A pointer to user's data.
+ *
+ * @return True if packet was successfully sent. False otherwise.
+ */
+bool sol_oic_client_get_platform_info_by_addr(struct sol_oic_client *client,
+    struct sol_network_link_addr *cliaddr,
+    void (*info_received_cb)(struct sol_oic_client *cli,
+    const struct sol_oic_platform_information *info, void *data),
+    void *data);
+
+/**
  * @brief Retrieve server information.
  *
- * Sends a packet to server asking for server information defined at
- * @ref sol_oic_server_information.
+ * Sends a packet to @a resource's server asking for server information
+ * defined at @ref sol_oic_server_information.
  *
  * When a response is received, the function @a info_received_cb will be
  * called.
@@ -217,6 +273,34 @@ bool sol_oic_client_find_resource(struct sol_oic_client *client,
  */
 bool sol_oic_client_get_server_info(struct sol_oic_client *client,
     struct sol_oic_resource *resource,
+    void (*info_received_cb)(struct sol_oic_client *cli,
+    const struct sol_oic_server_information *info, void *data),
+    void *data);
+
+/**
+ * @brief Retrieve server information from @a cliaddr.
+ *
+ * Sends a packet to server identified by @a cliaddr asking for server
+ * information defined at @ref sol_oic_server_information.
+ *
+ * When a response is received, the function @a info_received_cb will be
+ * called.
+ * After internal timeout is reached @a info_received_cb will be called with
+ * @c NULL @a info and any clean up can be performed.
+ *
+ * @param client An oic client instance.
+ * @param resource The resource that is going to receive the request.
+ * @param info_received_cb Callback to be called when response is received or
+ *        when timeout is reached. Parameter cli is the sol_oic_client used to
+ *        perform the request, info is the @ref sol_oic_server_information
+ *        structure with server info data, data is a pointer to user's data
+ *        parameter.
+ * @param data A pointer to user's data.
+ *
+ * @return True if packet was successfully sent. False otherwise.
+ */
+bool sol_oic_client_get_server_info_by_addr(struct sol_oic_client *client,
+    struct sol_network_link_addr *cliaddr,
     void (*info_received_cb)(struct sol_oic_client *cli,
     const struct sol_oic_server_information *info, void *data),
     void *data);

--- a/src/lib/comms/include/sol-oic-common.h
+++ b/src/lib/comms/include/sol-oic-common.h
@@ -60,11 +60,12 @@ extern "C" {
 
 /**
  * @brief Structure containing all fields that are retrived by
- * @ref sol_oic_client_get_server_info()
+ * @ref sol_oic_client_get_platform_info() and @ref
+ * sol_oic_client_get_platform_info_by_addr
  */
-struct sol_oic_server_information {
+struct sol_oic_platform_information {
 #ifndef SOL_NO_API_VERSION
-#define SOL_OIC_SERVER_INFORMATION_API_VERSION (1)
+#define SOL_OIC_PLATFORM_INFORMATION_API_VERSION (1)
     uint16_t api_version; /**< @brief API version */
     int : 0; /**< @brief Unused. Save possible hole for a future field */
 #endif
@@ -168,6 +169,36 @@ enum sol_oic_resource_flag {
          * Connection established with a secure devices is secure.
          */
         SOL_OIC_FLAG_SECURE = 1 << 4
+};
+
+/**
+ * @brief Structure containing all fields that are retrived by
+ * @ref sol_oic_client_get_server_info() and @ref
+ * sol_oic_client_get_server_info_by_addr
+ */
+struct sol_oic_server_information {
+#ifndef SOL_NO_API_VERSION
+#define SOL_OIC_SERVER_INFORMATION_API_VERSION (1)
+    uint16_t api_version; /**< @brief API version */
+    int : 0; /**< @brief Unused. Save possible hole for a future field */
+#endif
+
+    /**
+     * @brief Device name
+     */
+    struct sol_str_slice device_name;
+    /**
+     * @brief Spec version of the core specification implemented by this device.
+     */
+    struct sol_str_slice spec_version;
+    /**
+     * @brief Unique device identifier.
+     */
+    struct sol_str_slice device_id;
+    /**
+     * @brief Spec version of data model.
+     */
+    struct sol_str_slice data_model_version;
 };
 
 /**

--- a/src/lib/comms/include/sol-oic-server.h
+++ b/src/lib/comms/include/sol-oic-server.h
@@ -55,6 +55,18 @@ extern "C" {
  * @{
  */
 
+#ifndef OIC_PLATFORM_ID
+/**
+ * @brief Default Platform ID
+ *
+ * To override this just define OIC_PLATFORM_ID before including this
+ * header.
+ *
+ * @see sol_oic_platform_information
+ */
+#define OIC_PLATFORM_ID "Unknown"
+#endif
+
 #ifndef OIC_MANUFACTURER_NAME
 /**
  * @brief Default manufacturer name
@@ -62,7 +74,7 @@ extern "C" {
  * To override this just define OIC_MANUFACTURER_NAME before including this
  * header.
  *
- * @see sol_oic_server_information
+ * @see sol_oic_platform_information
  */
 #define OIC_MANUFACTURER_NAME "Soletta"
 #endif
@@ -73,7 +85,7 @@ extern "C" {
  * To override this just define OIC_MANUFACTURER_URL before including this
  * header.
  *
- * @see sol_oic_server_information
+ * @see sol_oic_platform_information
  */
 #define OIC_MANUFACTURER_URL "https://soletta-project.org"
 #endif
@@ -84,7 +96,7 @@ extern "C" {
  * To override this just define OIC_MODEL_NUMBER before including this
  * header.
  *
- * @see sol_oic_server_information
+ * @see sol_oic_platform_information
  */
 #define OIC_MODEL_NUMBER "Unknown"
 #endif
@@ -95,7 +107,7 @@ extern "C" {
  * To override this just define OIC_MANUFACTURE_DATE before including this
  * header.
  *
- * @see sol_oic_server_information
+ * @see sol_oic_platform_information
  */
 #define OIC_MANUFACTURE_DATE "2015-01-01"
 #endif
@@ -106,7 +118,7 @@ extern "C" {
  * To override this just define OIC_PLATFORM_VERSION before including this
  * header.
  *
- * @see sol_oic_server_information
+ * @see sol_oic_platform_information
  */
 #define OIC_PLATFORM_VERSION "Unknown"
 #endif
@@ -117,7 +129,7 @@ extern "C" {
  * To override this just define OIC_HARDWARE_VERSION before including this
  * header.
  *
- * @see sol_oic_server_information
+ * @see sol_oic_platform_information
  */
 #define OIC_HARDWARE_VERSION "Unknown"
 #endif
@@ -128,7 +140,7 @@ extern "C" {
  * To override this just define OIC_FIRMWARE_VERSION before including this
  * header.
  *
- * @see sol_oic_server_information
+ * @see sol_oic_platform_information
  */
 #define OIC_FIRMWARE_VERSION "Unknown"
 #endif
@@ -139,9 +151,42 @@ extern "C" {
  * To override this just define OIC_SUPPORT_URL before including this
  * header.
  *
- * @see sol_oic_server_information
+ * @see sol_oic_platform_information
  */
 #define OIC_SUPPORT_URL "Unknown"
+#endif
+#ifndef OIC_DEVICE_NAME
+/**
+ * @brief Default device name.
+ *
+ * To override this just define OIC_DEVICE_NAME before including this
+ * header.
+ *
+ * @see sol_oic_server_information
+ */
+#define OIC_DEVICE_NAME "Unknown"
+#endif
+#ifndef OIC_SPEC_VERSION
+/**
+ * @brief Default spec version
+ *
+ * To override this just define OIC_SPEC_VERSION before including this
+ * header.
+ *
+ * @see sol_oic_server_information
+ */
+#define OIC_SPEC_VERSION ""
+#endif
+#ifndef OIC_DATA_MODEL_VERSION
+/**
+ * @brief Default data model version.
+ *
+ * To override this just define OIC_DATA_MODEL_VERSION before including this
+ * header.
+ *
+ * @see sol_oic_server_information
+ */
+#define OIC_DATA_MODEL_VERSION "Unknown"
 #endif
 
 /**
@@ -232,7 +277,7 @@ struct sol_oic_resource_type {
      *
      * @return The coap response code of this request.
      */
-    delete;
+        delete;
 };
 
 /**

--- a/src/lib/comms/sol-oic-cbor.h
+++ b/src/lib/comms/sol-oic-cbor.h
@@ -75,4 +75,6 @@ enum sol_oic_payload_type {
 #define SOL_OIC_KEY_INTERFACES "if"
 #define SOL_OIC_KEY_POLICY "p"
 #define SOL_OIC_KEY_BITMAP "bm"
-
+#define SOL_OIC_KEY_DEVICE_NAME "n"
+#define SOL_OIC_KEY_SPEC_VERSION "lcv"
+#define SOL_OIC_KEY_DATA_MODEL_VERSION "dmv"

--- a/src/lib/comms/sol-oic-client.c
+++ b/src/lib/comms/sol-oic-client.c
@@ -372,6 +372,7 @@ _server_info_reply_cb(struct sol_coap_server *server,
     free((char *)info.os_version.data);
     free((char *)info.hardware_version.data);
     free((char *)info.support_url.data);
+    free((char *)info.firmware_version.data);
     free((char *)info.system_time.data);
 
 free_ctx:


### PR DESCRIPTION
Supported to well known url /oic/d was implemented in soletta, but with
the expected result to /oic/p url. So /oic/d was renamed to /oic/p and
/oic/d was implemented.

Also sending platform_id in expected way in /oic/p url.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>