### PR TITLE
Locale: Fix missing locale symbols in some platforms.

### DIFF
--- a/src/lib/common/sol-platform-impl-contiki.c
+++ b/src/lib/common/sol-platform-impl-contiki.c
@@ -267,3 +267,17 @@ sol_platform_impl_load_locales(char **locale_cache)
     SOL_WRN("Not implemented");
     return -ENOTSUP;
 }
+
+int
+sol_platform_impl_locale_to_c_category(enum sol_platform_locale_category category)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+const char *
+sol_platform_impl_locale_to_c_str_category(enum sol_platform_locale_category category)
+{
+    SOL_WRN("Not implemented");
+    return NULL;
+}

--- a/src/lib/common/sol-platform-impl-riot.c
+++ b/src/lib/common/sol-platform-impl-riot.c
@@ -334,3 +334,17 @@ sol_platform_impl_load_locales(char **locale_cache)
     SOL_WRN("Not implemented");
     return -ENOTSUP;
 }
+
+int
+sol_platform_impl_locale_to_c_category(enum sol_platform_locale_category category)
+{
+    SOL_WRN("Not implemented");
+    return -ENOTSUP;
+}
+
+const char *
+sol_platform_impl_locale_to_c_str_category(enum sol_platform_locale_category category)
+{
+    SOL_WRN("Not implemented");
+    return NULL;
+}

--- a/src/lib/common/sol-platform-impl.h
+++ b/src/lib/common/sol-platform-impl.h
@@ -100,3 +100,7 @@ int sol_platform_impl_load_locales(char **locale_cache);
 
 int sol_platform_locale_to_c_category(enum sol_platform_locale_category type);
 const char *sol_platform_locale_to_c_str_category(enum sol_platform_locale_category type);
+
+int sol_platform_impl_locale_to_c_category(enum sol_platform_locale_category category);
+
+const char *sol_platform_impl_locale_to_c_str_category(enum sol_platform_locale_category category);

--- a/src/lib/common/sol-platform-linux-common.c
+++ b/src/lib/common/sol-platform-linux-common.c
@@ -1004,3 +1004,49 @@ err_val:
     fclose(f);
     return r;
 }
+
+int
+sol_platform_impl_locale_to_c_category(enum sol_platform_locale_category category)
+{
+    switch (category) {
+    case SOL_PLATFORM_LOCALE_ADDRESS:
+        return LC_ADDRESS;
+    case SOL_PLATFORM_LOCALE_IDENTIFICATION:
+        return LC_IDENTIFICATION;
+    case SOL_PLATFORM_LOCALE_MESSAGES:
+        return LC_MESSAGES;
+    case SOL_PLATFORM_LOCALE_PAPER:
+        return LC_PAPER;
+    case SOL_PLATFORM_LOCALE_NAME:
+        return LC_NAME;
+    case SOL_PLATFORM_LOCALE_TELEPHONE:
+        return LC_TELEPHONE;
+    case SOL_PLATFORM_LOCALE_MEASUREMENT:
+        return LC_MEASUREMENT;
+    default:
+        return -EINVAL;
+    }
+}
+
+const char *
+sol_platform_impl_locale_to_c_str_category(enum sol_platform_locale_category category)
+{
+    switch (category) {
+    case SOL_PLATFORM_LOCALE_ADDRESS:
+        return "LC_ADDRESS";
+    case SOL_PLATFORM_LOCALE_IDENTIFICATION:
+        return "LC_IDENTIFICATION";
+    case SOL_PLATFORM_LOCALE_MEASUREMENT:
+        return "LC_MEASUREMENT";
+    case SOL_PLATFORM_LOCALE_MESSAGES:
+        return "LC_MESSAGES";
+    case SOL_PLATFORM_LOCALE_NAME:
+        return "LC_NAME";
+    case SOL_PLATFORM_LOCALE_PAPER:
+        return "LC_PAPER";
+    case SOL_PLATFORM_LOCALE_TELEPHONE:
+        return "LC_TELEPHONE";
+    default:
+        return NULL;
+    }
+}

--- a/src/lib/common/sol-platform.c
+++ b/src/lib/common/sol-platform.c
@@ -760,32 +760,18 @@ sol_platform_locale_to_c_category(enum sol_platform_locale_category category)
     switch (category) {
     case SOL_PLATFORM_LOCALE_LANGUAGE:
         return LC_ALL;
-    case SOL_PLATFORM_LOCALE_ADDRESS:
-        return LC_ADDRESS;
     case SOL_PLATFORM_LOCALE_COLLATE:
         return LC_COLLATE;
     case SOL_PLATFORM_LOCALE_CTYPE:
         return LC_CTYPE;
-    case SOL_PLATFORM_LOCALE_IDENTIFICATION:
-        return LC_IDENTIFICATION;
-    case SOL_PLATFORM_LOCALE_MEASUREMENT:
-        return LC_MEASUREMENT;
-    case SOL_PLATFORM_LOCALE_MESSAGES:
-        return LC_MESSAGES;
     case SOL_PLATFORM_LOCALE_MONETARY:
         return LC_MONETARY;
-    case SOL_PLATFORM_LOCALE_NAME:
-        return LC_NAME;
     case SOL_PLATFORM_LOCALE_NUMERIC:
         return LC_NUMERIC;
-    case SOL_PLATFORM_LOCALE_PAPER:
-        return LC_PAPER;
-    case SOL_PLATFORM_LOCALE_TELEPHONE:
-        return LC_TELEPHONE;
     case SOL_PLATFORM_LOCALE_TIME:
         return LC_TIME;
     default:
-        return -EINVAL;
+        return sol_platform_impl_locale_to_c_category(category);
     }
 }
 
@@ -795,31 +781,17 @@ sol_platform_locale_to_c_str_category(enum sol_platform_locale_category category
     switch (category) {
     case SOL_PLATFORM_LOCALE_LANGUAGE:
         return "LANG";
-    case SOL_PLATFORM_LOCALE_ADDRESS:
-        return "LC_ADDRESS";
     case SOL_PLATFORM_LOCALE_COLLATE:
         return "LC_COLLATE";
     case SOL_PLATFORM_LOCALE_CTYPE:
         return "LC_CTYPE";
-    case SOL_PLATFORM_LOCALE_IDENTIFICATION:
-        return "LC_IDENTIFICATION";
-    case SOL_PLATFORM_LOCALE_MEASUREMENT:
-        return "LC_MEASUREMENT";
-    case SOL_PLATFORM_LOCALE_MESSAGES:
-        return "LC_MESSAGES";
     case SOL_PLATFORM_LOCALE_MONETARY:
         return "LC_MONETARY";
-    case SOL_PLATFORM_LOCALE_NAME:
-        return "LC_NAME";
     case SOL_PLATFORM_LOCALE_NUMERIC:
         return "LC_NUMERIC";
-    case SOL_PLATFORM_LOCALE_PAPER:
-        return "LC_PAPER";
-    case SOL_PLATFORM_LOCALE_TELEPHONE:
-        return "LC_TELEPHONE";
     case SOL_PLATFORM_LOCALE_TIME:
         return "LC_TIME";
     default:
-        return NULL;
+        return sol_platform_impl_locale_to_c_str_category(category);
     }
 }


### PR DESCRIPTION
Some platforms may support more categories, in order to do not
break the build, these extented categories should be handled
in their spefic backend.

Signed-off-by: Guilherme Iscaro <guilherme.iscaro@intel.com>