### PR TITLE
WIP: Node.js bindings

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -216,3 +216,12 @@ menu "Test suite"
 depends on FEATURE_RUNNABLE_PROGRAMS
 source "src/test/Kconfig"
 endmenu
+
+menu "Bindings"
+config NODE_BINDINGS
+	bool "Node.js bindings"
+	depends on HAVE_NODE
+	default n
+	help
+		Enable Node.js bindings
+endmenu

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,23 @@ include $(top_srcdir)tools/build/Makefile.vars
 
 include $(top_srcdir)tools/build/Makefile.common
 
+ifneq ($(NODE_BINDINGS),)
+
+bins-out += node_bindings
+
+node_bindings: $(SOL_LIB_OUTPUT)
+
+	# Install dependencies without building the package
+	npm install --ignore-scripts
+
+	# Build the package without clobbering build/
+	SOLETTA_FROM_MAKE=true $$(dirname `which node`)/../lib/node_modules/npm/bin/node-gyp-bin/node-gyp configure
+	SOLETTA_FROM_MAKE=true $$(dirname `which node`)/../lib/node_modules/npm/bin/node-gyp-bin/node-gyp build
+
+PHONY += node_bindings
+
+endif
+
 # kconfig interface rules
 ifeq (help, $(filter help,$(MAKECMDGOALS)))
 help: soletta_help

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,67 @@
+{
+	"variables": {
+		"BUILD_SOLETTA": '<!(bindings/nodejs/establish-flags.sh BUILD_SOLETTA)',
+		"SOLETTA_CFLAGS": '<!(bindings/nodejs/establish-flags.sh SOLETTA_CFLAGS)',
+		"SOLETTA_LIBS": '<!(bindings/nodejs/establish-flags.sh SOLETTA_LIBS)'
+	},
+	"conditions": [
+		[ "'<(BUILD_SOLETTA)'=='true'", {
+			"targets+": [
+				{
+					"target_name": "csdk",
+					"type": "none",
+					"actions": [ {
+						"action_name": "build-csdk",
+						"message": "Building C SDK",
+						"outputs": [ "build/soletta_sysroot" ],
+						"inputs": [ "" ],
+						"action": [
+							"sh",
+							"bindings/nodejs/build-csdk.sh",
+							'<!@(if test "x${npm_config_debug}x" == "xtruex"; then echo "--debug"; else echo ""; fi)'
+						]
+					} ]
+				}
+			]
+		} ]
+	],
+	"targets": [
+		{
+			"target_name": "collectbindings",
+			"type": "none",
+			"actions": [ {
+				"action_name": "collectbindings",
+				"message": "Collecting bindings",
+				"outputs": [ "bindings/nodejs/generated/main.cc" ],
+				"inputs": [
+					"bindings/nodejs/generated/main.cc.prologue",
+					"bindings/nodejs/generated/main.cc.epilogue",
+				],
+				"action": [ "sh", "-c", "cd ./bindings/nodejs && ./generate-main.sh <(SOLETTA_CFLAGS)" ]
+			} ],
+
+			# Ensure that soletta is built first if it needs to be built at all
+			"conditions": [
+				[ "'<(BUILD_SOLETTA)'=='true'", {
+					"dependencies": [ "csdk" ]
+				} ]
+			]
+		},
+		{
+			"target_name": "soletta",
+			"sources": [
+				"bindings/nodejs/generated/main.cc",
+				"bindings/nodejs/src/functions/simple.cc"
+			],
+			"include_dirs": [
+				"<!(node -e \"require('nan')\")"
+			],
+			"cflags": [ '<(SOLETTA_CFLAGS)' ],
+			"xcode_settings": {
+				"OTHER_CFLAGS": [ '<SOLETTA_CFLAGS)' ]
+			},
+			"libraries": [ '<(SOLETTA_LIBS)' ],
+			"dependencies": [ "collectbindings" ]
+		}
+	]
+}

--- a/bindings/nodejs/build-csdk.sh
+++ b/bindings/nodejs/build-csdk.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+if test "x${V}x" != "xx"; then
+	set -x
+fi
+
+DO_DEBUG=false
+
+while test $# -gt 0; do
+	if test "x$1x" = "x--debugx" -o "x$1x" = "x-dx"; then
+		DO_DEBUG=true
+	elif test "x$1x" = "x--helpx" -o "x$1x" = "x-hx"; then
+		echo "$( basename "$0" ) [options...]"
+		echo ""
+		echo "Possible options:"
+		echo "--debug or -d : Build in debug mode"
+		exit 0
+	fi
+	shift
+done
+
+unset PYTHON || exit 1
+unset PYTHON_PATH || exit 1
+make alldefconfig || exit 1
+if test "x${DO_DEBUG}x" == "xtruex"; then
+	( cat .config | awk '{
+		if ( $0 ~ /^CONFIG_CFLAGS=/ ) {
+			print( "CONFIG_CFLAGS=\"-g -Wall -O0\"" );
+		} else {
+			print;
+		}
+	}' > .config.new && mv .config.new .config ) || exit 1
+fi
+make || exit 1

--- a/bindings/nodejs/establish-flags.sh
+++ b/bindings/nodejs/establish-flags.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# By default, build soletta using defaults
+SOLETTA_CFLAGS="-I$(pwd)/build/soletta_sysroot/usr/include/soletta"
+SOLETTA_LIBS="-L$(pwd)/build/soletta_sysroot/usr/lib -lsoletta -Wl,-rpath $(pwd)/build/soletta_sysroot/usr/lib"
+BUILD_SOLETTA="true"
+
+# If we're running from soletta's build process, establish the prefix, use
+# local include files, and link with no rpath
+if test "x${SOLETTA_FROM_MAKE}x" == "xtruex"; then
+	PREFIX="$(cat .config | grep '^PREFIX=' | sed -r 's/^[^"]*"([^"]*)"/\1/')"
+	PREFIX="${PREFIX##/}"
+
+	SOLETTA_CFLAGS="-I$(pwd)/build/soletta_sysroot/${PREFIX}/include/soletta"
+	SOLETTA_LIBS="-L $(pwd)/build/soletta_sysroot/${PREFIX}/lib -lsoletta"
+	BUILD_SOLETTA="false"
+
+# Otherwise, try to find soletta via pkg-config
+elif pkg-config --exists soletta > /dev/null 2>&1; then
+	SOLETTA_CFLAGS="$(pkg-config --cflags soletta)"
+	SOLETTA_LIBS="$(pkg-config --libs soletta)"
+	BUILD_SOLETTA="false"
+fi
+
+if test "x${1}x" == "xBUILD_SOLETTAx"; then
+	echo "${BUILD_SOLETTA}"
+elif test "x${1}x" == "xSOLETTA_CFLAGSx"; then
+	echo "${SOLETTA_CFLAGS}"
+elif test "x${1}x" == "xSOLETTA_LIBSx"; then
+	echo "${SOLETTA_LIBS}"
+fi

--- a/bindings/nodejs/generate-main.sh
+++ b/bindings/nodejs/generate-main.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+if test "x${V}x" != "xx"; then
+	set -x
+fi
+
+SOLETTA_SEARCH_PATHS=$(node -p '
+	"'"$@"'"
+		.match( /-I\s*\S+/g )
+		.map( function( item ) {
+			return item.replace( /-I\s*/, "" );
+		} )
+		.join( " " );
+')
+
+cat generated/main.cc.prologue > generated/main.cc || exit 1
+cat generated/main.h.prologue > generated/main.h || exit 1
+
+# Add constants and enums from selected files
+FILES=\
+'sol-platform.h'
+
+for file in $FILES; do
+	echo "#include <$file>" >> generated/main.h
+	for path in $SOLETTA_SEARCH_PATHS; do
+		if test -f $path/$file; then
+			cat $path/$file | awk '
+				BEGIN {
+					enum_values[0] = 0;
+					delete enum_values[0];
+					enum_name = "";
+					inside_enum = 0;
+					new_enum = 0;
+					last_line_was_blank=0;
+				}
+				/^#define/ {
+					if ( NF > 2 && $2 ~ /^[A-Za-z_][_A-Za-z0-9]*$/ ) {
+						print "  SET_CONSTANT_" ( ( substr($3, 1, 1) == "\"" ) ? "STRING": "NUMBER" ) "(exports, " $2 ");" >> "generated/main.cc"
+						last_line_was_blank = 0;
+					}
+				}
+				/^(typedef\s+)?enum\s+[^{]*{$/ {
+					enum_name = ( $2 == "enum" ) ? $3 : $2;
+					gsub(/{/, "", enum_name);
+					inside_enum = 1;
+					new_enum = 1;
+				}
+				/\s*}\s*(\S*)?\s*;\s*$/ {
+					if ( inside_enum == 1 ) {
+						if ( enum_name == "" ) {
+							enum_name = $0;
+							gsub(/(\s|[};])/, "", enum_name);
+						}
+						if ( enum_name != "" ) {
+							if ( last_line_was_blank == 0 ) {
+								print "" >> "generated/main.cc"
+							}
+							print "  Local<Object> bind_" enum_name " = Nan::New<Object>();" >> "generated/main.cc"
+							for ( enum_value in enum_values ) {
+								print "  SET_CONSTANT_NUMBER(bind_" enum_name ", " enum_value ");" >> "generated/main.cc"
+							}
+							for ( enum_value in enum_values ) {
+								delete enum_values[ enum_value ];
+							}
+							print "  SET_CONSTANT_OBJECT(exports, " enum_name ");" >> "generated/main.cc"
+							print "" >> "generated/main.cc"
+							last_line_was_blank = 1;
+						}
+						enum_name = "";
+						inside_enum = 0;
+					}
+				}
+				{
+					if ( new_enum == 1 ) {
+						new_enum = 0;
+					}
+					else
+					if ( inside_enum == 1 ) {
+						enum_member = $1;
+						gsub( /,/, "", enum_member );
+						if ( enum_member ~ /[A-Za-z][A-Za-z0-9]*/ ) {
+							enum_values[ enum_member ] = 0;
+						}
+					}
+				}
+			'
+		fi
+	done
+done
+
+echo "" >> "generated/main.h"
+
+# Add all the bound functions
+find src -type f | while read; do
+	cat "${REPLY}" | grep NAN_METHOD | while read; do
+		echo "$REPLY" | sed 's/).*$/);/' >> generated/main.h
+		echo "$REPLY" | sed -r 's/^\s*NAN_METHOD\s*\(\s*bind_([^)]*).*$/  SET_FUNCTION(exports, \1);/' >> generated/main.cc
+	done
+done
+
+cat generated/main.cc.epilogue >> generated/main.cc || exit 1
+cat generated/main.h.epilogue >> generated/main.h || exit 1

--- a/bindings/nodejs/generated/main.cc.epilogue
+++ b/bindings/nodejs/generated/main.cc.epilogue
@@ -1,0 +1,3 @@
+}
+
+NODE_MODULE(soletta, Init)

--- a/bindings/nodejs/generated/main.cc.prologue
+++ b/bindings/nodejs/generated/main.cc.prologue
@@ -1,0 +1,10 @@
+#include <v8.h>
+#include <node.h>
+#include <nan.h>
+
+using namespace v8;
+
+#include "main.h"
+#include "../src/common.h"
+
+void Init(Handle<Object> exports, Handle<Object> module) {

--- a/bindings/nodejs/generated/main.h.epilogue
+++ b/bindings/nodejs/generated/main.h.epilogue
@@ -1,0 +1,2 @@
+
+#endif /* ndef __SOLETTA_JS_MAIN_H__ */

--- a/bindings/nodejs/generated/main.h.prologue
+++ b/bindings/nodejs/generated/main.h.prologue
@@ -1,0 +1,7 @@
+#ifndef __SOLETTA_JS_MAIN_H__
+#define __SOLETTA_JS_MAIN_H__
+
+#include <v8.h>
+#include <node.h>
+#include <nan.h>
+

--- a/bindings/nodejs/src/common.h
+++ b/bindings/nodejs/src/common.h
@@ -1,0 +1,113 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __SOLETTA_NODE_COMMON_H__
+#define __SOLETTA_NODE_COMMON_H__
+
+#define SET_FUNCTION(destination, functionName) \
+    Nan::ForceSet((destination), Nan::New(#functionName).ToLocalChecked(), \
+    Nan::GetFunction(Nan::New<FunctionTemplate>( \
+    bind_ ## functionName)).ToLocalChecked(), \
+    (v8::PropertyAttribute)(v8::DontDelete));
+
+#define SET_CONSTANT_NUMBER(destination, name) \
+    Nan::ForceSet((destination), Nan::New(#name).ToLocalChecked(), \
+    Nan::New((name)), \
+    (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete));
+
+#define SET_CONSTANT_STRING(destination, name) \
+    Nan::ForceSet((destination), Nan::New(#name).ToLocalChecked(), \
+    Nan::New((name)).ToLocalChecked(), \
+    (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete));
+
+#define SET_CONSTANT_OBJECT(destination, name) \
+    Nan::ForceSet((destination), Nan::New(#name).ToLocalChecked(), \
+    bind_ ## name, \
+    (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete));
+
+#define VALIDATE_CALLBACK_RETURN_VALUE_TYPE(value, typecheck, message) \
+    if (!value->typecheck()) { \
+        Nan::ThrowTypeError( \
+            message " callback return value type must satisfy " #typecheck "()"); \
+    }
+
+#define VALIDATE_ARGUMENT_COUNT(args, length) \
+    if ((args).Length() < (length)) { \
+        return Nan::ThrowRangeError("Argument count must be exactly " #length); \
+    }
+
+#define VALIDATE_ARGUMENT_TYPE(args, index, typecheck) \
+    if (!(args)[(index)]->typecheck()) { \
+        return Nan::ThrowTypeError("Argument " #index " must satisfy " #typecheck \
+            "()"); \
+    }
+
+#define VALIDATE_VALUE_TYPE(value, typecheck, message, failReturn) \
+    if (!(value)->typecheck()) { \
+        Nan::ThrowTypeError(message " must satisfy " #typecheck "()"); \
+        return failReturn; \
+    }
+
+#define VALIDATE_VALUE_TYPE_OR_FREE(value, typecheck, message, failReturn, \
+        pointer_to_free, free_function) \
+    if (!(value)->typecheck()) { \
+        Nan::ThrowTypeError(message " must satisfy " #typecheck "()"); \
+        free_function((pointer_to_free)); \
+        return failReturn; \
+    }
+
+#define VALIDATE_ARGUMENT_TYPE_OR_NULL(args, index, typecheck) \
+    if (!((args)[(index)]->typecheck() || (args)[(index)]->IsNull())) { \
+        return Nan::ThrowTypeError("Argument " #index " must satisfy " #typecheck \
+            "() or IsNull()"); \
+    }
+
+#define SET_STRING_IF_NOT_NULL(destination, source, memberName) \
+    if ((source)->memberName) { \
+        Nan::Set((destination), Nan::New(#memberName).ToLocalChecked(), \
+            Nan::New((source)->memberName).ToLocalChecked()); \
+    }
+
+#define SET_VALUE_ON_OBJECT(destination, type, source, memberName) \
+    Nan::Set((destination), Nan::New(#memberName).ToLocalChecked(), \
+    Nan::New<type>((source)->memberName));
+
+#define VALIDATE_AND_ASSIGN(destination, memberName, destinationType, \
+        typecheck, message, failReturn, source, accessor) \
+    Local<Value> memberName = \
+        Nan::Get(source, Nan::New(#memberName).ToLocalChecked()) \
+        .ToLocalChecked(); \
+    VALIDATE_VALUE_TYPE(memberName, typecheck, message "." #memberName, \
+    failReturn); \
+    destination.memberName = (destinationType)memberName->accessor();
+
+#endif /* ndef __SOLETTA_NODE_COMMON_H__ */

--- a/bindings/nodejs/src/functions/simple.cc
+++ b/bindings/nodejs/src/functions/simple.cc
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <nan.h>
+#include "../common.h"
+
+#include <sol-platform.h>
+
+using namespace v8;
+
+NAN_METHOD(bind_sol_platform_get_machine_id) {
+  VALIDATE_ARGUMENT_COUNT(info, 0);
+
+  const char *machineId = 0;
+
+  machineId = sol_platform_get_machine_id();
+
+  info.GetReturnValue().Set( Nan::New( machineId ).ToLocalChecked() );
+}

--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -360,6 +360,11 @@
       "exec": "genhtml"
     },
     {
+      "dependency": "node",
+      "type": "exec",
+      "exec": "node"
+    },
+    {
       "dependency": "chrpath",
       "type": "exec",
       "exec": "chrpath"

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+// Export low-level bindings for now
+module.exports = require( "./lowlevel" );

--- a/lowlevel.js
+++ b/lowlevel.js
@@ -1,0 +1,1 @@
+module.exports = require( "bindings" )( "soletta" );

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "soletta",
+  "version": "0.0.1",
+  "description": "Node.js bindings for Soletta",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/solettaproject/soletta.git"
+  },
+  "keywords": [
+    "soletta",
+    "IoT",
+    "bindings"
+  ],
+  "author": "",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/solettaproject/soletta/issues"
+  },
+  "homepage": "https://github.com/solettaproject/soletta#readme",
+  "dependencies": {
+    "bindings": "^1.2.1",
+    "nan": "^2.1.0"
+  }
+}


### PR DESCRIPTION
This PR adds the infrastructure for creating Node.js bindings, and binds the very simple function ```sol_platform_get_machine_id()```. Some things to note/problems to work out:

0. <s>I also needed to bind dlfcn, because I need to try loading libsoletta.so from "./build/soletta_sysroot/usr/lib" before I can load the bindings. I wanted to do that to avoid using rpath, which would make it difficult to implement installation later on.</s>

0. I don't exactly know what I should run in response to make install. Should I do ```npm install -g```?

0. <s>A<a id="build-integration">l</a>though I've tried to integrate the build process with Kconfig, building the bindings currently only works if you start via npm install. That's because if you start with make menuconfig, turn on the bindings, and then run make, it runs npm install after it's done building soletta, but because node-gyp also uses ```build/``` as the output directory, it first deletes it and then creates it. This causes ```build/soletta_sysroot``` to disappear, so I can't subsequently use the header files and the .so that I need. I can do hacky things like ```cp -a build/soletta_sysroot somewhere/else```, run npm install, and copy it back to ```build/soletta_sysroot``` from inside the node-gyp build process, but I'd rather discuss this with you. Is it possible that we change the output from ```build/soletta_sysroot``` to something else, like, maybe, ```out/soletta_sysroot```?

    If you start with npm install, it works because it runs make alldefconfig && make as part of npm install, so by the time it runs those, node-gyp will already have performed the step of removing ```build/``` and creating a new directory ```build/```.</s>