### PR TITLE
Add support for CoAP ping messages. V3

### DIFF
--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -217,6 +217,13 @@ typedef enum {
 } sol_coap_responsecode_t;
 
 /**
+ * @brief Macro to indicates that the header code was not set.
+ *
+ * To be used with sol_coap_header_set_code()
+ */
+#define SOL_COAP_CODE_EMPTY (0)
+
+/**
  * @brief Some content-types available for use with the CONTENT_FORMAT option.
  *
  * Refer to RFC 7252, section 12.3 for more information.
@@ -380,6 +387,7 @@ uint8_t *sol_coap_header_get_token(const struct sol_coap_packet *pkt, uint8_t *l
  *
  * If the packet is a request, the code returned is one of #sol_coap_method_t.
  * If it's a response, it will be one of #sol_coap_responsecode_t.
+ * If the code was not set, it will return #SOL_COAP_CODE_EMPTY.
  *
  * @param pkt The packet to get the code from.
  *

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -203,10 +203,11 @@ sol_coap_header_get_code(const struct sol_coap_packet *pkt)
     case SOL_COAP_RSPCODE_SERVICE_UNAVAILABLE:
     case SOL_COAP_RSPCODE_GATEWAY_TIMEOUT:
     case SOL_COAP_RSPCODE_PROXYING_NOT_SUPPORTED:
+    case SOL_COAP_CODE_EMPTY:
         return code;
     default:
         SOL_WRN("Invalid code (%d)", code);
-        return 0;
+        return SOL_COAP_CODE_EMPTY;
     }
 }
 

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -1182,6 +1182,17 @@ error:
     return -EINVAL;
 }
 
+static bool
+is_coap_ping(struct sol_coap_packet *req)
+{
+    uint8_t tokenlen;
+
+    (void)sol_coap_header_get_token(req, &tokenlen);
+    return (sol_coap_header_get_type(req) == SOL_COAP_TYPE_CON &&
+            sol_coap_header_get_code(req) == SOL_COAP_CODE_EMPTY &&
+            tokenlen == 0 && !sol_coap_packet_has_payload(req));
+}
+
 static int
 respond_packet(struct sol_coap_server *server, struct sol_coap_packet *req,
     const struct sol_network_link_addr *cliaddr)
@@ -1197,6 +1208,15 @@ respond_packet(struct sol_coap_server *server, struct sol_coap_packet *req,
     uint16_t i;
     uint8_t code;
     bool remove_outgoing = true;
+
+    if (is_coap_ping(req)) {
+        struct sol_coap_packet *pong;
+        SOL_DBG("Coap ping, sending pong");
+        pong = sol_coap_packet_new(req);
+        SOL_NULL_CHECK(pong, -ENOMEM);
+        sol_coap_header_set_type(pong, SOL_COAP_TYPE_RESET);
+        return sol_coap_send_packet(server, pong, cliaddr);
+    }
 
     code = sol_coap_header_get_code(req);
 


### PR DESCRIPTION
Changes since v2:
* Warn if packet is invalid, but still returns empty.
* ping response should be reset and not ack.