### PR TITLE
fix: Public header uses private thing

### DIFF
--- a/src/lib/common/include/sol-platform.h
+++ b/src/lib/common/include/sol-platform.h
@@ -74,7 +74,7 @@ extern "C" {
  * When this time is reached, stops the * chunk reading and allow mainloop to run again.
  * This keeps interactivity.
  */
-#define CHUNK_MAX_TIME_NS (20 * (NSEC_PER_MSEC))
+#define CHUNK_MAX_TIME_NS (20 * 1000000)
 
 /**
  * @brief Retrieves the name of the board on which Soletta is running.


### PR DESCRIPTION
Since the value used in the public header is arbitrary and the constant
is not necessary, it's just changing the code to use the value directly.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>