### PR TITLE
Mark noreturn function with SOL_ATTR_NORETURN

### DIFF
--- a/src/lib/common/include/sol-macros.h
+++ b/src/lib/common/include/sol-macros.h
@@ -148,6 +148,13 @@
  * @param n Size of the array
  */
 
+/**
+ * @def SOL_UNREACHABLE
+ *
+ * @brief Macro to mark a location of code that is unreachable, usually after
+ * calling a SOL_ATTR_NORETURN function.
+ */
+
 #if __GNUC__ >= 4
 #define SOL_API  __attribute__((visibility("default")))
 #define SOL_ATTR_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
@@ -162,6 +169,7 @@
 #define SOL_ATTR_SENTINEL __attribute__((sentinel))
 #define SOL_ATTR_NORETURN __attribute__((noreturn))
 #define SOL_ATTR_PURE __attribute__((pure))
+#define SOL_UNREACHABLE() __builtin_unreachable()
 #else
 #define SOL_API
 #define SOL_ATTR_WARN_UNUSED_RESULT
@@ -176,6 +184,7 @@
 #define SOL_ATTR_SENTINEL
 #define SOL_ATTR_NORETURN
 #define SOL_ATTR_PURE
+#define SOL_UNREACHABLE() ((void)0)
 #endif
 
 #ifdef __cplusplus

--- a/src/modules/linux-micro/rc-d/rc-d.c
+++ b/src/modules/linux-micro/rc-d/rc-d.c
@@ -62,7 +62,7 @@ static struct sol_ptr_vector monitors = SOL_PTR_VECTOR_INIT;
 static struct sol_timeout *monitor_timer;
 static struct sol_vector pendings = SOL_VECTOR_INIT(struct pending);
 
-static void
+static void SOL_ATTR_NORETURN
 find_exec(const char *service, const char *arg)
 {
     const char **itr, *dirs[] = {
@@ -177,7 +177,7 @@ rc_d_stop(const struct sol_platform_linux_micro_module *mod, const char *service
             sigemptyset(&emptyset);
             sigprocmask(SIG_SETMASK, &emptyset, NULL);
             find_exec(service, "stop");
-            return -errno;
+            SOL_UNREACHABLE();
         } else if (pid < 0)
             return -errno;
         else {


### PR DESCRIPTION
This avoids the mistaken interpretation that the function returned to
the caller from inside the child process.