### PR TITLE
Use pipe2(2) instead of pipe(2)

### DIFF
--- a/src/lib/common/sol-mainloop-impl-posix.c
+++ b/src/lib/common/sol-mainloop-impl-posix.c
@@ -36,6 +36,7 @@
 #include <poll.h>
 #include <signal.h>
 #include <sys/wait.h>
+#include <fcntl.h>
 
 #include "sol-mainloop-common.h"
 #include "sol-mainloop-impl.h"
@@ -157,7 +158,7 @@ threads_init(void)
 {
     int err;
 
-    err = pipe(pipe_fds);
+    err = pipe2(pipe_fds, O_CLOEXEC);
     SOL_INT_CHECK(err, != 0);
 
     main_thread = pthread_self();

--- a/src/lib/common/sol-platform-linux-common.c
+++ b/src/lib/common/sol-platform-linux-common.c
@@ -163,7 +163,7 @@ sol_platform_linux_fork_run(void (*on_fork)(void *data), void (*on_child_exit)(v
     errno = EINVAL;
     SOL_NULL_CHECK(on_fork, NULL);
 
-    if (pipe(pfds) < 0) {
+    if (pipe2(pfds, O_CLOEXEC) < 0) {
         SOL_WRN("could not create pipe: %s", sol_util_strerrora(errno));
         return NULL;
     }


### PR DESCRIPTION
Since Soletta is meant to be thread-safe, this is required. pipe(2) is
not thread-safe therefore it MUST NEVER be used in a threaded
application.

It's ok to use it in the child process between fork(2) and execve(2).