### PR TITLE
LWM2M: Add LWM2M server.

### DIFF
--- a/src/lib/comms/Kconfig
+++ b/src/lib/comms/Kconfig
@@ -115,3 +115,11 @@ config MAVLINK
             MAVLink or Micro Air Vehicle Link is a protocol for communicating with
             small unmanned vehicle. It is designed as a header-only message marshaling
             library.
+
+config LWM2M
+       bool "LWM2M"
+       default y
+       depends on COAP
+       help
+           LWM2M is a protocol for communication beetween IoT devices defined by OMA
+           (Open Mobile Alliance)

--- a/src/lib/comms/Makefile
+++ b/src/lib/comms/Makefile
@@ -100,6 +100,9 @@ obj-networking-$(MAVLINK)-extra-cflags += \
 	-I$(MAVLINK_SRC_PATH)/ardupilotmega/ \
 	-Wno-declaration-after-statement
 
+obj-networking-$(LWM2M) += \
+	sol-lwm2m.o
+
 headers-$(NETWORK) += \
     include/sol-network.h
 
@@ -125,3 +128,6 @@ headers-$(MQTT) += \
 
 headers-$(MAVLINK) += \
 	include/sol-mavlink.h
+
+headers-$(LWM2M) += \
+    include/sol-lwm2m.h

--- a/src/lib/comms/include/sol-lwm2m.h
+++ b/src/lib/comms/include/sol-lwm2m.h
@@ -1,0 +1,761 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sol-coap.h"
+#include "sol-network.h"
+#include "sol-str-slice.h"
+#include "sol-vector.h"
+#include "sol-buffer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file
+ * @brief Routines that handle LWM2M protocol.
+ *
+ */
+
+/**
+ * @defgroup LWM2M LWM2M
+ * @ingroup Comms
+ *
+ * @brief Routines that handle LWM2M protocol.
+ *
+ * @{
+ */
+
+/**
+ * @brief Macro that defines the default port for a LWM2M server.
+ */
+#define SOL_LWM2M_DEFAULT_SERVER_PORT (5683)
+
+/**
+ * @struct sol_lwm2m_server
+ * @brief A handle to a LWM2M server.
+ * @see sol_lwm2m_server_new()
+ */
+struct sol_lwm2m_server;
+
+/**
+ * @struct sol_lwm2m_client_info
+ * @brief A handle that contains information about a registered LWM2M client.
+ * @see sol_lwm2m_server_get_clients()
+ */
+struct sol_lwm2m_client_info;
+
+/**
+ * @struct sol_lwm2m_client_object_instance
+ * @brief A handle that contains information about a client object instance.
+ */
+struct sol_lwm2m_client_object_instance;
+
+/**
+ * @struct sol_lwm2m_client_object
+ * @brief A handle of a
+ * @see sol_lwm2m_client_info_get_objects()
+ */
+struct sol_lwm2m_client_object;
+
+/**
+ * @brief LWM2M Client biding mode.
+ *
+ * A LWM2M server, may support multiple forms of binding.
+ * The biding mode is requested by a client during its registration.
+ *
+ * In Queue binding mode a client flags to the server that it
+ * may not be available for communication all the time, thus
+ * the server must wait until it receives a heartbeat from the
+ * client until it can send requests. The queue binding mode
+ * is usefull, because the client may enter in deep sleep
+ * and save battery and only wake up in certain times.
+ *
+ * @note The default biding mode is #SOL_LWM2M_BINDING_MODE_U and is the only one supported right know.
+ * @see sol_lwm2m_client_info_get_binding_mode()
+ */
+enum sol_lwm2m_binding_mode {
+    /**
+     * Indicates that the client is reacheable all the time
+     * and all the communication must be done using UDP.
+     */
+    SOL_LWM2M_BINDING_MODE_U,
+    /**
+     * Indicate that the client is using Queued UDP binding
+     * and all the communication must be done using UDP.
+     */
+    SOL_LWM2M_BINDING_MODE_UQ,
+    /**
+     * Indicates that the client is reacheable all the time
+     * and all the communication must be done using SMS.
+     */
+    SOL_LWM2M_BINDING_MODE_S,
+    /**
+     * Indicates that the client is using Queued SMS binding
+     * and all the communication must be done using SMS
+     */
+    SOL_LWM2M_BINDING_MODE_SQ,
+    /**
+     * Indicates that the client is using UDP and SMS binding.
+     * When the server sends an UDP request the client must
+     * send the response using UDP.
+     * When the server sends a SMS request the client must
+     * send the response using SMS.
+     */
+    SOL_LWM2M_BINDING_MODE_US,
+    /**
+     * Indicates that the client using Queued SMS and UDP binding.
+     * When the server sends an UDP request the client must
+     * send the response using UDP.
+     * When the server sends a SMS request the client must
+     * send the response using SMS.
+     */
+    SOL_LWM2M_BINDING_MODE_UQS,
+    /**
+     * It was not possible to determine the client binding.
+     */
+    SOL_LWM2M_BINDING_MODE_UNKNOWN = -1,
+};
+
+/**
+ * @brief Enum that express a LWM2M client lifecycle changes.
+ *
+ * @see sol_lwm2m_server_add_registration_monitor()
+ */
+enum sol_lwm2m_registration_event {
+    /**
+     * Indicates that a client was registered in the server.
+     */
+    SOL_LWM2M_REGISTRATION_EVENT_REGISTER,
+    /**
+     * Indicates that a client updated itself in the server.
+     */
+    SOL_LWM2M_REGISTRATION_EVENT_UPDATE,
+    /**
+     * Indicates that a client was unregistered.
+     */
+    SOL_LWM2M_REGISTRATION_EVENT_UNREGISTER,
+    /**
+     * Indicates that the server is discarting a client, since
+     * the server did hear from it after some time.
+     */
+    SOL_LWM2M_REGISTRATION_EVENT_TIMEOUT
+};
+
+/**
+ * @brief Enum that represent a LWM2M response/request content type.
+ */
+enum sol_lwm2m_content_type {
+    /**
+     * The content type message is pure text.
+     */
+    SOL_LWM2M_CONTENT_TYPE_TEXT = 0,
+    /**
+     * The content type of the message is indeterminated, in order
+     * words, is an array of bytes.
+     */
+    SOL_LWM2M_CONTENT_TYPE_OPAQUE = 42,
+    /**
+     * The content type of the message is in TLV format.
+     */
+    SOL_LWM2M_CONTENT_TYPE_TLV = 1542,
+    /**
+     * The content type of the message is in JSON.
+     * JSON content types are not supported right now.
+     */
+    SOL_LWM2M_CONTENT_TYPE_JSON = 1543
+};
+
+/**
+ * @brief Enum that represent the TLV type.
+ * @see #sol_lwm2m_tlv
+ */
+enum sol_lwm2m_tlv_type {
+    /**
+     * The TLV represents an object instance
+     */
+    SOL_LWM2M_TLV_TYPE_OBJECT_INSTANCE = 0,
+    /**
+     * The TLV repreents an resource instance.
+     */
+    SOL_LWM2M_TLV_TYPE_RESOURCE_INSTANCE = 64,
+    /**
+     * The TLV is composed of multiple resources.
+     */
+    SOL_LWM2M_TLV_TYPE_MULTIPLE_RESOURCES = 128,
+    /**
+     * The TLV is a resource.
+     */
+    SOL_LWM2M_TLV_TYPE_RESOURCE_WITH_VALUE = 192
+};
+
+/**
+ * @brief Enum that represents an LWM2M resource type.
+ * @see #sol_lwm2m_resource
+ */
+enum sol_lwm2m_resource_type {
+    /**
+     * The resource value is a string.
+     */
+    SOL_LWM2M_RESOURCE_TYPE_STRING,
+    /**
+     * The resource value is an integer.
+     */
+    SOL_LWM2M_RESOURCE_TYPE_INT,
+    /**
+     * The resource value is a float.
+     */
+    SOL_LWM2M_RESOURCE_TYPE_FLOAT,
+    /**
+     * The resource value is a boolean.
+     */
+    SOL_LWM2M_RESOURCE_TYPE_BOOLEAN,
+    /**
+     * The resource value is opaque.
+     */
+    SOL_LWM2M_RESOURCE_TYPE_OPAQUE,
+    /**
+       The resource value is a timestamp (Unix time).
+     */
+    SOL_LWM2M_RESOURCE_TYPE_TIME,
+    /**
+     * The resource value is a object link.
+     */
+    SOL_LWM2M_RESOURCE_TYPE_OBJ_LINK,
+    /**
+     * The resource value is indeterminated.
+     */
+    SOL_LWM2M_RESOURCE_TYPE_NONE = -1
+};
+
+/**
+ * @brief Struct that represents TLV data.
+ * @see sol_lwm2m_parse_tlv()
+ * @see sol_lwm2m_resource_to_tlv()
+ */
+struct sol_lwm2m_tlv {
+#ifndef SOL_NO_API_VERSION
+#define SOL_LWM2M_TLV_API_VERSION (1)
+    /** @brief API version */
+    uint16_t api_version;
+    /** @brief Unused */
+    uint16_t reserved;
+#endif
+    /** @brief The TLV type */
+    enum sol_lwm2m_tlv_type type;
+    /** @brief The id of the object/instance/resource */
+    uint16_t id;
+    /** @brief The TLV header len */
+    size_t header_len;
+    /** @brief The TLV content */
+    struct sol_buffer content;
+};
+
+/**
+ * @brief Struct that represents an LWM2M resource.
+ * @see sol_lwm2m_resource_init()
+ * @see sol_lwm2m_resource_to_tlv()
+ */
+struct sol_lwm2m_resource {
+#ifndef SOL_NO_API_VERSION
+#define SOL_LWM2M_RESOURCE_API_VERSION (1)
+    /** @brief API version */
+    uint16_t api_version;
+    /** @brief Unused */
+    uint16_t reserved;
+#endif
+    /** @brief The resource type */
+    enum sol_lwm2m_resource_type type;
+    /** @brief The resource id */
+    uint16_t id;
+    /** @brief The resource data */
+    union {
+        /** @brief The resource is opaque or an string */
+        struct sol_str_slice bytes;
+        /** @brief The resource is a integer value */
+        int64_t integer;
+        /** @brief The resource is a float value */
+        double fp;
+        /** @brief The resource is a bool value */
+        bool b;
+    } data;
+};
+
+/**
+ * @brief Initializes an LWM2M resource.
+ *
+ * This function makes it easir to init a LWM2M resource, it
+ * will set the proper fields and fill its data. Note that
+ * the last argument type varies with the resource type and one
+ * must follow the table below.
+ *
+ * Resource type | Last argument type
+ * ------------- | ------------------
+ * SOL_LWM2M_RESOURCE_TYPE_STRING | const char *
+ * SOL_LWM2M_RESOURCE_TYPE_INT | int64_t
+ * SOL_LWM2M_RESOURCE_TYPE_FLOAT | double
+ * SOL_LWM2M_RESOURCE_TYPE_BOOLEAN | bool
+ * SOL_LWM2M_RESOURCE_TYPE_OPAQUE | struct sol_str_slice
+ * SOL_LWM2M_RESOURCE_TYPE_TIME | int64_t
+ * SOL_LWM2M_RESOURCE_TYPE_OBJ_LINK | uint16_t, uint16_t
+ *
+ * @param resource The resource to be initialized.
+ * @param id The resource id.
+ * @param type The resource type.
+ * @param ... The LWM2M resource data, respecting the table according to the resource type.
+ * @return 0 on success, negative errno on error.
+ */
+int sol_lwm2m_resource_init(struct sol_lwm2m_resource *resource, uint16_t id, enum sol_lwm2m_resource_type type, ...);
+
+/**
+ * @brief Callback that is used to inform a LWM2M client registration event.
+ *
+ * @param server The LWM2M server.
+ * @param cinfo The client that generated the registration event.
+ * @param event The registration event itself.
+ * @param data User data.
+ * @see #sol_lwm2m_registration_event
+ * @see sol_lwm2m_server_add_registration_monitor()
+ */
+typedef void (*sol_lwm2m_server_regisration_event_cb)(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *cinfo,
+    enum sol_lwm2m_registration_event event, void *data);
+
+/**
+ * @brief Callback used to inform a observable/read response.
+ *
+ * @param server The LWM2M server
+ * @param client The LWM2M client
+ * @param path The client's path
+ * @param response_code The reponse code.
+ * @param content_type The reponse content type.
+ * @param content The reponse content.
+ * @param data User data.
+ * @see sol_lwm2m_server_add_observer()
+ * @see sol_lwm2m_server_management_read()
+ * @see sol_lwm2m_parse_tlv()
+ */
+typedef void (*sol_lwm2m_server_content_cb)
+    (struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client,
+    const char *path,
+    sol_coap_responsecode_t response_code,
+    enum sol_lwm2m_content_type content_type,
+    struct sol_str_slice content, void *data);
+
+/**
+ * @brief Callback used to inform create/write/execute/delete response.
+ *
+ * @param server The LW2M server
+ * @param client The LWM2M client
+ * @param path The client's path
+ * @param response_code The operation @c response_code
+ * @param data User data.
+ * @see sol_lwl2m_server_management_write()
+ * @see sol_lwl2m_server_management_execute()
+ * @see sol_lwl2m_server_management_create()
+ * @see sol_lwl2m_server_management_delete()
+ */
+typedef void (*sol_lwm2m_server_management_status_response_cb)(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client, const char *path,
+    sol_coap_responsecode_t response_code, void *data);
+
+/**
+ * @brief Creates a new LWM2M server.
+ *
+ * The server will be immediately operational and waiting for connections.
+ *
+ * @param port The UDP port to be used.
+ * @return The LWM2M server or @c NULL on error.
+ */
+struct sol_lwm2m_server *sol_lwm2m_server_new(uint16_t port);
+
+/**
+ * @brief Parses a binary content into TLV.
+ *
+ * @param content A binary data that contains the TLV.
+ * @param tlv_values An array of #sol_lwm2m_tlv that will be filled.
+ *
+ * @return 0 on success, -errno on error.
+ */
+int sol_lwm2m_parse_tlv(const struct sol_str_slice content, struct sol_vector *tlv_values);
+
+/**
+ * @brief Converts a resource into TLV format.
+ *
+ * @param resource The resource to be converted.
+ * @param tlv Where the TLV data will be stored.
+ * @return 0 on success, -errno on error.
+ */
+int sol_lwm2m_resource_to_tlv(struct sol_lwm2m_resource *resource, struct sol_lwm2m_tlv *tlv);
+
+/**
+ * @brief Clears an TLV array.
+ *
+ * @param tlvs The TLVs array to be cleared.
+ */
+void sol_lwm2m_tlv_array_clear(struct sol_vector *tlvs);
+
+/**
+ * @brief Clear a TLV.
+ *
+ * @param tlv The TLV the be cleared.
+ */
+void sol_lwm2m_tlv_clear(struct sol_lwm2m_tlv *tlv);
+
+/**
+ * @brief Converts an TLV value to float value.
+ *
+ * @param tlv The tlv data.
+ * @param value The converted value.
+ * @return 0 on success, -errno on error.
+ */
+int sol_lwl2m_tlv_to_float(struct sol_lwm2m_tlv *tlv, double *value);
+
+/**
+ * @brief Converts an TLV value to boolean value.
+ *
+ * @param tlv The tlv data.
+ * @param value The converted value.
+ * @return 0 on success, -errno on error.
+ */
+int sol_lwl2m_tlv_to_bool(struct sol_lwm2m_tlv *tlv, bool *value);
+
+/**
+ * @brief Converts an TLV value to int value.
+ *
+ * @param tlv The tlv data.
+ * @param value The converted value.
+ * @return 0 on success, -errno on error.
+ */
+int sol_lwl2m_tlv_to_int(struct sol_lwm2m_tlv *tlv, int64_t *value);
+
+/**
+ *
+ * @brief Get TLV content is plain bytes.
+ * @param tlv The tlv data.
+ * @param bytes The content.
+ * @param len The length of @c bytes
+ * @return 0 on succes, -errno on error.
+ */
+int sol_lwm2m_tlv_get_bytes(struct sol_lwm2m_tlv *tlv, uint8_t **bytes, uint16_t *len);
+
+/**
+ * @brief Converts an TLV value to object link.
+ *
+ * @param tlv The tlv data.
+ * @param object_id The object id.
+ * @param instance_id the instance id.
+ * @return 0 on success, -errno on error.
+ */
+int sol_lwm2m_tlv_to_obj_link(struct sol_lwm2m_tlv *tlv, uint16_t *object_id, uint16_t *instance_id);
+
+/**
+ * @brief Adds a registration monitor.
+ *
+ * This function register a monitor, making it easir to observe a LWM2M client's life cycle.
+ * This means that everytime a LWM2M client is registered, updated, deleted or timedout,
+ * @c cb will be called.
+ *
+ * @param server The LWM2M server.
+ * @param cb The previous registered callback.
+ * @param data The user data to @c cb.
+ * @return 0 on success, -errno on error.
+ * @see sol_lwm2m_server_add_registration_monitor()
+ * @see #sol_lwm2m_server_regisration_event_cb
+ */
+int sol_lwm2m_server_add_registration_monitor(struct sol_lwm2m_server *server,
+    sol_lwm2m_server_regisration_event_cb cb, void *data);
+
+/**
+ * @brief Removes a registration monitor.
+ *
+ * @param server The LWM2M server.
+ * @param cb The previous registered callback.
+ * @param data The user data to @c cb.
+ * @return 0 on success, -errno on error.
+ * @see sol_lwm2m_server_add_registration_monitor()
+ */
+int sol_lwm2m_server_del_registration_monitor(struct sol_lwm2m_server *server,
+    sol_lwm2m_server_regisration_event_cb cb, void *data);
+
+/**
+ * @brief Gets all registerd clients.
+ *
+ * @param server The LWM2M Server.
+ * @return An vector of #sol_lwm2m_client_info or @c NULL on error.
+ * @note One must not add or remove elements from the returned vector.
+ * @see sol_lwm2m_server_add_registration_monitor()
+ */
+const struct sol_ptr_vector *sol_lwm2m_server_get_clients(const struct sol_lwm2m_server *server);
+
+/**
+ * @brief Observers an client object, instance or resource.
+ *
+ * Every time the observed path changes, the client will notify the LWM2M server.
+ *
+ * @param server The LWM2M server.
+ * @param client The LWM2M client to be observed.
+ * @param path The path to be observed (Example: /3/0/0).
+ * @param cb A callback to eb called when the observed path changes.
+ * @param data User data to @c cb
+ * @return 0 on success, -errno on error.
+ * @see #sol_lwm2m_server_content_cb
+ * @see sol_lwm2m_server_del_observer()
+ */
+int sol_lwm2m_server_add_observer(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client,
+    const char *path, sol_lwm2m_server_content_cb cb, void *data);
+
+/**
+ * @brief Unobserve a client object, instance or resource.
+ *
+ * @param server The LWM2M server.
+ * @param client The LWM2M client to be unobserved.
+ * @param path The path to be unobserved (Example: /3/0/0).
+ * @param cb The previous registered callback.
+ * @param data User data to @c cb
+ * @return 0 on success, -errno on error.
+ *
+ * @note In order do completly unobserve a path, all observers must be deleted.
+ * @see #sol_lwm2m_server_content_cb
+ * @see sol_lwm2m_server_add_observer()
+ */
+int sol_lwm2m_server_del_observer(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client,
+    const char *path,  sol_lwm2m_server_content_cb cb, void *data);
+
+/**
+ * @brief Writes an object instance or resource.
+ *
+ * @param server The LWM2M server.
+ * @param client The LWM2M client info to write
+ * @param path The object path to be written (Example /1/1).
+ * @param resources An array of #sol_lwm2m_resource
+ * @param len The length of @c resources
+ * @param replacing The objects instance is being replaced, this means that all required resources must be provided.
+ * @param cb A callback to be called when the write operation is completed.
+ * @param data User data to @c cb
+ * @return 0 on success, -errno on error.
+ *
+ * @note All data is sent using TLV.
+ *
+ * @see #sol_lwm2m_server_management_status_response_cb
+ */
+int sol_lwl2m_server_management_write(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client, const char *path,
+    struct sol_lwm2m_resource *resources, size_t len, bool replacing,
+    sol_lwm2m_server_management_status_response_cb cb, void *data);
+
+/**
+ * @brief Deletes an object instance on a client.
+ *
+ * @param server The LWM2M server.
+ * @param client The LWM2M client info to delete an object
+ * @param path The object path to be deleted (Example /1/1).
+ * @param cb A callback to be called when the delete operation is completed.
+ * @param data User data to @c cb
+ * @return 0 on success, -errno on error.
+ *
+ * @see #sol_lwm2m_server_management_status_response_cb
+ */
+int sol_lwm2m_server_management_delete(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client, const char *path,
+    sol_lwm2m_server_management_status_response_cb cb, void *data);
+
+/**
+ * @brief Executes an resource on a client.
+ *
+ * @param server The LWM2M server.
+ * @param client The LWM2M client info to execute the resource.
+ * @param path The object path to be executed (Example /1/1/8).
+ * @param args Arguments to the execute command.
+ * @param cb A callback to be called when the execute operation is completed.
+ * @param data User data to @c cb
+ * @return 0 on success, -errno on error.
+ *
+ * @see #sol_lwm2m_server_management_status_response_cb
+ */
+int sol_lwm2m_server_management_execute(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client, const char *path, const char *args,
+    sol_lwm2m_server_management_status_response_cb cb, void *data);
+
+/**
+ * @brief Creates an object instance on a client.
+ *
+ * @param server The LWM2M server.
+ * @param client The LWM2M client info to create an object instance.
+ * @param path The object path to create be created (Example /1).
+ * @param resources An array of #sol_lwm2m_resource which contains the required resources to create an object.
+ * @param len The length of @c resources.
+ * @param cb A callback to be called when the create operation is completed.
+ * @param data User data to @c cb
+ * @return 0 on success, -errno on error.
+ *
+ * @note All data is sent using TLV.
+ *
+ * @see #sol_lwm2m_server_management_status_response_cb
+ */
+int sol_lwm2m_server_management_create(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client, const char *path,
+    struct sol_lwm2m_resource *resources, size_t len,
+    sol_lwm2m_server_management_status_response_cb cb, void *data);
+
+/**
+ * @brief Reads an object, instance or object from a client.
+ *
+ * @param server The LWM2M server.
+ * @param client The LWM2M client info to be read.
+ * @param path The path to be read (Example /3/0/0).
+ * @param cb A callback to be called when the read operation is completed.
+ * @param data User data to @c cb
+ * @return 0 on success, -errno on error.
+ *
+ * @see #sol_lwm2m_server_content_cb
+ */
+int sol_lwm2m_server_management_read(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client, const char *path,
+    sol_lwm2m_server_content_cb cb, void *data);
+
+/**
+ * @brief Deletes a server instance.
+ *
+ * Use this function to stop the LWM2M server and release its resources.
+ *
+ * @param server The LWM2M server to be deleted.
+ * @see sol_lwm2m_server_del()
+ */
+void sol_lwm2m_server_del(struct sol_lwm2m_server *server);
+
+/**
+ * @brief Gets the name of client.
+ *
+ * @param client The LWM2M cliento info.
+ * @return The @c client name or @c NULL on error.
+ */
+const char *sol_lwm2m_client_info_get_name(const struct sol_lwm2m_client_info *client);
+
+/**
+ * @brief Gets the client location path in the LWM2M server.
+ *
+ * This value is specified by the LWM2M server and it will be used by the client
+ * to identify itself.
+ *
+ * @param client The LWM2M client info.
+ * @return The @c client location path or @c NULL on error.
+ */
+const char *sol_lwm2m_client_info_get_location(const struct sol_lwm2m_client_info *client);
+
+/**
+ * @brief Gets the client SMS number.
+ *
+ * A client may specify an SMS number to be used for communication.
+ *
+ * @param client The LWM2M client info.
+ * @return The SMS number or @c NULL.
+ */
+const char *sol_lwm2m_client_info_get_sms(const struct sol_lwm2m_client_info *client);
+
+/**
+ * @brief Gets the client objects path.
+ *
+ * A LWM2M client may specify an alternate objects path.
+ *
+ * @param client The LWM2M client info.
+ * @return The objects path or @c NULL.
+ * @note The objects path may be @c NULL.
+ */
+const char *sol_lwm2m_client_info_get_objects_path(const struct sol_lwm2m_client_info *client);
+
+/**
+ * @brief Gets the client lifetime.
+ *
+ * @param client The LWM2M client info.
+ * @param lifetime The client lifetime to be set.
+ * @return 0 on success, -errno on error.
+ */
+int sol_lwm2m_client_info_get_lifetime(const struct sol_lwm2m_client_info *client, uint32_t *lifetime);
+
+/**
+ * @brief Gets the client binding mode.
+ *
+ * @param client The LWM2M client info.
+ * @return The client binding mode or #SOL_LWM2M_BINDING_MODE_UNKNOWN on error.
+ */
+enum sol_lwm2m_binding_mode sol_lwm2m_client_info_get_binding_mode(const struct sol_lwm2m_client_info *client);
+
+/**
+ * @brief Gets the client address.
+ *
+ * @param client The LWM2M client info.
+ * @return The @c client address or @c NULL on error.
+ */
+const struct sol_network_link_addr *sol_lwm2m_client_info_get_address(const struct sol_lwm2m_client_info *client);
+
+/**
+ * @brief Get client objects.
+ *
+ * @param client The LWM2M client info.
+ * @return A array of #sol_lwm2m_client_object or @c NULL on error.
+ * @note One must not add or remove elements from the returned vector.
+ * @see #sol_lwm2m_client_object
+ */
+const struct sol_vector *sol_lwm2m_client_info_get_objects(const struct sol_lwm2m_client_info *client);
+
+/**
+ * @brief Gets the object id.
+ *
+ * @param object The LWM2M object to get the id.
+ * @param id The object id to be filled.
+ * @return 0 success, negative errno on error.
+ */
+int sol_lwm2m_client_object_get_id(const struct sol_lwm2m_client_object *object, uint16_t *id);
+
+/**
+ * @brief Gets the instances of a given object.
+ *
+ * @param object The LWM2M object object to get the instances.
+ * @return An array of uint16_t or @c NULL on error.
+ * @note One must not add or remove elements from the returned vector.
+ */
+const struct sol_vector *sol_lwm2m_client_object_get_instances(const struct sol_lwm2m_client_object *object);
+
+/**
+ * @}
+ */
+#ifdef __cplusplus
+}
+#endif

--- a/src/lib/comms/sol-lwm2m.c
+++ b/src/lib/comms/sol-lwm2m.c
@@ -1,0 +1,1967 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <alloca.h>
+#include <errno.h>
+#include <float.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define SOL_LOG_DOMAIN &_lwm2m_domain
+
+#include "sol-log-internal.h"
+#include "sol-list.h"
+#include "sol-lwm2m.h"
+#include "sol-macros.h"
+#include "sol-mainloop.h"
+#include "sol-monitors.h"
+#include "sol-random.h"
+#include "sol-str-slice.h"
+#include "sol-str-table.h"
+#include "sol-util.h"
+
+SOL_LOG_INTERNAL_DECLARE_STATIC(_lwm2m_domain, "lwm2m");
+
+#define DEFAULT_CLIENT_LIFETIME (86400)
+#define DEFAULT_BINDING_MODE (SOL_LWM2M_BINDING_MODE_U)
+#define DEFAULT_LOCATION_PATH_SIZE (10)
+#define TLV_TYPE_MASK (192)
+#define TLV_ID_SIZE_MASK (32)
+#define TLV_CONTENT_LENGTH_MASK (24)
+#define TLV_CONTENT_LENGHT_CUSTOM_MASK (7)
+#define REMOVE_SIGN_BIT_MASK (127)
+#define SIGN_BIT_MASK (128)
+#define ID_HAS_16BITS_MASK (32)
+#define OBJ_LINK_LEN (4)
+#define LEN_IS_8BITS_MASK (8)
+#define LEN_IS_16BITS_MASK (16)
+#define LEN_IS_24BITS_MASK (24)
+#define UINT24_BITS (16777215)
+
+#ifndef SOL_NO_API_VERSION
+#define LWM2M_TLV_CHECK_API(_tlv, ...) \
+    do { \
+        if (unlikely((_tlv).api_version != \
+            SOL_LWM2M_TLV_API_VERSION)) { \
+            SOL_WRN("Couldn't handle tlv that has unsupported version " \
+                "'%u', expected version is '%u'", \
+                (_tlv).api_version, SOL_LWM2M_TLV_API_VERSION); \
+            return __VA_ARGS__; \
+        } \
+    } while (0);
+#define LWM2M_RESOURCE_CHECK_API(_resource, ...) \
+    do { \
+        if (unlikely((_resource).api_version != \
+            SOL_LWM2M_RESOURCE_API_VERSION)) { \
+            SOL_WRN("Couldn't handle resource that has unsupported version " \
+                "'%u', expected version is '%u'", \
+                (_resource).api_version, SOL_LWM2M_RESOURCE_API_VERSION); \
+            return __VA_ARGS__; \
+        } \
+    } while (0);
+#else
+#define LWM2M_TLV_CHECK_API(_tlv, ...)
+#define LWM2M_RESOURCE_CHECK_API(_resource, ...)
+#endif
+
+enum tlv_length_size_type {
+    LENGTH_SIZE_CHECK_NEXT_TWO_BITS = 0,
+    LENGTH_SIZE_8_BITS = 8,
+    LENGTH_SIZE_16_BITS = 16,
+    LENGTH_SIZE_24_BITS = 32
+};
+
+struct sol_lwm2m_server {
+    struct sol_coap_server *coap;
+    struct sol_ptr_vector clients;
+    struct sol_ptr_vector clients_to_delete;
+    struct sol_monitors registration;
+    struct sol_vector observers;
+    struct {
+        struct sol_timeout *timeout;
+        uint32_t lifetime;
+    } lifetime_ctx;
+};
+
+struct sol_lwm2m_client_object {
+    struct sol_vector instances;
+    uint16_t id;
+};
+
+struct sol_lwm2m_client_info {
+    struct sol_vector objects;
+    char *name;
+    char *location;
+    char *sms;
+    char *objects_path;
+    uint32_t lifetime;
+    time_t register_time;
+    struct sol_lwm2m_server *server;
+    struct sol_network_link_addr cliaddr;
+    enum sol_lwm2m_binding_mode binding;
+    struct sol_coap_resource resource;
+};
+
+struct observer_entry {
+    struct sol_monitors monitors;
+    struct sol_lwm2m_server *server;
+    struct sol_lwm2m_client_info *cinfo;
+    int64_t token;
+    char *path;
+    bool removed;
+};
+
+enum management_type {
+    MANAGEMENT_DELETE,
+    MANAGEMENT_READ,
+    MANAGEMENT_CREATE,
+    MANAGEMENT_WRITE,
+    MANAGEMENT_EXECUTE
+};
+
+struct management_ctx {
+    enum management_type type;
+    struct sol_lwm2m_server *server;
+    struct sol_lwm2m_client_info *cinfo;
+    char *path;
+    void *cb;
+    void *data;
+};
+
+static bool lifetime_timeout(void *data);
+
+static void
+send_ack_if_needed(struct sol_coap_server *coap, struct sol_coap_packet *msg,
+    const struct sol_network_link_addr *cliaddr)
+{
+    struct sol_coap_packet *ack;
+
+    if (sol_coap_header_get_type(msg) == SOL_COAP_TYPE_CON) {
+        ack = sol_coap_packet_new(msg);
+        if (ack) {
+            sol_coap_header_set_type(ack, SOL_COAP_TYPE_ACK);
+            if (sol_coap_send_packet(coap, ack, cliaddr) < 0)
+                SOL_WRN("Could not send the reponse ACK");
+        } else
+            SOL_WRN("Could not create the response ACK");
+    }
+}
+
+static void
+dispatch_registration_event(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *cinfo,
+    enum sol_lwm2m_registration_event event)
+{
+    uint16_t i;
+    struct sol_monitors_entry *m;
+
+    SOL_MONITORS_WALK (&server->registration, m, i)
+        ((sol_lwm2m_server_regisration_event_cb)m->cb)(server, cinfo, event,
+            (void *)m->data);
+}
+
+static void
+client_objects_clear(struct sol_vector *objects)
+{
+    uint16_t i;
+    struct sol_lwm2m_client_object *object;
+
+    SOL_VECTOR_FOREACH_IDX (objects, object, i)
+        sol_vector_clear(&object->instances);
+
+    sol_vector_clear(objects);
+}
+
+static void
+client_info_del(struct sol_lwm2m_client_info *cinfo)
+{
+    free(cinfo->sms);
+    free(cinfo->location);
+    free(cinfo->name);
+    free(cinfo->objects_path);
+    client_objects_clear(&cinfo->objects);
+    free(cinfo);
+}
+
+static enum sol_lwm2m_binding_mode
+get_binding_mode_from_str(const struct sol_str_slice binding)
+{
+    static const struct sol_str_table map[] = {
+        SOL_STR_TABLE_PTR_ITEM("U", SOL_LWM2M_BINDING_MODE_U),
+        //TODO: The modes below are not supported for now.
+        SOL_STR_TABLE_PTR_ITEM("UQ", SOL_LWM2M_BINDING_MODE_UNKNOWN),
+        SOL_STR_TABLE_PTR_ITEM("S", SOL_LWM2M_BINDING_MODE_UNKNOWN),
+        SOL_STR_TABLE_PTR_ITEM("SQ", SOL_LWM2M_BINDING_MODE_UNKNOWN),
+        SOL_STR_TABLE_PTR_ITEM("US", SOL_LWM2M_BINDING_MODE_UNKNOWN),
+        SOL_STR_TABLE_PTR_ITEM("UQS", SOL_LWM2M_BINDING_MODE_UNKNOWN),
+        { }
+    };
+
+    return sol_str_table_lookup_fallback(map, binding,
+        SOL_LWM2M_BINDING_MODE_UNKNOWN);
+}
+
+static void
+clients_to_delete_clear(struct sol_ptr_vector *to_delete)
+{
+    uint16_t i;
+    struct sol_lwm2m_client_info *cinfo;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (to_delete, cinfo, i)
+        client_info_del(cinfo);
+    sol_ptr_vector_clear(to_delete);
+}
+
+static void
+remove_client(struct sol_lwm2m_client_info *cinfo, bool del)
+{
+    int r = 0;
+
+    r = sol_ptr_vector_remove(&cinfo->server->clients, cinfo);
+    if (r < 0)
+        SOL_WRN("Could not remove the client %s from the clients list",
+            cinfo->name);
+    r = sol_coap_server_unregister_resource(cinfo->server->coap,
+        &cinfo->resource);
+    if (r < 0)
+        SOL_WRN("Could not unregister coap resource for the client: %s",
+            cinfo->name);
+    if (del)
+        client_info_del(cinfo);
+    else {
+        r = sol_ptr_vector_append(&cinfo->server->clients_to_delete, cinfo);
+        if (r < 0)
+            SOL_WRN("Could not add the client to pending clients list");
+    }
+}
+
+static struct sol_lwm2m_client_object *
+find_client_object_by_id(struct sol_vector *objects,
+    uint16_t id)
+{
+    uint16_t i;
+    struct sol_lwm2m_client_object *cobject;
+
+    SOL_VECTOR_FOREACH_IDX (objects, cobject, i) {
+        if (cobject->id == id)
+            return cobject;
+    }
+
+    return NULL;
+}
+
+static int
+fill_client_objects(struct sol_lwm2m_client_info *cinfo,
+    struct sol_coap_packet *req, bool update)
+{
+    uint8_t *buf;
+    uint16_t len, i;
+    int r;
+    bool has_content;
+    struct sol_vector objects;
+    struct sol_str_slice content, *object;
+    struct sol_lwm2m_client_object *cobject;
+    uint16_t *instance;
+
+#define TO_INT(_data, _endptr, _len, _i) \
+    _i = sol_util_strtol(_data, &_endptr, _len, 10); \
+    if (_endptr == _data) { \
+        SOL_WRN("Could not convert object to int. (%.*s)", \
+            SOL_STR_SLICE_PRINT(*object)); \
+        r = -EINVAL; \
+        goto err_exit; \
+    }
+#define EXIT_IF_FAIL(_condition) \
+    if (_condition) { \
+        r = -EINVAL; \
+        SOL_WRN("Malformed object: %.*s", \
+            SOL_STR_SLICE_PRINT(*object)); \
+        goto err_exit; \
+    }
+
+    has_content = sol_coap_packet_has_payload(req);
+
+    if (!has_content && !update) {
+        SOL_WRN("The registration request has no payload!");
+        return -ENOENT;
+    } else if (!has_content)
+        return 0;
+
+    client_objects_clear(&cinfo->objects);
+
+    r = sol_coap_packet_get_payload(req, &buf, &len);
+    SOL_INT_CHECK(r, < 0, r);
+    content.data = (const char *)buf;
+    content.len = len;
+
+    SOL_DBG("Register payload content: %.*s", (int)len, buf);
+    objects = sol_str_slice_split(content, ",", 0);
+
+    if (!objects.len) {
+        SOL_WRN("The objects list is empty!");
+        return -EINVAL;
+    }
+
+    SOL_VECTOR_FOREACH_IDX (&objects, object, i) {
+        char *endptr;
+        uint16_t id;
+
+        *object = sol_str_slice_trim(*object);
+
+        EXIT_IF_FAIL(object->len < 4 || object->data[0] != '<');
+
+        /*
+           Object form: </ObjectId[/InstanceID]>
+           Where ObjectId is an integer (must be present)
+           InstanceId is an integer, may not be present and can not be UINT16_MAX
+           Alternate path: </a/path>[;rt="oma.lwm2m"][;ct=1058]
+         */
+        if (sol_str_slice_str_contains(*object, "rt=\"oma.lwm2m\"")) {
+            struct sol_str_slice path;
+            endptr = memrchr(object->data, '>', object->len);
+            EXIT_IF_FAIL(!endptr);
+            path.data = object->data + 1;
+            path.len = endptr - path.data;
+            r = sol_util_replace_str_from_slice_if_changed(&cinfo->objects_path,
+                path);
+            SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+            if (cinfo->objects_path && streq(cinfo->objects_path, "/")) {
+                free(cinfo->objects_path);
+                cinfo->objects_path = NULL;
+            }
+            continue;
+        } else if (sol_str_slice_str_contains(*object, "ct=")) {
+            //The content type value for json was not defined yet.
+            //TODO: Support JSON formats.
+            SOL_WRN("Only text format is supported for now");
+            r = -EINVAL;
+            goto err_exit;
+        }
+
+        EXIT_IF_FAIL(object->data[object->len - 1] != '>');
+
+        //Removing '<', '>' and '/'
+        object->data += 2;
+        object->len -= 3;
+
+        TO_INT(object->data, endptr, object->len, id);
+
+        cobject = find_client_object_by_id(&cinfo->objects, id);
+
+        if (!cobject) {
+            cobject = sol_vector_append(&cinfo->objects);
+            SOL_NULL_CHECK_GOTO(cobject, err_exit_nomem);
+            sol_vector_init(&cobject->instances, sizeof(uint16_t));
+            cobject->id = id;
+        }
+
+        //Advance to instance ID
+        object->len -= endptr - object->data;
+
+        //Instance ID not provided.
+        if (!object->len)
+            continue;
+
+        //Skip '/'
+        object->data = endptr + 1;
+        object->len--;
+
+        instance = sol_vector_append(&cobject->instances);
+        SOL_NULL_CHECK_GOTO(instance, err_exit_nomem);
+
+        TO_INT(object->data, endptr, object->len, *instance);
+
+        if (*instance == UINT16_MAX) {
+            SOL_WRN("The instance id value: %" PRIu16 " must not be used!",
+                UINT16_MAX);
+            r = -EPERM;
+            goto err_exit;
+        }
+    }
+
+    sol_vector_clear(&objects);
+    return 0;
+
+err_exit_nomem:
+    r = -ENOMEM;
+err_exit:
+    sol_vector_clear(&objects);
+    return r;
+
+#undef EXIT_IF_FAIL
+#undef TO_INT
+}
+
+static int
+fill_client_info(struct sol_lwm2m_client_info *cinfo,
+    struct sol_coap_packet *req, bool update)
+{
+    uint16_t i, count, max_count;
+    bool has_name = false;
+    struct sol_str_slice query[5];
+    int r;
+
+    if (update)
+        max_count = 4;
+    else
+        max_count = 5;
+
+    r = sol_coap_find_options(req, SOL_COAP_OPTION_URI_QUERY, query, max_count);
+    SOL_INT_CHECK(r, < 0, r);
+    count = r;
+
+    for (i = 0; i < count; i++) {
+        struct sol_str_slice key, value;
+        const char *sep;
+
+        SOL_DBG("Query:%.*s", SOL_STR_SLICE_PRINT(query[i]));
+        sep = memchr(query[i].data, '=', query[i].len);
+
+        if (!sep) {
+            SOL_WRN("Could not find the separator '=' at: %.*s",
+                SOL_STR_SLICE_PRINT(query[i]));
+            break;
+        }
+
+        key.data = query[i].data;
+        key.len = sep - query[i].data;
+        value.data = sep + 1;
+        value.len = query[i].len - key.len - 1;
+
+        if (sol_str_slice_str_eq(key, "ep")) {
+            if (update) {
+                SOL_WRN("The lwm2m client can not update it's name"
+                    " during the update");
+                r = -EPERM;
+                goto err_cinfo_prop;
+            }
+            //Required info
+            has_name = true;
+            cinfo->name = sol_str_slice_to_string(value);
+            SOL_NULL_CHECK_GOTO(cinfo->name, err_cinfo_prop);
+        } else if (sol_str_slice_str_eq(key, "lt")) {
+            uint32_t lifetime;
+            char *endptr;
+            lifetime = sol_util_strtoul(value.data, &endptr, value.len, 10);
+            if (endptr == value.data) {
+                SOL_WRN("Could not convert the lifetime to integer."
+                    " Lifetime: %.*s", SOL_STR_SLICE_PRINT(value));
+                goto err_cinfo_prop;
+            }
+
+            //Add some spare time.
+            lifetime += 2;
+            //To milliseconds
+            r = sol_util_uint32_mul(lifetime, 1000, &cinfo->lifetime);
+            SOL_INT_CHECK_GOTO(r, < 0, err_cinfo_prop);
+        } else if (sol_str_slice_str_eq(key, "sms")) {
+            r = sol_util_replace_str_from_slice_if_changed(&cinfo->sms, value);
+            SOL_INT_CHECK_GOTO(r, < 0, err_cinfo_prop);
+        } else if (sol_str_slice_str_eq(key, "lwm2m") &&
+            !sol_str_slice_str_eq(value, "1.0")) {
+            r = -EINVAL;
+            SOL_WRN("LWM2M version not supported:%.*s",
+                SOL_STR_SLICE_PRINT(value));
+            goto err_cinfo_prop;
+        } else if (sol_str_slice_str_eq(key, "b")) {
+            cinfo->binding = get_binding_mode_from_str(value);
+            r = -EINVAL;
+            SOL_INT_CHECK_GOTO(cinfo->binding,
+                == SOL_LWM2M_BINDING_MODE_UNKNOWN, err_cinfo_prop);
+        }
+    }
+
+    if (has_name || update)
+        return fill_client_objects(cinfo, req, update);
+    else {
+        SOL_WRN("The client did not provide its name!");
+        return -EINVAL;
+    }
+
+err_cinfo_prop:
+    return r;
+}
+
+static int
+reschedule_timeout(struct sol_lwm2m_server *server)
+{
+    struct sol_lwm2m_client_info *cinfo;
+    uint32_t smallest_remeaning, remeaning, lf;
+    time_t now;
+    uint16_t i;
+
+    clients_to_delete_clear(&server->clients_to_delete);
+
+    if (server->lifetime_ctx.timeout)
+        sol_timeout_del(server->lifetime_ctx.timeout);
+
+    if (!sol_ptr_vector_get_len(&server->clients)) {
+        server->lifetime_ctx.timeout = NULL;
+        server->lifetime_ctx.lifetime = 0;
+        return 0;
+    }
+
+    smallest_remeaning = UINT32_MAX;
+    now = time(NULL);
+    SOL_PTR_VECTOR_FOREACH_IDX (&server->clients, cinfo, i) {
+        remeaning = cinfo->lifetime - (now - cinfo->register_time);
+        if (remeaning < smallest_remeaning) {
+            smallest_remeaning = remeaning;
+            lf = cinfo->lifetime;
+        }
+    }
+
+    server->lifetime_ctx.timeout = sol_timeout_add(smallest_remeaning,
+        lifetime_timeout, server);
+    SOL_NULL_CHECK(server->lifetime_ctx.timeout, -ENOMEM);
+    server->lifetime_ctx.lifetime = lf;
+    return 0;
+}
+
+static bool
+lifetime_timeout(void *data)
+{
+    struct sol_ptr_vector to_delete = SOL_PTR_VECTOR_INIT;
+    struct sol_lwm2m_server *server = data;
+    struct sol_lwm2m_client_info *cinfo;
+    uint16_t i;
+    int r;
+
+    SOL_DBG("Lifetime timeout! (%" PRIu32 ")", server->lifetime_ctx.lifetime);
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&server->clients, cinfo, i) {
+        if (server->lifetime_ctx.lifetime != cinfo->lifetime)
+            continue;
+        SOL_DBG("Deleting client %s for inactivity", cinfo->name);
+        r = sol_ptr_vector_append(&to_delete, cinfo);
+        SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+    }
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&to_delete, cinfo, i) {
+        dispatch_registration_event(server, cinfo,
+            SOL_LWM2M_REGISTRATION_EVENT_TIMEOUT);
+        remove_client(cinfo, true);
+    }
+
+    sol_ptr_vector_clear(&to_delete);
+
+    r = reschedule_timeout(server);
+    if (r < 0)
+        SOL_WRN("Could not reschedule the lifetime timeout");
+    return false;
+
+err_exit:
+    sol_ptr_vector_clear(&to_delete);
+    return true;
+}
+
+static int
+update_client(struct sol_coap_server *coap,
+    const struct sol_coap_resource *resource,
+    struct sol_coap_packet *req,
+    const struct sol_network_link_addr *cliaddr, void *data)
+{
+    struct sol_lwm2m_client_info *cinfo = data;
+    struct sol_coap_packet *response;
+    int r;
+
+    SOL_DBG("Client update request (name: %s)", cinfo->name);
+
+    response = sol_coap_packet_new(req);
+    SOL_NULL_CHECK(response, -ENOMEM);
+
+    r = fill_client_info(cinfo, req, true);
+    SOL_INT_CHECK_GOTO(r, < 0, err_update);
+
+    r = reschedule_timeout(cinfo->server);
+    SOL_INT_CHECK_GOTO(r, < 0, err_update);
+
+    dispatch_registration_event(cinfo->server, cinfo,
+        SOL_LWM2M_REGISTRATION_EVENT_UPDATE);
+
+    sol_coap_header_set_code(response, SOL_COAP_RSPCODE_CHANGED);
+    return sol_coap_send_packet(coap, response, cliaddr);
+
+err_update:
+    sol_coap_header_set_code(response, SOL_COAP_RSPCODE_BAD_REQUEST);
+    (void)sol_coap_send_packet(coap, response, cliaddr);
+    return r;
+}
+
+static int
+delete_client(struct sol_coap_server *coap,
+    const struct sol_coap_resource *resource,
+    struct sol_coap_packet *req,
+    const struct sol_network_link_addr *cliaddr, void *data)
+{
+    struct sol_lwm2m_client_info *cinfo = data;
+    struct sol_coap_packet *response;
+
+    SOL_DBG("Client delete request (name: %s)", cinfo->name);
+
+    response = sol_coap_packet_new(req);
+    SOL_NULL_CHECK(response, -ENOMEM);
+
+    remove_client(cinfo, false);
+
+    if (!sol_ptr_vector_get_len(&cinfo->server->clients) &&
+        cinfo->server->lifetime_ctx.timeout) {
+        sol_timeout_del(cinfo->server->lifetime_ctx.timeout);
+        cinfo->server->lifetime_ctx.timeout = NULL;
+        cinfo->server->lifetime_ctx.lifetime = 0;
+        SOL_DBG("Client list is empty");
+    }
+
+    dispatch_registration_event(cinfo->server, cinfo,
+        SOL_LWM2M_REGISTRATION_EVENT_UNREGISTER);
+
+    sol_coap_header_set_code(response, SOL_COAP_RSPCODE_DELETED);
+    return sol_coap_send_packet(coap, response, cliaddr);
+}
+
+static int
+generate_location(char **location)
+{
+    int r;
+    char uuid[37];
+
+    r = sol_util_uuid_gen(false, false, uuid);
+    SOL_INT_CHECK(r, < 0, r);
+    *location = strndup(uuid, DEFAULT_LOCATION_PATH_SIZE);
+    SOL_NULL_CHECK(*location, -ENOMEM);
+    return 0;
+}
+
+static int
+new_client_info(struct sol_lwm2m_client_info **cinfo,
+    const struct sol_network_link_addr *cliaddr,
+    struct sol_lwm2m_server *server)
+{
+    int r;
+
+    *cinfo = calloc(1, sizeof(struct sol_lwm2m_client_info) +
+        (sizeof(struct sol_str_slice) * 2));
+    SOL_NULL_CHECK(cinfo, -ENOMEM);
+
+    (*cinfo)->lifetime = DEFAULT_CLIENT_LIFETIME;
+    (*cinfo)->binding = DEFAULT_BINDING_MODE;
+    r = generate_location(&(*cinfo)->location);
+    SOL_INT_CHECK(r, < 0, r);
+
+    (*cinfo)->resource.flags = SOL_COAP_FLAGS_NONE;
+    (*cinfo)->resource.path[0] = sol_str_slice_from_str((*cinfo)->location);
+    (*cinfo)->resource.path[1] = sol_str_slice_from_str("");
+    (*cinfo)->resource.del = delete_client;
+    /*
+       FIXME: Current spec says that the client update should be handled using
+       the post method, however some old clients still uses put.
+     */
+    (*cinfo)->resource.post = update_client;
+    (*cinfo)->resource.put = update_client;
+    (*cinfo)->server = server;
+    (*cinfo)->register_time = time(NULL);
+    sol_vector_init(&(*cinfo)->objects, sizeof(struct sol_lwm2m_client_object));
+    memcpy(&(*cinfo)->cliaddr, cliaddr, sizeof(struct sol_network_link_addr));
+    SOL_SET_API_VERSION((*cinfo)->resource.api_version = SOL_COAP_RESOURCE_API_VERSION; )
+    return 0;
+}
+
+static struct sol_lwm2m_client_info *
+get_client_info_by_name(struct sol_ptr_vector *clients,
+    const char *name)
+{
+    struct sol_lwm2m_client_info *cinfo;
+    uint16_t i;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (clients, cinfo, i) {
+        if (streq(name, cinfo->name))
+            return cinfo;
+    }
+
+    return NULL;
+}
+
+static int
+registration_request(struct sol_coap_server *coap,
+    const struct sol_coap_resource *resource,
+    struct sol_coap_packet *req,
+    const struct sol_network_link_addr *cliaddr, void *data)
+{
+    struct sol_lwm2m_client_info *cinfo, *old_cinfo;
+    struct sol_lwm2m_server *server = data;
+    struct sol_coap_packet *response;
+    struct sol_buffer path = SOL_BUFFER_INIT_EMPTY;
+    int r;
+    bool b;
+
+    SOL_DBG("Client registration request");
+
+    response = sol_coap_packet_new(req);
+    SOL_NULL_CHECK(response, -ENOMEM);
+
+    r = new_client_info(&cinfo, cliaddr, server);
+    SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+
+    r = fill_client_info(cinfo, req, false);
+    SOL_INT_CHECK_GOTO(r, < 0, err_exit_del_client);
+
+    r = sol_buffer_append_printf(&path, "/rd/%s", cinfo->location);
+    SOL_INT_CHECK_GOTO(r, < 0, err_exit_del_client);
+
+    old_cinfo = get_client_info_by_name(&server->clients,
+        cinfo->name);
+    if (old_cinfo) {
+        SOL_DBG("Client %s already exists, replacing it.", old_cinfo->name);
+        remove_client(old_cinfo, true);
+    }
+
+    b = sol_coap_server_register_resource(server->coap, &cinfo->resource,
+        cinfo);
+    if (!b) {
+        SOL_WRN("Could not register the coap resource for client: %s",
+            cinfo->name);
+        goto err_exit_del_client;
+    }
+
+    r = sol_ptr_vector_append(&server->clients, cinfo);
+    SOL_INT_CHECK_GOTO(r, < 0, err_exit_unregister);
+
+    r = reschedule_timeout(server);
+    SOL_INT_CHECK_GOTO(r, < 0, err_exit_unregister);
+
+    r = sol_coap_add_option(response,
+        SOL_COAP_OPTION_LOCATION_PATH, path.data, path.used);
+    SOL_INT_CHECK_GOTO(r, < 0, err_exit_unregister);
+
+    sol_coap_header_set_code(response, SOL_COAP_RSPCODE_CREATED);
+    sol_buffer_fini(&path);
+
+    SOL_DBG("Client %s registered. Location: %s, SMS: %s, binding: %u,"
+        " lifetime: %" PRIu32 " objects paths: %s",
+        cinfo->name, cinfo->location, cinfo->sms,
+        cinfo->binding, cinfo->lifetime, cinfo->objects_path);
+    dispatch_registration_event(server, cinfo,
+        SOL_LWM2M_REGISTRATION_EVENT_REGISTER);
+
+    return sol_coap_send_packet(coap, response, cliaddr);
+
+err_exit_unregister:
+    if (sol_coap_server_unregister_resource(server->coap, &cinfo->resource) < 0)
+        SOL_WRN("Could not unregister resource for client: %s", cinfo->name);
+err_exit_del_client:
+    client_info_del(cinfo);
+err_exit:
+    sol_coap_header_set_code(response, SOL_COAP_RSPCODE_BAD_REQUEST);
+    (void)sol_coap_send_packet(coap, response, cliaddr);
+    sol_buffer_fini(&path);
+    return r;
+}
+
+static const struct sol_coap_resource registration_interface = {
+    SOL_SET_API_VERSION(.api_version = SOL_COAP_RESOURCE_API_VERSION, )
+    .post = registration_request,
+    .flags = SOL_COAP_FLAGS_NONE,
+    .path = {
+        SOL_STR_SLICE_LITERAL("rd"),
+        SOL_STR_SLICE_EMPTY
+    }
+};
+
+static void
+observer_entry_del(struct observer_entry *entry)
+{
+    sol_monitors_clear(&entry->monitors);
+    free(entry->path);
+}
+
+static void
+remove_observer_entry(struct sol_vector *entries, struct observer_entry *entry)
+{
+    int r;
+
+    r = sol_vector_del_element(entries, entry);
+    SOL_INT_CHECK(r, < 0);
+    observer_entry_del(entry);
+}
+
+static struct observer_entry *
+find_observer_entry(struct sol_vector *entries,
+    struct sol_lwm2m_client_info *cinfo, const char *path)
+{
+    uint16_t i;
+    struct observer_entry *entry;
+
+    SOL_VECTOR_FOREACH_IDX (entries, entry, i) {
+        if (entry->cinfo == cinfo && streq(path, entry->path))
+            return entry;
+    }
+
+    return NULL;
+}
+
+static int
+observer_entry_init(struct observer_entry *entry,
+    struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *cinfo, const char *path)
+{
+    sol_monitors_init(&entry->monitors, NULL);
+    entry->server = server;
+    entry->cinfo = cinfo;
+    entry->path = strdup(path);
+    SOL_NULL_CHECK(entry->path, -ENOMEM);
+    return 0;
+}
+
+static int
+observer_entry_new(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *cinfo, const char *path,
+    struct observer_entry **entry)
+{
+    int r;
+
+    *entry = sol_vector_append(&server->observers);
+    SOL_NULL_CHECK(*entry, -ENOMEM);
+
+    r = observer_entry_init(*entry, server, cinfo, path);
+    SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+    return 0;
+
+err_exit:
+    sol_vector_del_element(&server->observers, *entry);
+    return r;
+}
+
+static int
+observer_entry_add_monitor(struct observer_entry *entry,
+    sol_lwm2m_server_content_cb cb, void *data)
+{
+    struct sol_monitors_entry *e;
+
+    e = sol_monitors_append(&entry->monitors, (sol_monitors_cb_t)cb, data);
+    SOL_NULL_CHECK(e, -ENOMEM);
+    return 0;
+}
+
+static int
+observer_entry_del_monitor(struct observer_entry *entry,
+    sol_lwm2m_server_content_cb cb, void *data)
+{
+    int r;
+
+    r = sol_monitors_find(&entry->monitors, (sol_monitors_cb_t)cb, data);
+    SOL_INT_CHECK(r, < 0, r);
+
+    return sol_monitors_del(&entry->monitors, r);
+}
+
+SOL_API struct sol_lwm2m_server *
+sol_lwm2m_server_new(uint16_t port)
+{
+    struct sol_lwm2m_server *server;
+    bool b;
+
+    SOL_LOG_INTERNAL_INIT_ONCE;
+
+    server = calloc(1, sizeof(struct sol_lwm2m_server));
+    SOL_NULL_CHECK(server, NULL);
+
+    server->coap = sol_coap_server_new(port);
+    SOL_NULL_CHECK_GOTO(server->coap, err_coap);
+
+    sol_ptr_vector_init(&server->clients);
+    sol_ptr_vector_init(&server->clients_to_delete);
+    sol_monitors_init(&server->registration, NULL);
+    sol_vector_init(&server->observers, sizeof(struct observer_entry));
+
+    b = sol_coap_server_register_resource(server->coap,
+        &registration_interface, server);
+    if (!b) {
+        SOL_WRN("Could not register the server resources");
+        goto err_register;
+    }
+
+    return server;
+
+err_register:
+    sol_coap_server_unref(server->coap);
+err_coap:
+    free(server);
+    return NULL;
+}
+
+SOL_API void
+sol_lwm2m_server_del(struct sol_lwm2m_server *server)
+{
+    uint16_t i;
+    struct sol_lwm2m_client_info *cinfo;
+    struct observer_entry *entry;
+
+    SOL_NULL_CHECK(server);
+
+    sol_coap_server_unref(server->coap);
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&server->clients, cinfo, i)
+        client_info_del(cinfo);
+
+    SOL_VECTOR_FOREACH_IDX (&server->observers, entry, i)
+        observer_entry_del(entry);
+
+    if (server->lifetime_ctx.timeout)
+        sol_timeout_del(server->lifetime_ctx.timeout);
+
+    clients_to_delete_clear(&server->clients_to_delete);
+    sol_monitors_clear(&server->registration);
+    sol_vector_clear(&server->observers);
+    sol_ptr_vector_clear(&server->clients);
+    free(server);
+}
+
+SOL_API int
+sol_lwm2m_server_add_registration_monitor(struct sol_lwm2m_server *server,
+    sol_lwm2m_server_regisration_event_cb cb, void *data)
+{
+    struct sol_monitors_entry *m;
+
+    SOL_NULL_CHECK(cb, -EINVAL);
+    SOL_NULL_CHECK(server, -EINVAL);
+
+    m = sol_monitors_append(&server->registration,
+        (sol_monitors_cb_t)cb, data);
+    SOL_NULL_CHECK(m, -ENOMEM);
+    return 0;
+}
+
+SOL_API int
+sol_lwm2m_server_del_registration_monitor(struct sol_lwm2m_server *server,
+    sol_lwm2m_server_regisration_event_cb cb, void *data)
+{
+    int i;
+
+    SOL_NULL_CHECK(server, -EINVAL);
+    SOL_NULL_CHECK(cb, -EINVAL);
+
+    i = sol_monitors_find(&server->registration, (sol_monitors_cb_t)cb, data);
+    if (i < 0)
+        return i;
+
+    return sol_monitors_del(&server->registration, i);
+}
+
+SOL_API const struct sol_ptr_vector *
+sol_lwm2m_server_get_clients(const struct sol_lwm2m_server *server)
+{
+    SOL_NULL_CHECK(server, NULL);
+
+    return &server->clients;
+}
+
+SOL_API const char *
+sol_lwm2m_client_info_get_name(const struct sol_lwm2m_client_info *client)
+{
+    SOL_NULL_CHECK(client, NULL);
+
+    return client->name;
+}
+
+SOL_API const char *
+sol_lwm2m_client_info_get_location(const struct sol_lwm2m_client_info *client)
+{
+    SOL_NULL_CHECK(client, NULL);
+
+    return client->location;
+}
+
+SOL_API const char *
+sol_lwm2m_client_info_get_sms(const struct sol_lwm2m_client_info *client)
+{
+    SOL_NULL_CHECK(client, NULL);
+
+    return client->sms;
+}
+
+SOL_API const char *
+sol_lwm2m_client_info_get_objects_path(
+    const struct sol_lwm2m_client_info *client)
+{
+    SOL_NULL_CHECK(client, NULL);
+
+    return client->objects_path;
+}
+
+SOL_API int
+sol_lwm2m_client_info_get_lifetime(const struct sol_lwm2m_client_info *client,
+    uint32_t *lifetime)
+{
+    SOL_NULL_CHECK(client, -EINVAL);
+    SOL_NULL_CHECK(lifetime, -EINVAL);
+
+    *lifetime = client->lifetime;
+    return 0;
+}
+
+SOL_API enum sol_lwm2m_binding_mode
+sol_lwm2m_client_info_get_binding_mode(
+    const struct sol_lwm2m_client_info *client)
+{
+    SOL_NULL_CHECK(client, SOL_LWM2M_BINDING_MODE_UNKNOWN);
+
+    return client->binding;
+}
+
+SOL_API const struct sol_network_link_addr *
+sol_lwm2m_client_info_get_address(const struct sol_lwm2m_client_info *client)
+{
+    SOL_NULL_CHECK(client, NULL);
+
+    return &client->cliaddr;
+}
+
+SOL_API const struct sol_vector *
+sol_lwm2m_client_info_get_objects(const struct sol_lwm2m_client_info *client)
+{
+    SOL_NULL_CHECK(client, NULL);
+
+    return &client->objects;
+}
+
+SOL_API int
+sol_lwm2m_client_object_get_id(const struct sol_lwm2m_client_object *object,
+    uint16_t *id)
+{
+    SOL_NULL_CHECK(object, -EINVAL);
+    SOL_NULL_CHECK(id, -EINVAL);
+
+    *id = object->id;
+    return 0;
+}
+
+SOL_API const struct sol_vector *
+sol_lwm2m_client_object_get_instances(
+    const struct sol_lwm2m_client_object *object)
+{
+    SOL_NULL_CHECK(object, NULL);
+
+    return &object->instances;
+}
+
+static size_t
+get_int_size(int64_t i)
+{
+    if (i >= INT8_MIN && i <= INT8_MAX)
+        return 1;
+    if (i >= INT16_MIN && i <= INT16_MAX)
+        return 2;
+    if (i >= INT32_MIN && i <= INT32_MAX)
+        return 4;
+    return 8;
+}
+
+static size_t
+get_double_size(double fp)
+{
+    if (fp >= FLT_MIN && fp <= FLT_MAX)
+        return 4;
+    return 8;
+}
+
+static int
+get_resource_len(const struct sol_lwm2m_resource *resource, size_t *len)
+{
+    switch (resource->type) {
+    case SOL_LWM2M_RESOURCE_TYPE_STRING:
+    case SOL_LWM2M_RESOURCE_TYPE_OPAQUE:
+        *len = resource->data.bytes.len;
+        return 0;
+    case SOL_LWM2M_RESOURCE_TYPE_INT:
+    case SOL_LWM2M_RESOURCE_TYPE_TIME:
+        *len = get_int_size(resource->data.integer);
+        return 0;
+    case SOL_LWM2M_RESOURCE_TYPE_BOOLEAN:
+        *len = 1;
+        return 0;
+    case SOL_LWM2M_RESOURCE_TYPE_FLOAT:
+        *len = get_double_size(resource->data.fp);
+        return 0;
+    case SOL_LWM2M_RESOURCE_TYPE_OBJ_LINK:
+        *len = OBJ_LINK_LEN;
+        return 0;
+    default:
+        return -EINVAL;
+    }
+}
+
+static void
+swap_bytes(uint8_t *to_swap, size_t len, bool machine)
+{
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    return;
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    uint8_t *original;
+    size_t i, j;
+
+    original = alloca(len);
+    memcpy(original, to_swap, len);
+    if (machine) {
+        for (i = 0, j = len - 1; i < len; i++, j--)
+            to_swap[i] = original[j];
+    } else {
+        for (i = len - 1, j = 0; i < len; i--, j++)
+            to_swap[i] = original[j];
+    }
+#else
+#error "Unknown byte order"
+#endif
+}
+
+static void
+to_machine_order(uint8_t *to_swap, size_t len)
+{
+    swap_bytes(to_swap, len, true);
+}
+
+static void
+to_network_order(uint8_t *to_swap, size_t len)
+{
+    swap_bytes(to_swap, len, false);
+}
+
+static int
+add_float_resource(struct sol_buffer *buf, double fp, size_t len)
+{
+    uint8_t *bytes = NULL;
+    float f;
+    double d;
+
+    if (len == 4) {
+        f = (float)fp;
+        to_network_order((uint8_t *)&f, len);
+        bytes = (uint8_t *)&f;
+    } else {
+        d = fp;
+        to_network_order((uint8_t *)&d, len);
+        bytes = (uint8_t *)&d;
+    }
+
+    return sol_buffer_append_bytes(buf, bytes, len);
+}
+
+static int
+add_resource_bytes_to_buffer(struct sol_buffer *buf,
+    const struct sol_lwm2m_resource *resource, size_t len)
+{
+    uint8_t b;
+    uint8_t bytes[sizeof(int64_t)];
+    size_t i, j;
+
+    switch (resource->type) {
+    case SOL_LWM2M_RESOURCE_TYPE_STRING:
+    case SOL_LWM2M_RESOURCE_TYPE_OPAQUE:
+        return sol_buffer_append_slice(buf, resource->data.bytes);
+    case SOL_LWM2M_RESOURCE_TYPE_INT:
+    case SOL_LWM2M_RESOURCE_TYPE_TIME:
+    case SOL_LWM2M_RESOURCE_TYPE_OBJ_LINK:
+        for (i = 0, j = len - 1; i < len; i++, j--)
+            bytes[j] = (resource->data.integer >> (8 * i)) & 255;
+        return sol_buffer_append_bytes(buf, bytes, len);
+    case SOL_LWM2M_RESOURCE_TYPE_BOOLEAN:
+        b = resource->data.integer != 0 ? 1 : 0;
+        return sol_buffer_append_bytes(buf, (uint8_t *)&b, 1);
+    case SOL_LWM2M_RESOURCE_TYPE_FLOAT:
+        return add_float_resource(buf, resource->data.fp, len);
+    default:
+        return -EINVAL;
+    }
+}
+
+static int
+set_packet_payload(struct sol_coap_packet *pkt,
+    const uint8_t *data, uint16_t len)
+{
+    int r;
+    uint16_t payload_len;
+    uint8_t *payload;
+
+    r = sol_coap_packet_get_payload(pkt, &payload, &payload_len);
+    SOL_INT_CHECK(r, < 0, r);
+    SOL_INT_CHECK(len, > payload_len, -ENOMEM);
+
+    memcpy(payload, data, len);
+    return sol_coap_packet_set_payload_used(pkt, len);
+}
+
+static int
+setup_tlv_header(struct sol_lwm2m_resource *resource, struct sol_buffer *buf,
+    size_t *header_len)
+{
+    int r;
+    uint8_t tlv_data[6];
+    size_t tlv_data_len, data_len;
+
+    LWM2M_RESOURCE_CHECK_API(*resource, -EINVAL);
+    tlv_data_len = 2;
+
+    r = get_resource_len(resource, &data_len);
+    SOL_INT_CHECK(r, < 0, r);
+
+    tlv_data[0] = SOL_LWM2M_TLV_TYPE_RESOURCE_WITH_VALUE;
+
+    if (resource->id > UINT8_MAX) {
+        tlv_data[0] |= ID_HAS_16BITS_MASK;
+        tlv_data[1] = (resource->id >> 8) & 255;
+        tlv_data[2] = resource->id & 255;
+        tlv_data_len++;
+    } else
+        tlv_data[1] = resource->id;
+
+    if (data_len <= 7)
+        tlv_data[0] |= data_len;
+    else if (data_len <= UINT8_MAX) {
+        tlv_data[tlv_data_len++] = data_len;
+        tlv_data[0] |= LEN_IS_8BITS_MASK;
+    } else if (data_len <= UINT16_MAX) {
+        tlv_data[tlv_data_len++] = (data_len >> 8) & 255;
+        tlv_data[tlv_data_len++] = data_len & 255;
+        tlv_data[0] |= LEN_IS_16BITS_MASK;
+    } else if (data_len <= UINT24_BITS) {
+        tlv_data[tlv_data_len++] = (data_len >> 16) & 255;
+        tlv_data[tlv_data_len++] = (data_len >> 8) & 255;
+        tlv_data[tlv_data_len++] = data_len & 255;
+        tlv_data[0] |= LEN_IS_24BITS_MASK;
+    }
+
+    r = sol_buffer_append_bytes(buf, tlv_data, tlv_data_len);
+    SOL_INT_CHECK(r, < 0, r);
+
+    r = add_resource_bytes_to_buffer(buf, resource, data_len);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (header_len)
+        *header_len = tlv_data_len;
+
+    return 0;
+}
+
+SOL_API int
+sol_lwm2m_resource_to_tlv(struct sol_lwm2m_resource *resource,
+    struct sol_lwm2m_tlv *tlv)
+{
+    int r;
+
+    SOL_NULL_CHECK(resource, -EINVAL);
+    SOL_NULL_CHECK(tlv, -EINVAL);
+
+    tlv->type = SOL_LWM2M_TLV_TYPE_RESOURCE_WITH_VALUE;
+    tlv->id = resource->id;
+    sol_buffer_init(&tlv->content);
+
+    r = setup_tlv_header(resource, &tlv->content, &tlv->header_len);
+    SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+
+    SOL_SET_API_VERSION(tlv->api_version = SOL_LWM2M_TLV_API_VERSION; )
+
+    return 0;
+
+err_exit:
+    sol_buffer_fini(&tlv->content);
+    return r;
+}
+
+static int
+resources_to_tlv(struct sol_lwm2m_resource *resources,
+    size_t len, struct sol_buffer *tlvs)
+{
+    int r;
+    size_t i;
+
+    for (i = 0; i < len; i++) {
+        r = setup_tlv_header(&resources[i], tlvs, NULL);
+        SOL_INT_CHECK_GOTO(r, < 0, exit);
+    }
+
+    return 0;
+
+exit:
+    return r;
+}
+
+static int
+setup_coap_packet(sol_coap_method_t method,
+    sol_coap_msgtype_t type, const char *objects_path, const char *path,
+    uint8_t *obs, int64_t *token, struct sol_lwm2m_resource *resources,
+    size_t len,
+    const char *execute_args,
+    struct sol_coap_packet **pkt)
+{
+    struct sol_buffer buf = SOL_BUFFER_INIT_EMPTY;
+    struct sol_buffer tlvs =
+        SOL_BUFFER_INIT_FLAGS(NULL, 0, SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+    struct sol_random *random;
+    uint16_t content_type, content_len = 0;
+    const uint8_t *content_data;
+    int64_t t;
+    int r;
+
+    random = sol_random_new(SOL_RANDOM_DEFAULT, 0);
+    SOL_NULL_CHECK(random, -ENOMEM);
+
+    *pkt = sol_coap_packet_request_new(method, type);
+    r = -ENOMEM;
+    SOL_NULL_CHECK_GOTO(*pkt, exit);
+
+    if (!sol_random_get_int64(random, &t)) {
+        SOL_WRN("Could not generate a random number");
+        r = -ECANCELED;
+        goto exit;
+    }
+
+    if (!sol_coap_header_set_token(*pkt, (uint8_t *)&t,
+        (uint8_t)sizeof(int64_t))) {
+        SOL_WRN("Could not set the token");
+        r = -ECANCELED;
+        goto exit;
+    }
+
+    if (token)
+        *token = t;
+
+    if (obs) {
+        r = sol_coap_add_option(*pkt, SOL_COAP_OPTION_OBSERVE,
+            obs, sizeof(uint8_t));
+        SOL_INT_CHECK_GOTO(r, < 0, exit);
+    }
+
+    if (objects_path) {
+        r = sol_buffer_append_slice(&buf,
+            sol_str_slice_from_str(objects_path));
+        SOL_INT_CHECK_GOTO(r, < 0, exit);
+    }
+
+    r = sol_buffer_append_slice(&buf, sol_str_slice_from_str(path));
+    SOL_INT_CHECK_GOTO(r, < 0, exit);
+
+    r = sol_coap_packet_add_uri_path_option(*pkt, buf.data);
+    SOL_INT_CHECK_GOTO(r, < 0, exit);
+
+    if (execute_args) {
+        size_t str_len;
+        content_type = SOL_LWM2M_CONTENT_TYPE_TEXT;
+        content_data = (const uint8_t *)execute_args;
+        str_len = strlen(execute_args);
+        r = -ENOMEM;
+        SOL_INT_CHECK_GOTO(str_len, >= UINT16_MAX, exit);
+        content_len = str_len;
+    } else if (resources) {
+        content_type = SOL_LWM2M_CONTENT_TYPE_TLV;
+        r = resources_to_tlv(resources, len, &tlvs);
+        SOL_INT_CHECK_GOTO(r, < 0, exit);
+        r = -ENOMEM;
+        SOL_INT_CHECK_GOTO(tlvs.used, >= UINT16_MAX, exit);
+        content_data = tlvs.data;
+        content_len = tlvs.used;
+    }
+
+    if (content_len > 0) {
+        r = sol_coap_add_option(*pkt, SOL_COAP_OPTION_CONTENT_FORMAT,
+            &content_type, sizeof(content_type));
+        SOL_INT_CHECK_GOTO(r, < 0, exit);
+
+        r = set_packet_payload(*pkt, content_data, content_len);
+        SOL_INT_CHECK_GOTO(r, < 0, exit);
+    }
+
+    r = 0;
+
+exit:
+    if (r < 0)
+        sol_coap_packet_unref(*pkt);
+    sol_buffer_fini(&tlvs);
+    sol_buffer_fini(&buf);
+    sol_random_del(random);
+    return r;
+}
+
+static void
+extract_content(struct sol_coap_packet *req, uint8_t *code,
+    enum sol_lwm2m_content_type *type, struct sol_str_slice *content)
+{
+    uint16_t len;
+    uint8_t *buf;
+    int r;
+
+    *code = sol_coap_header_get_code(req);
+
+    if (*code == SOL_COAP_RSPCODE_CONTENT) {
+        const void *format;
+        format = sol_coap_find_first_option(req,
+            SOL_COAP_OPTION_CONTENT_FORMAT, &len);
+        if (!format) {
+            SOL_WRN("Could not get the response content type");
+        } else
+            memcpy(type, format, sizeof(len));
+        if (sol_coap_packet_has_payload(req)) {
+            r = sol_coap_packet_get_payload(req, &buf, &len);
+            if (r < 0) {
+                SOL_WRN("Could not get the reposnse content");
+            } else {
+                content->len = len;
+                content->data = (const char *)buf;
+            }
+        }
+    }
+}
+
+static bool
+observation_request_reply(struct sol_coap_server *coap_server,
+    struct sol_coap_packet *req, const struct sol_network_link_addr *cliaddr,
+    void *data)
+{
+    struct observer_entry *entry = data;
+    struct sol_monitors_entry *m;
+    struct sol_str_slice content = SOL_STR_SLICE_EMPTY;
+    enum sol_lwm2m_content_type type = SOL_LWM2M_CONTENT_TYPE_TEXT;
+    uint16_t i;
+    uint8_t code = SOL_COAP_RSPCODE_GATEWAY_TIMEOUT;
+    bool keep_alive = true;
+
+    if (!cliaddr && !req) {
+        //Cancel observation
+        if (entry->removed) {
+            remove_observer_entry(&entry->server->observers, entry);
+            return false;
+        }
+        SOL_WRN("Could not complete the observation request on client:%s"
+            " path:%s", entry->path, entry->cinfo->name);
+        keep_alive = false;
+    } else {
+        extract_content(req, &code, &type, &content);
+        send_ack_if_needed(coap_server, req, cliaddr);
+    }
+
+    SOL_MONITORS_WALK (&entry->monitors, m, i)
+        ((sol_lwm2m_server_content_cb)m->cb)(entry->server, entry->cinfo,
+            entry->path, code, type, content, (void *)m->data);
+
+    return keep_alive;
+}
+
+SOL_API int
+sol_lwm2m_server_add_observer(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client,
+    const char *path, sol_lwm2m_server_content_cb cb, void *data)
+{
+    struct observer_entry *entry;
+    struct sol_coap_packet *pkt;
+    uint8_t obs = 0;
+    int r;
+    bool send_msg = false;
+
+    SOL_NULL_CHECK(server, -EINVAL);
+    SOL_NULL_CHECK(path, -EINVAL);
+    SOL_NULL_CHECK(client, -EINVAL);
+
+    entry = find_observer_entry(&server->observers, client, path);
+
+    if (!entry) {
+        send_msg = true;
+        r = observer_entry_new(server, client, path, &entry);
+        SOL_INT_CHECK(r, < 0, r);
+    }
+
+    r = observer_entry_add_monitor(entry, cb, data);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (!send_msg)
+        return 0;
+
+    r = setup_coap_packet(SOL_COAP_METHOD_GET, SOL_COAP_TYPE_CON,
+        client->objects_path, path, &obs, &entry->token, NULL, 0, NULL, &pkt);
+    SOL_INT_CHECK(r, < 0, r);
+
+    return sol_coap_send_packet_with_reply(server->coap, pkt, &client->cliaddr,
+        observation_request_reply, entry);
+}
+
+SOL_API int
+sol_lwm2m_server_del_observer(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client, const char *path,
+    sol_lwm2m_server_content_cb cb, void *data)
+{
+    struct observer_entry *entry;
+    int r;
+
+    SOL_NULL_CHECK(server, -EINVAL);
+    SOL_NULL_CHECK(path, -EINVAL);
+    SOL_NULL_CHECK(client, -EINVAL);
+
+    entry = find_observer_entry(&server->observers, client, path);
+    SOL_NULL_CHECK(entry, -ENOENT);
+
+    r = observer_entry_del_monitor(entry, cb, data);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (entry->monitors.entries.len)
+        return 0;
+
+    entry->removed = true;
+
+    return sol_coap_unobserve_server(server->coap, &entry->cinfo->cliaddr,
+        (uint8_t *)&entry->token, sizeof(entry->token));
+}
+
+static bool
+management_reply(struct sol_coap_server *server,
+    struct sol_coap_packet *req, const struct sol_network_link_addr *cliaddr,
+    void *data)
+{
+    struct management_ctx *ctx = data;
+    uint8_t code = 0;
+    enum sol_lwm2m_content_type content_type = SOL_LWM2M_CONTENT_TYPE_TEXT;
+    struct sol_str_slice content = SOL_STR_SLICE_EMPTY;
+
+    if (!cliaddr && !req)
+        code = SOL_COAP_RSPCODE_GATEWAY_TIMEOUT;
+
+    switch (ctx->type) {
+    case MANAGEMENT_DELETE:
+    case MANAGEMENT_CREATE:
+    case MANAGEMENT_WRITE:
+    case MANAGEMENT_EXECUTE:
+        if (!code)
+            code = sol_coap_header_get_code(req);
+        ((sol_lwm2m_server_management_status_response_cb)ctx->cb)
+            (ctx->server, ctx->cinfo, ctx->path, code, ctx->data);
+        break;
+    default: //Read
+        if (!code)
+            extract_content(req, &code, &content_type, &content);
+        ((sol_lwm2m_server_content_cb)ctx->cb)(ctx->server, ctx->cinfo,
+            ctx->path, code, content_type, content, ctx->data);
+        break;
+    }
+
+    if (code != SOL_COAP_RSPCODE_GATEWAY_TIMEOUT)
+        send_ack_if_needed(server, req, cliaddr);
+    free(ctx->path);
+    free(ctx);
+    return false;
+}
+
+static int
+send_management_packet(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client, const char *path,
+    enum management_type type, void *cb, void *data,
+    sol_coap_method_t method,
+    struct sol_lwm2m_resource *resources, size_t len, const char *execute_args)
+{
+    int r;
+    struct sol_coap_packet *pkt;
+    struct management_ctx *ctx;
+
+    r = setup_coap_packet(method, SOL_COAP_TYPE_CON,
+        client->objects_path, path, NULL, NULL, resources, len,
+        execute_args, &pkt);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (!cb)
+        return sol_coap_send_packet(server->coap, pkt, &client->cliaddr);
+
+    ctx = malloc(sizeof(struct management_ctx));
+    SOL_NULL_CHECK_GOTO(ctx, err_exit);
+
+    ctx->path = strdup(path);
+    SOL_NULL_CHECK_GOTO(ctx->path, err_exit);
+    ctx->type = type;
+    ctx->server = server;
+    ctx->cinfo = client;
+    ctx->data = data;
+    ctx->cb = cb;
+
+    return sol_coap_send_packet_with_reply(server->coap, pkt, &client->cliaddr,
+        management_reply, ctx);
+
+err_exit:
+    free(ctx);
+    sol_coap_packet_unref(pkt);
+    return -ENOMEM;
+}
+
+
+SOL_API int
+sol_lwl2m_server_management_write(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client, const char *path,
+    struct sol_lwm2m_resource *resources, size_t len, bool replacing,
+    sol_lwm2m_server_management_status_response_cb cb, void *data)
+{
+    sol_coap_method_t method = SOL_COAP_METHOD_PUT;
+
+    SOL_NULL_CHECK(server, -EINVAL);
+    SOL_NULL_CHECK(client, -EINVAL);
+
+    if (replacing)
+        method = SOL_COAP_METHOD_POST;
+
+    return send_management_packet(server, client, path,
+        MANAGEMENT_WRITE, cb, data, method, resources, len, NULL);
+}
+
+SOL_API int
+sol_lwm2m_server_management_execute(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client, const char *path, const char *args,
+    sol_lwm2m_server_management_status_response_cb cb, void *data)
+{
+    SOL_NULL_CHECK(server, -EINVAL);
+    SOL_NULL_CHECK(client, -EINVAL);
+
+    return send_management_packet(server, client, path,
+        MANAGEMENT_EXECUTE, cb, data, SOL_COAP_METHOD_POST, NULL, 0, args);
+}
+
+SOL_API int
+sol_lwm2m_server_management_delete(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client, const char *path,
+    sol_lwm2m_server_management_status_response_cb cb, void *data)
+{
+    SOL_NULL_CHECK(server, -EINVAL);
+    SOL_NULL_CHECK(client, -EINVAL);
+    SOL_NULL_CHECK(path, -EINVAL);
+
+    return send_management_packet(server, client, path,
+        MANAGEMENT_DELETE, cb, data, SOL_COAP_METHOD_DELETE, NULL, 0, NULL);
+}
+
+SOL_API int
+sol_lwm2m_server_management_create(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client, const char *path,
+    struct sol_lwm2m_resource *resources, size_t len,
+    sol_lwm2m_server_management_status_response_cb cb, void *data)
+{
+    SOL_NULL_CHECK(server, -EINVAL);
+    SOL_NULL_CHECK(client, -EINVAL);
+    SOL_NULL_CHECK(path, -EINVAL);
+    SOL_NULL_CHECK(resources, -EINVAL);
+
+    return send_management_packet(server, client, path,
+        MANAGEMENT_CREATE, cb, data, SOL_COAP_METHOD_POST, resources,
+        len, NULL);
+}
+
+SOL_API int
+sol_lwm2m_server_management_read(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client, const char *path,
+    sol_lwm2m_server_content_cb cb, void *data)
+{
+    SOL_NULL_CHECK(server, -EINVAL);
+    SOL_NULL_CHECK(client, -EINVAL);
+    SOL_NULL_CHECK(path, -EINVAL);
+    SOL_NULL_CHECK(cb, -EINVAL);
+
+    return send_management_packet(server, client, path,
+        MANAGEMENT_READ, cb, data, SOL_COAP_METHOD_GET, NULL, 0, NULL);
+}
+
+static void
+tlv_clear(struct sol_lwm2m_tlv *tlv)
+{
+    LWM2M_TLV_CHECK_API(*tlv);
+    sol_buffer_fini(&tlv->content);
+}
+
+SOL_API void
+sol_lwm2m_tlv_clear(struct sol_lwm2m_tlv *tlv)
+{
+    SOL_NULL_CHECK(tlv);
+    tlv_clear(tlv);
+}
+
+SOL_API void
+sol_lwm2m_tlv_array_clear(struct sol_vector *tlvs)
+{
+    uint16_t i;
+    struct sol_lwm2m_tlv *tlv;
+
+    SOL_NULL_CHECK(tlvs);
+
+    SOL_VECTOR_FOREACH_IDX (tlvs, tlv, i)
+        tlv_clear(tlv);
+    sol_vector_clear(tlvs);
+}
+
+SOL_API int
+sol_lwm2m_parse_tlv(const struct sol_str_slice content, struct sol_vector *out)
+{
+    size_t i, offset;
+    struct sol_lwm2m_tlv *tlv;
+    int r;
+
+    SOL_NULL_CHECK(out, -EINVAL);
+
+    sol_vector_init(out, sizeof(struct sol_lwm2m_tlv));
+
+    for (i = 0; i < content.len;) {
+        struct sol_str_slice tlv_content;
+        tlv = sol_vector_append(out);
+        r = -ENOMEM;
+        SOL_NULL_CHECK_GOTO(tlv, err_exit);
+
+        sol_buffer_init(&tlv->content);
+
+        SOL_SET_API_VERSION(tlv->api_version = SOL_LWM2M_TLV_API_VERSION; )
+
+        tlv->type = content.data[i] & TLV_TYPE_MASK;
+
+        if ((content.data[i] & TLV_ID_SIZE_MASK) != TLV_ID_SIZE_MASK) {
+            tlv->id = content.data[i + 1];
+            offset = i + 2;
+        } else {
+            tlv->id = (content.data[i + 1] << 8) | content.data[i + 2];
+            offset = i + 3;
+        }
+
+        SOL_INT_CHECK_GOTO(offset, >= content.len, err_would_overflow);
+
+        switch (content.data[i] & TLV_CONTENT_LENGTH_MASK) {
+        case LENGTH_SIZE_24_BITS:
+            tlv_content.len = (content.data[offset] << 16) |
+                (content.data[offset + 1] << 8) | content.data[offset + 2];
+            offset += 3;
+            break;
+        case LENGTH_SIZE_16_BITS:
+            tlv_content.len |= (content.data[offset] << 8) |
+                content.data[offset + 1];
+            offset += 2;
+            break;
+        case LENGTH_SIZE_8_BITS:
+            tlv_content.len = content.data[offset];
+            offset++;
+            break;
+        default:
+            tlv_content.len = content.data[i] & TLV_CONTENT_LENGHT_CUSTOM_MASK;
+        }
+
+        SOL_INT_CHECK_GOTO(offset, >= content.len, err_would_overflow);
+
+        tlv_content.data = content.data + offset;
+
+        r = sol_buffer_append_slice(&tlv->content, tlv_content);
+        SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+
+        SOL_DBG("tlv type: %u, ID: %" PRIu16 ", Size: %zu, Content: %.*s",
+            tlv->type, tlv->id, tlv_content.len,
+            SOL_STR_SLICE_PRINT(tlv_content));
+
+        tlv->header_len = (offset - i);
+        if (tlv->type != SOL_LWM2M_TLV_TYPE_MULTIPLE_RESOURCES &&
+            tlv->type != SOL_LWM2M_TLV_TYPE_OBJECT_INSTANCE)
+            i += (tlv->header_len + tlv_content.len);
+        else
+            i += tlv->header_len;
+    }
+
+    return 0;
+
+err_would_overflow:
+    r = -EOVERFLOW;
+err_exit:
+    sol_lwm2m_tlv_array_clear(out);
+    return r;
+}
+
+static int
+is_resource(struct sol_lwm2m_tlv *tlv)
+{
+    if (tlv->type != SOL_LWM2M_TLV_TYPE_RESOURCE_WITH_VALUE &&
+        tlv->type != SOL_LWM2M_TLV_TYPE_RESOURCE_INSTANCE)
+        return -EINVAL;
+    return 0;
+}
+
+SOL_API int
+sol_lwl2m_tlv_to_int(struct sol_lwm2m_tlv *tlv, int64_t *value)
+{
+    size_t i, data_len;
+    char *buf;
+
+    SOL_NULL_CHECK(tlv, -EINVAL);
+    SOL_NULL_CHECK(value, -EINVAL);
+    SOL_INT_CHECK(is_resource(tlv), < 0, -EINVAL);
+    LWM2M_TLV_CHECK_API(*tlv, -EINVAL);
+
+    data_len = tlv->content.used - tlv->header_len;
+
+    if (data_len != 1 &&
+        data_len != 2 &&
+        data_len != 4 &&
+        data_len != 8)
+        return -EINVAL;
+
+    buf = ((char *)tlv->content.data) + tlv->header_len;
+
+    //Remove the sign bit.
+    for (i = 1, *value = buf[0] & REMOVE_SIGN_BIT_MASK;
+        i < data_len; i++)
+        *value = ((*value) << 8) | (buf[i] & 255);
+
+    //Apply sign bit
+    if ((buf[0] & SIGN_BIT_MASK) == SIGN_BIT_MASK)
+        (*value) *= -1;
+
+    SOL_DBG("TLV has integer data. Value: %" PRId64 "", *value);
+    return 0;
+}
+
+SOL_API int
+sol_lwl2m_tlv_to_bool(struct sol_lwm2m_tlv *tlv, bool *value)
+{
+    SOL_NULL_CHECK(tlv, -EINVAL);
+    SOL_NULL_CHECK(value, -EINVAL);
+    SOL_INT_CHECK(is_resource(tlv), < 0, -EINVAL);
+    LWM2M_TLV_CHECK_API(*tlv, -EINVAL);
+    SOL_INT_CHECK(tlv->content.used - tlv->header_len, != 1, -EINVAL);
+
+    *value = (((char *)tlv->content.data) + tlv->header_len)[0] == 1;
+    SOL_DBG("TLV data as bool: %d", (int)*value);
+    return 0;
+}
+
+SOL_API int
+sol_lwl2m_tlv_to_float(struct sol_lwm2m_tlv *tlv, double *value)
+{
+    size_t data_len;
+
+    SOL_NULL_CHECK(tlv, -EINVAL);
+    SOL_NULL_CHECK(value, -EINVAL);
+    SOL_INT_CHECK(is_resource(tlv), < 0, -EINVAL);
+    LWM2M_TLV_CHECK_API(*tlv, -EINVAL);
+
+    data_len = tlv->content.used - tlv->header_len;
+    if (data_len == 4) {
+        float f;
+        memcpy(&f, (char *)tlv->content.data + tlv->header_len, sizeof(float));
+        to_machine_order((uint8_t *)&f, sizeof(float));
+        *value = f;
+    } else if (data_len == 8) {
+        memcpy(value, (char *)tlv->content.data + tlv->header_len, sizeof(double));
+        to_machine_order((uint8_t *)value, sizeof(double));
+    } else
+        return -EINVAL;
+
+    SOL_DBG("TLV has float data. Value: %g", *value);
+    return 0;
+}
+
+SOL_API int
+sol_lwm2m_tlv_to_obj_link(struct sol_lwm2m_tlv *tlv,
+    uint16_t *object_id, uint16_t *instance_id)
+{
+    int32_t i = 0;
+
+    SOL_NULL_CHECK(tlv, -EINVAL);
+    SOL_NULL_CHECK(object_id, -EINVAL);
+    SOL_NULL_CHECK(instance_id, -EINVAL);
+    SOL_INT_CHECK(is_resource(tlv), < 0, -EINVAL);
+    LWM2M_TLV_CHECK_API(*tlv, -EINVAL);
+    SOL_INT_CHECK(tlv->content.used - tlv->header_len, != OBJ_LINK_LEN, -EINVAL);
+
+
+    memcpy(&i, (char *)tlv->content.data + tlv->header_len, OBJ_LINK_LEN);
+    to_machine_order((uint8_t *)&i, OBJ_LINK_LEN);
+    *object_id = (i >> 16) & 0xFFFF;
+    *instance_id = i & 0xFFFF;
+
+    SOL_DBG("TLV has object link value. Object id:%" PRIu16
+        "  Instance id:%" PRIu16 "", *object_id, *instance_id);
+    return 0;
+}
+
+SOL_API int
+sol_lwm2m_tlv_get_bytes(struct sol_lwm2m_tlv *tlv, uint8_t **bytes, uint16_t *len)
+{
+    SOL_NULL_CHECK(tlv, -EINVAL);
+    SOL_NULL_CHECK(bytes, -EINVAL);
+    SOL_NULL_CHECK(len, -EINVAL);
+    SOL_INT_CHECK(is_resource(tlv), < 0, -EINVAL);
+    LWM2M_TLV_CHECK_API(*tlv, -EINVAL);
+
+    *bytes = ((uint8_t *)tlv->content.data) + tlv->header_len;
+    *len = tlv->content.used - tlv->header_len;
+
+    return 0;
+}
+
+SOL_API int
+sol_lwm2m_resource_init(struct sol_lwm2m_resource *resource,
+    uint16_t id, enum sol_lwm2m_resource_type type, ...)
+{
+    va_list ap;
+    int r = 0;
+
+    SOL_NULL_CHECK(resource, -EINVAL);
+    SOL_INT_CHECK(type, == SOL_LWM2M_RESOURCE_TYPE_NONE, -EINVAL);
+
+    va_start(ap, type);
+
+    resource->id = id;
+    resource->type = type;
+
+    switch (resource->type) {
+    case SOL_LWM2M_RESOURCE_TYPE_STRING:
+        resource->data.bytes = sol_str_slice_from_str(va_arg(ap, const char *));
+        break;
+    case SOL_LWM2M_RESOURCE_TYPE_OPAQUE:
+        resource->data.bytes = va_arg(ap, struct sol_str_slice);
+        break;
+    case SOL_LWM2M_RESOURCE_TYPE_FLOAT:
+        resource->data.fp = va_arg(ap, double);
+        break;
+    case SOL_LWM2M_RESOURCE_TYPE_INT:
+    case SOL_LWM2M_RESOURCE_TYPE_TIME:
+        resource->data.integer = va_arg(ap, int64_t);
+        break;
+    case SOL_LWM2M_RESOURCE_TYPE_BOOLEAN:
+        resource->data.integer = va_arg(ap, int);
+        break;
+    case SOL_LWM2M_RESOURCE_TYPE_OBJ_LINK:
+        resource->data.integer = (uint16_t)va_arg(ap, int);
+        resource->data.integer = (resource->data.integer << 16) |
+            (uint16_t)va_arg(ap, int);
+        break;
+    default:
+        r = -EINVAL;
+        SOL_WRN("Unknown resource type '%d'", resource->type);
+        break;
+    }
+
+    SOL_SET_API_VERSION(resource->api_version = SOL_LWM2M_RESOURCE_API_VERSION; )
+    va_end(ap);
+    return r;
+}

--- a/src/samples/coap/Kconfig
+++ b/src/samples/coap/Kconfig
@@ -11,3 +11,8 @@ config OIC_SAMPLES
 	bool "OIC samples"
 	depends on OIC && COAP_SAMPLES
 	default y
+
+config LWM2M_SAMPLES
+       bool "LWM2M samples"
+       depends on LWM2M_SERVER && COAP_SAMPLES
+       default y

--- a/src/samples/coap/Makefile
+++ b/src/samples/coap/Makefile
@@ -5,3 +5,6 @@ sample-coap-sample-server-$(COAP_CLIENT_SERVER_SAMPLES) := simple-server.c
 sample-$(OIC_SAMPLES) += oic-sample-client oic-sample-server
 sample-oic-sample-client-$(OIC_SAMPLES) := oic-client.c
 sample-oic-sample-server-$(OIC_SAMPLES) := oic-server.c
+
+sample-$(LWM2M_SAMPLES) += lwm2m-sample-server
+sample-lwm2m-sample-server-$(LWM2M_SAMPLES) := lwm2m-server.c

--- a/src/samples/coap/lwm2m-server.c
+++ b/src/samples/coap/lwm2m-server.c
@@ -1,0 +1,393 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * This sample will wait for connections of LWM2M clients.
+ * After a LWM2M client is connected, it will create a server instance in it,
+ * write some data, observe it and delete the created instance.
+ */
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+
+#include "sol-lwm2m.h"
+#include "sol-mainloop.h"
+#include "sol-coap.h"
+
+#define TEN_SECONDS (10000)
+
+static struct sol_timeout *timeout = NULL;
+
+static void
+management_reply_cb(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client,
+    const char *path,
+    sol_coap_responsecode_t code,
+    void *data);
+
+static const char *
+binding_as_string(enum sol_lwm2m_binding_mode mode)
+{
+    switch (mode) {
+    case SOL_LWM2M_BINDING_MODE_U:
+        return "U";
+    case SOL_LWM2M_BINDING_MODE_UQ:
+        return "UQ";
+    case SOL_LWM2M_BINDING_MODE_S:
+        return "S";
+    case SOL_LWM2M_BINDING_MODE_SQ:
+        return "SQ";
+    case SOL_LWM2M_BINDING_MODE_US:
+        return "US";
+    case SOL_LWM2M_BINDING_MODE_UQS:
+        return "UQS";
+    default:
+        return "Unknown";
+    }
+}
+
+static void
+show_client_info(const struct sol_lwm2m_server *server,
+    const struct sol_lwm2m_client_info *client)
+{
+    const struct sol_vector *objects, *instances;
+    uint16_t *instance;
+    struct sol_lwm2m_client_object *object;
+    uint16_t i, j, obj_id;
+    uint32_t lf;
+    const char *name;
+
+    name = sol_lwm2m_client_info_get_name(client);
+    sol_lwm2m_client_info_get_lifetime(client, &lf);
+
+    printf("--- LWM2M Client info --- \n");
+    printf("Name: %s\n", name);
+    printf("SMS: %s\n", sol_lwm2m_client_info_get_sms(client));
+    printf("Location-path:%s\n", sol_lwm2m_client_info_get_location(client));
+    printf("Objects path:%s\n", sol_lwm2m_client_info_get_objects_path(client));
+    printf("Lifetime:%" PRIu32 "\n", lf);
+    printf("Binding: %s\n",
+        binding_as_string(sol_lwm2m_client_info_get_binding_mode(client)));
+
+    objects = sol_lwm2m_client_info_get_objects(client);
+
+    SOL_VECTOR_FOREACH_IDX (objects, object, i) {
+        instances = sol_lwm2m_client_object_get_instances(object);
+        sol_lwm2m_client_object_get_id(object, &obj_id);
+        printf("Object ID (%" PRIu16 ") instances\n", obj_id);
+        SOL_VECTOR_FOREACH_IDX (instances, instance, j) {
+            printf("Instance ID: %" PRIu16 "\n", *instance);
+        }
+    }
+}
+
+static void
+delete_instance(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client)
+{
+    int r;
+
+    r = sol_lwm2m_server_management_delete(server, client, "/1/10",
+        management_reply_cb, NULL);
+
+    printf("Deleting server instance at path '/1/10 on '%s'\n",
+        sol_lwm2m_client_info_get_name(client));
+
+    if (r < 0) {
+        fprintf(stderr, "Could not send a message to delete object '/0/0' to client '%s'\n",
+            sol_lwm2m_client_info_get_name(client));
+    }
+}
+
+static void
+execute_resource(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client)
+{
+
+    int r;
+
+    r = sol_lwm2m_server_management_execute(server, client, "/1/10/8", NULL,
+        management_reply_cb, NULL);
+
+    printf("Executing resource '/1/10/8' on '%s'\n",
+        sol_lwm2m_client_info_get_name(client));
+
+    if (r < 0) {
+        fprintf(stderr, "Could not send a message to obserse '/3/0' to client '%s'\n",
+            sol_lwm2m_client_info_get_name(client));
+    }
+}
+
+static void
+write_resource(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client)
+{
+    struct sol_lwm2m_resource resource;
+    int r;
+
+    if (sol_lwm2m_resource_init(&resource, 1, SOL_LWM2M_RESOURCE_TYPE_INT, 20) < 0) {
+        fprintf(stderr, "Could not init the resource\n");
+        return;
+    }
+
+    r = sol_lwl2m_server_management_write(server, client, "/1/10", &resource, 1,
+        false, management_reply_cb, NULL);
+
+    printf("Writing a new server id at '/1/10' for '%s'\n",
+        sol_lwm2m_client_info_get_name(client));
+
+    if (r < 0) {
+        fprintf(stderr, "Could not send a message to write at path '/1/10' on client '%s'\n",
+            sol_lwm2m_client_info_get_name(client));
+    }
+}
+
+static void
+content_cb(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client,
+    const char *path,
+    sol_coap_responsecode_t response_code,
+    enum sol_lwm2m_content_type content_type,
+    struct sol_str_slice content, void *data)
+{
+    struct sol_lwm2m_tlv *tlv;
+    uint16_t i;
+    struct sol_vector tlvs;
+    const char *name;
+    int r;
+
+    name = sol_lwm2m_client_info_get_name(client);
+
+    printf("Client '%s' Path '%s' content\n", name, path);
+
+    if (response_code != SOL_COAP_RSPCODE_CONTENT) {
+        fprintf(stderr, "Invalid content response '%d'\n", response_code);
+        return;
+    }
+
+    printf("Content type: %d\n", content_type);
+    if (content_type == SOL_LWM2M_CONTENT_TYPE_TLV) {
+        printf("Content is TLV type\n");
+        r = sol_lwm2m_parse_tlv(content, &tlvs);
+        if (r < 0)
+            fprintf(stderr, "Could not parse tlv. Path '%s' Client '%s'", path, name);
+        else {
+            SOL_VECTOR_FOREACH_IDX (&tlvs, tlv, i) {
+                if (tlv->id == 7)
+                    printf("Binding: %.*s\n", SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&tlv->content)));
+                else if (tlv->id == 1) {
+                    int64_t t;
+                    r = sol_lwl2m_tlv_to_int(tlv, &t);
+                    if (r < 0)
+                        fprintf(stderr, "Could not extract int from the TLV\n");
+                    else
+                        printf("Lifetime: %" PRId64 "\n", t);
+                    break;
+                }
+            }
+            sol_lwm2m_tlv_array_clear(&tlvs);
+            write_resource(server, client);
+        }
+    } else {
+        printf("Update method: %.*s\n", SOL_STR_SLICE_PRINT(content));
+        execute_resource(server, client);
+    }
+}
+
+static void
+read_resource(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client)
+{
+    int r;
+
+    r = sol_lwm2m_server_management_read(server, client, "/1/10/8",
+        content_cb, NULL);
+
+    printf("Reading resource /1/10/8 on '%s'\n",
+        sol_lwm2m_client_info_get_name(client));
+
+    if (r < 0) {
+        fprintf(stderr, "Could not send a message to read resource '/3/0/0' to client '%s'\n",
+            sol_lwm2m_client_info_get_name(client));
+    }
+}
+
+static void
+observe_object(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client)
+{
+    int r;
+
+    r = sol_lwm2m_server_add_observer(server, client, "/1/10",
+        content_cb, NULL);
+
+    printf("Observing object instance /1/10 on '%s'\n",
+        sol_lwm2m_client_info_get_name(client));
+
+    if (r < 0) {
+        fprintf(stderr, "Could not send a message to observe '/3/0' to client '%s'\n",
+            sol_lwm2m_client_info_get_name(client));
+    }
+}
+
+static void
+management_reply_cb(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client,
+    const char *path,
+    sol_coap_responsecode_t code,
+    void *data)
+{
+    const char *name;
+
+    name = sol_lwm2m_client_info_get_name(client);
+
+    if (code == SOL_COAP_RSPCODE_DELETED) {
+        printf("Object instance '%s' deleted for client '%s'\n", path, name);
+        sol_quit();
+    } else if (code == SOL_COAP_RSPCODE_CREATED) {
+        printf("Path Object instance of '%s' for client '%s' created\n", path, name);
+        read_resource(server, client);
+    } else if (code == SOL_COAP_RSPCODE_CHANGED && !strcmp(path, "/1/10/8")) {
+        printf("The path '%s' in client '%s' has been executed\n", path, name);
+        observe_object(server, client);
+    } else if (code == SOL_COAP_RSPCODE_CHANGED && !strcmp(path, "/1/10")) {
+        printf("The path '%s' in client '%s' has been written\n", path, name);
+        delete_instance(server, client);
+    } else
+        fprintf(stderr, "Code: '%d' not expected for path '%s' and client '%s'\n", code, path, name);
+}
+
+static void
+create_server_instance(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client)
+{
+    int r;
+    struct sol_lwm2m_resource resources[5];
+
+    if (sol_lwm2m_resource_init(&resources[0], 0, SOL_LWM2M_RESOURCE_TYPE_INT, 10) < 0 ||
+        sol_lwm2m_resource_init(&resources[1], 1, SOL_LWM2M_RESOURCE_TYPE_INT, 2) < 0 ||
+        sol_lwm2m_resource_init(&resources[2], 6, SOL_LWM2M_RESOURCE_TYPE_BOOLEAN, false) < 0 ||
+        sol_lwm2m_resource_init(&resources[3], 7, SOL_LWM2M_RESOURCE_TYPE_STRING, "U") < 0 ||
+        sol_lwm2m_resource_init(&resources[4], 8, SOL_LWM2M_RESOURCE_TYPE_STRING, "Lwm2mDevKit.Registration.update();") < 0) {
+        fprintf(stderr, "Could not add the string resources\n");
+        return;
+    }
+
+    r = sol_lwm2m_server_management_create(server, client, "/1/10",
+        resources, 5, management_reply_cb, NULL);
+
+    printf("Creating server object instance in '%s' with path '/1/10'\n",
+        sol_lwm2m_client_info_get_name(client));
+
+    if (r < 0) {
+        fprintf(stderr, "Could not send a message to create an instance object '/1' to client '%s'\n",
+            sol_lwm2m_client_info_get_name(client));
+    }
+}
+
+static bool
+show_all_clients(void *data)
+{
+    struct sol_lwm2m_server *server = data;
+    uint16_t i;
+    struct sol_lwm2m_client_info *client;
+    const struct sol_ptr_vector *clients;
+
+    printf("Displaying all connected clients\n");
+    clients = sol_lwm2m_server_get_clients(server);
+
+    SOL_PTR_VECTOR_FOREACH_IDX (clients, client, i)
+        create_server_instance(server, client);
+
+    return true;
+}
+
+static void
+registration_event_cb(struct sol_lwm2m_server *server,
+    struct sol_lwm2m_client_info *client,
+    enum sol_lwm2m_registration_event event, void *data)
+{
+    if (event == SOL_LWM2M_REGISTRATION_EVENT_REGISTER) {
+        printf("Client '%s' registered\n",
+            sol_lwm2m_client_info_get_name(client));
+        show_client_info(server, client);
+    } else if (event == SOL_LWM2M_REGISTRATION_EVENT_UPDATE) {
+        printf("Client '%s' updated\n", sol_lwm2m_client_info_get_name(client));
+    } else if (event == SOL_LWM2M_REGISTRATION_EVENT_UNREGISTER)
+        printf("Client '%s' was unregistered\n",
+            sol_lwm2m_client_info_get_name(client));
+    else
+        printf("Client '%s' timeout!\n", sol_lwm2m_client_info_get_name(client));
+}
+
+int
+main(int argc, char *argv[])
+{
+    struct sol_lwm2m_server *server;
+    int r = -1;
+
+    sol_init();
+    server = sol_lwm2m_server_new(SOL_LWM2M_DEFAULT_SERVER_PORT);
+
+    if (!server) {
+        fprintf(stderr, "Could not create the server\n");
+        goto err_exit;
+    }
+
+    timeout = sol_timeout_add(TEN_SECONDS, show_all_clients, server);
+
+    if (!timeout) {
+        fprintf(stderr, "Could not create a timeout\n");
+        sol_lwm2m_server_del(server);
+        goto err_timeout;
+    }
+
+    r = sol_lwm2m_server_add_registration_monitor(server,
+        registration_event_cb, NULL);
+
+    if (r < 0) {
+        fprintf(stderr, "Could not add a registration monitor\n");
+        goto err_registration;
+    }
+
+    sol_run();
+    r = 0;
+
+err_registration:
+    sol_timeout_del(timeout);
+err_timeout:
+    sol_lwm2m_server_del(server);
+err_exit:
+    sol_shutdown();
+    return r;
+}

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -105,6 +105,24 @@ sol_util_strtol(const char *nptr, char **endptr, ssize_t len, int base)
     return r;
 }
 
+unsigned long int
+sol_util_strtoul(const char *nptr, char **endptr, ssize_t len, int base)
+{
+    char *tmpbuf, *tmpbuf_endptr;
+    unsigned long int r;
+
+    if (len < 0)
+        len = (ssize_t)strlen(nptr);
+
+    tmpbuf = strndupa(nptr, len);
+    errno = 0;
+    r = strtoul(tmpbuf, &tmpbuf_endptr, base);
+
+    if (endptr)
+        *endptr = (char *)nptr + (tmpbuf_endptr - tmpbuf);
+    return r;
+}
+
 double
 sol_util_strtodn(const char *nptr, char **endptr, ssize_t len, bool use_locale)
 {

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -61,6 +61,8 @@
 #define OVERFLOW_UINT64 OVERFLOW_TYPE(uint64_t)
 #define OVERFLOW_SIZE_T OVERFLOW_TYPE(size_t)
 #define OVERFLOW_INT64 OVERFLOW_TYPE(int64_t)
+#define OVERFLOW_INT32 OVERFLOW_TYPE(int32_t)
+#define OVERFLOW_UINT32 OVERFLOW_TYPE(uint32_t)
 
 /**
  * Extracted from Hacker's Delight, 2nd edition, chapter 2-13
@@ -129,6 +131,8 @@ double sol_util_strtodn(const char *nptr, char **endptr, ssize_t len, bool use_l
  * @return the converted value, if any.
  */
 long int sol_util_strtol(const char *nptr, char **endptr, ssize_t len, int base);
+
+unsigned long int sol_util_strtoul(const char *nptr, char **endptr, ssize_t len, int base);
 
 #define STATIC_ASSERT_LITERAL(_s) ("" _s)
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
@@ -398,6 +402,36 @@ sol_util_uint64_add(const uint64_t a, const uint64_t b, uint64_t *out)
     if (a > 0 && b > UINT64_MAX - a)
         return -EOVERFLOW;
     *out = a + b;
+#endif
+    return 0;
+}
+
+static inline int
+sol_util_int32_mul(const int32_t a, const int32_t b, int32_t *out)
+{
+#ifdef HAVE_BUILTIN_MUL_OVERFLOW
+    if (__builtin_mul_overflow(a, b, out))
+        return -EOVERFLOW;
+#else
+    if ((a >= OVERFLOW_INT32 || b >= OVERFLOW_INT32) &&
+        a > 0 && INT32_MAX / a < b)
+        return -EOVERFLOW;
+    *out = a * b;
+#endif
+    return 0;
+}
+
+static inline int
+sol_util_uint32_mul(const uint32_t a, const uint32_t b, uint32_t *out)
+{
+#ifdef HAVE_BUILTIN_MUL_OVERFLOW
+    if (__builtin_mul_overflow(a, b, out))
+        return -EOVERFLOW;
+#else
+    if ((a >= OVERFLOW_UINT32 || b >= OVERFLOW_UINT32) &&
+        a > 0 && UINT32_MAX / a < b)
+        return -EOVERFLOW;
+    *out = a * b;
 #endif
     return 0;
 }

--- a/src/test/Kconfig
+++ b/src/test/Kconfig
@@ -115,3 +115,8 @@ config TEST_CERTIFICATE
     bool "Certificate API"
     depends on PLATFORM_LINUX
     default y
+
+config TEST_LWM2M
+       bool "lwm2m"
+       depends on COAP
+       default y

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -83,3 +83,6 @@ test-test-http-$(TEST_HTTP) := test.c test-http.c
 
 test-$(TEST_CERTIFICATE) += test-certificate
 test-test-certificate-$(TEST_CERTIFICATE) := test.c test-certificate.c
+
+test-$(TEST_LWM2M) += test-lwm2m
+test-test-lwm2m-$(TEST_LWM2M) := test.c test-lwm2m.c

--- a/src/test/test-lwm2m.c
+++ b/src/test/test-lwm2m.c
@@ -1,0 +1,163 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <time.h>
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+
+#include "test.h"
+#include "sol-util.h"
+#include "sol-lwm2m.h"
+
+DEFINE_TEST(test_tlv);
+
+#define STR ("I love LWM2M")
+#define STR2 ("")
+#define STR3 ("THIS IS BIG TEXTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT")
+#define STR4 ("OPAQUE STRING")
+
+static void
+test_tlv(void)
+{
+    uint16_t obj, instance;
+    struct sol_lwm2m_resource resources[21];
+    struct sol_lwm2m_tlv tlv;
+    size_t i;
+    int r;
+
+    obj = 2;
+    instance = UINT16_MAX;
+
+    r = sol_lwm2m_resource_init(&resources[0], 0, SOL_LWM2M_RESOURCE_TYPE_BOOLEAN, true);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[1], 20, SOL_LWM2M_RESOURCE_TYPE_BOOLEAN, false);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[2], 40, SOL_LWM2M_RESOURCE_TYPE_STRING, STR);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[3], UINT16_MAX, SOL_LWM2M_RESOURCE_TYPE_STRING, STR2);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[4], UINT16_MAX, SOL_LWM2M_RESOURCE_TYPE_STRING, STR3);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[5], 66, SOL_LWM2M_RESOURCE_TYPE_INT, 2);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[6], 66, SOL_LWM2M_RESOURCE_TYPE_INT, -10);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[7], 66, SOL_LWM2M_RESOURCE_TYPE_INT, 100);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[8], 66, SOL_LWM2M_RESOURCE_TYPE_INT, 40);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[9], 66, SOL_LWM2M_RESOURCE_TYPE_INT, INT64_MAX);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[10], 66, SOL_LWM2M_RESOURCE_TYPE_OBJ_LINK, obj, instance);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[11], 66, SOL_LWM2M_RESOURCE_TYPE_TIME, time(NULL));
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[12], 22, SOL_LWM2M_RESOURCE_TYPE_FLOAT, (double)2.5);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[13], 1000, SOL_LWM2M_RESOURCE_TYPE_FLOAT, (double)3.4);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[14], 256, SOL_LWM2M_RESOURCE_TYPE_FLOAT, (double)-2.3);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[15], 255, SOL_LWM2M_RESOURCE_TYPE_FLOAT, (double)-300.23);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[16], 255, SOL_LWM2M_RESOURCE_TYPE_FLOAT, DBL_MAX);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[17], 255, SOL_LWM2M_RESOURCE_TYPE_FLOAT, DBL_MIN);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[18], 255, SOL_LWM2M_RESOURCE_TYPE_FLOAT, FLT_MIN);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[19], 255, SOL_LWM2M_RESOURCE_TYPE_FLOAT, FLT_MAX);
+    ASSERT_INT_EQ(r, 0);
+    r = sol_lwm2m_resource_init(&resources[20], 255, SOL_LWM2M_RESOURCE_TYPE_OPAQUE, sol_str_slice_from_str(STR4));
+    ASSERT_INT_EQ(r, 0);
+
+    for (i = 0; i < ARRAY_SIZE(resources); i++) {
+        r = sol_lwm2m_resource_to_tlv(&resources[i], &tlv);
+        ASSERT_INT_EQ(r, 0);
+        ASSERT_INT_EQ(resources[i].id, tlv.id);
+        switch (resources[i].type) {
+        case SOL_LWM2M_RESOURCE_TYPE_STRING:
+        case SOL_LWM2M_RESOURCE_TYPE_OPAQUE:
+        {
+            uint8_t *bytes;
+            uint16_t len;
+
+            r  = sol_lwm2m_tlv_get_bytes(&tlv, &bytes, &len);
+            ASSERT_INT_EQ(r, 0);
+            ASSERT(len == resources[i].data.bytes.len);
+            ASSERT(!memcmp(bytes, resources[i].data.bytes.data, len));
+            break;
+        }
+        case SOL_LWM2M_RESOURCE_TYPE_FLOAT:
+        {
+            double fp, rel;
+            r = sol_lwl2m_tlv_to_float(&tlv, &fp);
+            ASSERT_INT_EQ(r, 0);
+            rel = fabs(fp - resources[i].data.fp) / resources[i].data.fp;
+            ASSERT(rel <= 0.0032);
+            break;
+        }
+        case SOL_LWM2M_RESOURCE_TYPE_INT:
+        case SOL_LWM2M_RESOURCE_TYPE_TIME:
+        {
+            int64_t v;
+            r = sol_lwl2m_tlv_to_int(&tlv, &v);
+            ASSERT_INT_EQ(r, 0);
+            ASSERT(v == resources[i].data.integer);
+            break;
+        }
+        case SOL_LWM2M_RESOURCE_TYPE_BOOLEAN:
+        {
+            bool b;
+            r = sol_lwl2m_tlv_to_bool(&tlv, &b);
+            ASSERT_INT_EQ(r, 0);
+            ASSERT(b == (bool)resources[i].data.integer);
+            break;
+        }
+        case SOL_LWM2M_RESOURCE_TYPE_OBJ_LINK:
+        {
+            uint16_t o, in;
+            r = sol_lwm2m_tlv_to_obj_link(&tlv, &o, &in);
+            ASSERT_INT_EQ(r, 0);
+            ASSERT_INT_EQ(o, obj);
+            ASSERT_INT_EQ(in, instance);
+            break;
+        }
+        default:
+            break;
+        }
+        sol_lwm2m_tlv_clear(&tlv);
+    }
+}
+
+TEST_MAIN();


### PR DESCRIPTION
This patch introduces a LWM2M server with the following features:

* Registration interface.
* Discovery interface.
* Management interface.
* TLV data types.

What is not supported yet.
* Secure connections. (Data is not encrypted right now)
* LWM2M JSON.
* Queue mode operation.
* SMS support.

Signed-off-by: Guilherme Iscaro <guilherme.iscaro@intel.com>