### PR TITLE
Mainloop improvements v3

### DIFF
--- a/src/lib/common/include/sol-glib-integration.h
+++ b/src/lib/common/include/sol-glib-integration.h
@@ -448,7 +448,7 @@ sol_glib_integration(void)
     mdata->timeout = -1;
     mdata->max_prio = 0;
 
-    msource = sol_mainloop_source_new(&_sol_glib_integration_source_type, gsource);
+    msource = sol_mainloop_source_add(&_sol_glib_integration_source_type, gsource);
     SOL_NULL_CHECK_GOTO(msource, failed_mainloop_source);
 
     g_main_context_ref(ctx);

--- a/src/lib/common/include/sol-mainloop.h
+++ b/src/lib/common/include/sol-mainloop.h
@@ -147,6 +147,8 @@ int sol_run(void);
  * @brief Terminates the main loop.
  *
  * Stops the main loop and sets the return value of sol_run() to EXIT_SUCCESS.
+ *
+ * @note MT-safe if compiled with threads support.
  */
 void sol_quit(void);
 
@@ -157,6 +159,8 @@ void sol_quit(void);
  * Usually used to indicate that the application should end with an error.
  *
  * @param return_code The exit code that @ref sol_run() will return
+ *
+ * @note MT-safe if compiled with threads support.
  */
 void sol_quit_with_code(int return_code);
 
@@ -188,6 +192,8 @@ struct sol_timeout;
  * @param data The user data pointer to pass to the function
  *
  * @return A handle that can be used to delete the timeout
+ *
+ * @note MT-safe if compiled with threads support.
  */
 struct sol_timeout *sol_timeout_add(uint32_t timeout_ms, bool (*cb)(void *data), const void *data);
 
@@ -201,6 +207,8 @@ struct sol_timeout *sol_timeout_add(uint32_t timeout_ms, bool (*cb)(void *data),
  *
  * @return True if the timeout was deleted, false if the handle is invalid or
  * if it had been marked as removed already
+ *
+ * @note MT-safe if compiled with threads support.
  */
 bool sol_timeout_del(struct sol_timeout *handle);
 
@@ -227,6 +235,8 @@ struct sol_idle;
  * @param data The user data pointer to pass to the function
  *
  * @return A handle that can be used to delete the idler
+ *
+ * @note MT-safe if compiled with threads support.
  */
 struct sol_idle *sol_idle_add(bool (*cb)(void *data), const void *data);
 
@@ -237,6 +247,8 @@ struct sol_idle *sol_idle_add(bool (*cb)(void *data), const void *data);
  *
  * @return True if the idler was deleted, false if the handle is invalid or
  * if it had been marked as removed already
+ *
+ * @note MT-safe if compiled with threads support.
  */
 bool sol_idle_del(struct sol_idle *handle);
 
@@ -295,6 +307,8 @@ struct sol_fd;
  * @param data The user data pointer to pass to the function
  *
  * @return A handle that can be used to delete the file descriptor watcher
+ *
+ * @note MT-safe if compiled with threads support.
  */
 struct sol_fd *sol_fd_add(int fd, uint32_t flags, bool (*cb)(void *data, int fd, uint32_t active_flags), const void *data);
 
@@ -304,6 +318,8 @@ struct sol_fd *sol_fd_add(int fd, uint32_t flags, bool (*cb)(void *data, int fd,
  * @param handle The handle to delete
  *
  * @return True if the handle was deleted, false it is invalid or already marked as removed
+ *
+ * @note MT-safe if compiled with threads support.
  */
 bool sol_fd_del(struct sol_fd *handle);
 
@@ -314,6 +330,8 @@ bool sol_fd_del(struct sol_fd *handle);
  * @param flags The new set of flags to watch for
  *
  * @return True on success, false if the handle is invalid
+ *
+ * @note MT-safe if compiled with threads support.
  */
 bool sol_fd_set_flags(struct sol_fd *handle, uint32_t flags);
 
@@ -324,6 +342,8 @@ bool sol_fd_set_flags(struct sol_fd *handle, uint32_t flags);
  * @param flags The flags to remove from the set the handle is watching
  *
  * @return True on success, false if the handle is invalid
+ *
+ * @note MT-safe if compiled with threads support.
  */
 bool sol_fd_unset_flags(struct sol_fd *handle, uint32_t flags);
 
@@ -333,6 +353,8 @@ bool sol_fd_unset_flags(struct sol_fd *handle, uint32_t flags);
  * @param handle The handle to get the flags for
  *
  * @return The flags that are currently being watched for by the handle
+ *
+ * @note MT-safe if compiled with threads support.
  */
 uint32_t sol_fd_get_flags(const struct sol_fd *handle);
 #endif
@@ -359,6 +381,8 @@ struct sol_child_watch;
  * @param data The user data pointer to pass to the function
  *
  * @return A handler that can be used to delete the watcher
+ *
+ * @note MT-safe if compiled with threads support.
  */
 struct sol_child_watch *sol_child_watch_add(uint64_t pid, void (*cb)(void *data, uint64_t pid, int status), const void *data);
 
@@ -372,6 +396,8 @@ struct sol_child_watch *sol_child_watch_add(uint64_t pid, void (*cb)(void *data,
  * @param handle The handle to remove
  *
  * @return True on success, false if the handle is invalid or it was already marked as removed
+ *
+ * @note MT-safe if compiled with threads support.
  */
 bool sol_child_watch_del(struct sol_child_watch *handle);
 #endif
@@ -521,6 +547,8 @@ struct sol_mainloop_source;
  * @return the new main loop source instance or @c NULL on failure
  *
  * @see sol_mainloop_source_del()
+ *
+ * @note MT-safe if compiled with threads support.
  */
 struct sol_mainloop_source *sol_mainloop_source_add(const struct sol_mainloop_source_type *type, const void *data);
 
@@ -531,6 +559,8 @@ struct sol_mainloop_source *sol_mainloop_source_add(const struct sol_mainloop_so
  *        sol_mainloop_source_add().
  *
  * @see sol_mainloop_source_add()
+ *
+ * @note MT-safe if compiled with threads support.
  */
 void sol_mainloop_source_del(struct sol_mainloop_source *handle);
 
@@ -544,6 +574,8 @@ void sol_mainloop_source_del(struct sol_mainloop_source *handle);
  *         parameter. NULL is a valid return.
  *
  * @see sol_mainloop_source_add()
+ *
+ * @note MT-safe if compiled with threads support.
  */
 void *sol_mainloop_source_get_data(const struct sol_mainloop_source *handle);
 

--- a/src/lib/common/include/sol-mainloop.h
+++ b/src/lib/common/include/sol-mainloop.h
@@ -522,15 +522,15 @@ struct sol_mainloop_source;
  *
  * @see sol_mainloop_source_del()
  */
-struct sol_mainloop_source *sol_mainloop_source_new(const struct sol_mainloop_source_type *type, const void *data);
+struct sol_mainloop_source *sol_mainloop_source_add(const struct sol_mainloop_source_type *type, const void *data);
 
 /**
  * @brief Destroy a source of main loop events.
  *
  * @param handle a valid handle previously created with
- *        sol_mainloop_source_new()
+ *        sol_mainloop_source_add().
  *
- * @see sol_mainloop_source_new()
+ * @see sol_mainloop_source_add()
  */
 void sol_mainloop_source_del(struct sol_mainloop_source *handle);
 
@@ -538,12 +538,12 @@ void sol_mainloop_source_del(struct sol_mainloop_source *handle);
  * @brief Retrieve the user data (context) given to the source at creation time.
  *
  * @param handle a valid handle previously created with
- *        sol_mainloop_source_new()
+ *        sol_mainloop_source_add().
  *
- * @return whatever was given to sol_mainloop_source_new() as second
- *         parameter. NULL is a valid return
+ * @return whatever was given to sol_mainloop_source_add() as second
+ *         parameter. NULL is a valid return.
  *
- * @see sol_mainloop_source_new()
+ * @see sol_mainloop_source_add()
  */
 void *sol_mainloop_source_get_data(const struct sol_mainloop_source *handle);
 

--- a/src/lib/common/include/sol-mainloop.h
+++ b/src/lib/common/include/sol-mainloop.h
@@ -252,6 +252,19 @@ struct sol_idle *sol_idle_add(bool (*cb)(void *data), const void *data);
  */
 bool sol_idle_del(struct sol_idle *handle);
 
+/**
+ * @def SOL_MAINLOOP_FD_ENABLED
+ *
+ * This macro is defined by Soletta at build time and will state if
+ * file descriptor (fd) functionality is available, this is common in
+ * Linux/UNIX environments.
+ */
+#ifndef SOL_MAINLOOP_FD_ENABLED
+/* keep doxygen happy */
+#define SOL_MAINLOOP_FD_ENABLED
+#undef SOL_MAINLOOP_FD_ENABLED
+#endif
+
 #ifdef SOL_MAINLOOP_FD_ENABLED
 /**
  * @brief Flags to be used with file descriptor watchers.
@@ -359,6 +372,20 @@ bool sol_fd_unset_flags(struct sol_fd *handle, uint32_t flags);
 uint32_t sol_fd_get_flags(const struct sol_fd *handle);
 #endif
 
+
+/**
+ * @def SOL_MAINLOOP_FORK_WATCH_ENABLED
+ *
+ * This macro is defined by Soletta at build time and will state if
+ * monitoring (watch) of child process functionality is available,
+ * this is common in Linux/UNIX environments.
+ */
+#ifndef SOL_MAINLOOP_FORK_WATCH_ENABLED
+/* keep doxygen happy */
+#define SOL_MAINLOOP_FORK_WATCH_ENABLED
+#undef SOL_MAINLOOP_FORK_WATCH_ENABLED
+#endif
+
 #ifdef SOL_MAINLOOP_FORK_WATCH_ENABLED
 
 /**
@@ -400,6 +427,47 @@ struct sol_child_watch *sol_child_watch_add(uint64_t pid, void (*cb)(void *data,
  * @note MT-safe if compiled with threads support.
  */
 bool sol_child_watch_del(struct sol_child_watch *handle);
+#endif
+
+/**
+ * @def SOL_NO_API_VERSION
+ *
+ * This macro is defined by Soletta at build time and will state if
+ * @c api_version structure members and related defines shouldn't be
+ * used.
+ *
+ * API Version is used when dynamic libraries are available so we can
+ * check in runtime if the structures match expectations. However in
+ * static builds such as those in Small OSes it's guaranteed at build
+ * time and the space and checks can be saved.
+ *
+ * Users can rely on macros SOL_SET_API_VERSION() to set these members
+ * in a conditional way.
+ */
+#ifndef SOL_NO_API_VERSION
+/* keep doxygen happy */
+#define SOL_NO_API_VERSION
+#undef SOL_NO_API_VERSION
+#endif
+
+/**
+ * @def SOL_SET_API_VERSION
+ *
+ * This macro will cope with #SOL_NO_API_VERSION and allows easy
+ * declaration of @c api_version fields.
+ *
+ * @code
+ * struct sol_mainloop_source_type mytype = {
+ *     SOL_SET_API_VERSION(.api_version = SOL_MAINLOOP_SOURCE_TYPE_API_VERSION,)
+ *     .prepare = my_prepare,
+ *     // ...
+ * };
+ * @endcode
+ */
+#ifndef SOL_SET_API_VERSION
+/* keep doxygen happy */
+#define SOL_SET_API_VERSION(x)
+#undef SOL_SET_API_VERSION
 #endif
 
 /**
@@ -578,6 +646,369 @@ void sol_mainloop_source_del(struct sol_mainloop_source *handle);
  * @note MT-safe if compiled with threads support.
  */
 void *sol_mainloop_source_get_data(const struct sol_mainloop_source *handle);
+
+/**
+ * @brief Structure representing a mainloop implementation (hooks).
+ */
+struct sol_mainloop_implementation {
+#ifndef SOL_NO_API_VERSION
+#define SOL_MAINLOOP_IMPLEMENTATION_API_VERSION (1)  /**< compile time API version to be checked during runtime */
+    /**
+     * must match #SOL_MAINLOOP_IMPLEMENTATION_API_VERSION at runtime.
+     */
+    uint16_t api_version;
+#endif
+
+    /**
+     * Function to be called to initialize the mainloop implementation.
+     *
+     * This function will be called whenever sol_init() is called.
+     *
+     * Must not be NULL.
+     */
+    int (*init)(void);
+
+    /**
+     * Function to be called to shutdown (cleanup) the mainloop implementation.
+     *
+     * This function will be called whenever sol_shutdown() is called.
+     *
+     * Must not be NULL.
+     */
+    void (*shutdown)(void);
+
+    /**
+     * Function to be called to run the mainloop.
+     *
+     * This function will be called whenever sol_run() is called and
+     * it should block until its sibling @c quit is called.
+     *
+     * Must not be NULL.
+     */
+    void (*run)(void);
+
+    /**
+     * Function to be called to quit the mainloop.
+     *
+     * This function will be called whenever sol_quit() or
+     * sol_quit_with_code() are called and it should stop the blocking
+     * event loop executed by its sibling @c run.
+     *
+     * Do not cleanup resources here, but in the @c shutdown callback.
+     *
+     * Must not be NULL.
+     */
+    void (*quit)(void);
+
+    /**
+     * Function to be called to register a timeout to be dispatched.
+     *
+     * This function receives the number of milliseconds since the
+     * current time it should wait before calling the given pointer @c
+     * cb with the context @c data.
+     *
+     * After calling @c cb, if it returns @c true, then the timeout is
+     * renewed, otherwise it's automatically cancelled and @c
+     * timeout_del may not be called. Please note that calling
+     * sol_timeout_del() (and thus @c timeout_del) from the callback
+     * @c cb and returning @c false @b is a valid case and must be
+     * supported (guard against double-free).
+     *
+     * This function must return an internal handle that will
+     * represent the timeout. It will be given to sol_timeout_del() in
+     * order to cancel it before it fires.
+     *
+     * This function will be called whenever sol_timeout_add() is called.
+     *
+     * Must not be NULL.
+     */
+    void *(*timeout_add)(uint32_t timeout_ms, bool (*cb)(void *data), const void *data);
+
+    /**
+     * Function to be called to remove a timeout to be dispatched.
+     *
+     * This function receives the handle returned by sol_timeout_add()
+     * (and thus @c timeout_add), deleting it so the registered
+     * callback is not called anymore.
+     *
+     * This function returns true if timeout was successfully deleted.
+     *
+     * This function will be called whenever sol_timeout_del() is called.
+     *
+     * Must not be NULL.
+     */
+    bool (*timeout_del)(void *handle);
+
+    /**
+     * Function to be called to register an idler to be dispatched.
+     *
+     * This function will register an entry so the pointer @c cb will
+     * be called with the context @c data when there is nothing else
+     * to do. This prevents the mainloop from sleeping, as it will
+     * keep calling all registered idlers in sequence.
+     *
+     * After calling @c cb, if it returns @c true, then the idle is
+     * renewed, otherwise it's automatically cancelled and @c idle_del
+     * may not be called. Please note that calling sol_idle_del() (and
+     * thus @c idle_del) from the callback @c cb and returning @c
+     * false @b is a valid case and must be supported (guard against
+     * double-free).
+     *
+     * Should exist more than one idle entry, they are executed only
+     * once in the order they are registered. At the end it wraps back
+     * to the first element and continues.
+     *
+     * This function must return an internal handle that will
+     * represent the idle. It will be given to sol_idle_del() in
+     * order to cancel it before it fires.
+     *
+     * This function will be called whenever sol_idle_add() is called.
+     *
+     * Must not be NULL.
+     */
+    void *(*idle_add)(bool (*cb)(void *data), const void *data);
+
+    /**
+     * Function to be called to remove an idler to be dispatched.
+     *
+     * This function receives the handle returned by sol_idle_add()
+     * (and thus @c idle_add), deleting it so the registered
+     * callback is not called anymore.
+     *
+     * This function returns true if idle was successfully deleted.
+     *
+     * This function will be called whenever sol_idle_del() is called.
+     *
+     * Must not be NULL.
+     */
+    bool (*idle_del)(void *handle);
+
+#ifdef SOL_MAINLOOP_FD_ENABLED
+    /**
+     * Function to be called to register an fd watcher.
+     *
+     * This function will register a file descriptor (@c fd) to be
+     * monitored for events defined in @c flags, whenever one of these
+     * events happen, @c cb is called providing the context as @c
+     * data, the @c fd and the active event flags @c active_flags.
+     *
+     * After calling @c cb, if it returns @c true, then the fd watcher
+     * is renewed, otherwise it's automatically cancelled and @c
+     * fd_del may not be called. Please note that calling sol_fd_del()
+     * (and thus @c fd_del) from the callback @c cb and returning @c
+     * false @b is a valid case and must be supported (guard against
+     * double-free).
+     *
+     * This function must return an internal handle that will
+     * represent the fd watcher. It will be given to sol_fd_del() in
+     * order to cancel it before it fires.
+     *
+     * This function will be called whenever sol_fd_add() is called.
+     *
+     * Must not be NULL.
+     *
+     * @note the existence of this pointer is conditional to
+     * #SOL_MAINLOOP_FD_ENABLED, which is defined when soletta is
+     * configured and built.
+     */
+    void *(*fd_add)(int fd, uint32_t flags, bool (*cb)(void *data, int fd, uint32_t active_flags), const void *data);
+
+    /**
+     * Function to be called to remove an fd watcher.
+     *
+     * This function receives the handle returned by sol_fd_add()
+     * (and thus @c fd_add), deleting it so the registered
+     * callback is not called anymore.
+     *
+     * This function returns true if fd watcher was successfully
+     * deleted.
+     *
+     * This function will be called whenever sol_fd_del() is called.
+     *
+     * Must not be NULL.
+     *
+     * @note the existence of this pointer is conditional to
+     * #SOL_MAINLOOP_FD_ENABLED, which is defined when soletta is
+     * configured and built.
+     */
+    bool (*fd_del)(void *handle);
+
+    /**
+     * Function to be called to change the events of fd watcher.
+     *
+     * This function will change the events @c flags that an existing
+     * fd watcher will use.
+     *
+     * This function will be called whenever sol_fd_set_flags() is
+     * called.
+     *
+     * Must not be NULL.
+     *
+     * @note the existence of this pointer is conditional to
+     * #SOL_MAINLOOP_FD_ENABLED, which is defined when soletta is
+     * configured and built.
+     */
+    bool (*fd_set_flags)(void *handle, uint32_t flags);
+
+    /**
+     * Function to be called to retrieve the events of fd watcher.
+     *
+     * This function will query the events @c flags that an existing
+     * fd watcher will use.
+     *
+     * This function will be called whenever sol_fd_get_flags() is
+     * called.
+     *
+     * Must not be NULL.
+     *
+     * @note the existence of this pointer is conditional to
+     * #SOL_MAINLOOP_FD_ENABLED, which is defined when soletta is
+     * configured and built.
+     */
+    uint32_t (*fd_get_flags)(const void *handle);
+#endif
+
+#ifdef SOL_MAINLOOP_FORK_WATCH_ENABLED
+    /**
+     * Function to be called to register an child process watcher.
+     *
+     * This function will register a child process identifier (@c pid)
+     * to be monitored. Whenever this process exits, then @c cb is
+     * called with the given context @c data.
+     *
+     * This function must return an internal handle that will
+     * represent the child monitor. It will be given to
+     * sol_child_watch_del() in order to cancel it before it fires.
+     *
+     * This function will be called whenever sol_child_watch_add() is
+     * called.
+     *
+     * Must not be NULL.
+     *
+     * @note the existence of this pointer is conditional to
+     * #SOL_MAINLOOP_FORK_WATCH_ENABLED, which is defined when soletta is
+     * configured and built.
+     */
+    void *(*child_watch_add)(uint64_t pid, void (*cb)(void *data, uint64_t pid, int status), const void *data);
+
+    /**
+     * Function to be called to remove an child process watcher.
+     *
+     * This function receives the handle returned by
+     * sol_child_watch_add() (and thus @c child_watch_add), deleting
+     * it so the registered callback is not called anymore.
+     *
+     * This function returns true if child watch was successfully deleted.
+     *
+     * This function will be called whenever sol_child_watch_del() is called.
+     *
+     * Must not be NULL.
+     *
+     * @note the existence of this pointer is conditional to
+     * #SOL_MAINLOOP_FORK_WATCH_ENABLED, which is defined when soletta is
+     * configured and built.
+     */
+    bool (*child_watch_del)(void *handle);
+#endif
+
+    /**
+     * Function to be called to register a mainloop event source.
+     *
+     * This function will register an event source that will be called
+     * during the mainloop execution, allowing different mainloops to
+     * be integrated. The actual functions to be called are defined in
+     * @c type.
+     *
+     * This function must return an internal handle that will
+     * represent the source. It will be given to
+     * sol_mainloop_source_del() in order to remove it.
+     *
+     * This function will be called whenever sol_mainloop_source_add()
+     * is called.
+     *
+     * Must not be NULL.
+     */
+    void *(*source_add)(const struct sol_mainloop_source_type *type, const void *data);
+
+    /**
+     * Function to be called to remove mainloop event source.
+     *
+     * This function receives the handle returned by
+     * sol_mainloop_source_add() (and thus @c source_add), deleting
+     * it so it is not used anymore.
+     *
+     * This function will be called whenever sol_mainloop_source_del() is called.
+     *
+     * Must not be NULL.
+     */
+    void (*source_del)(void *handle);
+
+    /**
+     * Function to be called to retrieve mainloop event source internal data.
+     *
+     * This function returns the @c data given to @c source_add.
+     *
+     * This function will be called whenever
+     * sol_mainloop_source_get_data() is called.
+     *
+     * Must not be NULL.
+     */
+    void *(*source_get_data)(const void *handle);
+};
+
+/**
+ * Pointer to Soletta's internal mainloop implementation, that is the
+ * default to be used if no other is set.
+ */
+extern const struct sol_mainloop_implementation *SOL_MAINLOOP_IMPLEMENTATION_DEFAULT;
+
+/**
+ * @brief Returns the current mainloop implementation in use.
+ *
+ * By default it is #SOL_MAINLOOP_IMPLEMENTATION_DEFAULT, but can be
+ * changed by sol_mainloop_set_implementation().
+ *
+ * Before accessing the members of the returned pointer check if your
+ * known #SOL_MAINLOOP_IMPLEMENTATION_API_VERSION matches its @c
+ * api_version field (which is conditional to #SOL_NO_API_VERSION).
+ *
+ * @return the pointer to the current implementation, always non-null.
+ */
+const struct sol_mainloop_implementation *sol_mainloop_get_implementation(void);
+
+/**
+ * @brief Changes the mainloop implementation.
+ *
+ * By setting the mainloop implementation one can override the Soletta
+ * behavior, this is often useful if libsoletta is being used as a
+ * guest library in some system that already hosts one, such as a
+ * Node.JS application. In this case we want to forward requests to
+ * that mainloop and be as lean as possible.
+ *
+ * This is an alternative to sol_mainloop_source_add(), in that case
+ * Soletta would be the host and other main loops can be the guest,
+ * see sol-glib-integration.h for one example.
+ *
+ * @note Primitives such as sol_idle_add(), sol_idle_del(),
+ *       sol_timeout_add(), sol_timeout_del(), sol_fd_add(),
+ *       sol_fd_del(), sol_fd_set_flags(), sol_fd_get_flags(),
+ *       sol_child_watch_add() and sol_child_watch_del(),
+ *       sol_mainloop_source_add(), sol_mainloop_source_del() and
+ *       sol_mainloop_source_get_data() may be called from threads,
+ *       then handle these as such.
+ *
+ * @note this function must be called @b before sol_init() is called
+ *       the first time, otherwise it will refuse and will return
+ *       error.
+ *
+ * @param impl a valid handle, this means @c api_version field must
+ *        match #SOL_MAINLOOP_IMPLEMENTATION_API_VERSION and all
+ *        pointers are non-NULL. It is not copied, so the pointer must
+ *        be valid until a new one is set to replace it.
+ *
+ * @return true on success or false on failure.
+ */
+bool sol_mainloop_set_implementation(const struct sol_mainloop_implementation *impl);
 
 /**
  * @brief Gets the argument count the application was launched with, if any.

--- a/src/lib/common/sol-bus.c
+++ b/src/lib/common/sol-bus.c
@@ -163,7 +163,7 @@ event_create_source(sd_event *event)
         on_sd_event_fd, ctx);
     SOL_NULL_CHECK_GOTO(ctx->fd_handler, error_fd);
 
-    source = sol_mainloop_source_new(&source_type, ctx);
+    source = sol_mainloop_source_add(&source_type, ctx);
     SOL_NULL_CHECK_GOTO(source, error_source);
 
     return source;

--- a/src/lib/common/sol-mainloop-common.c
+++ b/src/lib/common/sol-mainloop-common.c
@@ -176,7 +176,7 @@ void
 sol_mainloop_common_timeout_process(void)
 {
     struct timespec now;
-    unsigned int i;
+    uint32_t i;
 
     sol_mainloop_impl_lock();
     sol_ptr_vector_steal(&TIMEOUT_PROCESS, &TIMEOUT_ACUM);
@@ -186,6 +186,8 @@ sol_mainloop_common_timeout_process(void)
     now = sol_util_timespec_get_current();
     for (i = 0; i < TIMEOUT_PROCESS.base.len; i++) {
         struct sol_timeout_common *timeout = sol_ptr_vector_get(&TIMEOUT_PROCESS, i);
+        int32_t r;
+
         if (!sol_mainloop_common_loop_check())
             break;
         if (timeout->remove_me)
@@ -204,9 +206,11 @@ sol_mainloop_common_timeout_process(void)
         }
 
         sol_util_timespec_sum(&now, &timeout->timeout, &timeout->expire);
-        sol_ptr_vector_del(&TIMEOUT_PROCESS, i);
-        sol_ptr_vector_insert_sorted(&TIMEOUT_PROCESS, timeout, timeout_compare);
-        i--;
+        r = sol_ptr_vector_update_sorted(&TIMEOUT_PROCESS, i, timeout_compare);
+        if (r < 0)
+            break;
+        if ((uint32_t)r != i)
+            i--;
     }
 
     sol_mainloop_impl_lock();
@@ -574,7 +578,7 @@ sol_mainloop_impl_timeout_add(uint32_t timeout_ms, bool (*cb)(void *data), const
     now = sol_util_timespec_get_current();
     sol_util_timespec_sum(&now, &timeout->timeout, &timeout->expire);
     ret = sol_ptr_vector_insert_sorted(&timeout_vector, timeout, timeout_compare);
-    SOL_INT_CHECK_GOTO(ret, != 0, clean);
+    SOL_INT_CHECK_GOTO(ret, < 0, clean);
 
     sol_mainloop_common_main_thread_check_notify();
     sol_mainloop_impl_unlock();

--- a/src/lib/common/sol-mainloop-common.c
+++ b/src/lib/common/sol-mainloop-common.c
@@ -654,7 +654,7 @@ sol_mainloop_impl_idle_del(void *handle)
 }
 
 void *
-sol_mainloop_impl_source_new(const struct sol_mainloop_source_type *type, const void *data)
+sol_mainloop_impl_source_add(const struct sol_mainloop_source_type *type, const void *data)
 {
     int ret;
     struct sol_mainloop_source_common *source = malloc(sizeof(struct sol_mainloop_source_common));

--- a/src/lib/common/sol-mainloop-impl-glib.c
+++ b/src/lib/common/sol-mainloop-impl-glib.c
@@ -353,7 +353,7 @@ static GSourceFuncs source_funcs = {
 };
 
 void *
-sol_mainloop_impl_source_new(const struct sol_mainloop_source_type *type, const void *data)
+sol_mainloop_impl_source_add(const struct sol_mainloop_source_type *type, const void *data)
 {
     struct source_wrap_data *wrap_data;
     guint id;

--- a/src/lib/common/sol-mainloop-impl.h
+++ b/src/lib/common/sol-mainloop-impl.h
@@ -63,6 +63,6 @@ void *sol_mainloop_impl_child_watch_add(uint64_t pid, void (*cb)(void *data, uin
 bool sol_mainloop_impl_child_watch_del(void *handle);
 #endif
 
-void *sol_mainloop_impl_source_new(const struct sol_mainloop_source_type *type, const void *data);
+void *sol_mainloop_impl_source_add(const struct sol_mainloop_source_type *type, const void *data);
 void sol_mainloop_impl_source_del(void *handle);
 void *sol_mainloop_impl_source_get_data(const void *handle);

--- a/src/lib/common/sol-mainloop.c
+++ b/src/lib/common/sol-mainloop.c
@@ -338,7 +338,7 @@ sol_child_watch_del(struct sol_child_watch *handle)
 #endif
 
 SOL_API struct sol_mainloop_source *
-sol_mainloop_source_new(const struct sol_mainloop_source_type *type, const void *data)
+sol_mainloop_source_add(const struct sol_mainloop_source_type *type, const void *data)
 {
     SOL_NULL_CHECK(type, NULL);
 
@@ -355,7 +355,7 @@ sol_mainloop_source_new(const struct sol_mainloop_source_type *type, const void 
     SOL_NULL_CHECK(type->check, NULL);
     SOL_NULL_CHECK(type->dispatch, NULL);
 
-    return sol_mainloop_impl_source_new(type, data);
+    return sol_mainloop_impl_source_add(type, data);
 }
 
 SOL_API void

--- a/src/lib/common/sol-mainloop.c
+++ b/src/lib/common/sol-mainloop.c
@@ -91,11 +91,43 @@ extern int sol_update_init(void);
 extern void sol_update_shutdown(void);
 #endif
 
+static const struct sol_mainloop_implementation _sol_mainloop_implementation_default = {
+    SOL_SET_API_VERSION(.api_version = SOL_MAINLOOP_IMPLEMENTATION_API_VERSION, )
+    .init = sol_mainloop_impl_init,
+    .shutdown =  sol_mainloop_impl_shutdown,
+    .run =  sol_mainloop_impl_run,
+    .quit =  sol_mainloop_impl_quit,
+    .timeout_add =  sol_mainloop_impl_timeout_add,
+    .timeout_del =  sol_mainloop_impl_timeout_del,
+    .idle_add =  sol_mainloop_impl_idle_add,
+    .idle_del =  sol_mainloop_impl_idle_del,
+
+#ifdef SOL_MAINLOOP_FD_ENABLED
+    .fd_add =  sol_mainloop_impl_fd_add,
+    .fd_del =  sol_mainloop_impl_fd_del,
+    .fd_set_flags =  sol_mainloop_impl_fd_set_flags,
+    .fd_get_flags =  sol_mainloop_impl_fd_get_flags,
+#endif
+
+#ifdef SOL_MAINLOOP_FORK_WATCH_ENABLED
+    .child_watch_add =  sol_mainloop_impl_child_watch_add,
+    .child_watch_del =  sol_mainloop_impl_child_watch_del,
+#endif
+
+    .source_add =  sol_mainloop_impl_source_add,
+    .source_del =  sol_mainloop_impl_source_del,
+    .source_get_data =  sol_mainloop_impl_source_get_data,
+};
+
 static int _init_count;
 static bool mainloop_running;
 static int mainloop_return_code;
 static int _argc;
 static char **_argv;
+static const struct sol_mainloop_implementation *mainloop_impl = &_sol_mainloop_implementation_default;
+
+SOL_API const struct sol_mainloop_implementation *SOL_MAINLOOP_IMPLEMENTATION_DEFAULT = &_sol_mainloop_implementation_default;
+
 
 SOL_API int
 sol_init(void)
@@ -112,7 +144,7 @@ sol_init(void)
 
     sol_log_domain_init_level(SOL_LOG_DOMAIN);
 
-    r = sol_mainloop_impl_init();
+    r = mainloop_impl->init();
     if (r < 0)
         goto impl_error;
 
@@ -174,7 +206,7 @@ blob_error:
 pin_mux_error:
     sol_platform_shutdown();
 platform_error:
-    sol_mainloop_impl_shutdown();
+    mainloop_impl->shutdown();
 impl_error:
     sol_log_shutdown();
 log_error:
@@ -196,7 +228,7 @@ sol_run(void)
 
     SOL_DBG("run");
     mainloop_running = true;
-    sol_mainloop_impl_run();
+    mainloop_impl->run();
     return mainloop_return_code;
 }
 
@@ -221,7 +253,7 @@ sol_quit_with_code(int return_code)
     SOL_DBG("quit with code %d", return_code);
     mainloop_return_code = return_code;
     mainloop_running = false;
-    sol_mainloop_impl_quit();
+    mainloop_impl->quit();
 }
 
 SOL_API void
@@ -246,7 +278,7 @@ sol_shutdown(void)
     sol_blob_shutdown();
     sol_pin_mux_shutdown();
     sol_platform_shutdown();
-    sol_mainloop_impl_shutdown();
+    mainloop_impl->shutdown();
     sol_modules_clear_cache();
 #ifdef USE_UPDATE
     sol_update_shutdown();
@@ -259,28 +291,28 @@ SOL_API struct sol_timeout *
 sol_timeout_add(uint32_t timeout_ms, bool (*cb)(void *data), const void *data)
 {
     SOL_NULL_CHECK(cb, NULL);
-    return sol_mainloop_impl_timeout_add(timeout_ms, cb, data);
+    return mainloop_impl->timeout_add(timeout_ms, cb, data);
 }
 
 SOL_API bool
 sol_timeout_del(struct sol_timeout *handle)
 {
     SOL_NULL_CHECK(handle, false);
-    return sol_mainloop_impl_timeout_del(handle);
+    return mainloop_impl->timeout_del(handle);
 }
 
 SOL_API struct sol_idle *
 sol_idle_add(bool (*cb)(void *data), const void *data)
 {
     SOL_NULL_CHECK(cb, NULL);
-    return sol_mainloop_impl_idle_add(cb, data);
+    return mainloop_impl->idle_add(cb, data);
 }
 
 SOL_API bool
 sol_idle_del(struct sol_idle *handle)
 {
     SOL_NULL_CHECK(handle, false);
-    return sol_mainloop_impl_idle_del(handle);
+    return mainloop_impl->idle_del(handle);
 }
 
 #ifdef SOL_MAINLOOP_FD_ENABLED
@@ -288,35 +320,35 @@ SOL_API struct sol_fd *
 sol_fd_add(int fd, uint32_t flags, bool (*cb)(void *data, int fd, uint32_t active_flags), const void *data)
 {
     SOL_NULL_CHECK(cb, NULL);
-    return sol_mainloop_impl_fd_add(fd, flags, cb, data);
+    return mainloop_impl->fd_add(fd, flags, cb, data);
 }
 
 SOL_API bool
 sol_fd_del(struct sol_fd *handle)
 {
     SOL_NULL_CHECK(handle, false);
-    return sol_mainloop_impl_fd_del(handle);
+    return mainloop_impl->fd_del(handle);
 }
 
 SOL_API bool
 sol_fd_set_flags(struct sol_fd *handle, uint32_t flags)
 {
     SOL_NULL_CHECK(handle, false);
-    return sol_mainloop_impl_fd_set_flags(handle, flags);
+    return mainloop_impl->fd_set_flags(handle, flags);
 }
 
 SOL_API uint32_t
 sol_fd_get_flags(const struct sol_fd *handle)
 {
     SOL_NULL_CHECK(handle, false);
-    return sol_mainloop_impl_fd_get_flags(handle);
+    return mainloop_impl->fd_get_flags(handle);
 }
 
 SOL_API bool
 sol_fd_unset_flags(struct sol_fd *handle, uint32_t flags)
 {
     SOL_NULL_CHECK(handle, false);
-    return sol_mainloop_impl_fd_set_flags(handle, sol_mainloop_impl_fd_get_flags(handle) & ~flags);
+    return mainloop_impl->fd_set_flags(handle, mainloop_impl->fd_get_flags(handle) & ~flags);
 }
 #endif
 
@@ -326,14 +358,14 @@ sol_child_watch_add(uint64_t pid, void (*cb)(void *data, uint64_t pid, int statu
 {
     SOL_INT_CHECK(pid, < 1, NULL);
     SOL_NULL_CHECK(cb, NULL);
-    return sol_mainloop_impl_child_watch_add(pid, cb, data);
+    return mainloop_impl->child_watch_add(pid, cb, data);
 }
 
 SOL_API bool
 sol_child_watch_del(struct sol_child_watch *handle)
 {
     SOL_NULL_CHECK(handle, false);
-    return sol_mainloop_impl_child_watch_del(handle);
+    return mainloop_impl->child_watch_del(handle);
 }
 #endif
 
@@ -355,21 +387,73 @@ sol_mainloop_source_add(const struct sol_mainloop_source_type *type, const void 
     SOL_NULL_CHECK(type->check, NULL);
     SOL_NULL_CHECK(type->dispatch, NULL);
 
-    return sol_mainloop_impl_source_add(type, data);
+    return mainloop_impl->source_add(type, data);
 }
 
 SOL_API void
 sol_mainloop_source_del(struct sol_mainloop_source *handle)
 {
     SOL_NULL_CHECK(handle);
-    sol_mainloop_impl_source_del(handle);
+    mainloop_impl->source_del(handle);
 }
 
 SOL_API void *
 sol_mainloop_source_get_data(const struct sol_mainloop_source *handle)
 {
     SOL_NULL_CHECK(handle, NULL);
-    return sol_mainloop_impl_source_get_data(handle);
+    return mainloop_impl->source_get_data(handle);
+}
+
+SOL_API const struct sol_mainloop_implementation *
+sol_mainloop_get_implementation(void)
+{
+    return mainloop_impl;
+}
+
+SOL_API bool
+sol_mainloop_set_implementation(const struct sol_mainloop_implementation *impl)
+{
+    SOL_NULL_CHECK(impl, false);
+
+#ifndef SOL_NO_API_VERSION
+    if (impl->api_version != SOL_MAINLOOP_IMPLEMENTATION_API_VERSION) {
+        SOL_WRN("impl(%p)->api_version(%hu) != "
+            "SOL_MAINLOOP_IMPLEMENTATION_API_VERSION(%hu)",
+            impl, impl->api_version,
+            SOL_MAINLOOP_IMPLEMENTATION_API_VERSION);
+        return false;
+    }
+#endif
+
+    SOL_NULL_CHECK(impl->init, false);
+    SOL_NULL_CHECK(impl->shutdown, false);
+    SOL_NULL_CHECK(impl->run, false);
+    SOL_NULL_CHECK(impl->quit, false);
+    SOL_NULL_CHECK(impl->timeout_add, false);
+    SOL_NULL_CHECK(impl->timeout_del, false);
+    SOL_NULL_CHECK(impl->idle_add, false);
+    SOL_NULL_CHECK(impl->idle_del, false);
+
+#ifdef SOL_MAINLOOP_FD_ENABLED
+    SOL_NULL_CHECK(impl->fd_add, false);
+    SOL_NULL_CHECK(impl->fd_del, false);
+    SOL_NULL_CHECK(impl->fd_set_flags, false);
+    SOL_NULL_CHECK(impl->fd_get_flags, false);
+#endif
+
+#ifdef SOL_MAINLOOP_FORK_WATCH_ENABLED
+    SOL_NULL_CHECK(impl->child_watch_add, false);
+    SOL_NULL_CHECK(impl->child_watch_del, false);
+#endif
+
+    SOL_NULL_CHECK(impl->source_add, false);
+    SOL_NULL_CHECK(impl->source_del, false);
+    SOL_NULL_CHECK(impl->source_get_data, false);
+
+    SOL_INT_CHECK(_init_count, > 0, false);
+
+    mainloop_impl = impl;
+    return true;
 }
 
 SOL_API int

--- a/src/lib/common/sol-platform.c
+++ b/src/lib/common/sol-platform.c
@@ -130,8 +130,11 @@ void
 sol_platform_shutdown(void)
 {
     free(board_name);
+    board_name = NULL;
     free(os_version);
+    os_version = NULL;
     free(serial_number);
+    serial_number = NULL;
     sol_monitors_clear(&_ctx.state_monitors);
     sol_monitors_clear(&_ctx.service_monitors);
     sol_monitors_clear(&_ctx.hostname_monitors);

--- a/src/lib/common/sol-update.c
+++ b/src/lib/common/sol-update.c
@@ -190,6 +190,7 @@ sol_update_shutdown(void)
         update_module->shutdown();
 
     sol_lib_loader_del(update_module_loader);
+    update_module_loader = NULL;
 }
 
 SOL_API struct sol_update_handle *

--- a/src/lib/datatypes/include/sol-vector.h
+++ b/src/lib/datatypes/include/sol-vector.h
@@ -117,23 +117,44 @@ void *sol_vector_append(struct sol_vector *v);
 void *sol_vector_append_n(struct sol_vector *v, uint16_t n);
 
 /**
- * @brief Return the element of the vector at the given index.
+ * @brief Return the element of the vector at the given index (no safety checks).
+ *
+ * This is similar to sol_vector_get(), but does no safety checks such
+ * as array boundaries. Only use this whenever you're sure the index
+ * @a i exists.
  *
  * @param v Vector pointer
  * @param i Index of the element to return
  *
  * @return Pointer to the element at the index @c i
+ *
+ * @see sol_vector_get()
+ */
+static inline void *
+sol_vector_get_nocheck(const struct sol_vector *v, uint16_t i)
+{
+    const unsigned char *data;
+
+    data = (const unsigned char *)v->data;
+
+    return (void *)&data[v->elem_size * i];
+}
+
+/**
+ * @brief Return the element of the vector at the given index.
+ *
+ * @param v Vector pointer
+ * @param i Index of the element to return
+ *
+ * @return Pointer to the element at the index @c i or @c NULL on errors.
  */
 static inline void *
 sol_vector_get(const struct sol_vector *v, uint16_t i)
 {
-    const unsigned char *data;
-
     if (i >= v->len)
         return NULL;
-    data = (const unsigned char *)v->data;
 
-    return (void *)&data[v->elem_size * i];
+    return sol_vector_get_nocheck(v, i);
 }
 
 /**
@@ -213,7 +234,7 @@ sol_vector_take_data(struct sol_vector *v)
  */
 #define SOL_VECTOR_FOREACH_IDX(vector, itrvar, idx)                      \
     for (idx = 0;                                                       \
-        idx < (vector)->len && (itrvar = sol_vector_get((vector), idx), true); \
+        idx < (vector)->len && (itrvar = (typeof(itrvar))sol_vector_get_nocheck((vector), idx), true); \
         idx++)
 
 /**
@@ -226,7 +247,7 @@ sol_vector_take_data(struct sol_vector *v)
  */
 #define SOL_VECTOR_FOREACH_REVERSE_IDX(vector, itrvar, idx)              \
     for (idx = (vector)->len - 1;                                       \
-        idx != ((typeof(idx)) - 1) && (itrvar = sol_vector_get((vector), idx), true); \
+        idx != ((typeof(idx)) - 1) && (itrvar = (typeof(itrvar))sol_vector_get_nocheck((vector), idx), true); \
         idx--)
 /**
  * @}
@@ -312,6 +333,29 @@ sol_ptr_vector_get_len(const struct sol_ptr_vector *pv)
 int sol_ptr_vector_append(struct sol_ptr_vector *pv, void *ptr);
 
 /**
+ * @brief Return the element of the vector at the given index (no safety checks).
+ *
+ * This is similar to sol_ptr_vector_get(), but does no safety checks
+ * such as array boundaries. Only use this whenever you're sure the
+ * index @a i exists.
+ *
+ * @param pv Pointer Vector pointer
+ * @param i Index of the element to return
+ *
+ * @return Pointer at the index @c i.
+ *
+ * @see sol_ptr_vector_get()
+ */
+static inline void *
+sol_ptr_vector_get_nocheck(const struct sol_ptr_vector *pv, uint16_t i)
+{
+    void **data;
+
+    data = (void **)sol_vector_get_nocheck(&pv->base, i);
+    return *data;
+}
+
+/**
  * @brief Return the element of the vector at the given index.
  *
  * @param pv Pointer Vector pointer
@@ -322,12 +366,10 @@ int sol_ptr_vector_append(struct sol_ptr_vector *pv, void *ptr);
 static inline void *
 sol_ptr_vector_get(const struct sol_ptr_vector *pv, uint16_t i)
 {
-    void **data;
-
-    data = (void **)sol_vector_get(&pv->base, i);
-    if (!data)
+    if (i >= pv->base.len)
         return NULL;
-    return *data;
+
+    return sol_ptr_vector_get_nocheck(pv, i);
 }
 
 /**
@@ -481,7 +523,7 @@ sol_ptr_vector_take_data(struct sol_ptr_vector *pv)
 #define SOL_PTR_VECTOR_FOREACH_IDX(vector, itrvar, idx) \
     for (idx = 0; \
         idx < (vector)->base.len && \
-        ((itrvar = *(((void **)(vector)->base.data) + idx)), true); \
+        ((itrvar = (typeof(itrvar))sol_ptr_vector_get_nocheck((vector), idx)), true); \
         idx++)
 
 /**
@@ -495,7 +537,7 @@ sol_ptr_vector_take_data(struct sol_ptr_vector *pv)
 #define SOL_PTR_VECTOR_FOREACH_REVERSE_IDX(vector, itrvar, idx) \
     for (idx = (vector)->base.len - 1; \
         idx != ((typeof(idx)) - 1) && \
-        (itrvar = *(((void **)(vector)->base.data) + idx), true); \
+        (itrvar = (typeof(itrvar))sol_ptr_vector_get_nocheck((vector), idx), true); \
         idx--)
 
 /**

--- a/src/lib/datatypes/include/sol-vector.h
+++ b/src/lib/datatypes/include/sol-vector.h
@@ -403,13 +403,16 @@ int sol_ptr_vector_insert_sorted(struct sol_ptr_vector *pv, void *ptr, int (*com
 /**
  * @brief Remove an pointer from the vector.
  *
- * Removes the pointer @c ptr from the vector. It stops when the
- * first occurrence is found.
+ * Removes the pointer @c ptr from the vector. It stops when the first
+ * occurrence is found. To delete all use sol_ptr_vector_del_element()
  *
  * @param pv Pointer Vector pointer
  * @param ptr Pointer to remove
  *
  * @return @c 0 on success, error code (always negative) otherwise
+ *
+ * @see sol_ptr_vector_del()
+ * @see sol_ptr_vector_del_element()
  */
 int sol_ptr_vector_remove(struct sol_ptr_vector *pv, const void *ptr);
 
@@ -420,6 +423,9 @@ int sol_ptr_vector_remove(struct sol_ptr_vector *pv, const void *ptr);
  * @param i Index of the element to remove
  *
  * @return @c 0 on success, error code (always negative) otherwise
+ *
+ * @see sol_ptr_vector_del_element()
+ * @see sol_ptr_vector_remove()
  */
 static inline int
 sol_ptr_vector_del(struct sol_ptr_vector *pv, uint16_t i)
@@ -434,6 +440,9 @@ sol_ptr_vector_del(struct sol_ptr_vector *pv, uint16_t i)
  * @param elem Element to remove
  *
  * @return @c 0 on success, error code (always negative) otherwise
+ *
+ * @see sol_ptr_vector_del()
+ * @see sol_ptr_vector_remove()
  */
 int sol_ptr_vector_del_element(struct sol_ptr_vector *pv, const void *elem);
 

--- a/src/lib/datatypes/include/sol-vector.h
+++ b/src/lib/datatypes/include/sol-vector.h
@@ -35,6 +35,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <errno.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -397,8 +398,59 @@ int sol_ptr_vector_set(struct sol_ptr_vector *pv, uint16_t i, void *ptr);
  * @param compare_cb Function to compare elements in the list. It should return an integer
  * less than, equal to, or greater than zero if @c data1 is found, respectively,
  * to be less than, to match, or be greater than @c data2 in the sort order
+ *
+ * @return index (>=0) or negative errno on errors.
+ *
+ * @see sol_ptr_vector_append()
+ * @see sol_ptr_vector_insert_at()
+ * @see sol_ptr_vector_match_sorted()
+ * @see sol_ptr_vector_find_sorted()
+ * @see sol_ptr_vector_find_first_sorted()
+ * @see sol_ptr_vector_find_last_sorted()
  */
-int sol_ptr_vector_insert_sorted(struct sol_ptr_vector *pv, void *ptr, int (*compare_cb)(const void *data1, const void *data2));
+int32_t sol_ptr_vector_insert_sorted(struct sol_ptr_vector *pv, void *ptr, int (*compare_cb)(const void *data1, const void *data2));
+
+/**
+ * @brief Update sorted pointer vector so the element is still in order.
+ *
+ * This function takes an index @c i and checks it is in correct order
+ * in the previously sorted array. It is an optimized version to be
+ * used instead of deleting and inserting it again, so array size is
+ * untouched.
+ *
+ * @param pv Pointer Vector pointer
+ * @param i The index that was updated and may be repositioned
+ * @param compare_cb Function to compare elements in the list. It should return an integer
+ * less than, equal to, or greater than zero if @c data1 is found, respectively,
+ * to be less than, to match, or be greater than @c data2 in the sort order
+ *
+ * @return the index (>=0) on success, which may be the same if it
+ * wasn't changed, or negative errno on failure.
+ */
+int32_t sol_ptr_vector_update_sorted(struct sol_ptr_vector *pv, uint16_t i, int (*compare_cb)(const void *data1, const void *data2));
+
+/**
+ * @brief Insert a pointer in the pointer vector at a given position.
+ *
+ * This function inserts a new element @a ptr at index @a i. All
+ * existing elements with index greater than @a i will be moved, thus
+ * their index will increase by one. If the index is the last position
+ * (sol_ptr_vector_get_len()), then it will have the same effect as
+ * sol_ptr_vector_append().
+ *
+ * @param pv Pointer Vector pointer
+ * @param i Index to insert element at.
+ * @param ptr The pointer
+ *
+ * @return 0 on success or negative errno on errors.
+ *
+ * @see sol_ptr_vector_append()
+ * @see sol_ptr_vector_match_sorted()
+ * @see sol_ptr_vector_find_sorted()
+ * @see sol_ptr_vector_find_first_sorted()
+ * @see sol_ptr_vector_find_last_sorted()
+ */
+int sol_ptr_vector_insert_at(struct sol_ptr_vector *pv, uint16_t i, void *ptr);
 
 /**
  * @brief Remove an pointer from the vector.
@@ -426,6 +478,9 @@ int sol_ptr_vector_remove(struct sol_ptr_vector *pv, const void *ptr);
  *
  * @see sol_ptr_vector_del_element()
  * @see sol_ptr_vector_remove()
+ * @see sol_ptr_vector_find()
+ * @see sol_ptr_vector_match_sorted()
+ * @see sol_ptr_vector_find_sorted()
  */
 static inline int
 sol_ptr_vector_del(struct sol_ptr_vector *pv, uint16_t i)
@@ -548,6 +603,344 @@ sol_ptr_vector_take_data(struct sol_ptr_vector *pv)
         idx != ((typeof(idx)) - 1) && \
         (itrvar = (typeof(itrvar))sol_ptr_vector_get_nocheck((vector), idx), true); \
         idx--)
+
+/**
+ * @brief Find the last occurrence of @c elem from the vector @c pv.
+ *
+ * @param pv Pointer Vector pointer
+ * @param elem Element to find
+ *
+ * @return index (>=0) on success, error code (always negative) otherwise
+ *
+ * @see sol_ptr_vector_find_first()
+ * @see sol_ptr_vector_find_first_sorted()
+ * @see sol_ptr_vector_match_first()
+ * @see sol_ptr_vector_match_last()
+ * @see sol_ptr_vector_find_last_sorted()
+ * @see sol_ptr_vector_match_sorted()
+ * @see sol_ptr_vector_find_sorted()
+ */
+static inline int
+sol_ptr_vector_find_last(const struct sol_ptr_vector *pv, const void *elem)
+{
+    uint16_t i;
+    const void *p;
+
+    SOL_PTR_VECTOR_FOREACH_REVERSE_IDX (pv, p, i) {
+        if (elem == p)
+            return i;
+    }
+
+    return -ENODATA;
+}
+
+/**
+ * @brief Find the first occurrence of @c elem from the vector @c pv.
+ *
+ * @param pv Pointer Vector pointer
+ * @param elem Element to find
+ *
+ * @return index (>=0) on success, error code (always negative) otherwise
+ *
+ * @see sol_ptr_vector_find_last()
+ * @see sol_ptr_vector_find_first_sorted()
+ * @see sol_ptr_vector_find_last_sorted()
+ * @see sol_ptr_vector_match_first()
+ * @see sol_ptr_vector_match_last()
+ * @see sol_ptr_vector_match_sorted()
+ * @see sol_ptr_vector_find_sorted()
+ */
+static inline int
+sol_ptr_vector_find_first(const struct sol_ptr_vector *pv, const void *elem)
+{
+    uint16_t i;
+    const void *p;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (pv, p, i) {
+        if (elem == p)
+            return i;
+    }
+
+    return -ENODATA;
+}
+
+/**
+ * @brief Match for the first occurrence matching template @c elem.
+ *
+ * @note this function returns a match given @a compare_cb, that is,
+ *       one that returns 0. To find the actual pointer @a elem, use
+ *       sol_ptr_vector_find_first().
+ *
+ * @param pv Pointer Vector pointer
+ * @param elem Element (template) to find, the returned index may not
+ * be of @a elem pointer, but to another element which makes @a
+ * compare_cb return 0.
+ * @param compare_cb Function to compare elements in the list. It should return an integer
+ * less than, equal to, or greater than zero if @c data1 is found, respectively,
+ * to be less than, to match, or be greater than @c data2 in the sort order
+ *
+ * @return index (>=0) on success, error code (always negative) otherwise
+ *
+ * @see sol_ptr_vector_match_last()
+ * @see sol_ptr_vector_find_first()
+ * @see sol_ptr_vector_find_first_sorted()
+ */
+static inline int32_t
+sol_ptr_vector_match_first(const struct sol_ptr_vector *pv, const void *elem, int (*compare_cb)(const void *data1, const void *data2))
+{
+    uint16_t i;
+    const void *p;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (pv, p, i) {
+        if (compare_cb(elem, p) == 0)
+            return i;
+    }
+
+    return -ENODATA;
+}
+
+/**
+ * @brief Match for the last occurrence matching template @c elem.
+ *
+ * @note this function returns a match given @a compare_cb, that is,
+ *       one that returns 0. To find the actual pointer @a elem, use
+ *       sol_ptr_vector_find_first() or sol_ptr_vector_find_last().
+ *
+ * @param pv Pointer Vector pointer
+ * @param elem Element (template) to find, the returned index may not
+ * be of @a elem pointer, but to another element which makes @a
+ * compare_cb return 0.
+ * @param compare_cb Function to compare elements in the list. It should return an integer
+ * less than, equal to, or greater than zero if @c data1 is found, respectively,
+ * to be less than, to match, or be greater than @c data2 in the sort order
+ *
+ * @return index (>=0) on success, error code (always negative) otherwise
+ *
+ * @see sol_ptr_vector_match_first()
+ * @see sol_ptr_vector_find_last()
+ * @see sol_ptr_vector_find_last_sorted()
+ */
+static inline int32_t
+sol_ptr_vector_match_last(const struct sol_ptr_vector *pv, const void *elem, int (*compare_cb)(const void *data1, const void *data2))
+{
+    uint16_t i;
+    const void *p;
+
+    SOL_PTR_VECTOR_FOREACH_REVERSE_IDX (pv, p, i) {
+        if (compare_cb(elem, p) == 0)
+            return i;
+    }
+
+    return -ENODATA;
+}
+
+/**
+ * @brief Match for occurrence matching template @c elem in the sorted vector @c pv.
+ *
+ * @note this function returns a match given @a compare_cb, that is,
+ *       one that returns 0. To find the actual pointer @a elem, use
+ *       sol_ptr_vector_find_sorted().
+ *
+ * @param pv Pointer Vector pointer (already sorted)
+ * @param elem Element (template) to find, the returned index may not
+ * be of @a elem pointer, but to another element which makes @a
+ * compare_cb return 0.
+ * @param compare_cb Function to compare elements in the list. It should return an integer
+ * less than, equal to, or greater than zero if @c data1 is found, respectively,
+ * to be less than, to match, or be greater than @c data2 in the sort order
+ *
+ * @return index (>=0) on success, error code (always negative) otherwise
+ *
+ * @see sol_ptr_vector_find_first()
+ * @see sol_ptr_vector_find_last()
+ * @see sol_ptr_vector_find_first_sorted()
+ * @see sol_ptr_vector_find_last_sorted()
+ * @see sol_ptr_vector_find_sorted()
+ * @see sol_ptr_vector_insert_sorted()
+ * @see sol_ptr_vector_match_first()
+ * @see sol_ptr_vector_match_last()
+ */
+int32_t sol_ptr_vector_match_sorted(const struct sol_ptr_vector *pv, const void *elem, int (*compare_cb)(const void *data1, const void *data2));
+
+/**
+ * @brief Find the exact occurrence of @c elem in the sorted vector @c pv.
+ *
+ * This function will find the exact pointer to @a elem, so an
+ * existing element must be used. For a query-element (only used for
+ * reference in the @a compare_cb), use sol_ptr_vector_match_sorted().
+ *
+ * Unlike sol_ptr_vector_find_first_sorted() and
+ * sol_ptr_vector_find_last_sorted(), it will do a binary search and
+ * return the first occurence of the pointer @a elem. In the case of
+ * multiple occurences, it may be an element in the middle of those
+ * that would match (@a compare_cb returns 0).
+ *
+ * @param pv Pointer Vector pointer (already sorted)
+ * @param elem Element to find
+ * @param compare_cb Function to compare elements in the list. It should return an integer
+ * less than, equal to, or greater than zero if @c data1 is found, respectively,
+ * to be less than, to match, or be greater than @c data2 in the sort order
+ *
+ * @return index (>=0) on success, error code (always negative) otherwise
+ *
+ * @see sol_ptr_vector_find_first()
+ * @see sol_ptr_vector_find_last()
+ * @see sol_ptr_vector_find_first_sorted()
+ * @see sol_ptr_vector_find_last_sorted()
+ * @see sol_ptr_vector_find_sorted()
+ * @see sol_ptr_vector_insert_sorted()
+ * @see sol_ptr_vector_match_first()
+ * @see sol_ptr_vector_match_last()
+ * @see sol_ptr_vector_match_sorted()
+ */
+static inline int32_t
+sol_ptr_vector_find_sorted(const struct sol_ptr_vector *pv, const void *elem, int (*compare_cb)(const void *data1, const void *data2))
+{
+    uint16_t i;
+    int32_t r;
+
+    r = sol_ptr_vector_match_sorted(pv, elem, compare_cb);
+    if (r < 0)
+        return r;
+
+    for (i = r; i < pv->base.len; i++) {
+        const void *other = sol_ptr_vector_get_nocheck(pv, i);
+
+        if (compare_cb(elem, other) != 0)
+            break;
+
+        if (elem == other)
+            return i;
+    }
+
+    for (i = r; i > 0; i--) {
+        const void *other = sol_ptr_vector_get_nocheck(pv, i - 1);
+
+        if (compare_cb(elem, other) != 0)
+            break;
+
+        if (elem == other)
+            return i - 1;
+    }
+
+    return -ENODATA;
+}
+
+/**
+ * @brief Find the last occurrence of @c elem in the sorted vector @c pv.
+ *
+ * @param pv Pointer Vector pointer (already sorted)
+ * @param elem Element to find
+ * @param compare_cb Function to compare elements in the list. It should return an integer
+ * less than, equal to, or greater than zero if @c data1 is found, respectively,
+ * to be less than, to match, or be greater than @c data2 in the sort order
+ *
+ * @return index (>=0) on success, error code (always negative) otherwise
+ *
+ * @see sol_ptr_vector_find_first()
+ * @see sol_ptr_vector_find_last()
+ * @see sol_ptr_vector_find_first_sorted()
+ * @see sol_ptr_vector_match_sorted()
+ * @see sol_ptr_vector_match_first()
+ * @see sol_ptr_vector_match_last()
+ * @see sol_ptr_vector_find_sorted()
+ * @see sol_ptr_vector_insert_sorted()
+ */
+static inline int32_t
+sol_ptr_vector_find_last_sorted(const struct sol_ptr_vector *pv, const void *elem, int (*compare_cb)(const void *data1, const void *data2))
+{
+    uint16_t i;
+    int32_t r, found_i = -ENODATA;
+
+    r = sol_ptr_vector_match_sorted(pv, elem, compare_cb);
+    if (r < 0)
+        return r;
+
+    for (i = r; i < pv->base.len; i++) {
+        const void *other = sol_ptr_vector_get_nocheck(pv, i);
+
+        if (compare_cb(elem, other) != 0)
+            break;
+
+        if (elem == other)
+            found_i = i;
+    }
+
+    if (found_i >= 0)
+        return found_i;
+
+    for (i = r; i > 0; i--) {
+        const void *other = sol_ptr_vector_get_nocheck(pv, i - 1);
+
+        if (compare_cb(elem, other) != 0)
+            break;
+
+        if (elem == other)
+            return i - 1;
+    }
+
+    return -ENODATA;
+}
+
+/**
+ * @brief Find the first occurrence of @c elem in the sorted vector @c pv.
+ *
+ * @param pv Pointer Vector pointer (already sorted)
+ * @param elem Element to find
+ * @param compare_cb Function to compare elements in the list. It should return an integer
+ * less than, equal to, or greater than zero if @c data1 is found, respectively,
+ * to be less than, to match, or be greater than @c data2 in the sort order
+ *
+ * @return index (>=0) on success, error code (always negative) otherwise
+ *
+ * @see sol_ptr_vector_find_first()
+ * @see sol_ptr_vector_find_first()
+ * @see sol_ptr_vector_find_first_sorted()
+ * @see sol_ptr_vector_match_sorted()
+ * @see sol_ptr_vector_match_first()
+ * @see sol_ptr_vector_match_last()
+ * @see sol_ptr_vector_find_sorted()
+ * @see sol_ptr_vector_insert_sorted()
+ */
+static inline int32_t
+sol_ptr_vector_find_first_sorted(const struct sol_ptr_vector *pv, const void *elem, int (*compare_cb)(const void *data1, const void *data2))
+{
+    uint16_t i;
+    int32_t r, found_i = -ENODATA;
+
+    r = sol_ptr_vector_match_sorted(pv, elem, compare_cb);
+    if (r < 0)
+        return r;
+
+    for (i = r;;) {
+        const void *other = sol_ptr_vector_get_nocheck(pv, i);
+
+        if (compare_cb(elem, other) != 0)
+            break;
+
+        if (elem == other)
+            found_i = i;
+
+        if (i == 0)
+            break;
+        i--;
+    }
+
+    if (found_i >= 0)
+        return found_i;
+
+    for (i = r; i + 1 < pv->base.len; i++) {
+        const void *other = sol_ptr_vector_get_nocheck(pv, i + 1);
+
+        if (compare_cb(elem, other) != 0)
+            break;
+
+        if (elem == other)
+            return i + 1;
+    }
+
+    return -ENODATA;
+}
 
 /**
  * @}

--- a/src/lib/datatypes/include/sol-vector.h
+++ b/src/lib/datatypes/include/sol-vector.h
@@ -345,6 +345,11 @@ int sol_ptr_vector_set(struct sol_ptr_vector *pv, uint16_t i, void *ptr);
  * @brief Insert a pointer in the pointer vector, using the given comparison function
  * to determine its position.
  *
+ * This function should be stable, if the new element @a ptr matches
+ * an existing in the vector (ie: @a compare_cb returns 0), then it
+ * will insert the new element @b after the last matching, keeping
+ * instances in a stable order.
+ *
  * @param pv Pointer Vector pointer
  * @param ptr The pointer
  * @param compare_cb Function to compare elements in the list. It should return an integer

--- a/src/lib/datatypes/sol-vector.c
+++ b/src/lib/datatypes/sol-vector.c
@@ -223,6 +223,10 @@ sol_ptr_vector_insert_sorted(struct sol_ptr_vector *pv, void *ptr, int (*compare
     }
 
     index = ptr_vector_find_sorted(pv, 0, pv->base.len - 1, ptr, compare, &dir);
+    while (dir == 0 && index < pv->base.len - 1U) {
+        index++;
+        dir = compare(ptr, sol_ptr_vector_get(pv, index));
+    }
     return ptr_vector_insert_at(pv, ptr, index, dir);
 }
 

--- a/src/lib/datatypes/sol-vector.c
+++ b/src/lib/datatypes/sol-vector.c
@@ -166,6 +166,14 @@ ptr_vector_find_sorted(struct sol_ptr_vector *pv, unsigned int low, unsigned int
 {
     unsigned int mid;
 
+    *dir = compare(ptr, sol_ptr_vector_get(pv, low));
+    if (*dir <= 0 || low == high)
+        return low;
+
+    *dir = compare(ptr, sol_ptr_vector_get(pv, high));
+    if (*dir >= 0)
+        return high;
+
     while (true) {
         if (low == high) {
             *dir = compare(ptr, sol_ptr_vector_get(pv, low));

--- a/src/lib/datatypes/sol-vector.c
+++ b/src/lib/datatypes/sol-vector.c
@@ -161,10 +161,11 @@ sol_vector_clear(struct sol_vector *v)
     v->len = 0;
 }
 
-static int
-ptr_vector_find_sorted(struct sol_ptr_vector *pv, unsigned int low, unsigned int high, void *ptr, int (*compare)(const void *data1, const void *data2), int *dir)
+/* this function returns an approximate match if dir != 0. */
+static uint16_t
+ptr_vector_find_sorted(const struct sol_ptr_vector *pv, uint16_t low, uint16_t high, const void *ptr, int (*compare)(const void *data1, const void *data2), int *dir)
 {
-    unsigned int mid;
+    uint16_t mid;
 
     *dir = compare(ptr, sol_ptr_vector_get_nocheck(pv, low));
     if (*dir <= 0 || low == high)
@@ -180,7 +181,7 @@ ptr_vector_find_sorted(struct sol_ptr_vector *pv, unsigned int low, unsigned int
             return low;
         }
 
-        mid = (low + high) >> 1;
+        mid = ((uint32_t)low + (uint32_t)high) >> 1;
         *dir = compare(ptr, sol_ptr_vector_get_nocheck(pv, mid));
         if (*dir == 0)
             return mid;
@@ -191,35 +192,38 @@ ptr_vector_find_sorted(struct sol_ptr_vector *pv, unsigned int low, unsigned int
     }
 }
 
-static int
-ptr_vector_insert_at(struct sol_ptr_vector *pv, void *ptr, unsigned int index, int dir)
+SOL_API int
+sol_ptr_vector_insert_at(struct sol_ptr_vector *pv, uint16_t i, void *ptr)
 {
     unsigned char *data, *dst, *src;
 
+    SOL_INT_CHECK(i, > pv->base.len, -ERANGE);
+
+    if (i == pv->base.len)
+        return sol_ptr_vector_append(pv, ptr);
+
     if (sol_vector_grow(&pv->base, 1) != 0)
-        return -1;
+        return -ENOMEM;
 
     data = pv->base.data;
-    dst = &data[pv->base.elem_size * (index + 1)];
-    src = &data[pv->base.elem_size * index];
-    memmove(dst, src, pv->base.elem_size * (pv->base.len - 1 - index));
+    dst = &data[pv->base.elem_size * (i + 1)];
+    src = &data[pv->base.elem_size * i];
+    memmove(dst, src, pv->base.elem_size * (pv->base.len - 1 - i));
 
-    if (dir < 0) {
-        sol_ptr_vector_set(pv, index, ptr);
-    } else {
-        sol_ptr_vector_set(pv, index + 1, ptr);
-    }
-    return 0;
+    return sol_ptr_vector_set(pv, i, ptr);
 }
 
-SOL_API int
+SOL_API int32_t
 sol_ptr_vector_insert_sorted(struct sol_ptr_vector *pv, void *ptr, int (*compare)(const void *data1, const void *data2))
 {
     int dir;
-    unsigned int index;
+    uint32_t index;
 
     if (!pv->base.len) {
-        return sol_ptr_vector_append(pv, ptr);
+        dir = sol_ptr_vector_append(pv, ptr);
+        if (dir < 0)
+            return dir;
+        return sol_ptr_vector_get_len(pv) - 1;
     }
 
     index = ptr_vector_find_sorted(pv, 0, pv->base.len - 1, ptr, compare, &dir);
@@ -227,7 +231,73 @@ sol_ptr_vector_insert_sorted(struct sol_ptr_vector *pv, void *ptr, int (*compare
         index++;
         dir = compare(ptr, sol_ptr_vector_get_nocheck(pv, index));
     }
-    return ptr_vector_insert_at(pv, ptr, index, dir);
+
+    if (dir >= 0)
+        index++;
+
+    dir = sol_ptr_vector_insert_at(pv, index, ptr);
+    if (dir < 0)
+        return dir;
+    return index;
+}
+
+SOL_API int32_t
+sol_ptr_vector_update_sorted(struct sol_ptr_vector *pv, uint16_t i, int (*compare_cb)(const void *data1, const void *data2))
+{
+    void *ptr, *other;
+    size_t tail_len;
+
+    if (i >= pv->base.len)
+        return -ERANGE;
+
+    if (pv->base.len == 1)
+        return 0;
+
+    ptr = sol_ptr_vector_get_nocheck(pv, i);
+    if (i > 0) {
+        other = sol_ptr_vector_get_nocheck(pv, i - 1);
+        if (compare_cb(other, ptr) > 0)
+            goto fix_it;
+    }
+
+    if (i + 1 < pv->base.len) {
+        other = sol_ptr_vector_get_nocheck(pv, i + 1);
+        if (compare_cb(ptr, other) >= 0)
+            goto fix_it;
+    }
+
+    return i;
+
+fix_it:
+    pv->base.len--;
+    tail_len = pv->base.len - i;
+
+    if (tail_len) {
+        unsigned char *data, *dst, *src;
+        data = pv->base.data;
+        dst = &data[pv->base.elem_size * i];
+        src = dst + pv->base.elem_size;
+        memmove(dst, src, pv->base.elem_size * tail_len);
+    }
+
+    return sol_ptr_vector_insert_sorted(pv, ptr, compare_cb);
+}
+
+SOL_API int32_t
+sol_ptr_vector_match_sorted(const struct sol_ptr_vector *pv, const void *elem, int (*compare_cb)(const void *data1, const void *data2))
+{
+    int dir;
+    uint16_t i;
+
+    if (!pv->base.len) {
+        return -ENODATA;
+    }
+
+    i = ptr_vector_find_sorted(pv, 0, pv->base.len - 1, elem, compare_cb, &dir);
+    if (dir != 0)
+        return -ENODATA;
+
+    return i;
 }
 
 SOL_API int
@@ -257,16 +327,12 @@ sol_ptr_vector_set(struct sol_ptr_vector *pv, uint16_t i, void *ptr)
 SOL_API int
 sol_ptr_vector_remove(struct sol_ptr_vector *pv, const void *ptr)
 {
-    uint16_t i;
-    void *p;
+    int32_t i = sol_ptr_vector_find_last(pv, ptr);
 
-    SOL_PTR_VECTOR_FOREACH_REVERSE_IDX (pv, p, i) {
-        if (ptr == p) {
-            sol_ptr_vector_del(pv, i);
-            return 0;
-        }
-    }
-    return -ENODATA;
+    if (i < 0)
+        return i;
+
+    return sol_ptr_vector_del(pv, i);
 }
 
 SOL_API int

--- a/src/lib/datatypes/sol-vector.c
+++ b/src/lib/datatypes/sol-vector.c
@@ -166,22 +166,22 @@ ptr_vector_find_sorted(struct sol_ptr_vector *pv, unsigned int low, unsigned int
 {
     unsigned int mid;
 
-    *dir = compare(ptr, sol_ptr_vector_get(pv, low));
+    *dir = compare(ptr, sol_ptr_vector_get_nocheck(pv, low));
     if (*dir <= 0 || low == high)
         return low;
 
-    *dir = compare(ptr, sol_ptr_vector_get(pv, high));
+    *dir = compare(ptr, sol_ptr_vector_get_nocheck(pv, high));
     if (*dir >= 0)
         return high;
 
     while (true) {
         if (low == high) {
-            *dir = compare(ptr, sol_ptr_vector_get(pv, low));
+            *dir = compare(ptr, sol_ptr_vector_get_nocheck(pv, low));
             return low;
         }
 
         mid = (low + high) >> 1;
-        *dir = compare(ptr, sol_ptr_vector_get(pv, mid));
+        *dir = compare(ptr, sol_ptr_vector_get_nocheck(pv, mid));
         if (*dir == 0)
             return mid;
         if (*dir < 0)
@@ -225,7 +225,7 @@ sol_ptr_vector_insert_sorted(struct sol_ptr_vector *pv, void *ptr, int (*compare
     index = ptr_vector_find_sorted(pv, 0, pv->base.len - 1, ptr, compare, &dir);
     while (dir == 0 && index < pv->base.len - 1U) {
         index++;
-        dir = compare(ptr, sol_ptr_vector_get(pv, index));
+        dir = compare(ptr, sol_ptr_vector_get_nocheck(pv, index));
     }
     return ptr_vector_insert_at(pv, ptr, index, dir);
 }

--- a/src/lib/flow/sol-flow-parser-dynamic.c
+++ b/src/lib/flow/sol-flow-parser-dynamic.c
@@ -86,4 +86,5 @@ void
 loaded_metatype_cache_shutdown(void)
 {
     sol_lib_loader_del(metatype_loader);
+    metatype_loader = NULL;
 }

--- a/src/shared/sol-conffile.c
+++ b/src/shared/sol-conffile.c
@@ -518,7 +518,7 @@ _json_to_vector(struct sol_json_scanner scanner)
             goto entry_err;
         }
 
-        if (sol_ptr_vector_insert_sorted(&_conffile_entry_vector, entry, _entry_sort_cb) == -1) {
+        if (sol_ptr_vector_insert_sorted(&_conffile_entry_vector, entry, _entry_sort_cb) < 0) {
             SOL_DBG("Error: Couldn't setup config entry");
             goto entry_err;
         }

--- a/src/test/Kconfig
+++ b/src/test/Kconfig
@@ -50,6 +50,10 @@ config TEST_MAINLOOP_LINUX
 	depends on PLATFORM_LINUX
 	default y
 
+config TEST_MAINLOOP_IMPLEMENTATION
+	bool "mainloop implementation"
+	default y
+
 config TEST_MAINLOOP_THREADS
 	bool "mainloop threads"
 	depends on PTHREAD && MAINLOOP_POSIX

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -45,6 +45,9 @@ test-test-mainloop-glib-integration-$(TEST_MAINLOOP_GLIB_INTEGRATION) := test-ma
 test-test-mainloop-glib-integration-$(TEST_MAINLOOP_GLIB_INTEGRATION)-extra-cflags += $(GLIB_CFLAGS)
 test-test-mainloop-glib-integration-$(TEST_MAINLOOP_GLIB_INTEGRATION)-extra-ldflags += $(GLIB_LDFLAGS)
 
+test-$(TEST_MAINLOOP_IMPLEMENTATION) += test-mainloop-implementation
+test-test-mainloop-implementation-$(TEST_MAINLOOP_IMPLEMENTATION) := test-mainloop-implementation.c
+
 test-$(TEST_MONITORS) += test-monitors
 test-test-monitors-$(TEST_MONITORS) := test.c test-monitors.c
 

--- a/src/test/test-mainloop-implementation.c
+++ b/src/test/test-mainloop-implementation.c
@@ -1,0 +1,341 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdbool.h>
+
+#include "sol-mainloop.h"
+
+#include "test.h"
+
+#define TEST_MAINLOOP_MAIN_FN test_mainloop_main
+int TEST_MAINLOOP_MAIN_FN(int argc, char *argv[]);
+#include "test-mainloop.c"
+
+#ifdef SOL_PLATFORM_LINUX
+#define TEST_MAINLOOP_LINUX_MAIN_FN test_mainloop_linux_main
+int TEST_MAINLOOP_LINUX_MAIN_FN(int argc, char *argv[]);
+#include "test-mainloop-linux.c"
+#endif
+
+/* implementations may create timers, fds and others internally */
+#ifdef SOL_PLATFORM_LINUX
+/* sol-network-impl-linux.c adds netlink socket fd */
+/* sol-mainloop-impl-posix.c adds pipe to notify main thread */
+#ifdef MAINLOOP_POSIX
+#define BASE_CALL_COUNT_FD_ADD 2
+#define BASE_CALL_COUNT_FD_DEL 2
+#else
+#define BASE_CALL_COUNT_FD_ADD 1
+#define BASE_CALL_COUNT_FD_DEL 1
+#endif
+#else
+#define BASE_CALL_COUNT_FD_DEL 0
+#endif
+
+static int _call_count_init;
+static int _call_count_shutdown;
+static int _call_count_run;
+static int _call_count_quit;
+static int _call_count_timeout_add;
+static int _call_count_timeout_del;
+static int _call_count_idle_add;
+static int _call_count_idle_del;
+
+#ifdef SOL_MAINLOOP_FD_ENABLED
+static int _call_count_fd_add;
+static int _call_count_fd_del;
+static int _call_count_fd_set_flags;
+static int _call_count_fd_get_flags;
+#endif
+
+#ifdef SOL_MAINLOOP_FORK_WATCH_ENABLED
+static int _call_count_child_watch_add;
+static int _call_count_child_watch_del;
+#endif
+
+static int _call_count_source_add;
+static int _call_count_source_del;
+static int _call_count_source_get_data;
+
+static void
+call_count_reset(void)
+{
+    _call_count_init = 0;
+    _call_count_shutdown = 0;
+    _call_count_run = 0;
+    _call_count_quit = 0;
+    _call_count_timeout_add = 0;
+    _call_count_timeout_del = 0;
+    _call_count_idle_add = 0;
+    _call_count_idle_del = 0;
+
+#ifdef SOL_MAINLOOP_FD_ENABLED
+    _call_count_fd_add = 0;
+    _call_count_fd_del = 0;
+    _call_count_fd_set_flags = 0;
+    _call_count_fd_get_flags = 0;
+#endif
+
+#ifdef SOL_MAINLOOP_FORK_WATCH_ENABLED
+    _call_count_child_watch_add = 0;
+    _call_count_child_watch_del = 0;
+#endif
+
+    _call_count_source_add = 0;
+    _call_count_source_del = 0;
+    _call_count_source_get_data = 0;
+}
+
+static int
+wrapper_ml_init(void)
+{
+    _call_count_init++;
+    return SOL_MAINLOOP_IMPLEMENTATION_DEFAULT->init();
+}
+
+static void
+wrapper_ml_shutdown(void)
+{
+    _call_count_shutdown++;
+    SOL_MAINLOOP_IMPLEMENTATION_DEFAULT->shutdown();
+}
+
+static void
+wrapper_ml_run(void)
+{
+    _call_count_run++;
+    SOL_MAINLOOP_IMPLEMENTATION_DEFAULT->run();
+}
+
+static void
+wrapper_ml_quit(void)
+{
+    _call_count_quit++;
+    SOL_MAINLOOP_IMPLEMENTATION_DEFAULT->quit();
+}
+
+static void *
+wrapper_ml_timeout_add(uint32_t timeout_ms, bool (*cb)(void *data), const void *data)
+{
+    _call_count_timeout_add++;
+    return SOL_MAINLOOP_IMPLEMENTATION_DEFAULT->timeout_add(timeout_ms, cb, data);
+}
+
+static bool
+wrapper_ml_timeout_del(void *handle)
+{
+    _call_count_timeout_del++;
+    return SOL_MAINLOOP_IMPLEMENTATION_DEFAULT->timeout_del(handle);
+}
+
+static void *
+wrapper_ml_idle_add(bool (*cb)(void *data), const void *data)
+{
+    _call_count_idle_add++;
+    return SOL_MAINLOOP_IMPLEMENTATION_DEFAULT->idle_add(cb, data);
+}
+
+static bool
+wrapper_ml_idle_del(void *handle)
+{
+    _call_count_idle_del++;
+    return SOL_MAINLOOP_IMPLEMENTATION_DEFAULT->idle_del(handle);
+}
+
+#ifdef SOL_MAINLOOP_FD_ENABLED
+static void *
+wrapper_ml_fd_add(int fd, uint32_t flags, bool (*cb)(void *data, int fd, uint32_t active_flags), const void *data)
+{
+    _call_count_fd_add++;
+    return SOL_MAINLOOP_IMPLEMENTATION_DEFAULT->fd_add(fd, flags, cb, data);
+}
+
+static bool
+wrapper_ml_fd_del(void *handle)
+{
+    _call_count_fd_del++;
+    return SOL_MAINLOOP_IMPLEMENTATION_DEFAULT->fd_del(handle);
+}
+
+static bool
+wrapper_ml_fd_set_flags(void *handle, uint32_t flags)
+{
+    _call_count_fd_set_flags++;
+    return SOL_MAINLOOP_IMPLEMENTATION_DEFAULT->fd_set_flags(handle, flags);
+}
+
+static uint32_t
+wrapper_ml_fd_get_flags(const void *handle)
+{
+    _call_count_fd_get_flags++;
+    return SOL_MAINLOOP_IMPLEMENTATION_DEFAULT->fd_get_flags(handle);
+}
+#endif
+
+#ifdef SOL_MAINLOOP_FORK_WATCH_ENABLED
+static void *
+wrapper_ml_child_watch_add(uint64_t pid, void (*cb)(void *data, uint64_t pid, int status), const void *data)
+{
+    _call_count_child_watch_add++;
+    return SOL_MAINLOOP_IMPLEMENTATION_DEFAULT->child_watch_add(pid, cb, data);
+}
+
+static bool
+wrapper_ml_child_watch_del(void *handle)
+{
+    _call_count_child_watch_del++;
+    return SOL_MAINLOOP_IMPLEMENTATION_DEFAULT->child_watch_del(handle);
+}
+#endif
+
+static void *
+wrapper_ml_source_add(const struct sol_mainloop_source_type *type, const void *data)
+{
+    _call_count_source_add++;
+    return SOL_MAINLOOP_IMPLEMENTATION_DEFAULT->source_add(type, data);
+}
+
+static void
+wrapper_ml_source_del(void *handle)
+{
+    _call_count_source_del++;
+    return SOL_MAINLOOP_IMPLEMENTATION_DEFAULT->source_del(handle);
+}
+
+static void *
+wrapper_ml_source_get_data(const void *handle)
+{
+    _call_count_source_get_data++;
+    return SOL_MAINLOOP_IMPLEMENTATION_DEFAULT->source_get_data(handle);
+}
+
+static const struct sol_mainloop_implementation wrapper_ml = {
+    SOL_SET_API_VERSION(.api_version = SOL_MAINLOOP_IMPLEMENTATION_API_VERSION, )
+    .init = wrapper_ml_init,
+    .shutdown =  wrapper_ml_shutdown,
+    .run =  wrapper_ml_run,
+    .quit =  wrapper_ml_quit,
+    .timeout_add =  wrapper_ml_timeout_add,
+    .timeout_del =  wrapper_ml_timeout_del,
+    .idle_add =  wrapper_ml_idle_add,
+    .idle_del =  wrapper_ml_idle_del,
+
+#ifdef SOL_MAINLOOP_FD_ENABLED
+    .fd_add =  wrapper_ml_fd_add,
+    .fd_del =  wrapper_ml_fd_del,
+    .fd_set_flags =  wrapper_ml_fd_set_flags,
+    .fd_get_flags =  wrapper_ml_fd_get_flags,
+#endif
+
+#ifdef SOL_MAINLOOP_FORK_WATCH_ENABLED
+    .child_watch_add =  wrapper_ml_child_watch_add,
+    .child_watch_del =  wrapper_ml_child_watch_del,
+#endif
+
+    .source_add =  wrapper_ml_source_add,
+    .source_del =  wrapper_ml_source_del,
+    .source_get_data =  wrapper_ml_source_get_data,
+};
+
+int
+main(int argc, char *argv[])
+{
+    int r;
+
+    ASSERT(sol_mainloop_set_implementation(&wrapper_ml));
+
+    /* test-mainloop.c */
+    call_count_reset();
+
+    r = test_mainloop_main(argc, argv);
+    ASSERT_INT_EQ(r, 0);
+
+    ASSERT_INT_EQ(_call_count_init, 1);
+    ASSERT_INT_EQ(_call_count_shutdown, 1);
+    ASSERT_INT_EQ(_call_count_run, 1);
+    ASSERT_INT_EQ(_call_count_quit, 1);
+    ASSERT_INT_EQ(_call_count_timeout_add, 5);
+    ASSERT_INT_EQ(_call_count_timeout_del, 1);
+    ASSERT_INT_EQ(_call_count_idle_add, 13);
+    ASSERT_INT_EQ(_call_count_idle_del, 1);
+
+#ifdef SOL_MAINLOOP_FD_ENABLED
+    ASSERT_INT_EQ(_call_count_fd_add, 0 + BASE_CALL_COUNT_FD_ADD);
+    ASSERT_INT_EQ(_call_count_fd_del, 0 + BASE_CALL_COUNT_FD_DEL);
+    ASSERT_INT_EQ(_call_count_fd_set_flags, 0);
+    ASSERT_INT_EQ(_call_count_fd_get_flags, 0);
+#endif
+
+#ifdef SOL_MAINLOOP_FORK_WATCH_ENABLED
+    ASSERT_INT_EQ(_call_count_child_watch_add, 0);
+    ASSERT_INT_EQ(_call_count_child_watch_del, 0);
+#endif
+
+    ASSERT_INT_EQ(_call_count_source_add, 0);
+    ASSERT_INT_EQ(_call_count_source_del, 0);
+    ASSERT_INT_EQ(_call_count_source_get_data, 0);
+
+    /* test-mainloop-linux.c */
+#ifdef SOL_PLATFORM_LINUX
+    call_count_reset();
+
+    r = test_mainloop_linux_main(argc, argv);
+    ASSERT_INT_EQ(r, 0);
+
+    ASSERT_INT_EQ(_call_count_init, 1);
+    ASSERT_INT_EQ(_call_count_shutdown, 1);
+    ASSERT_INT_EQ(_call_count_run, 1);
+    ASSERT_INT_EQ(_call_count_quit, 1);
+    ASSERT_INT_EQ(_call_count_timeout_add, 2);
+    ASSERT_INT_EQ(_call_count_timeout_del, 0);
+    ASSERT_INT_EQ(_call_count_idle_add, 2);
+    ASSERT_INT_EQ(_call_count_idle_del, 0);
+
+#ifdef SOL_MAINLOOP_FD_ENABLED
+    ASSERT_INT_EQ(_call_count_fd_add, 1 + BASE_CALL_COUNT_FD_ADD);
+    ASSERT_INT_EQ(_call_count_fd_del, 0 + BASE_CALL_COUNT_FD_DEL);
+    ASSERT_INT_EQ(_call_count_fd_set_flags, 0);
+    ASSERT_INT_EQ(_call_count_fd_get_flags, 0);
+#endif
+
+#ifdef SOL_MAINLOOP_FORK_WATCH_ENABLED
+    ASSERT_INT_EQ(_call_count_child_watch_add, 0);
+    ASSERT_INT_EQ(_call_count_child_watch_del, 0);
+#endif
+
+    ASSERT_INT_EQ(_call_count_source_add, 0);
+    ASSERT_INT_EQ(_call_count_source_del, 0);
+    ASSERT_INT_EQ(_call_count_source_get_data, 0);
+#endif
+
+    return 0;
+}

--- a/src/test/test-mainloop-linux.c
+++ b/src/test/test-mainloop-linux.c
@@ -70,7 +70,7 @@ on_idle_renew_twice(void *data)
 }
 
 static bool
-on_timeout_renew_twice(void *data)
+linux_on_timeout_renew_twice(void *data)
 {
     timeout_count++;
     if (timeout_count == 1)
@@ -105,8 +105,12 @@ on_fd(void *data, int fd, uint32_t active_flags)
     return true;
 }
 
+#ifndef TEST_MAINLOOP_LINUX_MAIN_FN
+#define TEST_MAINLOOP_LINUX_MAIN_FN main
+#endif
+
 int
-main(int argc, char *argv[])
+TEST_MAINLOOP_LINUX_MAIN_FN(int argc, char *argv[])
 {
     int err, fds[2];
     pid_t pid;
@@ -152,7 +156,7 @@ main(int argc, char *argv[])
     ASSERT_INT_EQ(err, 0);
 
     sol_fd_add(fds[0], SOL_FD_FLAGS_IN, on_fd, NULL);
-    sol_timeout_add(1, on_timeout_renew_twice, NULL);
+    sol_timeout_add(1, linux_on_timeout_renew_twice, NULL);
     sol_timeout_add(10000, watchdog, NULL);
     sol_idle_add(on_idle_renew_twice, &idler_count1);
     sol_run();

--- a/src/test/test-mainloop.c
+++ b/src/test/test-mainloop.c
@@ -121,8 +121,11 @@ on_idler_renew_twice(void *data)
     return idler_renewed < 2;
 }
 
+#ifndef TEST_MAINLOOP_MAIN_FN
+#define TEST_MAINLOOP_MAIN_FN main
+#endif
 int
-main(int argc, char *argv[])
+TEST_MAINLOOP_MAIN_FN(int argc, char *argv[])
 {
     int err, i;
     struct sol_timeout *timeout_to_del;

--- a/src/test/test-vector.c
+++ b/src/test/test-vector.c
@@ -131,16 +131,23 @@ static void
 test_ptr_vector_sorted(void)
 {
     struct sol_ptr_vector pv;
-    struct s *s;
+    struct s *s, match;
     uint16_t i;
     int array_unsorted[] = { 5, 3, 2, 9, 4, 3, 12, -1, 8, 30, 19, 10, 13, 2, 2 };
     int array_sorted[] = { -1, 2, 2, 2, 3, 3, 4, 5, 8, 9, 10, 12, 13, 19, 30 };
+    int32_t found;
 
     sol_ptr_vector_init(&pv);
     for (i = 0; i < (sizeof(array_unsorted) / sizeof(int)); i++) {
+        int32_t ret;
+
         s = create_s(array_unsorted[i]);
         s->b = i;
-        sol_ptr_vector_insert_sorted(&pv, s, sort_cb);
+        ret = sol_ptr_vector_insert_sorted(&pv, s, sort_cb);
+        ASSERT(ret >= 0);
+
+        found = sol_ptr_vector_find_sorted(&pv, s, sort_cb);
+        ASSERT_INT_EQ(ret, found);
     }
 
     SOL_PTR_VECTOR_FOREACH_IDX (&pv, s, i) {
@@ -153,7 +160,25 @@ test_ptr_vector_sorted(void)
             if (prev->a == s->a)
                 ASSERT(prev->b < s->b);
         }
+
+        found = sol_ptr_vector_find_first_sorted(&pv, s, sort_cb);
+        ASSERT_INT_EQ(found, (int)i);
+
+        found = sol_ptr_vector_find_last_sorted(&pv, s, sort_cb);
+        ASSERT_INT_EQ(found, (int)i);
     }
+
+    match.a = 2;
+
+    found = sol_ptr_vector_match_first(&pv, &match, sort_cb);
+    ASSERT_INT_EQ(found, 1);
+
+    found = sol_ptr_vector_match_last(&pv, &match, sort_cb);
+    ASSERT_INT_EQ(found, 3);
+
+    match.a = -1;
+    found = sol_ptr_vector_match_sorted(&pv, &match, sort_cb);
+    ASSERT_INT_EQ(found, 0);
 
     while (pv.base.len > 0)
         free(sol_ptr_vector_take(&pv, 0));

--- a/src/test/test-vector.c
+++ b/src/test/test-vector.c
@@ -133,16 +133,26 @@ test_ptr_vector_sorted(void)
     struct sol_ptr_vector pv;
     struct s *s;
     uint16_t i;
-    int array_unsorted[] = { 5, 3, 2, 9, 4, 3, 12, -1, 8, 30, 19, 10, 13 };
-    int array_sorted[] = { -1, 2, 3, 3, 4, 5, 8, 9, 10, 12, 13, 19, 30 };
+    int array_unsorted[] = { 5, 3, 2, 9, 4, 3, 12, -1, 8, 30, 19, 10, 13, 2, 2 };
+    int array_sorted[] = { -1, 2, 2, 2, 3, 3, 4, 5, 8, 9, 10, 12, 13, 19, 30 };
 
     sol_ptr_vector_init(&pv);
     for (i = 0; i < (sizeof(array_unsorted) / sizeof(int)); i++) {
-        sol_ptr_vector_insert_sorted(&pv, create_s(array_unsorted[i]), sort_cb);
+        s = create_s(array_unsorted[i]);
+        s->b = i;
+        sol_ptr_vector_insert_sorted(&pv, s, sort_cb);
     }
 
     SOL_PTR_VECTOR_FOREACH_IDX (&pv, s, i) {
         ASSERT_INT_EQ(s->a, array_sorted[i]);
+        if (i > 0) {
+            /* appending already existing elements should be after
+             * already existing (stable)
+             */
+            struct s *prev = sol_ptr_vector_get(&pv, i - 1);
+            if (prev->a == s->a)
+                ASSERT(prev->b < s->b);
+        }
     }
 
     while (pv.base.len > 0)


### PR DESCRIPTION
Changes since v2 (#1226):
 - rebased to master
 - C++ fixes

@ceolin will add a `make check-cxx` that will get all of our public headers, include them and compile with C++, this will avoid problems like that in the future. Grantes we still need to use some macros in that test, so the code expands, I spotted our `_FOREACH` macros would fail with C++.