### PR TITLE
coap: Add unknown resource flag.

### DIFF
--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -242,7 +242,12 @@ typedef enum {
 enum sol_coap_flags {
     SOL_COAP_FLAGS_NONE       = 0,
     /** If the resource should be exported in the CoRE well-known registry. */
-    SOL_COAP_FLAGS_WELL_KNOWN = (1 << 1)
+    SOL_COAP_FLAGS_WELL_KNOWN = (1 << 1),
+    /** When registering a resource as SOL_COAP_FLAGS_UNKNOWN_RESOURCE the path must be empty and only
+        one can be registered per server. A unknown resource is only used if the coap server could not
+        match the request's path or method (GET, POST, etc) in the registered resource base.
+     */
+    SOL_COAP_FLAGS_UNKNOWN_RESOURCE = (1 << 2)
 };
 
 /**


### PR DESCRIPTION
This flag is useful when one wants to treat by oneself the requests that
could not be matched with the registered resources.

Signed-off-by: Guilherme Iscaro <guilherme.iscaro@intel.com>