### PR TITLE
Platform: Delete timezone fd watcher before re-adding it

### DIFF
--- a/src/lib/common/sol-platform-impl-linux-micro.c
+++ b/src/lib/common/sol-platform-impl-linux-micro.c
@@ -1147,6 +1147,7 @@ static bool
 timezone_changed(void *data, int fd, uint32_t active_flags)
 {
     sol_platform_inform_timezone_changed();
+    sol_fd_del(timezone_monitor.watcher);
     close(timezone_monitor.fd);
     timezone_monitor.fd = -1;
     timezone_monitor.watcher = NULL;


### PR DESCRIPTION
This prevents a handle leak on the main loop.