### PR TITLE
macros: Add likely/unlikely in sol-macros.h

### DIFF
--- a/src/lib/common/include/sol-log.h
+++ b/src/lib/common/include/sol-log.h
@@ -82,11 +82,6 @@ extern "C" {
  */
 
 /**
- * @brief Convenience macro for @c unlikely branch annotation. Intended for local use.
- */
-#define log_unlikely(x) __builtin_expect(!!(x), 0)
-
-/**
  * @brief Convenience macro to check for @c NULL pointer.
  *
  * This macro logs a warning message and returns if the pointer @c ptr
@@ -97,7 +92,7 @@ extern "C" {
  */
 #define SOL_NULL_CHECK(ptr, ...) \
     do { \
-        if (log_unlikely(!(ptr))) { \
+        if (SOL_UNLIKELY(!(ptr))) { \
             SOL_WRN("" # ptr "== NULL"); \
             return __VA_ARGS__; \
         } \
@@ -115,7 +110,7 @@ extern "C" {
  */
 #define SOL_NULL_CHECK_GOTO(ptr, label) \
     do { \
-        if (log_unlikely(!(ptr))) { \
+        if (SOL_UNLIKELY(!(ptr))) { \
             SOL_WRN("" # ptr "== NULL"); \
             goto label; \
         } \
@@ -133,7 +128,7 @@ extern "C" {
  */
 #define SOL_NULL_CHECK_MSG(ptr, ret, fmt, ...) \
     do { \
-        if (log_unlikely(!(ptr))) { \
+        if (SOL_UNLIKELY(!(ptr))) { \
             SOL_WRN(fmt, ## __VA_ARGS__); \
             return ret; \
         } \
@@ -151,7 +146,7 @@ extern "C" {
  */
 #define SOL_NULL_CHECK_MSG_GOTO(ptr, label, fmt, ...) \
     do { \
-        if (log_unlikely(!(ptr))) { \
+        if (SOL_UNLIKELY(!(ptr))) { \
             SOL_WRN(fmt, ## __VA_ARGS__); \
             goto label; \
         } \
@@ -217,7 +212,7 @@ extern "C" {
  */
 #define SOL_INT_CHECK(var, exp, ...) \
     do { \
-        if (log_unlikely((var)exp)) { \
+        if (SOL_UNLIKELY((var)exp)) { \
             SOL_WRN(_SOL_INT_CHECK_FMT(var, exp), var); \
             return __VA_ARGS__; \
         } \
@@ -235,7 +230,7 @@ extern "C" {
  */
 #define SOL_INT_CHECK_GOTO(var, exp, label) \
     do { \
-        if (log_unlikely((var)exp)) { \
+        if (SOL_UNLIKELY((var)exp)) { \
             SOL_WRN(_SOL_INT_CHECK_FMT(var, exp), var); \
             goto label; \
         } \
@@ -252,7 +247,7 @@ extern "C" {
  */
 #define SOL_EXP_CHECK(exp, ...) \
     do { \
-        if (log_unlikely((exp))) { \
+        if (SOL_UNLIKELY((exp))) { \
             SOL_WRN("(" # exp ") is true"); \
             return __VA_ARGS__; \
         } \
@@ -269,7 +264,7 @@ extern "C" {
  */
 #define SOL_EXP_CHECK_GOTO(exp, label) \
     do { \
-        if (log_unlikely((exp))) { \
+        if (SOL_UNLIKELY((exp))) { \
             SOL_WRN("(" # exp ") is true"); \
             goto label; \
         } \

--- a/src/lib/common/include/sol-macros.h
+++ b/src/lib/common/include/sol-macros.h
@@ -140,6 +140,20 @@
  */
 
 /**
+ * @def SOL_LIKELY
+ *
+ * @brief Convenience macro for @c likely branch annotation. Provide the compiler with
+ * branch prediction information.
+ */
+
+/**
+ * @def SOL_UNLIKELY
+ *
+ * @brief Convenience macro for @c unlikely branch annotation. Provide the compiler with
+ * branch prediction information.
+ */
+
+/**
  * @def SOL_STATIC_ARRAY_SIZE(n)
  *
  * @brief Convenience macro to declare the size of a static array that will handle
@@ -162,6 +176,8 @@
 #define SOL_ATTR_SENTINEL __attribute__((sentinel))
 #define SOL_ATTR_NORETURN __attribute__((noreturn))
 #define SOL_ATTR_PURE __attribute__((pure))
+#define SOL_LIKELY(x)   __builtin_expect(!!(x), 1)
+#define SOL_UNLIKELY(x) __builtin_expect(!!(x), 0)
 #else
 #define SOL_API
 #define SOL_ATTR_WARN_UNUSED_RESULT
@@ -176,6 +192,8 @@
 #define SOL_ATTR_SENTINEL
 #define SOL_ATTR_NORETURN
 #define SOL_ATTR_PURE
+#define SOL_LIKELY(x)
+#define SOL_UNLIKELY(x)
 #endif
 
 #ifdef __cplusplus

--- a/src/lib/common/sol-log.c
+++ b/src/lib/common/sol-log.c
@@ -36,6 +36,7 @@
 
 #include "sol-util.h"
 #include "sol-log.h"
+#include "sol-macros.h"
 #include "sol-log-impl.h"
 
 /* NOTE: these are not static since we share them with sol-log-impl-*.c
@@ -65,7 +66,7 @@ const void *_print_function_data = NULL;
 static bool _inited = false;
 #define SOL_LOG_INIT_CHECK(fmt, ...)                                     \
     do {                                                                \
-        if (unlikely(!_inited)) {                                       \
+        if (SOL_UNLIKELY(!_inited)) {                                       \
             fprintf(stderr, "CRITICAL:%s:%d:%s() "                      \
                 "SOL_LOG used before initialization. "fmt "\n",       \
                 __FILE__, __LINE__, __PRETTY_FUNCTION__, ## __VA_ARGS__); \

--- a/src/lib/common/sol-mainloop.c
+++ b/src/lib/common/sol-mainloop.c
@@ -492,12 +492,12 @@ sol_mainloop_default_main(const struct sol_main_callbacks *callbacks, int argc, 
     _argc = argc;
     _argv = argv;
 
-    if (unlikely(!callbacks || !callbacks->startup)) {
+    if (SOL_UNLIKELY(!callbacks || !callbacks->startup)) {
         fprintf(stderr, "Missing startup function.\n");
         return EXIT_FAILURE;
     }
 
-    if (unlikely(sol_init() < 0)) {
+    if (SOL_UNLIKELY(sol_init() < 0)) {
         SOL_CRI("Cannot initialize soletta.");
         return EXIT_FAILURE;
     }

--- a/src/lib/common/sol-worker-thread.c
+++ b/src/lib/common/sol-worker-thread.c
@@ -47,7 +47,7 @@ sol_worker_thread_new(const struct sol_worker_thread_spec *spec)
     SOL_NULL_CHECK(spec->iterate, NULL);
 
 #ifndef SOL_NO_API_VERSION
-    if (unlikely(spec->api_version != SOL_WORKER_THREAD_SPEC_API_VERSION)) {
+    if (SOL_UNLIKELY(spec->api_version != SOL_WORKER_THREAD_SPEC_API_VERSION)) {
         SOL_WRN("Couldn't create worker thread with unsupported version '%u', "
             "expected version is '%u'",
             spec->api_version, SOL_WORKER_THREAD_SPEC_API_VERSION);

--- a/src/lib/comms/include/sol-http.h
+++ b/src/lib/comms/include/sol-http.h
@@ -34,6 +34,7 @@
 
 #include <sol-arena.h>
 #include <sol-buffer.h>
+#include <sol-macros.h>
 #include <sol-str-slice.h>
 #include <sol-vector.h>
 
@@ -210,7 +211,7 @@ struct sol_http_url {
  * to the macro.
  */
 #define SOL_HTTP_RESPONSE_CHECK_API_VERSION(response_, ...) \
-    if (unlikely(response_->api_version != \
+    if (SOL_UNLIKELY(response_->api_version != \
         SOL_HTTP_RESPONSE_API_VERSION)) { \
         SOL_ERR("Unexpected API version (response is %u, expected %u)", \
             response->api_version, SOL_HTTP_RESPONSE_API_VERSION); \
@@ -229,7 +230,7 @@ struct sol_http_url {
  */
 #define SOL_HTTP_RESPONSE_CHECK_API(response_, ...) \
     do { \
-        if (unlikely(!response_)) { \
+        if (SOL_UNLIKELY(!response_)) { \
             SOL_WRN("Error while reaching service."); \
             return __VA_ARGS__; \
         } \
@@ -244,7 +245,7 @@ struct sol_http_url {
  * In case it's a wrong version, it'll go to @a label.
  */
 #define SOL_HTTP_RESPONSE_CHECK_API_VERSION_GOTO(response_, label) \
-    if (unlikely(response_->api_version != \
+    if (SOL_UNLIKELY(response_->api_version != \
         SOL_HTTP_RESPONSE_API_VERSION)) { \
         SOL_ERR("Unexpected API version (response is %u, expected %u)", \
             response->api_version, SOL_HTTP_RESPONSE_API_VERSION); \
@@ -263,7 +264,7 @@ struct sol_http_url {
  */
 #define SOL_HTTP_RESPONSE_CHECK_API_GOTO(response_, label) \
     do { \
-        if (unlikely(!response_)) { \
+        if (SOL_UNLIKELY(!response_)) { \
             SOL_WRN("Error while reaching service."); \
             goto label; \
         } \

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -41,6 +41,7 @@
 
 #define SOL_LOG_DOMAIN &_sol_coap_log_domain
 #include "sol-log-internal.h"
+#include "sol-macros.h"
 #include "sol-mainloop.h"
 #include "sol-network.h"
 #include "sol-socket.h"
@@ -70,7 +71,7 @@ SOL_LOG_INTERNAL_DECLARE(_sol_coap_log_domain, "coap");
 #ifndef SOL_NO_API_VERSION
 #define COAP_RESOURCE_CHECK_API(...) \
     do { \
-        if (unlikely(resource->api_version != \
+        if (SOL_UNLIKELY(resource->api_version != \
             SOL_COAP_RESOURCE_API_VERSION)) { \
             SOL_WRN("Couldn't handle resource that has unsupported version " \
                 "'%u', expected version is '%u'", \

--- a/src/lib/comms/sol-http-client-impl-curl.c
+++ b/src/lib/comms/sol-http-client-impl-curl.c
@@ -41,6 +41,7 @@
 #include "sol-buffer.h"
 #include "sol-http-client.h"
 #include "sol-log.h"
+#include "sol-macros.h"
 #include "sol-mainloop.h"
 #include "sol-str-slice.h"
 #include "sol-util.h"
@@ -435,7 +436,7 @@ xferinfo_cb(void *clientp, curl_off_t dltotal, curl_off_t dlnow,
 {
     struct sol_http_client_connection *connection = clientp;
 
-    if (dltotal > 0 && unlikely(dltotal < dlnow)) {
+    if (dltotal > 0 && SOL_UNLIKELY(dltotal < dlnow)) {
         SOL_WRN("Received more than expected, aborting transfer ("
             CURL_FORMAT_OFF_T "< " CURL_FORMAT_OFF_T ")",
             dltotal, dlnow);
@@ -828,7 +829,7 @@ static bool
 check_param_api_version(const struct sol_http_params *params)
 {
 #ifndef SOL_NO_API_VERSION
-    if (unlikely(params->api_version != SOL_HTTP_PARAM_API_VERSION)) {
+    if (SOL_UNLIKELY(params->api_version != SOL_HTTP_PARAM_API_VERSION)) {
         SOL_ERR("Parameter has an invalid API version. Expected %u, got %u",
             SOL_HTTP_PARAM_API_VERSION, params->api_version);
         return false;

--- a/src/lib/comms/sol-mqtt-impl-mosquitto.c
+++ b/src/lib/comms/sol-mqtt-impl-mosquitto.c
@@ -36,6 +36,7 @@
 
 #define SOL_LOG_DOMAIN &_sol_mqtt_log_domain
 #include <sol-log-internal.h>
+#include <sol-macros.h>
 #include <sol-mainloop.h>
 #include <sol-util.h>
 
@@ -46,7 +47,7 @@ SOL_LOG_INTERNAL_DECLARE(_sol_mqtt_log_domain, "mqtt");
 static int init_ref;
 #define CHECK_INIT(ret) \
     do { \
-        if (unlikely(init_ref < 1)) { \
+        if (SOL_UNLIKELY(init_ref < 1)) { \
             SOL_WRN("sol-mqtt used before initialization"); \
             return ret; \
         } \
@@ -55,7 +56,7 @@ static int init_ref;
 #ifndef SOL_NO_API_VERSION
 #define MQTT_CHECK_API(ptr, ...) \
     do {                                        \
-        if (unlikely(ptr->api_version != \
+        if (SOL_UNLIKELY(ptr->api_version != \
             SOL_MQTT_CONFIG_API_VERSION)) { \
             SOL_WRN("Couldn't handle mqtt handler that has unsupported " \
                 "version '%u', expected version is '%u'", \

--- a/src/lib/comms/sol-network-impl-linux.c
+++ b/src/lib/comms/sol-network-impl-linux.c
@@ -49,6 +49,7 @@
 
 #define SOL_LOG_DOMAIN &_log_domain
 #include "sol-log-internal.h"
+#include "sol-macros.h"
 #include "sol-mainloop.h"
 #include "sol-network.h"
 #include "sol-util.h"
@@ -456,7 +457,7 @@ sol_network_link_get_name(const struct sol_network_link *link)
     SOL_NULL_CHECK(link, NULL);
 
 #ifndef SOL_NO_API_VERSION
-    if (unlikely(link->api_version != SOL_NETWORK_LINK_API_VERSION)) {
+    if (SOL_UNLIKELY(link->api_version != SOL_NETWORK_LINK_API_VERSION)) {
         SOL_WRN("Couldn't link that has unsupported version '%u', "
             "expected version is '%u'",
             link->api_version, SOL_NETWORK_LINK_API_VERSION);

--- a/src/lib/comms/sol-oic-client.c
+++ b/src/lib/comms/sol-oic-client.c
@@ -43,6 +43,7 @@
 #include "cbor.h"
 #include "sol-coap.h"
 #include "sol-log-internal.h"
+#include "sol-macros.h"
 #include "sol-mainloop.h"
 #include "sol-random.h"
 #include "sol-util.h"
@@ -60,7 +61,7 @@
 #ifndef SOL_NO_API_VERSION
 #define OIC_RESOURCE_CHECK_API(ptr, ...) \
     do { \
-        if (unlikely(ptr->api_version != \
+        if (SOL_UNLIKELY(ptr->api_version != \
             SOL_OIC_RESOURCE_API_VERSION)) { \
             SOL_WRN("Couldn't handle oic client resource that has unsupported " \
                 "version '%u', expected version is '%u'", \
@@ -71,7 +72,7 @@
 
 #define OIC_CLIENT_CHECK_API(ptr, ...) \
     do { \
-        if (unlikely(ptr->api_version != SOL_OIC_CLIENT_API_VERSION)) { \
+        if (SOL_UNLIKELY(ptr->api_version != SOL_OIC_CLIENT_API_VERSION)) { \
             SOL_WRN("Couldn't handle oic client that has unsupported " \
                 "version '%u', expected version is '%u'", \
                 ptr->api_version, SOL_OIC_CLIENT_API_VERSION); \
@@ -134,7 +135,7 @@ _set_token_and_mid(struct sol_coap_packet *pkt, int64_t *token)
     static struct sol_random *random = NULL;
     int32_t mid;
 
-    if (unlikely(!random)) {
+    if (SOL_UNLIKELY(!random)) {
         random = sol_random_new(SOL_RANDOM_DEFAULT, 0);
         SOL_NULL_CHECK(random, false);
     }
@@ -164,13 +165,13 @@ _pkt_has_same_token(const struct sol_coap_packet *pkt, int64_t token)
     uint8_t *token_data, token_len;
 
     token_data = sol_coap_header_get_token(pkt, &token_len);
-    if (unlikely(!token_data))
+    if (SOL_UNLIKELY(!token_data))
         return false;
 
-    if (unlikely(token_len != sizeof(token)))
+    if (SOL_UNLIKELY(token_len != sizeof(token)))
         return false;
 
-    return likely(memcmp(token_data, &token, sizeof(token)) == 0);
+    return SOL_LIKELY(memcmp(token_data, &token, sizeof(token)) == 0);
 }
 
 SOL_API struct sol_oic_resource *

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -42,6 +42,7 @@
 #include "sol-coap.h"
 #include "sol-json.h"
 #include "sol-log-internal.h"
+#include "sol-macros.h"
 #include "sol-platform.h"
 #include "sol-str-slice.h"
 #include "sol-util.h"
@@ -264,7 +265,7 @@ get_machine_id(void)
     static bool machine_id_set = false;
     const char *machine_id_buf;
 
-    if (unlikely(!machine_id_set)) {
+    if (SOL_UNLIKELY(!machine_id_set)) {
         machine_id_buf = sol_platform_get_machine_id();
 
         if (!machine_id_buf) {
@@ -691,7 +692,7 @@ sol_oic_server_add_resource(const struct sol_oic_resource_type *rt,
     SOL_NULL_CHECK(rt, NULL);
 
 #ifndef SOL_NO_API_VERSION
-    if (unlikely(rt->api_version != SOL_OIC_RESOURCE_TYPE_API_VERSION)) {
+    if (SOL_UNLIKELY(rt->api_version != SOL_OIC_RESOURCE_TYPE_API_VERSION)) {
         SOL_WRN("Couldn't add resource_type with "
             "version '%u'. Expected version '%u'.",
             rt->api_version, SOL_OIC_RESOURCE_TYPE_API_VERSION);

--- a/src/lib/datatypes/sol-str-table.c
+++ b/src/lib/datatypes/sol-str-table.c
@@ -32,6 +32,7 @@
 
 #include <inttypes.h>
 
+#include "sol-macros.h"
 #include "sol-str-table.h"
 #include "sol-util.h"
 
@@ -43,7 +44,7 @@ sol_str_table_lookup_fallback(const struct sol_str_table *table,
     const struct sol_str_table *iter;
     uint16_t len;
 
-    if (unlikely(key.len > INT16_MAX))
+    if (SOL_UNLIKELY(key.len > INT16_MAX))
         return fallback;
 
     len = (uint16_t)key.len;
@@ -64,7 +65,7 @@ sol_str_table_ptr_lookup_fallback(const struct sol_str_table_ptr *table,
     const struct sol_str_table_ptr *iter;
     size_t len;
 
-    if (unlikely(key.len > INT16_MAX))
+    if (SOL_UNLIKELY(key.len > INT16_MAX))
         return fallback;
 
     len = key.len;

--- a/src/lib/flow/sol-flow-packet.c
+++ b/src/lib/flow/sol-flow-packet.c
@@ -38,6 +38,7 @@
 
 #include "sol-flow-internal.h"
 #include "sol-flow-packet.h"
+#include "sol-macros.h"
 #include "sol-util.h"
 #include "sol-vector.h"
 #include "sol-buffer.h"
@@ -45,11 +46,11 @@
 
 #define SOL_FLOW_PACKET_CHECK(packet, _type, ...)        \
     do {                                                \
-        if (unlikely(!(packet))) {                      \
+        if (SOL_UNLIKELY(!(packet))) {                      \
             SOL_WRN("" # packet "== NULL");              \
             return __VA_ARGS__;                         \
         }                                               \
-        if (unlikely((packet)->type != _type)) {        \
+        if (SOL_UNLIKELY((packet)->type != _type)) {        \
             SOL_WRN("" # packet "->type != " # _type);   \
             return __VA_ARGS__;                         \
         }                                               \
@@ -134,7 +135,7 @@ sol_flow_packet_new(const struct sol_flow_packet_type *type, const void *value)
     struct sol_flow_packet *packet;
     int r;
 
-    if (unlikely(type == SOL_FLOW_PACKET_TYPE_ANY)) {
+    if (SOL_UNLIKELY(type == SOL_FLOW_PACKET_TYPE_ANY)) {
         SOL_WRN("Couldn't create packet with type ANY. This type is used only on ports.");
         return NULL;
     }
@@ -142,7 +143,7 @@ sol_flow_packet_new(const struct sol_flow_packet_type *type, const void *value)
     SOL_NULL_CHECK_MSG(type, NULL, "Couldn't create packet with NULL type");
 
 #ifndef SOL_NO_API_VERSION
-    if (unlikely(type->api_version != SOL_FLOW_PACKET_TYPE_API_VERSION)) {
+    if (SOL_UNLIKELY(type->api_version != SOL_FLOW_PACKET_TYPE_API_VERSION)) {
         SOL_WRN("Couldn't create packet with type '%s' that has unsupported version '%u', expected version is '%u'",
             type->name ? : "", type->api_version, SOL_FLOW_PACKET_TYPE_API_VERSION);
         return NULL;

--- a/src/lib/io/sol-gpio-impl-linux.c
+++ b/src/lib/io/sol-gpio-impl-linux.c
@@ -298,7 +298,7 @@ sol_gpio_open_raw(uint32_t pin, const struct sol_gpio_config *config)
     SOL_LOG_INTERNAL_INIT_ONCE;
 
 #ifndef SOL_NO_API_VERSION
-    if (unlikely(config->api_version != SOL_GPIO_CONFIG_API_VERSION)) {
+    if (SOL_UNLIKELY(config->api_version != SOL_GPIO_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open gpio that has unsupported version '%u', "
             "expected version is '%u'",
             config->api_version, SOL_GPIO_CONFIG_API_VERSION);

--- a/src/lib/io/sol-gpio-impl-riot.c
+++ b/src/lib/io/sol-gpio-impl-riot.c
@@ -38,6 +38,7 @@
 
 #define SOL_LOG_DOMAIN &_log_domain
 #include "sol-log-internal.h"
+#include "sol-macros.h"
 #include "sol-gpio.h"
 #include "sol-mainloop.h"
 #include "sol-util.h"
@@ -99,7 +100,7 @@ sol_gpio_open_raw(uint32_t pin, const struct sol_gpio_config *config)
     SOL_LOG_INTERNAL_INIT_ONCE;
 
 #ifndef SOL_NO_API_VERSION
-    if (unlikely(config->api_version != SOL_GPIO_CONFIG_API_VERSION)) {
+    if (SOL_UNLIKELY(config->api_version != SOL_GPIO_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open gpio that has unsupported version '%u', "
             "expected version is '%u'",
             config->api_version, SOL_GPIO_CONFIG_API_VERSION);

--- a/src/lib/io/sol-iio.c
+++ b/src/lib/io/sol-iio.c
@@ -43,6 +43,7 @@
 #include <unistd.h>
 
 #include <sol-log.h>
+#include <sol-macros.h>
 #include <sol-mainloop.h>
 #include <sol-str-slice.h>
 #include <sol-util.h>
@@ -622,7 +623,7 @@ sol_iio_open(int device_id, const struct sol_iio_config *config)
 
     SOL_NULL_CHECK(config, NULL);
 #ifndef SOL_NO_API_VERSION
-    if (unlikely(config->api_version != SOL_IIO_CONFIG_API_VERSION)) {
+    if (SOL_UNLIKELY(config->api_version != SOL_IIO_CONFIG_API_VERSION)) {
         SOL_WRN("IIO config version '%u' is unexpected, expected '%u'",
             config->api_version, SOL_IIO_CONFIG_API_VERSION);
         return NULL;
@@ -910,7 +911,7 @@ sol_iio_add_channel(struct sol_iio_device *device, const char *name, const struc
     SOL_NULL_CHECK(config, NULL);
 
 #ifndef SOL_NO_API_VERSION
-    if (unlikely(config->api_version != SOL_IIO_CHANNEL_CONFIG_API_VERSION)) {
+    if (SOL_UNLIKELY(config->api_version != SOL_IIO_CHANNEL_CONFIG_API_VERSION)) {
         SOL_WRN("IIO channel config version '%u' is unexpected, expected '%u'",
             config->api_version, SOL_IIO_CHANNEL_CONFIG_API_VERSION);
         return NULL;

--- a/src/lib/io/sol-pwm-impl-linux.c
+++ b/src/lib/io/sol-pwm-impl-linux.c
@@ -43,6 +43,7 @@
 
 #define SOL_LOG_DOMAIN &_log_domain
 #include "sol-log-internal.h"
+#include "sol-macros.h"
 #include "sol-pwm.h"
 #include "sol-util.h"
 
@@ -271,7 +272,7 @@ sol_pwm_open_raw(int device, int channel, const struct sol_pwm_config *config)
     SOL_LOG_INTERNAL_INIT_ONCE;
 
 #ifndef SOL_NO_API_VERSION
-    if (unlikely(config->api_version != SOL_PWM_CONFIG_API_VERSION)) {
+    if (SOL_UNLIKELY(config->api_version != SOL_PWM_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open pwm that has unsupported version '%u', "
             "expected version is '%u'",
             config->api_version, SOL_PWM_CONFIG_API_VERSION);

--- a/src/lib/io/sol-pwm-impl-riot.c
+++ b/src/lib/io/sol-pwm-impl-riot.c
@@ -35,6 +35,7 @@
 
 #define SOL_LOG_DOMAIN &_log_domain
 #include "sol-log-internal.h"
+#include "sol-macros.h"
 #include "sol-pwm.h"
 #include "sol-util.h"
 #include "sol-vector.h"
@@ -109,7 +110,7 @@ sol_pwm_open_raw(int device, int channel, const struct sol_pwm_config *config)
     SOL_LOG_INTERNAL_INIT_ONCE;
 
 #ifndef SOL_NO_API_VERSION
-    if (unlikely(config->api_version != SOL_PWM_CONFIG_API_VERSION)) {
+    if (SOL_UNLIKELY(config->api_version != SOL_PWM_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open pwm that has unsupported version '%u', "
             "expected version is '%u'",
             config->api_version, SOL_PWM_CONFIG_API_VERSION);

--- a/src/lib/io/sol-spi-impl-linux.c
+++ b/src/lib/io/sol-spi-impl-linux.c
@@ -204,7 +204,7 @@ sol_spi_open(unsigned int bus, const struct sol_spi_config *config)
     SOL_LOG_INTERNAL_INIT_ONCE;
 
 #ifndef SOL_NO_API_VERSION
-    if (unlikely(config->api_version != SOL_SPI_CONFIG_API_VERSION)) {
+    if (SOL_UNLIKELY(config->api_version != SOL_SPI_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open SPI that has unsupported version '%u', "
             "expected version is '%u'",
             config->api_version, SOL_SPI_CONFIG_API_VERSION);

--- a/src/lib/io/sol-spi-impl-riot.c
+++ b/src/lib/io/sol-spi-impl-riot.c
@@ -85,7 +85,7 @@ sol_spi_open(unsigned int bus, const struct sol_spi_config *config)
     SOL_LOG_INTERNAL_INIT_ONCE;
 
 #ifndef SOL_NO_API_VERSION
-    if (unlikely(config->api_version != SOL_SPI_CONFIG_API_VERSION)) {
+    if (SOL_UNLIKELY(config->api_version != SOL_SPI_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open SPI that has unsupported version '%u', "
             "expected version is '%u'",
             config->api_version, SOL_SPI_CONFIG_API_VERSION);

--- a/src/lib/io/sol-uart-impl-linux.c
+++ b/src/lib/io/sol-uart-impl-linux.c
@@ -41,6 +41,7 @@
 
 #define SOL_LOG_DOMAIN &_log_domain
 #include "sol-log-internal.h"
+#include "sol-macros.h"
 #include "sol-mainloop.h"
 #include "sol-uart.h"
 #include "sol-util.h"
@@ -112,7 +113,7 @@ sol_uart_open(const char *port_name, const struct sol_uart_config *config)
     SOL_LOG_INTERNAL_INIT_ONCE;
 
 #ifndef SOL_NO_API_VERSION
-    if (unlikely(config->api_version != SOL_UART_CONFIG_API_VERSION)) {
+    if (SOL_UNLIKELY(config->api_version != SOL_UART_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open UART that has unsupported version '%u', "
             "expected version is '%u'",
             config->api_version, SOL_UART_CONFIG_API_VERSION);

--- a/src/lib/io/sol-uart-impl-riot.c
+++ b/src/lib/io/sol-uart-impl-riot.c
@@ -38,6 +38,7 @@
 
 #define SOL_LOG_DOMAIN &_log_domain
 #include "sol-log-internal.h"
+#include "sol-macros.h"
 #include "sol-uart.h"
 #include "sol-mainloop.h"
 #include "sol-util.h"
@@ -120,7 +121,7 @@ sol_uart_open(const char *port_name, const struct sol_uart_config *config)
     SOL_LOG_INTERNAL_INIT_ONCE;
 
 #ifndef SOL_NO_API_VERSION
-    if (unlikely(config->api_version != SOL_UART_CONFIG_API_VERSION)) {
+    if (SOL_UNLIKELY(config->api_version != SOL_UART_CONFIG_API_VERSION)) {
         SOL_WRN("Couldn't open UART that has unsupported version '%u', "
             "expected version is '%u'",
             config->api_version, SOL_UART_CONFIG_API_VERSION);

--- a/src/lib/parsers/sol-json.c
+++ b/src/lib/parsers/sol-json.c
@@ -41,6 +41,7 @@
 
 #include "sol-json.h"
 #include "sol-log.h"
+#include "sol-macros.h"
 #include "sol-util.h"
 #include <float.h>
 #include <math.h>
@@ -507,7 +508,7 @@ sol_json_scanner_skip_over(struct sol_json_scanner *scanner,
         case SOL_JSON_TYPE_OBJECT_END:
         case SOL_JSON_TYPE_ARRAY_END:
             level--;
-            if (unlikely(level < 0)) {
+            if (SOL_UNLIKELY(level < 0)) {
                 errno = EINVAL;
                 return false;
             }

--- a/src/modules/flow/boolean/boolean.c
+++ b/src/modules/flow/boolean/boolean.c
@@ -32,6 +32,7 @@
 
 #include "sol-flow/boolean.h"
 #include "sol-flow-internal.h"
+#include "sol-macros.h"
 #include "sol-mainloop.h"
 #include "sol-vector.h"
 #include "sol-str-table.h"
@@ -107,7 +108,7 @@ multi_ports_process(struct sol_flow_node *node, void *data, uint16_t port_in, ui
     if (mdata->initialized != mdata->connected)
         return 0;
 
-    if (unlikely(!(ports = mdata->initialized)))
+    if (SOL_UNLIKELY(!(ports = mdata->initialized)))
         return 0;
 
     for (i = 0; !(ports & 1); i++)

--- a/src/modules/flow/thingspeak/thingspeak.c
+++ b/src/modules/flow/thingspeak/thingspeak.c
@@ -38,6 +38,7 @@
 #include <stdio.h>
 
 #include <sol-http-client.h>
+#include <sol-macros.h>
 #include <sol-mainloop.h>
 #include <sol-util.h>
 
@@ -72,7 +73,7 @@ struct thingspeak_channel_update_data {
 
 #define RESPONSE_CHECK_API(response_, mdata_) \
     do { \
-        if (unlikely(!response_)) { \
+        if (SOL_UNLIKELY(!response_)) { \
             sol_flow_send_error_packet(mdata_->node, EINVAL, \
                 "Error while reaching Thingspeak"); \
             return; \

--- a/src/modules/flow/update/update.c
+++ b/src/modules/flow/update/update.c
@@ -34,6 +34,7 @@
 #include "sol-flow/update.h"
 #include "sol-flow-internal.h"
 #include "sol-json.h"
+#include "sol-macros.h"
 #include "sol-str-slice.h"
 #include "sol-types.h"
 #include "sol-update.h"
@@ -92,7 +93,7 @@ check_cb(void *data, int status, const struct sol_update_info *response)
     }
 
 #ifndef SOL_NO_API_VERSION
-    if (unlikely(response->api_version != SOL_UPDATE_INFO_API_VERSION)) {
+    if (SOL_UNLIKELY(response->api_version != SOL_UPDATE_INFO_API_VERSION)) {
         SOL_WRN("Update info config version '%u' is unexpected, expected '%u'",
             response->api_version, SOL_UPDATE_INFO_API_VERSION);
         return;

--- a/src/shared/sol-modules.c
+++ b/src/shared/sol-modules.c
@@ -41,6 +41,7 @@
 #include <stdlib.h>
 
 #include "sol-log-internal.h"
+#include "sol-macros.h"
 
 #include "sol-util.h"
 #include "sol-vector.h"
@@ -141,7 +142,7 @@ get_module_path(char *buf, size_t len, const char *nspace, const char *modname)
 {
     static char rootdir[PATH_MAX] = { };
 
-    if (unlikely(!*rootdir)) {
+    if (SOL_UNLIKELY(!*rootdir)) {
         int ret;
 
         ret = sol_util_get_rootdir(rootdir, sizeof(rootdir));

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -42,6 +42,7 @@
 #endif
 
 #include "sol-buffer.h"
+#include "sol-macros.h"
 #include "sol-util.h"
 #include "sol-log.h"
 #include "sol-random.h"
@@ -124,7 +125,7 @@ sol_util_strtodn(const char *nptr, char **endptr, ssize_t len, bool use_locale)
     if (len < 0)
         len = (ssize_t)strlen(nptr);
 
-    if (unlikely(len > (DBL_MANT_DIG - DBL_MIN_EXP + 3))) {
+    if (SOL_UNLIKELY(len > (DBL_MANT_DIG - DBL_MIN_EXP + 3))) {
         errno = EINVAL;
         return FP_NAN;
     }
@@ -414,7 +415,7 @@ base64_index_of(char c, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)])
 {
     const char *p = memchr(base64_map, c, 65);
 
-    if (unlikely(!p))
+    if (SOL_UNLIKELY(!p))
         return UINT8_MAX;
     return p - base64_map;
 }
@@ -468,7 +469,7 @@ sol_util_base64_decode(void *buf, size_t buflen, const struct sol_str_slice slic
 static inline char
 base16_encode_digit(const uint8_t nibble, const char a)
 {
-    if (likely(nibble < 10))
+    if (SOL_LIKELY(nibble < 10))
         return '0' + nibble;
     return a + (nibble - 10);
 }
@@ -511,7 +512,7 @@ sol_util_base16_encode(void *buf, size_t buflen, const struct sol_str_slice slic
 static inline uint8_t
 base16_decode_digit(const char digit, const char a, const char f, const char A, const char F)
 {
-    if (likely('0' <= digit && digit <= '9'))
+    if (SOL_LIKELY('0' <= digit && digit <= '9'))
         return digit - '0';
     else if (a <= digit && digit <= f)
         return 10 + (digit - a);
@@ -550,7 +551,7 @@ sol_util_base16_decode(void *buf, size_t buflen, const struct sol_str_slice slic
         for (n = 0; n < 2; n++) {
             const uint8_t c = input[i + n];
             uint8_t nibble = base16_decode_digit(c, a, f, A, F);
-            if (unlikely(nibble == UINT8_MAX)) {
+            if (SOL_UNLIKELY(nibble == UINT8_MAX)) {
                 SOL_WRN("Invalid base16 char %c, index: %zd", c, i + n);
                 return -EINVAL;
             }

--- a/src/shared/sol-util.h
+++ b/src/shared/sol-util.h
@@ -136,9 +136,6 @@ long int sol_util_strtol(const char *nptr, char **endptr, ssize_t len, int base)
 #define PTR_TO_INT(p) ((int)((intptr_t)(p)))
 #define INT_TO_PTR(i) ((void *)((intptr_t)(i)))
 
-#define likely(x)   __builtin_expect(!!(x), 1)
-#define unlikely(x) __builtin_expect(!!(x), 0)
-
 /* number of nanoseconds in a second: 1,000,000,000 */
 #define NSEC_PER_SEC  1000000000ULL
 /* number of milliseconds in a second: 1,000 */
@@ -226,7 +223,7 @@ char *sol_util_strerror(int errnum, char *buf, size_t buflen);
         if (u <= 1) /* 0 is undefined for __builtin_clz() */ \
             return u; \
         left_zeros = clz_fn_(u - 1); \
-        if (unlikely(left_zeros <= 1)) \
+        if (SOL_UNLIKELY(left_zeros <= 1)) \
             return max_; \
         return (type_)1 << ((sizeof(u) * 8) - left_zeros); \
     }
@@ -249,7 +246,7 @@ align_power2_short_uint(unsigned short u)
 {
     unsigned int aligned = align_power2_uint(u);
 
-    return likely(aligned <= USHRT_MAX) ? aligned : USHRT_MAX;
+    return SOL_LIKELY(aligned <= USHRT_MAX) ? aligned : USHRT_MAX;
 }
 
 /* _Generic() from C11 would be better here, but it's not supported by


### PR DESCRIPTION
Those macros were defined in sol-util.h that is not exported but there
was public headers using them. Also, it was some re-define of the same
functionality, this commit attempts to sanitize it.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>