### PR TITLE
sol-socket: Convert from sol_to_af before using it.

### DIFF
--- a/src/lib/comms/sol-socket-impl-linux.c
+++ b/src/lib/comms/sol-socket-impl-linux.c
@@ -164,7 +164,7 @@ sol_socket_linux_new(int domain, enum sol_socket_type type, int protocol)
         return NULL;
     }
 
-    fd = socket(domain, socktype, protocol);
+    fd = socket(sol_network_sol_to_af(domain), socktype, protocol);
     SOL_INT_CHECK(fd, < 0, NULL);
 
     s = calloc(1, sizeof(*s));


### PR DESCRIPTION
Signed-off-by: Guilherme Iscaro <guilherme.iscaro@intel.com>