### PR TITLE
log: Add missing header

### DIFF
--- a/src/lib/common/include/sol-log.h
+++ b/src/lib/common/include/sol-log.h
@@ -39,6 +39,7 @@
 #include <stdint.h>
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <sys/types.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
check-cpp is failing without this.