### PR TITLE
Sol-platform: Register a new inotify if /etc/locale.conf was deleted.

### DIFF
--- a/src/lib/common/sol-platform-impl.h
+++ b/src/lib/common/sol-platform-impl.h
@@ -104,3 +104,5 @@ const char *sol_platform_locale_to_c_str_category(enum sol_platform_locale_categ
 int sol_platform_impl_locale_to_c_category(enum sol_platform_locale_category category);
 
 const char *sol_platform_impl_locale_to_c_str_category(enum sol_platform_locale_category category);
+
+void sol_platform_inform_locale_monitor_error(void);

--- a/src/lib/common/sol-platform.c
+++ b/src/lib/common/sol-platform.c
@@ -699,6 +699,18 @@ sol_platform_inform_locale_changed(void)
     }
 }
 
+void
+sol_platform_inform_locale_monitor_error(void)
+{
+    struct sol_monitors_entry *entry;
+    uint16_t i;
+
+    SOL_MONITORS_WALK (&_ctx.locale_monitors, entry, i) {
+        ((void (*)(void *, enum sol_platform_locale_category, const char *))
+         entry->cb)((void *)entry->data, SOL_PLATFORM_LOCALE_UNKNOWN, NULL);
+    }
+}
+
 static bool
 locale_timeout_cb(void *data)
 {

--- a/src/modules/flow/platform/platform.c
+++ b/src/modules/flow/platform/platform.c
@@ -57,6 +57,8 @@ struct monitor_node_type {
     int (*monitor_unregister)(struct sol_flow_node *);
 };
 
+static int locale_monitor_unregister(struct sol_flow_node *node);
+
 static int
 state_dispatch_ready(struct platform_data *mdata)
 {
@@ -419,6 +421,13 @@ timezone_process(struct sol_flow_node *node, void *data, uint16_t port,
 static int
 locale_send(struct sol_flow_node *node, enum sol_platform_locale_category category, const char *locale)
 {
+    if (category == SOL_PLATFORM_LOCALE_UNKNOWN && !locale) {
+        locale_monitor_unregister(node);
+        return sol_flow_send_error_packet(node, ECANCELED,
+            "Something wrong happened with the locale monitor,"
+            "stoping to monitor locale changes");
+    }
+
     if (!locale) {
         locale = sol_platform_get_locale(category);
         SOL_NULL_CHECK(locale, -EINVAL);


### PR DESCRIPTION
When one changes the locale using systemd's localectl, the systemd
will not simple open the /etc/locale.conf file and update its contents.
It will create a new file file and then replace the /etc/locale.conf.
(basically mv /etc/ANeWLocaleFile.conf /etc/locale.conf)
Since the old locale.conf was deleted, a new inode watcher must
be created.

Signed-off-by: Guilherme Iscaro <guilherme.iscaro@intel.com>