### PR TITLE
form: Fix memory leak

### DIFF
--- a/src/modules/flow/form/form.c
+++ b/src/modules/flow/form/form.c
@@ -3226,6 +3226,7 @@ numeric_loop:
         numeric_field_present = true;
 
         ptr = tmp + 1;
+        sol_buffer_fini(&mdata->formatted_value);
     }
 
     if (!numeric_field_present) {


### PR DESCRIPTION
sol_buffer_init was being called inside a loop causing the previous
allocated data being lost.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>