### PR TITLE
Remove compiler warning -Wno-cpp

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -86,6 +86,16 @@
       "append_to": "COMMON_CFLAGS"
     },
     {
+      "dependency": "check_cflags",
+      "type": "cflags",
+      "cflags": [
+        "-Wno-cpp",
+        "-Wno-#warnings"
+      ],
+      "comment": "append to CFLAGS_NO_SOURCE_WARNINGS",
+      "append_to": "CFLAGS_NO_SOURCE_WARNINGS"
+    },
+    {
       "dependency": "check_ldflags",
       "type": "ldflags",
       "ldflags": [

--- a/src/lib/comms/Makefile
+++ b/src/lib/comms/Makefile
@@ -53,7 +53,7 @@ obj-networking-$(OIC) += \
 
 obj-networking-$(OIC)-extra-cflags += \
     -I$(TINYCBOR_SRC_PATH) \
-    -Wno-cpp \
+    $(CFLAGS_NO_SOURCE_WARNINGS) \
     -Wno-declaration-after-statement \
     -Wno-float-equal \
     -Wno-undef


### PR DESCRIPTION
Clang doesn't understand it. The equivalent for Clang is -Wno-#warnings.

If you know of a way to detect which compiler it is, let me know.