### PR TITLE
Remove -e from echo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ endif
 
 ifneq (,$(NOT_FOUND))
 warning:
-	$(Q)echo -e "The following (required) dependencies were not met:\n"
-	$(Q)echo -e "$(NOT_FOUND)"
-	$(Q)echo -e "If you've just installed it, run: make reconf"
-	$(Q)echo -e "For more information/options, run: make help"
+	$(Q)echo "The following (required) dependencies were not met:\n"
+	$(Q)echo "$(NOT_FOUND)"
+	$(Q)echo "If you've just installed it, run: make reconf"
+	$(Q)echo "For more information/options, run: make help"
 $(warning-targets)
 else
 ifeq ($(HAVE_KCONFIG_CONFIG),)

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -231,7 +231,7 @@ PRE_GEN += $(all-gen-hdrs) $(all-dest-hdr) $(all-dest-bin)
 
 define make-warning
 $(1):
-	$(Q)echo -e "     [!]   "$($(1)-msg)
+	$(Q)echo "     [!]   "$($(1)-msg)
 
 all: $(1)
 PHONY += $(1)
@@ -241,7 +241,7 @@ $(foreach wrn,$(all-warnings),$(eval $(call make-warning,$(wrn))))
 define make-warning-header
 $(all-warnings): warning-header
 warning-header: default_target
-	$(Q)echo -e "*** ATTENTION:"
+	$(Q)echo "*** ATTENTION:"
 PHONY += warning-header
 endef
 $(if $(all-warnings),$(eval $(call make-warning-header,$(wrn))))


### PR DESCRIPTION
POSIX echo has no options. Otherwise, we get output like:
    
          -e The following (required) dependencies were not met:
    
          -e python module: jsonschema
    
          -e If you've just installed it, run: make reconf
          -e For more information/options, run: make help
