### PR TITLE
Add missing #pragma GCC diagnostic push

### DIFF
--- a/src/modules/flow/converter/converter.c
+++ b/src/modules/flow/converter/converter.c
@@ -2107,6 +2107,7 @@ timestamp_to_string_convert(struct sol_flow_node *node, void *data, uint16_t por
     if (!localtime_r(&in_value.tv_sec, &time_tm))
         goto timestamp_error;
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
 
     r = strftime(out_value, sizeof(out_value), mdata->string,

--- a/src/modules/flow/converter/string-format.c
+++ b/src/modules/flow/converter/string-format.c
@@ -1444,6 +1444,7 @@ ascii_format_double(struct sol_buffer *buffer,
         format = tmp_format;
     }
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
     /* Have snprintf do the hard work */
     r = sol_buffer_append_printf(buffer, format, d);


### PR DESCRIPTION
You can't pop without pushing first. Clang complains:
    
    warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
