### PR TITLE
sol-coap: Properly handle observe option.

### DIFF
--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -1056,6 +1056,8 @@ get_observe_option(struct sol_coap_packet *pkt)
 
     /* The value is in the network order, and has at max 3 bytes. */
     switch (option.len) {
+    case 0:
+        return 0;
     case 1:
         return option.data[0];
     case 2:


### PR DESCRIPTION
According to the spec the observe option may have its length
equals to 0.

Signed-off-by: Guilherme Iscaro <guilherme.iscaro@intel.com>

@vcgomes 