### PR TITLE
Fix use of non-POSIX errno name ENOTUNIQ

### DIFF
--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -481,7 +481,7 @@ sol_flow_builder_add_node(struct sol_flow_builder *builder, const char *name, co
     SOL_VECTOR_FOREACH_IDX (&builder->nodes, node_spec, i)
         if (!strcmp(name, node_spec->name)) {
             SOL_WRN("Node not added, name %s already exists.", name);
-            return -ENOTUNIQ;
+            return -EEXIST;
         }
 
     /* check if port names are unique */


### PR DESCRIPTION
It doesn't exist in POSIX, so this can't be used outside of Linux
systems. This fixes #1329.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>