### PR TITLE
Fix truncation of 64-bit value during abs() call

### DIFF
--- a/src/modules/flow/color/color.c
+++ b/src/modules/flow/color/color.c
@@ -92,11 +92,11 @@ color_luminance_process(struct sol_flow_node *node, void *data, uint16_t port, u
     diff = (int64_t)in_value.max - in_value.min;
 
     val = (int64_t)mdata->red * in_value.val / diff;
-    out.red = abs(val);
+    out.red = llabs(val);
     val = mdata->green * in_value.val / diff;
-    out.green = abs(val);
+    out.green = llabs(val);
     val = mdata->blue * in_value.val / diff;
-    out.blue = abs(val);
+    out.blue = llabs(val);
 
     return sol_flow_send_rgb_packet(node,
         SOL_FLOW_NODE_TYPE_COLOR_LUMINANCE_RGB__OUT__OUT,


### PR DESCRIPTION
The abs() function takes int, while llabs() takes long long. There's a
truncation when assigned to out.{red,green,blue}, but at least that
doesn't create a warning with Clang.

warning: absolute value function 'abs' given an argument of type 'int64_t' (aka 'long long') but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
note: use function 'llabs' instead

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>