### PR TITLE
Fix truncation-conversion of SIZE_MAX to int32_t

### DIFF
--- a/src/modules/flow/string/string-regexp.c
+++ b/src/modules/flow/string/string-regexp.c
@@ -551,7 +551,7 @@ string_regexp_replace_open(struct sol_flow_node *node,
         return -EINVAL;
     }
     mdata->max_regexp_replace = opts->max_regexp_replace > 0 ?
-        (size_t)opts->max_regexp_replace : SIZE_MAX;
+        opts->max_regexp_replace : INT32_MAX;
 
     if (!opts->regexp || !strlen(opts->regexp)) {
         SOL_WRN("A non-empty regular expression string must be provided");


### PR DESCRIPTION
max_regexp_replace is int32_t, so SIZE_MAX is too big.

string-regexp.c:554:44: warning: implicit conversion from 'unsigned long long' to 'int32_t' (aka 'int') changes value from 18446744073709551615 to -1 [-Wconstant-conversion]

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>