### PR TITLE
Fix build: led-7seg.c requires sol-gpio.h

### DIFF
--- a/src/modules/flow/led-7seg/led-7seg.c
+++ b/src/modules/flow/led-7seg/led-7seg.c
@@ -33,7 +33,7 @@
 #include "sol-flow/led-7seg.h"
 #include "sol-flow-internal.h"
 
-#include <sol-gpio.h>
+#include "../../../lib/io/include/sol-gpio.h"
 #include <sol-util-internal.h>
 #include <errno.h>
 


### PR DESCRIPTION
This is definitely wrong, but since I have no clue how to do it properly, I am sending the temporary fix. I'd appreciate instruction on how to set the include path. I can't find where that gets set.