### PR TITLE
Fix Clang warnings about printf format mismatches

### DIFF
--- a/src/lib/common/sol-blob.c
+++ b/src/lib/common/sol-blob.c
@@ -46,7 +46,7 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_sol_blob_log_domain, "blob");
     if (!(blob)->type->api_version) {               \
         SOL_WRN("" # blob                            \
             "(%p)->type->api_version(%hu) != "   \
-            "SOL_BLOB_TYPE_API_VERSION(%hu)",     \
+            "SOL_BLOB_TYPE_API_VERSION(%u)",     \
             (blob), (blob)->type->api_version,   \
             SOL_BLOB_TYPE_API_VERSION);           \
         return __VA_ARGS__;                         \

--- a/src/lib/common/sol-log.c
+++ b/src/lib/common/sol-log.c
@@ -258,7 +258,7 @@ sol_log_get_level(void)
 SOL_API void
 sol_log_set_show_colors(bool enabled)
 {
-    SOL_LOG_INIT_CHECK("enabled=%hhu", enabled);
+    SOL_LOG_INIT_CHECK("enabled=%s", enabled ? "true" : "false");
     _show_colors = enabled;
 }
 
@@ -272,7 +272,7 @@ sol_log_get_show_colors(void)
 SOL_API void
 sol_log_set_show_file(bool enabled)
 {
-    SOL_LOG_INIT_CHECK("enabled=%hhu", enabled);
+    SOL_LOG_INIT_CHECK("enabled=%s", enabled ? "true" : "false");
     _show_file = enabled;
 }
 
@@ -286,7 +286,7 @@ sol_log_get_show_file(void)
 SOL_API void
 sol_log_set_show_function(bool enabled)
 {
-    SOL_LOG_INIT_CHECK("enabled=%hhu", enabled);
+    SOL_LOG_INIT_CHECK("enabled=%s", enabled ? "true" : "false");
     _show_function = enabled;
 }
 
@@ -300,7 +300,7 @@ sol_log_get_show_function(void)
 SOL_API void
 sol_log_set_show_line(bool enabled)
 {
-    SOL_LOG_INIT_CHECK("enabled=%hhu", enabled);
+    SOL_LOG_INIT_CHECK("enabled=%s", enabled ? "true" : "false");
     _show_line = enabled;
 }
 

--- a/src/lib/common/sol-mainloop.c
+++ b/src/lib/common/sol-mainloop.c
@@ -377,7 +377,7 @@ sol_mainloop_source_add(const struct sol_mainloop_source_type *type, const void 
 #ifndef SOL_NO_API_VERSION
     if (type->api_version != SOL_MAINLOOP_SOURCE_TYPE_API_VERSION) {
         SOL_WRN("type(%p)->api_version(%hu) != "
-            "SOL_MAINLOOP_SOURCE_TYPE_API_VERSION(%hu)",
+            "SOL_MAINLOOP_SOURCE_TYPE_API_VERSION(%u)",
             type, type->api_version,
             SOL_MAINLOOP_SOURCE_TYPE_API_VERSION);
         return NULL;
@@ -418,7 +418,7 @@ sol_mainloop_set_implementation(const struct sol_mainloop_implementation *impl)
 #ifndef SOL_NO_API_VERSION
     if (impl->api_version != SOL_MAINLOOP_IMPLEMENTATION_API_VERSION) {
         SOL_WRN("impl(%p)->api_version(%hu) != "
-            "SOL_MAINLOOP_IMPLEMENTATION_API_VERSION(%hu)",
+            "SOL_MAINLOOP_IMPLEMENTATION_API_VERSION(%u)",
             impl, impl->api_version,
             SOL_MAINLOOP_IMPLEMENTATION_API_VERSION);
         return false;

--- a/src/lib/crypto/sol-message-digest-common.c
+++ b/src/lib/crypto/sol-message-digest-common.c
@@ -498,9 +498,9 @@ _sol_message_digest_feed_blob(struct sol_message_digest *handle)
     _sol_message_digest_unlock(handle);
 
     n = handle->ops->feed(handle, mem, len, is_last);
-    SOL_DBG("handle %p feed mem=%p (%zd bytes) (pending=%hu) is_last=%hhu:"
+    SOL_DBG("handle %p feed mem=%p (%zd bytes) (pending=%hu) is_last=%s:"
         " %zd bytes",
-        handle, mem, len, handle->pending_feed.len, is_last, n);
+        handle, mem, len, handle->pending_feed.len, is_last ? "true" : "false", n);
     if (n >= 0) {
         if (offset + n < input->size) { /* not fully sent, need to try again later */
             /* fetch first pending again as it's a sol_vector and

--- a/src/lib/crypto/sol-message-digest-impl-openssl.c
+++ b/src/lib/crypto/sol-message-digest-impl-openssl.c
@@ -171,7 +171,7 @@ sol_message_digest_new(const struct sol_message_digest_config *config)
 #ifndef SOL_NO_API_VERSION
     if (config->api_version != SOL_MESSAGE_DIGEST_CONFIG_API_VERSION) {
         SOL_WRN("sol_message_digest_config->api_version=%hu, "
-            "expected version is %hu.",
+            "expected version is %u.",
             config->api_version, SOL_MESSAGE_DIGEST_CONFIG_API_VERSION);
         return NULL;
     }

--- a/src/lib/flow/sol-flow-internal.h
+++ b/src/lib/flow/sol-flow-internal.h
@@ -200,7 +200,7 @@ extern const struct sol_flow_node_options sol_flow_node_options_empty;
         SOL_NULL_CHECK(options, __VA_ARGS__);                            \
         if (((const struct sol_flow_node_options *)options)->sub_api != (expected)) { \
             SOL_WRN("" # options "(%p)->sub_api(%hu) != "                \
-                "" # expected "(%hu)",                               \
+                "" # expected "(%u)",                                \
                 (options),                                           \
                 ((const struct sol_flow_node_options *)options)->sub_api, \
                 (expected));                                         \
@@ -213,7 +213,7 @@ extern const struct sol_flow_node_options sol_flow_node_options_empty;
         SOL_NULL_CHECK(options, __VA_ARGS__);                            \
         if (((const struct sol_flow_node_options *)options)->api_version != (expected)) { \
             SOL_WRN("Invalid " # options " %p API version(%hu), "        \
-                "expected " # expected "(%hu)",                      \
+                "expected " # expected "(%u)",                       \
                 (options),                                           \
                 ((const struct sol_flow_node_options *)options)->api_version, \
                 (expected));                                         \
@@ -226,7 +226,7 @@ extern const struct sol_flow_node_options sol_flow_node_options_empty;
         SOL_NULL_CHECK(description, __VA_ARGS__);                        \
         if (((const struct sol_flow_node_type_description *)description)->api_version != (expected)) { \
             SOL_WRN("Invalid " # description " %p API version(%lu), "    \
-                "expected " # expected "(%hu)",                      \
+                "expected " # expected "(%u)",                       \
                 (description),                                       \
                 ((const struct sol_flow_node_type_description *)description)->api_version, \
                 (expected));                                         \
@@ -239,7 +239,7 @@ extern const struct sol_flow_node_options sol_flow_node_options_empty;
         SOL_NULL_CHECK(type, __VA_ARGS__);                                 \
         if (((const struct sol_flow_node_type *)type)->api_version != (expected)) { \
             SOL_WRN("Invalid " # type " %p API version(%hu), "             \
-                "expected " # expected "(%hu)",                        \
+                "expected " # expected "(%u)",                         \
                 (type),                                                \
                 ((const struct sol_flow_node_type *)type)->api_version, \
                 (expected));                                           \
@@ -252,7 +252,7 @@ extern const struct sol_flow_node_options sol_flow_node_options_empty;
         SOL_NULL_CHECK(out, __VA_ARGS__);                                  \
         if (((const struct sol_flow_port_type_out *)out)->api_version != (expected)) { \
             SOL_WRN("Invalid " # out " %p API version(%hu), "              \
-                "expected " # expected "(%hu)",                        \
+                "expected " # expected "(%u)",                         \
                 (out),                                                 \
                 ((const struct sol_flow_port_type_out *)out)->api_version, \
                 (expected));                                           \
@@ -265,7 +265,7 @@ extern const struct sol_flow_node_options sol_flow_node_options_empty;
         SOL_NULL_CHECK(in, __VA_ARGS__);                                    \
         if (((const struct sol_flow_port_type_in *)in)->api_version != (expected)) { \
             SOL_WRN("Invalid " # in " %p API version(%hu), "                \
-                "expected " # expected "(%hu)",                         \
+                "expected " # expected "(%u)",                          \
                 (in),                                                   \
                 ((const struct sol_flow_port_type_in *)in)->api_version, \
                 (expected));                                            \

--- a/src/lib/flow/sol-flow-static.c
+++ b/src/lib/flow/sol-flow-static.c
@@ -769,7 +769,7 @@ setup_conn_specs(struct flow_static_type *type)
         if (spec->src < prev->src || ((spec->src == prev->src) && (spec->src_port < prev->src_port))) {
             SOL_WRN("Connection specification is not ordered: "
                 "src=%hu (previous: %hu), "
-                "src_port=%hu (previous: %hu)",
+                "src_port=%hu (previous: %u)",
                 spec->src, prev->src,
                 spec->src_port,
                 (spec->src == prev->src) ? prev->src_port : 0);


### PR DESCRIPTION
All of the API version numbers are declared as plain integer literals,
so using %hu is wrong. They are int, not unsigned short.

The booleans are not to be printed as %hhu.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>