### PR TITLE
Fix build: include sol-board-detect.h with the right #ifdef

### DIFF
--- a/src/lib/common/sol-platform.c
+++ b/src/lib/common/sol-platform.c
@@ -41,7 +41,7 @@
 #include "sol-log-internal.h"
 #include "sol-macros.h"
 #include "sol-monitors.h"
-#ifdef SOL_PLATFORM_LINUX
+#ifdef DETECT_BOARD_NAME
 #include "sol-board-detect.h"
 #endif
 #include "sol-platform.h"


### PR DESCRIPTION
The code that uses sol_board_detect is behind #ifdef DETECT_BOARD_NAME.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>