### PR TITLE
oic: Macro SOL_OIC_MAP_LOOP was never finishing with success

### DIFF
--- a/src/lib/comms/sol-oic-common.c
+++ b/src/lib/comms/sol-oic-common.c
@@ -77,7 +77,7 @@ sol_oic_map_loop_next(struct sol_oic_repr_field *repr, struct sol_oic_map_reader
 
     repr_field_free(repr);
     if (!cbor_value_is_valid((CborValue *)iterator))
-        goto err;
+        return false;
 
     err = sol_oic_cbor_repr_map_get_next_field((CborValue *)iterator, repr);
     if (err != CborNoError)


### PR DESCRIPTION
Commit b2d2c2b9 added parameter checking, but added this bug in
SOL_OIC_MAP_LOOP macro.

In case the cbor value is not valid, we reached the end of the list, so
reason shouldn't be updated.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>