### PR TITLE
Remove extra slash in find

### DIFF
--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -134,7 +134,7 @@ SCRIPTDIR := $(top_srcdir)data/scripts/
 # sub-modules and deps
 EXCLUDE_SUBDIRS := $(addprefix -not -path ,"$(top_srcdir)src/thirdparty/*")
 SUBDIRS := $(addprefix $(top_srcdir)src/lib/,common comms datatypes flow) $(top_srcdir)src/shared
-SUBDIRS := $(dir $(filter-out $(SUBDIRS),$(shell find $(top_srcdir)src/ $(EXCLUDE_SUBDIRS) -name 'Makefile')))
+SUBDIRS := $(dir $(filter-out $(SUBDIRS),$(shell find $(top_srcdir)src $(EXCLUDE_SUBDIRS) -name 'Makefile')))
 
 MAKEFILE_GEN := $(top_srcdir)Makefile.gen
 KCONFIG_GEN := $(top_srcdir)Kconfig.gen


### PR DESCRIPTION
This extra slash caused make rules with "src//lib", which obviously
don't match "src/lib" (make does string comparisons).

 make: *** No rule to make target `src//modules/flow/oic/oic.json', needed by `build/soletta_sysroot/usr/include/soletta/sol-flow/oic.h'.  Stop.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>