### PR TITLE
Remove fallback accept4 because it doesn't work

### DIFF
--- a/src/lib/common/sol-missing.h
+++ b/src/lib/common/sol-missing.h
@@ -49,36 +49,6 @@ extern "C" {
 #define strndupa(str_, len_)     __strndupa_internal__(str_, len_, __tmp__ ## __LINE__)
 #endif
 
-#if defined(HAVE_SOCKET) && !defined(HAVE_ACCEPT4)
-#include <fcntl.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <unistd.h>
-
-static inline int
-accept4(int sockfd, struct sockaddr *addr, socklen_t *len, int flags)
-{
-    int fl, fd = accept(sockfd, addr, len);
-
-    if (fd < 0)
-        return fd;
-
-    fl = fcntl(fd, F_GETFD);
-    if (fl == -1)
-        goto err;
-
-    fl |= flags;
-    if (fcntl(fd, F_SETFD, fl) == -1)
-        goto err;
-
-    return fd;
-
-err:
-    close(fd);
-    return -1;
-}
-#endif
-
 #ifndef HAVE_DECL_MEMMEM
 #include <string.h>
 


### PR DESCRIPTION
This was obviously never tested because this function does not properly
set the flags it purported to set. F_SETFD only recognises one flag,
FD_CLOEXEC, which will never match the values of SOCK_CLOEXEC and
SOCK_NONBLOCK that are used throughout Soletta. Using F_SETFL would have
helped with SOCK_NONBLOCK / O_NONBLOCK, but we'd need to handle
SOCK_CLOEXEC separately anyway.

Anyway, there were only two uses of accept4 in Soletta and one of them
is in a Linux-specific file. So instead just fix the other file
(portable code) with the direct fallback.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>