### PR TITLE
Modules fix

### DIFF
--- a/src/modules/pin-mux/intel-common/intel-common.c
+++ b/src/modules/pin-mux/intel-common/intel-common.c
@@ -33,6 +33,8 @@
 #include <stdio.h>
 #include <sys/stat.h>
 
+#define SOL_LOG_DOMAIN &_intel_mux_log_domain
+
 #include "intel-common.h"
 #include "sol-log-internal.h"
 #include "sol-util-file.h"

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -338,7 +338,7 @@ $($(1)-out): $(SOL_LIB_OUTPUT) $($(1)-objs) $(call find-deps,$(1)) $($(1)-bs)
 	$(Q)echo "     "MOD"   "$$@
 	$(Q)$(MKDIR) -p $(dir $($(1)-out))
 	$(Q)$(TARGETCC) $(MOD_CFLAGS) $(sort $($(1)-cflags)) $($(1)-objs) \
-		-shared -o $($(1)-out) $(sort $($(1)-ldflags))
+		-shared -o $($(1)-out) $(LINKED_OBJS_LDFLAGS) $(sort $($(1)-ldflags))
 endef
 $(foreach curr,$(mod-so),$(eval $(call make-mod-so,$(curr))))
 


### PR DESCRIPTION
Fix module's linkage, it was missing '-lsoletta'. @dorileo please check.

A second commit is to fix an issue with log level, not really required as part of this PR, but it was the reason we found the bug. see #1331 