### PR TITLE
Rename variables called "timezone"

### DIFF
--- a/src/lib/common/include/sol-platform.h
+++ b/src/lib/common/include/sol-platform.h
@@ -409,7 +409,7 @@ int sol_platform_del_system_clock_monitor(void (*cb)(void *data, int64_t timesta
 /**
  * @brief Set the system timezone.
  *
- * @param timezone The new timezone. (Example: America/Sao_Paulo)
+ * @param tzone The new timezone. (Example: America/Sao_Paulo)
  *
  * @return @c 0 on success, negative errno on error
  *
@@ -417,7 +417,7 @@ int sol_platform_del_system_clock_monitor(void (*cb)(void *data, int64_t timesta
  *
  * @see sol_platform_get_timezone()
  */
-int sol_platform_set_timezone(const char *timezone);
+int sol_platform_set_timezone(const char *tzone);
 
 /**
  * @brief Get the current timezone.

--- a/src/lib/common/sol-platform.c
+++ b/src/lib/common/sol-platform.c
@@ -643,22 +643,22 @@ sol_platform_del_system_clock_monitor(void (*cb)(void *data, int64_t timestamp),
 void
 sol_platform_inform_timezone_changed(void)
 {
-    const char *timezone;
+    const char *tzone;
     struct sol_monitors_entry *entry;
     uint16_t i;
 
-    timezone = sol_platform_impl_get_timezone();
-    SOL_NULL_CHECK(timezone);
+    tzone = sol_platform_impl_get_timezone();
+    SOL_NULL_CHECK(tzone);
 
     SOL_MONITORS_WALK (&_ctx.timezone_monitors, entry, i)
-        ((void (*)(void *, const char *))entry->cb)((void *)entry->data, timezone);
+        ((void (*)(void *, const char *))entry->cb)((void *)entry->data, tzone);
 }
 
 SOL_API int
-sol_platform_set_timezone(const char *timezone)
+sol_platform_set_timezone(const char *tzone)
 {
-    SOL_NULL_CHECK(timezone, -EINVAL);
-    return sol_platform_impl_set_timezone(timezone);
+    SOL_NULL_CHECK(tzone, -EINVAL);
+    return sol_platform_impl_set_timezone(tzone);
 }
 
 SOL_API const char *

--- a/src/modules/flow/platform/platform.c
+++ b/src/modules/flow/platform/platform.c
@@ -372,24 +372,24 @@ system_clock_process(struct sol_flow_node *node, void *data, uint16_t port,
 }
 
 static int
-timezone_send(const void *timezone, struct sol_flow_node *node)
+timezone_send(const void *tzone, struct sol_flow_node *node)
 {
     int r;
 
-    if (!timezone) {
-        timezone = sol_platform_get_timezone();
-        SOL_NULL_CHECK(timezone, -ECANCELED);
+    if (!tzone) {
+        tzone = sol_platform_get_timezone();
+        SOL_NULL_CHECK(tzone, -ECANCELED);
     }
 
-    r = sol_flow_send_string_packet(node, 0, timezone);
+    r = sol_flow_send_string_packet(node, 0, tzone);
     SOL_INT_CHECK(r, < 0, r);
     return 0;
 }
 
 static void
-timezone_changed(void *data, const char *timezone)
+timezone_changed(void *data, const char *tzone)
 {
-    timezone_send(timezone, data);
+    timezone_send(tzone, data);
 }
 
 static int


### PR DESCRIPTION
Since we build with -Wshadow, we can't use the name of the global
variable "timezone".

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>