### PR TITLE
Add pipe2 replacement implementation

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -208,6 +208,22 @@
       ]
     },
     {
+      "dependency": "pipe",
+      "type": "ccode",
+      "headers": [
+        "<unistd.h>"
+      ],
+      "fragment": "int fds[2]; pipe(fds);"
+    },
+    {
+      "dependency": "pipe2",
+      "type": "ccode",
+      "headers": [
+        "<unistd.h>"
+      ],
+      "fragment": "int fds[2]; pipe2(fds, 0);"
+    },
+    {
       "dependency": "accept4",
       "type": "ccode",
       "headers": [


### PR DESCRIPTION
This depends on O_CLOEXEC being defined, which is part of POSIX.1-2008.
So there's a good chance that the target platforms will have it.

When we run across a platform that is POSIX.1-2001 or earlier, we'll
need to add a suitable #define somewhere.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>