### PR TITLE
Fix Clang warning -Wmissing-noreturn

### DIFF
--- a/src/modules/flow/process/subprocess.c
+++ b/src/modules/flow/process/subprocess.c
@@ -147,7 +147,7 @@ process_subprocess_in_process(struct sol_flow_node *node, void *data, uint16_t p
     return 0;
 }
 
-static void
+static void SOL_ATTR_NORETURN
 on_fork(void *data)
 {
     struct subprocess_data *mdata = data;


### PR DESCRIPTION
This function doesn't return, so add the attribute.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>