### PR TITLE
Fix build: we insist on functions having prototypes

### DIFF
--- a/src/lib/common/sol-mainloop-impl-posix.c
+++ b/src/lib/common/sol-mainloop-impl-posix.c
@@ -609,6 +609,8 @@ fd_cleanup(void)
 }
 
 #ifndef HAVE_PPOLL
+int ppoll(struct pollfd *, nfds_t, const struct timespec *, const sigset_t *);
+
 int
 ppoll(struct pollfd *fds, nfds_t nfds, const struct timespec *timeout_ts, const sigset_t *sigmask)
 {


### PR DESCRIPTION
...but ppoll is supposed to be a replacement, so obviously it has no
previous prototype.

 sol-mainloop-impl-posix.c:614:1: error: no previous prototype for function 'ppoll' [-Werror,-Wmissing-prototypes]

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>