### PR TITLE
test-fbp: make expected output less strict

### DIFF
--- a/src/test-fbp/converter-error.fbp
+++ b/src/test-fbp/converter-error.fbp
@@ -50,4 +50,4 @@ const_error_code OUT -> IN[1] error_code_equal
 error_code_equal OUT -> RESULT error_converts_to_code(test/result)
 
 ## TEST-OUTPUT-REGEX
-# WRN: ./src/lib/common/sol-types.c:.*? sol_irange_division\(\) Division by zero: 10, 0
+# WRN: .* Division by zero: 10, 0

--- a/src/test-fbp/switcher-simple-forward.fbp
+++ b/src/test-fbp/switcher-simple-forward.fbp
@@ -112,4 +112,4 @@ const_error OUT -> IN[1] error_msg_equal
 error_msg_equal EQUAL -> RESULT result_switcher_error(test/result)
 
 ## TEST-OUTPUT-REGEX
-# WRN: ./src/lib/common/sol-types.c:.*? sol_irange_division\(\) Division by zero: 10, 0
+# WRN: .* Division by zero: 10, 0


### PR DESCRIPTION
Change the regex to look for the content that we explicitly print (the
division by zero), and don't be strict about the other content: the
exact filename and function name that leads to the warning.

These tests currently fail when compiled with Clang due to the different
output it uses for function name when SOL_WRN and friends are used.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>