### PR TITLE
soletta.pc: use paths relative to variables.

### DIFF
--- a/pc/soletta.pc.in
+++ b/pc/soletta.pc.in
@@ -1,11 +1,11 @@
 prefix={{@PREFIX@}}
-exec_prefix={{@PREFIX@}}
-libdir={{@LIBDIR@}}
-includedir={{@INCLUDEDIR@}}
-modulesdir={{@MODULESDIR@}}
-pkgdatadir={{@DATADIR@}}soletta
+exec_prefix=${prefix}
+libdir={{@LIBDIR_RELATIVE@}}
+includedir={{@INCLUDEDIR_RELATIVE@}}
+modulesdir={{@MODULESDIR_RELATIVE@}}
+pkgdatadir={{@DATADIR_RELATIVE@}}soletta
 nodeschemapath=${pkgdatadir}/flow/schemas/node-type-genspec.schema
-nodedescriptionpath={{@DESCDIR@}}
+nodedescriptionpath={{@DESCDIR_RELATIVE@}}
 
 Name: {{@PKGNAME@}}
 Description: Soletta Project is a framework for making IoT devices.

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -92,6 +92,7 @@ export INCLUDEDIR ?= $(PREFIX)/include
 export SOL_DATADIR := $(DATADIR)/$(PKGNAME)/
 export SOL_INCLUDEDIR := $(INCLUDEDIR)/$(PKGNAME)/
 export MODULESDIR := $(LIBDIR)$(PKGNAME)/modules/
+export PKGDATADIR := $(SOL_DATADIR)
 export SOL_FLOW_DATADIR := $(SOL_DATADIR)/flow/
 export DESCDIR := $(SOL_FLOW_DATADIR)/descriptions/
 export SCHEMADIR := $(SOL_FLOW_DATADIR)/schema/
@@ -102,6 +103,25 @@ export PINMUXDIR := $(MODULESDIR)/pin-mux/
 export LINUXMICROMODULESDIR := $(MODULESDIR)/linux-micro/
 export FLOWMETATYPEMODULESDIR := $(MODULESDIR)/flow-metatype/
 export UPDATEMODULESDIR := $(MODULESDIR)/update/
+
+# _RELATIVE variants replaces $(PREFIX) with `${prefix}', $(LIBDIR) with `${libdir}' and so on, to be used in shell scripts and ".pc" files
+export LIBDIR_RELATIVE := $(subst $(patsubst %/,%,$(PREFIX)),$${prefix},$(LIBDIR))
+export DATADIR_RELATIVE := $(subst $(patsubst %/,%,$(PREFIX)),$${prefix},$(DATADIR))
+export BINDIR_RELATIVE := $(subst $(patsubst %/,%,$(PREFIX)),$${prefix},$(BINDIR))
+export INCLUDEDIR_RELATIVE := $(subst $(patsubst %/,%,$(PREFIX)),$${prefix},$(INCLUDEDIR))
+export SOL_DATADIR_RELATIVE := $(subst $(patsubst %/,%,$(PREFIX)),$${prefix},$(SOL_DATADIR))
+export SOL_INCLUDEDIR_RELATIVE := $(subst $(patsubst %/,%,$(PREFIX)),$${prefix},$(SOL_INCLUDEDIR))
+export MODULESDIR_RELATIVE := $(subst $(patsubst %/,%,$(LIBDIR)),$${libdir},$(MODULESDIR))
+export SOL_FLOW_DATADIR_RELATIVE := $(subst $(patsubst %/,%,$(PREFIX)),$${prefix},$(SOL_FLOW_DATADIR))
+export DESCDIR_RELATIVE := $(subst $(patsubst %/,%,$(PKGDATADIR)),$${pkgdatadir},$(DESCDIR))
+export SCHEMADIR_RELATIVE := $(subst $(patsubst %/,%,$(PREFIX)),$${prefix},$(SCHEMADIR))
+export PCDIR_RELATIVE := $(subst $(patsubst %/,%,$(PREFIX)),$${prefix},$(PCDIR))
+export PKGSYSCONFDIR_RELATIVE := $(subst $(patsubst %/,%,$(PREFIX)),$${prefix},$(PKGSYSCONFDIR))
+export FLOWMODULESDIR_RELATIVE := $(subst $(patsubst %/,%,$(MODULESDIR)),$${modulesdir},$(FLOWMODULESDIR))
+export PINMUXDIR_RELATIVE := $(subst $(patsubst %/,%,$(PREFIX)),$${prefix},$(PINMUXDIR))
+export LINUXMICROMODULESDIR_RELATIVE := $(subst $(patsubst %/,%,$(MODULESDIR)),$${modulesdir},$(LINUXMICROMODULESDIR))
+export FLOWMETATYPEMODULESDIR_RELATIVE := $(subst $(patsubst %/,%,$(MODULESDIR)),$${modulesdir},$(FLOWMETATYPEMODULESDIR))
+export UPDATEMODULESDIR_RELATIVE := $(subst $(patsubst %/,%,$(MODULESDIR)),$${modulesdir},$(UPDATEMODULESDIR))
 
 # build dirs
 ## BUILDDIR is the user provided option


### PR DESCRIPTION
This allows us to use
build/soletta_sysroot/$PREFIX/lib/pkgconfig/soletta.pc while it's not
installed by calling:

```sh
   export BUILT_PREFIX=$PWD/build/soletta_sysroot/$PREFIX
   export PKG_CONFIG_PATH=$BUILT_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH
   pkg-config --cflags --libs --define-variable=prefix=$BUILT_PREFIX soletta
```

This may be required to simulate out-of-tree builds without installing
it.

Signed-off-by: Gustavo Sverzut Barbieri gustavo.barbieri@intel.com