### PR TITLE
Fix build: get_current_dir_name() is a GNU extension

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -401,6 +401,14 @@
       "exec": "getconf"
     },
     {
+      "dependency": "get_current_dir_name",
+      "type": "ccode",
+      "headers": [
+        "<unistd.h>"
+      ],
+      "fragment": "get_current_dir_name();"
+    },
+    {
       "dependency": "valgrind",
       "type": "exec",
       "exec": "valgrind"

--- a/src/lib/common/sol-missing.h
+++ b/src/lib/common/sol-missing.h
@@ -140,6 +140,40 @@ err:
 }
 #endif
 
+#if !defined(HAVE_GET_CURRENT_DIR_NAME) && defined(HAVE_UNIX)
+#include <errno.h>
+#include <limits.h>         /* for PATH_MAX */
+#include <stdlib.h>
+#include <unistd.h>
+
+static inline char *
+get_current_dir_name(void)
+{
+    size_t len = 0;
+    char *buffer = NULL;
+
+    while (1) {
+        len += PATH_MAX;
+        char *nb = (char *)realloc(buffer, len);
+
+        if (nb == NULL)
+            goto err_free;
+        nb = getcwd(buffer, len);
+        if (nb == NULL) {
+            if (errno == ERANGE)
+                continue;
+            goto err_free;
+        }
+        return buffer;
+    }
+
+err_free:
+    free(buffer);
+    return NULL;
+}
+
+#endif
+
 #ifndef HAVE_DECL_IFLA_INET6_MAX
 #define IFLA_INET6_UNSPEC 0
 #define IFLA_INET6_FLAGS 1


### PR DESCRIPTION
So add a replacemenet function.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>