### PR TITLE
generator: Fix tool dependency

### DIFF
--- a/src/bin/sol-fbp-generator/Kconfig
+++ b/src/bin/sol-fbp-generator/Kconfig
@@ -1,4 +1,4 @@
 config FBP_GENERATOR
 	bool "fbp generator"
-	depends on FLOW_SUPPORT
+	depends on NODE_DESCRIPTION
 	default y


### PR DESCRIPTION
Since metatype was introduced the generator uses code from
sol-flow-parser that only build if descriptions are enabled.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>