### PR TITLE
Build: Set -ffloat-store on non 64 bits architetures.

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -39,6 +39,14 @@
       }
     },
     {
+      "dependency": "check_cflag_float_store",
+      "type": "cflags",
+      "cflags": [
+        "-ffloat-store"
+      ],
+      "append_to": "CFLAG_FLOAT_STORE"
+    },
+    {
       "dependency": "check_cflags",
       "type": "cflags",
       "cflags": [
@@ -386,6 +394,11 @@
         "<stdlib.h>"
       ],
       "fragment": "strtod_l(0, 0, 0);"
+    },
+    {
+      "dependency": "getconf",
+      "type": "exec",
+      "exec": "getconf"
     },
     {
       "dependency": "valgrind",

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -176,6 +176,12 @@ GDB_AUTOLOAD_PY := $(top_srcdir)data/gdb/libsoletta.so-gdb.py
 COMMON_CFLAGS += $(CFLAGS)
 COMMON_LDFLAGS += $(LDFLAGS)
 
+ifeq (y, $(HAVE_GETCONF))
+ifneq (64, $(shell getconf LONG_BIT))
+COMMON_CFLAGS += $(CFLAG_FLOAT_STORE)
+endif
+endif
+
 ifeq (y,$(CC_SANITIZE))
 ifeq (y,$(CC_SANITIZE_UNDEFINED))
 ifeq (y,$(SHARED_LIBRARY))


### PR DESCRIPTION
Prevent excess precision on non 64 machines, this may lead to
wrong results.

Signed-off-by: Guilherme Iscaro <guilherme.iscaro@intel.com>