### PR TITLE
oic: Scan callback shouldn't set the connected resource

### DIFF
--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -1241,7 +1241,6 @@ scan_callback(struct sol_oic_client *oic_cli, struct sol_oic_resource *oic_res, 
         return true;
     }
 
-    resource->resource = sol_oic_resource_ref(oic_res);
     SOL_PTR_VECTOR_FOREACH_IDX(&resource->scanned_ids, id, i)
         if (memcmp(id, oic_res->device_id.data, DEVICE_ID_LEN) == 0)
             return true;


### PR DESCRIPTION
resource->resource variable is used to store which resource was being
observed by this node, if any. This variable was incorrectly set when
scanning.

Before trying to observer a resource that was previously scanned, we
were trying to unobserve it and in some cases this was preventing it to
be observed.

@ederson Can you test that?