### PR TITLE
Fix some compiler warnings.

### DIFF
--- a/src/modules/flow/console/console.c
+++ b/src/modules/flow/console/console.c
@@ -75,7 +75,7 @@ console_print_blob(struct console_data *mdata, const struct sol_blob *blob,
     buf = blob->mem;
     bufend = buf + blob->size;
     for (; buf < bufend; buf++) {
-        if (isprint(*buf))
+        if (isprint((uint8_t)*buf))
             fprintf(mdata->fp, "%#x(%c)", *buf, *buf);
         else
             fprintf(mdata->fp, "%#x", *buf);

--- a/src/modules/flow/converter/string-format.c
+++ b/src/modules/flow/converter/string-format.c
@@ -781,7 +781,7 @@ append_number(struct sol_buffer *out,
             for (t = 0; t < spec->n_prefix; t++) {
                 char c = *(char *)sol_buffer_at(out, pos + t);
 
-                c = toupper(c);
+                c = toupper((uint8_t)c);
                 write_char(out, pos + t, c);
             }
         }
@@ -814,7 +814,7 @@ append_number(struct sol_buffer *out,
         for (t = 0; t < spec->n_grouped_digits; t++) {
             char c = *(char *)sol_buffer_at(out, pos + t);
 
-            c = toupper(c);
+            c = toupper((uint8_t)c);
             write_char(out, pos + t, c);
         }
     }
@@ -1553,7 +1553,7 @@ double_to_buffer(double val,
         /* Convert to upper case. */
         char *p1;
         for (p1 = (char *)sol_buffer_at(out, 0); *p1; p1++)
-            *p1 = toupper(*p1);
+            *p1 = toupper((uint8_t)*p1);
     }
 
     if (type)

--- a/src/modules/flow/power-supply/power-supply.c
+++ b/src/modules/flow/power-supply/power-supply.c
@@ -227,7 +227,7 @@ get_capacity(struct sol_flow_node *node, void *data, uint16_t port, uint16_t con
         return sol_flow_send_error_packet(node, EINVAL,
             "Power supply %s doesn't exist.", mdata->name);
 
-    r = sol_power_supply_get_capacity(mdata->name, &capacity.val);
+    r = sol_power_supply_get_capacity(mdata->name, (int *)&capacity.val);
     if (r < 0) {
         r = sol_flow_send_error_packet(node, ENOENT,
             "Couldn't get power supply %s capacity.", mdata->name);


### PR DESCRIPTION
Again, given that char does not define whether it's signed or unsigned
in C, some compilers may issue warnings on these functions (leftover
from "various: Avoid using 'char' as an index" commit). At
power-supply.c, we cast to the right type for
sol_power_supply_get_capacity() usage.