### PR TITLE
Re-fix the case of XSI-compliant strerror_r

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -317,6 +317,14 @@
       "fragment": "random_r(NULL, NULL);"
     },
     {
+      "dependency": "xsi_strerror_r",
+      "type": "ccode",
+      "headers": [
+        "<string.h>"
+      ],
+      "fragment": "char *p; p[strerror_r(0, p, 0)];"
+    },
+    {
       "dependency": "builtin_mul_overflow",
       "type": "ccode",
       "fragment": "__builtin_mul_overflow(0ULL, 0ULL, (unsigned long long *)0);"

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -220,14 +220,15 @@ sol_util_strerror(int errnum, char *buf, size_t buflen)
     if (buflen < 1)
         return NULL;
 
-    buf[0] = '\0';
-
-    ret = (char *)(uintptr_t)strerror_r(errnum, buf, buflen);
-    /* if buf was used it means it can be XSI version (so ret won't be
-       pointing to msg string), or GNU version using non static string
-       (in this case ret == buf already) */
-    if (buf[0] != '\0')
-        ret = buf;
+#ifdef HAVE_XSI_STRERROR_R
+    /* XSI-compliant strerror_r returns int */
+    if (strerror_r(errnum, buf, buflen) != 0)
+        return NULL;
+    ret = buf;
+#else
+    /* GNU libc version of strerror_r returns char* */
+    ret = strerror_r(errnum, buf, buflen);
+#endif
 
     return ret;
 }


### PR DESCRIPTION
Instead of relying on whether buf[0] was modified or not, do a proper
detection.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>