### PR TITLE
Fix compile error on small OSes.

### DIFF
--- a/src/lib/common/sol-missing.h
+++ b/src/lib/common/sol-missing.h
@@ -91,7 +91,7 @@ memrchr(const void *haystack, int c, size_t n)
 }
 #endif
 
-#if !defined(HAVE_PIPE2) && defined(HAVE_PIPE)
+#if !defined(HAVE_PIPE2) && defined(HAVE_PIPE) && defined(FEATURE_FILESYSTEM)
 #include <fcntl.h>
 #include <unistd.h>
 #include <sol-util-file.h>


### PR DESCRIPTION
The pipe2() implementation trick should not even take place if
FEATURE_FILESYSTEM is not available, as it makes use of the
sol_util_fd_set_flag() function, defined at sol-util-file.c, compiled
under the rule

obj-libshared-$(FEATURE_FILESYSTEM) += \
    sol-util-file.o