### PR TITLE
oic: Support no payload packets and packets with empty map payload

### DIFF
--- a/src/lib/comms/include/sol-oic-client.h
+++ b/src/lib/comms/include/sol-oic-client.h
@@ -327,7 +327,8 @@ bool sol_oic_client_get_server_info_by_addr(struct sol_oic_client *client,
  * @param fill_repr_map A callback to be called to fill the request data.
  *        Parameter @a data is a pointer to user's @a fill_repr_map_data and
  *        @a repr_map is a handler to write data to request packet. Use @ref
- *        sol_oic_map_append() to append data to @a repr_map.
+ *        sol_oic_map_append() to append data to @a repr_map. If @c NULL
+ *        data will be added to request.
  * @param fill_repr_map_data User's data to be passed to @a fill_repr_map.
  * @param callback Callback to be called when a response from this request
  *        arrives. Parameter @a response_code is the header response code of
@@ -368,7 +369,8 @@ bool sol_oic_client_resource_request(struct sol_oic_client *client, struct sol_o
  * @param fill_repr_map A callback to be called to fill the request data.
  *        Parameter @a data is a pointer to user's @a fill_repr_map_data and
  *        @a repr_map is a handler to write data to request packet. Use @ref
- *        sol_oic_map_append() to append data to @a repr_map.
+ *        sol_oic_map_append() to append data to @a repr_map. If @c NULL, no
+ *        data will be added to request.
  * @param fill_repr_map_data User's data to be passed to @a fill_repr_map.
  * @param callback Callback to be called when a response from this request
  *        arrives. Parameter @a response_code is the header response code of

--- a/src/lib/comms/include/sol-oic-common.h
+++ b/src/lib/comms/include/sol-oic-common.h
@@ -387,6 +387,31 @@ struct sol_oic_repr_field {
 struct sol_oic_map_writer;
 
 /**
+ * @brief Used in @ref sol_oic_map_writer to state if the map has a content or not
+ *
+ * @see sol_oic_map_set_type()
+ * @see sol_oic_map_get_type()
+ */
+enum sol_oic_map_type {
+    /**
+     * @brief Map with no content
+     *
+     * When an oic map is used to create a packet and type is
+     * SOL_OIC_MAP_NO_CONTENT, no payload will be added to the packet.
+     **/
+    SOL_OIC_MAP_NO_CONTENT,
+    /**
+     * @brief Map with content.
+     *
+     * When an oic map is used to create a packet and type is
+     * SOL_OIC_MAP_CONTENT, a payload will be created and elements
+     * from map will be added to payload. If map contains no elements,
+     * an empty map will be added to payload.
+     */
+    SOL_OIC_MAP_CONTENT,
+};
+
+/**
  * @brief Handler for an oic packet map reader.
  *
  * This structure is used in callback parameters so users can read fields from
@@ -468,8 +493,37 @@ bool sol_oic_map_loop_next(struct sol_oic_repr_field *repr, struct sol_oic_map_r
  *
  * @see sol_oic_notify_observers()
  * @see sol_oic_client_resource_request()
+ * @note As this function adds elements to @a oic_map_writer, it will update
+ * its type to SOL_OIC_MAP_CONTENT when needed.
  */
 bool sol_oic_map_append(struct sol_oic_map_writer *oic_map_writer, struct sol_oic_repr_field *repr);
+
+/**
+ * @brief set current @a oic_map_writer type.
+ *
+ * Use this function if you want to change @a oic_map_writer type to
+ * SOL_OIC_MAP_CONTENT without adding elements to it. This will force oic to
+ * create a payload in packet with an empty list if map is empty.
+ * Trying to change from SOL_OIC_MAP_CONTENT to SOL_OIC_MAP_NO_CONTENT will fail
+ * if elements were already added to @a oic_map_writer.
+ *
+ * @param oic_map_writer The map to set the type.
+ * @param type The new type of @a oic_map_writer.
+ *
+ * @return False if @a oic_map_writer is NULL or if it was not possible to
+ * change the type. True otherwise.
+ */
+bool sol_oic_map_set_type(struct sol_oic_map_writer *oic_map_writer, enum sol_oic_map_type type);
+
+/**
+ * @brief get current @a oic_map_writer type.
+ *
+ * @param oic_map_writer The map to get the type from.
+ * @param type A pointer to an enum to be filled with @a oic_map_writer type.
+ *
+ * @return False if any param is NULL. True otherwise.
+ */
+bool sol_oic_map_get_type(struct sol_oic_map_writer *oic_map_writer, enum sol_oic_map_type *type);
 
 /**
  * @def SOL_OIC_MAP_LOOP(map_, current_, iterator_, end_reason_)
@@ -506,7 +560,7 @@ bool sol_oic_map_append(struct sol_oic_map_writer *oic_map_writer, struct sol_oi
  * @see sol_oic_map_loop_next
  */
 #define SOL_OIC_MAP_LOOP(map_, current_, iterator_, end_reason_) \
-    for (end_reason_ = sol_oic_map_loop_init(map_, iterator_, current_);  \
+    for (end_reason_ = sol_oic_map_loop_init(map_, iterator_, current_); \
         end_reason_ == SOL_OIC_MAP_LOOP_OK && \
         sol_oic_map_loop_next(current_, iterator_, &end_reason_);)
 

--- a/src/lib/comms/sol-oic-cbor.h
+++ b/src/lib/comms/sol-oic-cbor.h
@@ -40,7 +40,7 @@
 CborError sol_oic_packet_cbor_extract_repr_map(struct sol_coap_packet *pkt, CborParser *parser, CborValue *repr_map);
 CborError sol_oic_cbor_repr_map_get_next_field(CborValue *value, struct sol_oic_repr_field *repr);
 CborError sol_oic_packet_cbor_close(struct sol_coap_packet *pkt, struct sol_oic_map_writer *encoder);
-CborError sol_oic_packet_cbor_create(struct sol_coap_packet *pkt, const char *href, struct sol_oic_map_writer *encoder);
+void sol_oic_packet_cbor_create(struct sol_coap_packet *pkt, const char *href, struct sol_oic_map_writer *encoder);
 CborError sol_oic_packet_cbor_append(struct sol_oic_map_writer *encoder, struct sol_oic_repr_field *repr);
 bool sol_oic_pkt_has_cbor_content(const struct sol_coap_packet *pkt);
 bool sol_cbor_map_get_bytestr_value(const CborValue *map, const char *key, struct sol_str_slice *slice);
@@ -52,10 +52,14 @@ bool sol_cbor_map_get_array(const CborValue *map, const char *key, struct sol_ve
 bool sol_cbor_array_to_vector(CborValue *array, struct sol_vector *vector);
 bool sol_cbor_bsv_to_vector(const CborValue *value, char **data, struct sol_vector *vector);
 
+bool sol_cbor_map_get_type(struct sol_oic_map_writer *oic_map_writer, enum sol_oic_map_type *type);
+bool sol_cbor_map_set_type(struct sol_oic_map_writer *oic_map_writer, enum sol_oic_map_type type);
+
 struct sol_oic_map_writer {
     CborEncoder encoder, rep_map;
     uint8_t *payload;
-    bool has_data;
+    struct sol_coap_packet *pkt;
+    enum sol_oic_map_type type;
 };
 
 enum sol_oic_payload_type {

--- a/src/lib/comms/sol-oic-client.c
+++ b/src/lib/comms/sol-oic-client.c
@@ -892,7 +892,6 @@ _resource_request(struct sol_oic_client *client, struct sol_oic_resource *res,
     const struct sol_oic_map_reader *repr_vec, void *data),
     void *data, bool observe)
 {
-    const uint8_t format_cbor = SOL_COAP_CONTENTTYPE_APPLICATION_CBOR;
     CborError err;
     char *href;
 
@@ -935,11 +934,8 @@ _resource_request(struct sol_oic_client *client, struct sol_oic_resource *res,
         goto out;
     }
 
-    sol_coap_add_option(req, SOL_COAP_OPTION_CONTENT_FORMAT, &format_cbor, sizeof(format_cbor));
-
     if (fill_repr_map) {
-        err = sol_oic_packet_cbor_create(req, href, &map_encoder);
-        SOL_INT_CHECK_GOTO(err, != CborNoError, cbor_error);
+        sol_oic_packet_cbor_create(req, href, &map_encoder);
         if (!fill_repr_map(fill_repr_map_data, &map_encoder))
             goto out;
         err = sol_oic_packet_cbor_close(req, &map_encoder);

--- a/src/lib/comms/sol-oic-common.c
+++ b/src/lib/comms/sol-oic-common.c
@@ -76,6 +76,7 @@ sol_oic_map_loop_next(struct sol_oic_repr_field *repr, struct sol_oic_map_reader
     CborError err;
 
     SOL_NULL_CHECK_GOTO(repr, err);
+    SOL_NULL_CHECK_GOTO(iterator, err);
 
     repr_field_free(repr);
     if (!cbor_value_is_valid((CborValue *)iterator))
@@ -96,6 +97,9 @@ err:
 SOL_API bool
 sol_oic_map_append(struct sol_oic_map_writer *oic_map_writer, struct sol_oic_repr_field *repr)
 {
+    SOL_NULL_CHECK(oic_map_writer, false);
+    SOL_NULL_CHECK(repr, false);
+
     return sol_oic_packet_cbor_append(oic_map_writer, repr) == CborNoError;
 }
 
@@ -103,6 +107,8 @@ sol_oic_map_append(struct sol_oic_map_writer *oic_map_writer, struct sol_oic_rep
 SOL_API void
 sol_oic_payload_debug(struct sol_coap_packet *pkt)
 {
+    SOL_NULL_CHECK(pkt);
+
 #ifdef HAVE_STDOUT
     uint8_t *payload;
     uint16_t payload_len;

--- a/src/lib/comms/sol-oic-common.c
+++ b/src/lib/comms/sol-oic-common.c
@@ -103,6 +103,23 @@ sol_oic_map_append(struct sol_oic_map_writer *oic_map_writer, struct sol_oic_rep
     return sol_oic_packet_cbor_append(oic_map_writer, repr) == CborNoError;
 }
 
+SOL_API bool
+sol_oic_map_get_type(struct sol_oic_map_writer *oic_map_writer, enum sol_oic_map_type *type)
+{
+    SOL_NULL_CHECK(oic_map_writer, false);
+    SOL_NULL_CHECK(type, false);
+
+    return sol_cbor_map_get_type(oic_map_writer, type);
+}
+
+SOL_API bool
+sol_oic_map_set_type(struct sol_oic_map_writer *oic_map_writer, enum sol_oic_map_type type)
+{
+    SOL_NULL_CHECK(oic_map_writer, false);
+
+    return sol_cbor_map_set_type(oic_map_writer, type);
+}
+
 #ifdef SOL_LOG_ENABLED
 SOL_API void
 sol_oic_payload_debug(struct sol_coap_packet *pkt)

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -562,7 +562,6 @@ _sol_oic_resource_type_handle(
     const struct sol_network_link_addr *cliaddr,
     struct sol_oic_server_resource *res, bool expect_payload)
 {
-    const uint8_t format_cbor = SOL_COAP_CONTENTTYPE_APPLICATION_CBOR;
     struct sol_coap_packet *response;
     struct sol_oic_map_reader input;
     struct sol_oic_map_writer output;
@@ -593,10 +592,7 @@ _sol_oic_resource_type_handle(
         }
     }
 
-    sol_coap_add_option(response, SOL_COAP_OPTION_CONTENT_FORMAT, &format_cbor, sizeof(format_cbor));
-
-    if (sol_oic_packet_cbor_create(response, res->href, &output) != CborNoError)
-        goto done;
+    sol_oic_packet_cbor_create(response, res->href, &output);
     code = handle_fn(cliaddr, res->callback.data, &input, &output);
     if (sol_oic_packet_cbor_close(response, &output) != CborNoError)
         code = SOL_COAP_RSPCODE_INTERNAL_ERROR;
@@ -784,7 +780,6 @@ send_notification_to_server(struct sol_oic_server_resource *resource,
     bool (*fill_repr_map)(void *data, struct sol_oic_map_writer *oic_map_writer),
     const void *data)
 {
-    const uint8_t format_cbor = SOL_COAP_CONTENTTYPE_APPLICATION_CBOR;
     struct sol_coap_packet *pkt;
     struct sol_oic_map_writer oic_map_writer;
     uint8_t code = SOL_COAP_RSPCODE_INTERNAL_ERROR;
@@ -793,11 +788,7 @@ send_notification_to_server(struct sol_oic_server_resource *resource,
     pkt = sol_coap_packet_notification_new(oic_server.server, resource->coap);
     SOL_NULL_CHECK(pkt, false);
 
-    sol_coap_add_option(pkt, SOL_COAP_OPTION_CONTENT_FORMAT, &format_cbor,
-        sizeof(format_cbor));
-
-    err = sol_oic_packet_cbor_create(pkt, resource->href, &oic_map_writer);
-    SOL_INT_CHECK_GOTO(err, != CborNoError, end);
+    sol_oic_packet_cbor_create(pkt, resource->href, &oic_map_writer);
     if (!fill_repr_map((void *)data, &oic_map_writer))
         goto end;
     err = sol_oic_packet_cbor_close(pkt, &oic_map_writer);


### PR DESCRIPTION
It was impossible to have a packet with no payload when callback to fill
payload was called. No payload packets were only possible when callback
was NULL.

Add a function to set the type of the payload, so users can create no
payload packets and packets with an empty map as the payload. It is
similar but it is not handled the same way by iotivity and Soletta.

Fixes issue #1389

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>