### PR TITLE
oic: Coap option size is incorrect

### DIFF
--- a/src/lib/comms/sol-oic-cbor.c
+++ b/src/lib/comms/sol-oic-cbor.c
@@ -39,8 +39,7 @@ initialize_cbor_payload(struct sol_oic_map_writer *encoder)
 {
     int r;
     uint16_t size;
-    const sol_coap_content_type_t format_cbor =
-        SOL_COAP_CONTENTTYPE_APPLICATION_CBOR;
+    const uint8_t format_cbor = SOL_COAP_CONTENTTYPE_APPLICATION_CBOR;
 
     r = sol_coap_add_option(encoder->pkt, SOL_COAP_OPTION_CONTENT_FORMAT,
         &format_cbor, sizeof(format_cbor));

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -106,8 +106,7 @@ _sol_oic_server_d(struct sol_coap_server *server,
     const struct sol_coap_resource *resource, struct sol_coap_packet *req,
     const struct sol_network_link_addr *cliaddr, void *data)
 {
-    const sol_coap_content_type_t format_cbor =
-        SOL_COAP_CONTENTTYPE_APPLICATION_CBOR;
+    const uint8_t format_cbor = SOL_COAP_CONTENTTYPE_APPLICATION_CBOR;
     CborEncoder encoder, rep_map;
     CborError err;
     struct sol_coap_packet *response;
@@ -161,8 +160,7 @@ _sol_oic_server_p(struct sol_coap_server *server,
     const struct sol_coap_resource *resource, struct sol_coap_packet *req,
     const struct sol_network_link_addr *cliaddr, void *data)
 {
-    const sol_coap_content_type_t format_cbor =
-        SOL_COAP_CONTENTTYPE_APPLICATION_CBOR;
+    const uint8_t format_cbor = SOL_COAP_CONTENTTYPE_APPLICATION_CBOR;
     CborEncoder encoder, rep_map;
     CborError err;
     struct sol_coap_packet *response;
@@ -295,8 +293,7 @@ _sol_oic_server_res(struct sol_coap_server *server,
     struct sol_oic_server_resource *iter;
     struct sol_coap_packet *resp;
     uint16_t size;
-    const sol_coap_content_type_t format_cbor =
-        SOL_COAP_CONTENTTYPE_APPLICATION_CBOR;
+    const uint8_t format_cbor = SOL_COAP_CONTENTTYPE_APPLICATION_CBOR;
     uint8_t *payload;
     uint16_t idx;
     const uint8_t *uri_query;


### PR DESCRIPTION
Bug introduced by commit fd65ac4c when type of variable was changed. It
looked like it was an unharmful change, but changing the variable
definition caused a change in coap option size, afting the protocol
usage.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>