### PR TITLE
Normalize API versions fields across the project.

### DIFF
--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -1426,12 +1426,12 @@ generate_memory_map_struct(const struct sol_ptr_vector *maps, int *elements)
             "};\n");
 
         out("\nstatic const struct sol_memmap_map _memmap%d = {\n"
-            "   .version = %d,\n"
+            "   .api_version = %u,\n"
             "   .path = \"%s\",\n"
             "   .timeout = %u,\n"
             "   .entries = _memmap%d_entries\n"
             "};\n",
-            i, map->version, map->path, map->timeout, i);
+            i, map->api_version, map->path, map->timeout, i);
     }
 
     *elements = i;

--- a/src/lib/common/include/sol-worker-thread.h
+++ b/src/lib/common/include/sol-worker-thread.h
@@ -64,8 +64,6 @@ struct sol_worker_thread_spec {
 #define SOL_WORKER_THREAD_SPEC_API_VERSION (1)
     /** must match SOL_WORKER_THREAD_SPEC_API_VERSION in runtime */
     uint16_t api_version;
-    /* hole reserved for future use */
-    int : 0;
 #endif
     /** the context data to give to all functions. */
     const void *data;

--- a/src/lib/common/sol-platform-linux-micro.h
+++ b/src/lib/common/sol-platform-linux-micro.h
@@ -37,6 +37,7 @@
 #include "sol-platform-linux.h"
 #include <stdbool.h>
 #include <unistd.h>
+#include <stdint.h>
 
 
 #ifdef __cplusplus
@@ -45,8 +46,8 @@ extern "C" {
 
 struct sol_platform_linux_micro_module {
 #ifndef SOL_NO_API_VERSION
-    unsigned long int api_version;
-#define SOL_PLATFORM_LINUX_MICRO_MODULE_API_VERSION (1UL)
+    uint16_t api_version;
+#define SOL_PLATFORM_LINUX_MICRO_MODULE_API_VERSION (1)
 #endif
     const char *name;
     int (*init)(const struct sol_platform_linux_micro_module *module, const char *service);
@@ -61,13 +62,13 @@ struct sol_platform_linux_micro_module {
 void sol_platform_linux_micro_inform_service_state(const char *service, enum sol_platform_service_state state);
 
 #ifdef SOL_PLATFORM_LINUX_MICRO_MODULE_EXTERNAL
-#define SOL_PLATFORM_LINUX_MICRO_MODULE(_NAME, decl ...)                  \
+#define SOL_PLATFORM_LINUX_MICRO_MODULE(_NAME, decl ...) \
     SOL_API const struct sol_platform_linux_micro_module *SOL_PLATFORM_LINUX_MICRO_MODULE = &((const struct sol_platform_linux_micro_module) { \
             SOL_SET_API_VERSION(.api_version = SOL_PLATFORM_LINUX_MICRO_MODULE_API_VERSION, ) \
             decl \
         })
 #else
-#define SOL_PLATFORM_LINUX_MICRO_MODULE(_NAME, decl ...)                    \
+#define SOL_PLATFORM_LINUX_MICRO_MODULE(_NAME, decl ...) \
     const struct sol_platform_linux_micro_module SOL_PLATFORM_LINUX_MICRO_MODULE_ ## _NAME = { \
         SOL_SET_API_VERSION(.api_version = SOL_PLATFORM_LINUX_MICRO_MODULE_API_VERSION, ) \
         decl \

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -272,8 +272,6 @@ struct sol_coap_resource {
 #define SOL_COAP_RESOURCE_API_VERSION (1)
     /** @brief API version */
     uint16_t api_version;
-    /** @brief Unused */
-    uint16_t reserved; /* save possible hole for a future field */
 #endif
     /**
      * @brief GET request.

--- a/src/lib/comms/include/sol-http.h
+++ b/src/lib/comms/include/sol-http.h
@@ -122,7 +122,6 @@ struct sol_http_params {
 #ifndef SOL_NO_API_VERSION
 #define SOL_HTTP_PARAM_API_VERSION (1)
     uint16_t api_version;
-    uint16_t reserved;
 #endif
 
     struct sol_vector params; /**< vector of parameters, struct @ref sol_http_param_value */
@@ -174,7 +173,6 @@ struct sol_http_response {
 #ifndef SOL_NO_API_VERSION
 #define SOL_HTTP_RESPONSE_API_VERSION (1)
     uint16_t api_version;
-    uint16_t reserved;
 #endif
 
     const char *content_type;
@@ -283,10 +281,47 @@ struct sol_http_url {
  */
 #define SOL_HTTP_REQUEST_PARAMS_INIT \
     (struct sol_http_params) { \
-        SOL_SET_API_VERSION(.api_version = SOL_HTTP_PARAM_API_VERSION, .reserved = 0, ) \
+        SOL_SET_API_VERSION(.api_version = SOL_HTTP_PARAM_API_VERSION, ) \
         .params = SOL_VECTOR_INIT(struct sol_http_param_value), \
         .arena = NULL \
     }
+
+#ifndef SOL_NO_API_VERSION
+/**
+ * @brief Macro used to check if a struct @ref sol_http_params
+ * has the expected API version.
+ *
+ * In case it's a wrong version, it'll return extra arguments passed
+ * to the macro.
+ */
+#define SOL_HTTP_PARAMS_CHECK_API_VERSION(params_, ...) \
+    if (SOL_UNLIKELY((params_)->api_version != \
+        SOL_HTTP_PARAM_API_VERSION)) { \
+        SOL_ERR("Unexpected API version (response is %u, expected %u)", \
+            (params_)->api_version, SOL_HTTP_PARAM_API_VERSION); \
+        return __VA_ARGS__; \
+    }
+#else
+#define SOL_HTTP_PARAMS_CHECK_API_VERSION(params_, ...)
+#endif
+
+#ifndef SOL_NO_API_VERSIO
+/**
+ * @brief Macro used to check if a struct @ref sol_http_params
+ * has the expected API version.
+ *
+ * In case it's a wrong version, it'll go to @a label.
+ */
+#define SOL_HTTP_PARAMS_CHECK_API_VERSION_GOTO(params_, label_) \
+    if (SOL_UNLIKELY((params_)->api_version != \
+        SOL_HTTP_PARAM_API_VERSION)) { \
+        SOL_ERR("Unexpected API version (params is %u, expected %u)", \
+            (params_)->api_version, SOL_HTTP_PARAM_API_VERSION); \
+        goto label_; \
+    }
+#else
+#define SOL_HTTP_PARAMS_CHECK_API_VERSION_GOTO(params_, label_)
+#endif
 
 /**
  * @brief Macro to set a struct @ref sol_http_param_value with

--- a/src/lib/comms/include/sol-mqtt.h
+++ b/src/lib/comms/include/sol-mqtt.h
@@ -414,6 +414,25 @@ int sol_mqtt_publish(const struct sol_mqtt *mqtt, struct sol_mqtt_message *messa
  */
 int sol_mqtt_subscribe(const struct sol_mqtt *mqtt, const char *topic, sol_mqtt_qos qos);
 
+#ifndef SOL_NO_API_VERSION
+/**
+ * @brief Macro used to check if a struct @c struct sol_mqtt_message has
+ * the expected API version.
+ *
+ * In case it has wrong version, it'll return extra arguments passed
+ * to the macro.
+ */
+#define SOL_MQTT_MESSAGE_CHECK_API_VERSION(msg_, ...) \
+    if (SOL_UNLIKELY((msg_)->api_version != \
+        SOL_MQTT_MESSAGE_API_VERSION)) { \
+        SOL_ERR("Unexpected API version (message is %u, expected %u)", \
+            (msg_)->api_version, SOL_MQTT_MESSAGE_API_VERSION); \
+        return __VA_ARGS__; \
+    }
+#else
+#define SOL_MQTT_MESSAGE_CHECK_API_VERSION(msg_, ...)
+#endif
+
 /**
  * @}
  */

--- a/src/lib/comms/include/sol-network.h
+++ b/src/lib/comms/include/sol-network.h
@@ -149,7 +149,6 @@ struct sol_network_link {
 #ifndef SOL_NO_API_VERSION
 #define SOL_NETWORK_LINK_API_VERSION (1)
     uint16_t api_version; /**< @brief API version */
-    int : 0; /* save possible hole for a future field */
 #endif
     uint16_t index; /**< @brief the index of this link given by SO  */
     enum sol_network_link_flags flags; /**< @brief  The status of the link */
@@ -159,6 +158,25 @@ struct sol_network_link {
      **/
     struct sol_vector addrs;
 };
+
+#ifndef SOL_NO_API_VERSION
+/**
+ * @brief Macro used to check if a struct @c struct sol_network_link has
+ * the expected API version.
+ *
+ * In case it has wrong version, it'll return extra arguments passed
+ * to the macro.
+ */
+#define SOL_NETWORK_LINK_CHECK_VERSION(link_, ...) \
+    if (SOL_UNLIKELY((link_)->api_version != \
+        SOL_NETWORK_LINK_API_VERSION)) { \
+        SOL_WRN("Unexpected API version (message is %u, expected %u)", \
+            (link_)->api_version, SOL_NETWORK_LINK_API_VERSION); \
+        return __VA_ARGS__; \
+    }
+#else
+#define SOL_NETWORK_LINK_CHECK_VERSION(link_, ...)
+#endif
 
 /**
  * @brief Converts a @c sol_network_link_addr to a string.

--- a/src/lib/comms/include/sol-oic-client.h
+++ b/src/lib/comms/include/sol-oic-client.h
@@ -67,7 +67,6 @@ struct sol_oic_client {
 #ifndef SOL_NO_API_VERSION
 #define SOL_OIC_CLIENT_API_VERSION (1)
     uint16_t api_version; /**< @brief API version */
-    int : 0; /**< @brief Unused. Save possible hole for a future field */
 #endif
     /**
      * @brief An insecure coap connection to the server associated with this
@@ -88,7 +87,6 @@ struct sol_oic_resource {
 #ifndef SOL_NO_API_VERSION
 #define SOL_OIC_RESOURCE_API_VERSION (1)
     uint16_t api_version; /**< @brief API version */
-    int : 0; /**< @brief Unused. Save possible hole for a future field */
 #endif
     /**
      * @brief The resource address.

--- a/src/lib/comms/include/sol-oic-server.h
+++ b/src/lib/comms/include/sol-oic-server.h
@@ -207,7 +207,6 @@ struct sol_oic_resource_type {
 #ifndef SOL_NO_API_VERSION
 #define SOL_OIC_RESOURCE_TYPE_API_VERSION (1)
     uint16_t api_version; /**< @brief API version */
-    int : 0; /**< @brief Unused. Save possible hole for a future field */
 #endif
 
     /**

--- a/src/lib/comms/sol-http-server-impl-microhttpd.c
+++ b/src/lib/comms/sol-http-server-impl-microhttpd.c
@@ -931,6 +931,8 @@ sol_http_server_send_response(struct sol_http_request *request, struct sol_http_
     SOL_NULL_CHECK(request->connection, -EINVAL);
     SOL_NULL_CHECK(response, -EINVAL);
 
+    SOL_HTTP_RESPONSE_CHECK_API_VERSION(response, -EINVAL);
+
     MHD_resume_connection(request->connection);
 
     mhd_response = build_mhd_response(response);

--- a/src/lib/comms/sol-mavlink.c
+++ b/src/lib/comms/sol-mavlink.c
@@ -705,6 +705,24 @@ sol_mavlink_connect(const char *addr, const struct sol_mavlink_config *config, c
     int (*init) (struct sol_mavlink *mavlink);
 
     SOL_NULL_CHECK(addr, NULL);
+    SOL_NULL_CHECK(config, NULL);
+    SOL_NULL_CHECK(config->handlers, NULL);
+
+#ifndef SOL_NO_API_VERSION
+    if (SOL_UNLIKELY(config->api_version !=
+        SOL_MAVLINK_CONFIG_API_VERSION)) {
+        SOL_ERR("Unexpected API version (config is %u, expected %u)",
+            config->api_version, SOL_MAVLINK_CONFIG_API_VERSION);
+        return NULL;
+    }
+
+    if (SOL_UNLIKELY(config->handlers->api_version !=
+        SOL_MAVLINK_HANDLERS_API_VERSION)) {
+        SOL_ERR("Unexpected API version (config is %u, expected %u)",
+            config->handlers->api_version, SOL_MAVLINK_HANDLERS_API_VERSION);
+        return NULL;
+    }
+#endif
 
     init = sol_mavlink_parse_addr_protocol(addr, &address, &port);
     SOL_NULL_CHECK(init, NULL);

--- a/src/lib/comms/sol-network-impl-linux.c
+++ b/src/lib/comms/sol-network-impl-linux.c
@@ -482,15 +482,7 @@ sol_network_link_get_name(const struct sol_network_link *link)
     char name[IFNAMSIZ];
 
     SOL_NULL_CHECK(link, NULL);
-
-#ifndef SOL_NO_API_VERSION
-    if (SOL_UNLIKELY(link->api_version != SOL_NETWORK_LINK_API_VERSION)) {
-        SOL_WRN("Couldn't link that has unsupported version '%u', "
-            "expected version is '%u'",
-            link->api_version, SOL_NETWORK_LINK_API_VERSION);
-        return NULL;
-    }
-#endif
+    SOL_NETWORK_LINK_CHECK_VERSION(link, NULL);
 
     if (if_indextoname(link->index, name))
         return strdup(name);

--- a/src/lib/flow/include/sol-flow-inspector.h
+++ b/src/lib/flow/include/sol-flow-inspector.h
@@ -62,8 +62,8 @@ extern "C" {
  */
 struct sol_flow_inspector {
 #ifndef SOL_NO_API_VERSION
-    unsigned long api_version; /**< @brief API version */
-#define SOL_FLOW_INSPECTOR_API_VERSION (1UL)
+    uint16_t api_version; /**< @brief API version */
+#define SOL_FLOW_INSPECTOR_API_VERSION (1)
 #endif
     /**
      * @brief Callback to trigger when a node is open.

--- a/src/lib/flow/include/sol-flow-parser.h
+++ b/src/lib/flow/include/sol-flow-parser.h
@@ -72,8 +72,8 @@ struct sol_flow_parser;
  */
 struct sol_flow_parser_client {
 #ifndef SOL_NO_API_VERSION
-#define SOL_FLOW_PARSER_CLIENT_API_VERSION (1UL)
-    unsigned long api_version; /**< @brief API version */
+#define SOL_FLOW_PARSER_CLIENT_API_VERSION (1)
+    uint16_t api_version; /**< @brief API version */
 #endif
     void *data; /**< @brief Client data */
 

--- a/src/lib/flow/include/sol-flow-resolver.h
+++ b/src/lib/flow/include/sol-flow-resolver.h
@@ -67,8 +67,8 @@ extern "C" {
  */
 struct sol_flow_resolver {
 #ifndef SOL_NO_API_VERSION
-#define SOL_FLOW_RESOLVER_API_VERSION (1UL) /**< @brief Current API version number */
-    unsigned long api_version; /**< @brief API version number */
+#define SOL_FLOW_RESOLVER_API_VERSION (1) /**< @brief Current API version number */
+    uint16_t api_version; /**< @brief API version number */
 #endif
     const char *name; /**< @brief Resolver's name (useful for logging) */
     void *data; /**< @brief Resolver's context data (will be provided to @c resolve) */

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -762,7 +762,7 @@ struct sol_flow_node_type_description {
      * should be incremented.
      */
 #define SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION (1)
-    unsigned long api_version; /**< @brief Must match SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION at runtime */
+    uint16_t api_version; /**< @brief Must match SOL_FLOW_NODE_TYPE_DESCRIPTION_API_VERSION at runtime */
 #endif
     const char *name; /**< @brief The user-visible name. @b Mandatory. */
 

--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -291,6 +291,14 @@ sol_flow_builder_set_resolver(struct sol_flow_builder *builder,
     SOL_NULL_CHECK(builder);
     if (!resolver)
         resolver = sol_flow_get_default_resolver();
+#ifndef SOL_NO_API_VERSION
+    else if (SOL_UNLIKELY(resolver->api_version != SOL_FLOW_RESOLVER_API_VERSION)) {
+        SOL_WRN("Couldn't open gpio that has unsupported version '%u', "
+            "expected version is '%u'",
+            resolver->api_version, SOL_FLOW_RESOLVER_API_VERSION);
+        return NULL;
+    }
+#endif
     builder->resolver = resolver;
 }
 

--- a/src/lib/flow/sol-flow-resolver.c
+++ b/src/lib/flow/sol-flow-resolver.c
@@ -108,6 +108,15 @@ sol_flow_resolve(
         resolver = sol_flow_get_default_resolver();
     SOL_NULL_CHECK(resolver, -ENOENT);
 
+#ifndef SOL_NO_API_VERSION
+    if (SOL_UNLIKELY(resolver->api_version != SOL_FLOW_RESOLVER_API_VERSION)) {
+        SOL_WRN("Couldn't open gpio that has unsupported version '%u', "
+            "expected version is '%u'",
+            resolver->api_version, SOL_FLOW_RESOLVER_API_VERSION);
+        return NULL;
+    }
+#endif
+
     err = resolver->resolve(resolver->data, id, &tmp_type, &tmp_named_opts);
     if (err < 0) {
         SOL_DBG("could not resolve module for id='%s' using resolver=%s",

--- a/src/lib/flow/sol-flow-static.c
+++ b/src/lib/flow/sol-flow-static.c
@@ -143,6 +143,8 @@ dispatch_connect_in(struct sol_flow_node *node, uint16_t port, uint16_t conn_id,
 static int
 dispatch_disconnect_out(struct sol_flow_node *node, uint16_t port, uint16_t conn_id, const struct sol_flow_port_type_out *port_type)
 {
+    SOL_FLOW_PORT_TYPE_IN_API_CHECK(port_type, SOL_FLOW_PORT_TYPE_OUT_API_VERSION, 0);
+
     if (port_type->disconnect)
         return port_type->disconnect(node, node->data, port, conn_id);
     return 0;
@@ -151,6 +153,8 @@ dispatch_disconnect_out(struct sol_flow_node *node, uint16_t port, uint16_t conn
 static int
 dispatch_disconnect_in(struct sol_flow_node *node, uint16_t port, uint16_t conn_id, const struct sol_flow_port_type_in *port_type)
 {
+    SOL_FLOW_PORT_TYPE_IN_API_CHECK(port_type, SOL_FLOW_PORT_TYPE_IN_API_VERSION, 0);
+
     if (port_type->disconnect)
         return port_type->disconnect(node, node->data, port, conn_id);
     return 0;

--- a/src/lib/flow/sol-flow.c
+++ b/src/lib/flow/sol-flow.c
@@ -68,8 +68,8 @@ sol_flow_set_inspector(const struct sol_flow_inspector *inspector)
     if (inspector) {
 #ifndef SOL_NO_API_VERSION
         if (inspector->api_version != SOL_FLOW_INSPECTOR_API_VERSION) {
-            SOL_WRN("inspector(%p)->api_version(%lu) != "
-                "SOL_FLOW_INSPECTOR_API_VERSION(%lu)",
+            SOL_WRN("inspector(%p)->api_version(%" PRIu16 ") != "
+                "SOL_FLOW_INSPECTOR_API_VERSION(%" PRIu16 ")",
                 inspector, inspector->api_version,
                 SOL_FLOW_INSPECTOR_API_VERSION);
             return false;

--- a/src/lib/io/include/sol-memmap-storage.h
+++ b/src/lib/io/include/sol-memmap-storage.h
@@ -101,7 +101,7 @@ extern "C" {
     SOL_MEMMAP_ENTRY_BIT_SIZE(_name, _offset, 1, _bit_offset, 1)
 
 struct sol_memmap_map {
-    uint8_t version; /**< Version of map. Functions will refuse to read/write on storage if this version and the one storad differs */
+    uint16_t api_version; /**< Version of map. Functions will refuse to read/write on storage if this version and the one storad differs */
     const char *path; /**< Where to find the storage. Under Linux, it is the file mapping the storage, like @c /dev/nvram.
                        * Optionally, it can also be of form <tt> create,\<bus_type\>,\<rel_path\>,\<devnumber\>,\<devname\> </tt>, where:
                        * @arg @a bus_type is the bus type, supported values are: i2c

--- a/src/lib/io/sol-gpio-impl-contiki.c
+++ b/src/lib/io/sol-gpio-impl-contiki.c
@@ -75,6 +75,15 @@ sol_gpio_open_raw(uint32_t pin, const struct sol_gpio_config *config)
 
     SOL_LOG_INTERNAL_INIT_ONCE;
 
+#ifndef SOL_NO_API_VERSION
+    if (SOL_UNLIKELY(config->api_version != SOL_GPIO_CONFIG_API_VERSION)) {
+        SOL_WRN("Couldn't open gpio that has unsupported version '%u', "
+            "expected version is '%u'",
+            config->api_version, SOL_GPIO_CONFIG_API_VERSION);
+        return NULL;
+    }
+#endif
+
     process_start(&sensors_process, NULL);
 
     if (config->drive_mode != SOL_GPIO_DRIVE_NONE) {

--- a/src/lib/io/sol-memmap-storage.c
+++ b/src/lib/io/sol-memmap-storage.c
@@ -260,11 +260,13 @@ check_version(struct map_internal *map_internal)
     if (map_internal->checked)
         return true;
 
-    if (!map_internal->map->version || map_internal->map->version == 255) {
-        SOL_WRN("Invalid memory_map_version. Should be between 1 and 255. Found %d",
-            map_internal->map->version);
+#ifndef SOL_NO_API_VERSION
+    if (!map_internal->map->api_version || map_internal->map->api_version == UINT16_MAX) {
+        SOL_WRN("Invalid memory_map_version. Should be between 1 and %" PRIu16 ". Found %" PRIu16,
+            UINT16_MAX, map_internal->map->api_version);
         return false;
     }
+#endif
 
     if (!get_entry_metadata_on_map(MEMMAP_VERSION_ENTRY, map_internal->map, &entry,
         &mask)) {
@@ -275,11 +277,11 @@ check_version(struct map_internal *map_internal)
 
     ret = sol_memmap_read_raw_do(map_internal->resolved_path, entry, mask, &buf);
     if (ret >= 0 && (version == 0 || version == 255)) {
-        blob = sol_blob_new(SOL_BLOB_TYPE_NOFREE, NULL, &map_internal->map->version, sizeof(uint8_t));
+        blob = sol_blob_new(SOL_BLOB_TYPE_NOFREE, NULL, &map_internal->map->api_version, sizeof(uint16_t));
         SOL_NULL_CHECK(blob, false);
 
         /* No version on file, we should be initialising it */
-        version = map_internal->map->version;
+        version = map_internal->map->api_version;
         if (sol_memmap_write_raw_do(map_internal->resolved_path, MEMMAP_VERSION_ENTRY, entry, mask, blob, version_write_cb, NULL, NULL) < 0) {
             SOL_WRN("Could not write current map version to file");
             sol_blob_unref(blob);
@@ -290,9 +292,9 @@ check_version(struct map_internal *map_internal)
         return false;
     }
 
-    if (version != map_internal->map->version) {
+    if (version != map_internal->map->api_version) {
         SOL_WRN("Memory map version mismatch. Expected %d but found %d",
-            map_internal->map->version, version);
+            map_internal->map->api_version, version);
         return false;
     }
 

--- a/src/modules/flow/accelerometer/adxl45.c
+++ b/src/modules/flow/accelerometer/adxl45.c
@@ -38,6 +38,7 @@
 #include "sol-i2c.h"
 #include "sol-mainloop.h"
 #include "sol-util-internal.h"
+#include "sol-flow-internal.h"
 
 /* speed only works for riot */
 #define I2C_SPEED SOL_I2C_SPEED_10KBIT
@@ -446,7 +447,8 @@ accelerometer_adxl345_open(struct sol_flow_node *node,
     const struct sol_flow_node_type_accelerometer_adxl345_options *opts =
         (const struct sol_flow_node_type_accelerometer_adxl345_options *)options;
 
-    SOL_NULL_CHECK(options, -EINVAL);
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_ACCELEROMETER_ADXL345_OPTIONS_API_VERSION, -EINVAL);
 
     mdata->i2c = sol_i2c_open(opts->i2c_bus, I2C_SPEED);
     SOL_NULL_CHECK_MSG(mdata->i2c, -EIO, "Failed to open i2c bus");

--- a/src/modules/flow/calamari/calamari.c
+++ b/src/modules/flow/calamari/calamari.c
@@ -44,6 +44,7 @@
 #include "sol-pwm.h"
 #include "sol-spi.h"
 #include "sol-util-internal.h"
+#include "sol-flow-internal.h"
 
 ///////// SEGMENTS CTL ///////////
 
@@ -229,6 +230,10 @@ calamari_7seg_child_opts_set(const struct sol_flow_node_type *type,
         [SEG_DATA] = calamari_7seg_opts->data_pin
     };
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(child_opts,
+        SOL_FLOW_NODE_TYPE_GPIO_WRITER_OPTIONS_API_VERSION,
+        -EINVAL);
+
     if (child_index == SEG_CTL || child_index > SEG_DATA)
         return 0;
 
@@ -345,6 +350,10 @@ calamari_led_open(struct sol_flow_node *node, void *data, const struct sol_flow_
     const struct sol_flow_node_type_calamari_led_options *opts =
         (const struct sol_flow_node_type_calamari_led_options *)options;
     struct sol_pwm_config pwm_config = { 0 };
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_CALAMARI_LED_OPTIONS_API_VERSION,
+        -EINVAL);
 
     mdata->period = opts->period;
     mdata->val.min = opts->range.min;
@@ -467,7 +476,9 @@ calamari_lever_open(struct sol_flow_node *node, void *data, const struct sol_flo
         (const struct sol_flow_node_type_calamari_lever_options *)options;
     struct sol_spi_config spi_config;
 
-    SOL_NULL_CHECK(options, 0);
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_CALAMARI_LEVER_OPTIONS_API_VERSION,
+        -EINVAL);
 
     mdata->node = node;
     mdata->last_value = 0;
@@ -566,6 +577,10 @@ calamari_rgb_child_opts_set(const struct sol_flow_node_type *type,
         [RGB_LED_GREEN] = calamari_rgb_opts->green_pin,
         [RGB_LED_BLUE] = calamari_rgb_opts->blue_pin,
     };
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(child_opts,
+        SOL_FLOW_NODE_TYPE_GPIO_WRITER_OPTIONS_API_VERSION,
+        -EINVAL);
 
     // There is nothing to do for node 0, which is rgb-ctl
     if (child_index == RGB_LED_CTL || child_index > RGB_LED_BLUE)

--- a/src/modules/flow/evdev/evdev.c
+++ b/src/modules/flow/evdev/evdev.c
@@ -48,6 +48,7 @@
 #include "sol-util-internal.h"
 #include "sol-util-file.h"
 #include "sol-vector.h"
+#include "sol-flow-internal.h"
 
 struct evdev_fd_handler {
     const struct sol_flow_node *node;
@@ -303,6 +304,8 @@ evdev_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_op
     struct evdev_data *mdata = sol_flow_node_get_private_data(node);
     const struct sol_flow_node_type_evdev_boolean_options *opts =
         (const struct sol_flow_node_type_evdev_boolean_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_EVDEV_BOOLEAN_OPTIONS_API_VERSION, -EINVAL);
 
     if (opts->ev_code >= KEY_MAX)
         return -EINVAL;

--- a/src/modules/flow/grove/grove.c
+++ b/src/modules/flow/grove/grove.c
@@ -61,10 +61,16 @@ rotary_child_opts_set(const struct sol_flow_node_type *type, uint16_t child_inde
     if (child_index == ROTARY_CONVERTER_NODE_IDX) {
         struct sol_flow_node_type_grove_rotary_converter_options *converter_opts =
             (struct sol_flow_node_type_grove_rotary_converter_options *)child_opts;
+        SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(child_opts,
+            SOL_FLOW_NODE_TYPE_GROVE_ROTARY_CONVERTER_OPTIONS_API_VERSION,
+            -EINVAL);
         converter_opts->angular_range = container_opts->angular_range;
         converter_opts->input_range_mask = container_opts->mask;
     } else if (child_index == ROTARY_AIO_READER_NODE_IDX) {
         struct sol_flow_node_type_aio_reader_options *reader_opts = (struct sol_flow_node_type_aio_reader_options *)child_opts;
+        SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(child_opts,
+            SOL_FLOW_NODE_TYPE_AIO_READER_OPTIONS_API_VERSION,
+            -EINVAL);
         reader_opts->raw = container_opts->raw;
         reader_opts->pin = container_opts->pin ? strdup(container_opts->pin) : NULL;
         reader_opts->mask = container_opts->mask;
@@ -196,9 +202,15 @@ light_child_opts_set(const struct sol_flow_node_type *type, uint16_t child_index
 
     if (child_index == LIGHT_CONVERTER_NODE_IDX) {
         struct sol_flow_node_type_grove_light_converter_options *converter_opts = (struct sol_flow_node_type_grove_light_converter_options *)child_opts;
+        SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(child_opts,
+            SOL_FLOW_NODE_TYPE_GROVE_LIGHT_CONVERTER_OPTIONS_API_VERSION,
+            -EINVAL);
         converter_opts->input_range_mask = container_opts->mask;
     } else if (child_index == LIGHT_AIO_READER_NODE_IDX) {
         struct sol_flow_node_type_aio_reader_options *reader_opts = (struct sol_flow_node_type_aio_reader_options *)child_opts;
+        SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(child_opts,
+            SOL_FLOW_NODE_TYPE_AIO_READER_OPTIONS_API_VERSION,
+            -EINVAL);
         reader_opts->raw = container_opts->raw;
         reader_opts->pin = container_opts->pin ? strdup(container_opts->pin) : NULL;
         reader_opts->mask = container_opts->mask;
@@ -370,6 +382,9 @@ temperature_child_opts_set(const struct sol_flow_node_type *type, uint16_t child
     if (child_index == TEMPERATURE_CONVERTER_NODE_IDX) {
         struct sol_flow_node_type_grove_temperature_converter_options *converter_opts =
             (struct sol_flow_node_type_grove_temperature_converter_options *)child_opts;
+        SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(child_opts,
+            SOL_FLOW_NODE_TYPE_GROVE_TEMPERATURE_CONVERTER_OPTIONS_API_VERSION,
+            -EINVAL);
         converter_opts->thermistor_constant = container_opts->thermistor_constant;
         converter_opts->input_range_mask = container_opts->mask;
         converter_opts->resistance = container_opts->resistance;
@@ -377,6 +392,9 @@ temperature_child_opts_set(const struct sol_flow_node_type *type, uint16_t child
         converter_opts->thermistor_resistance = container_opts->thermistor_resistance;
     } else if (child_index == TEMPERATURE_AIO_READER_NODE_IDX) {
         struct sol_flow_node_type_aio_reader_options *reader_opts = (struct sol_flow_node_type_aio_reader_options *)child_opts;
+        SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(child_opts,
+            SOL_FLOW_NODE_TYPE_AIO_READER_OPTIONS_API_VERSION,
+            -EINVAL);
         reader_opts->raw = container_opts->raw;
         reader_opts->pin = container_opts->pin ? strdup(container_opts->pin) : NULL;
         reader_opts->pin = container_opts->pin;

--- a/src/modules/flow/gtk/led.c
+++ b/src/modules/flow/gtk/led.c
@@ -35,6 +35,7 @@
 #include "led.h"
 #include "sol-flow/gtk.h"
 #include "sol-types.h"
+#include "sol-flow-internal.h"
 
 #define LED_VIEW_DIMENSION (50)
 #define RGB_VALUE_MAX (255)
@@ -74,7 +75,9 @@ led_setup(struct gtk_common_data *data,
         (const struct sol_flow_node_type_gtk_led_options *)options;
     struct sol_rgb color;
 
-    SOL_NULL_CHECK(options, -EINVAL);
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_GTK_LED_OPTIONS_API_VERSION,
+        -EINVAL);
 
     color = opts->rgb;
     if (sol_rgb_set_max(&color, 255) < 0) {

--- a/src/modules/flow/gtk/pwm-editor.c
+++ b/src/modules/flow/gtk/pwm-editor.c
@@ -32,6 +32,7 @@
 
 #include "pwm-editor.h"
 #include "sol-flow/gtk.h"
+#include "sol-flow-internal.h"
 
 static void
 on_pwm_editor_toggle_changed(GtkToggleButton *toggle, gpointer data)
@@ -89,6 +90,10 @@ pwm_editor_setup(struct gtk_common_data *mdata, const struct sol_flow_node_optio
 
     const struct sol_flow_node_type_gtk_pwm_editor_options *opts =
         (const struct sol_flow_node_type_gtk_pwm_editor_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_GTK_PWM_EDITOR_OPTIONS_API_VERSION,
+        -EINVAL);
 
     if (opts) {
         range_min = opts->range.min;

--- a/src/modules/flow/gtk/pwm-viewer.c
+++ b/src/modules/flow/gtk/pwm-viewer.c
@@ -32,6 +32,7 @@
 
 #include "pwm-viewer.h"
 #include "sol-flow/gtk.h"
+#include "sol-flow-internal.h"
 
 #define CHART_HEIGHT 42
 #define CHART_WIDTH 340
@@ -98,6 +99,10 @@ pwm_viewer_setup(struct gtk_common_data *data, const struct sol_flow_node_option
     struct gtk_pwm_viewer_data *mdata = (struct gtk_pwm_viewer_data *)data;
 
     SOL_NULL_CHECK(mdata, -ENOMEM);
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_GTK_PWM_VIEWER_OPTIONS_API_VERSION,
+        -EINVAL);
 
     opts = (const struct sol_flow_node_type_gtk_pwm_viewer_options *)options;
 

--- a/src/modules/flow/gtk/slider.c
+++ b/src/modules/flow/gtk/slider.c
@@ -32,6 +32,7 @@
 
 #include "slider.h"
 #include "sol-flow/gtk.h"
+#include "sol-flow-internal.h"
 
 static void
 on_slider_changed(GtkRange *range, gpointer data)
@@ -61,6 +62,10 @@ slider_setup(struct gtk_common_data *data,
     struct gtk_common_data *mdata = (struct gtk_common_data *)data;
     const struct sol_flow_node_type_gtk_slider_options *opts =
         (const struct sol_flow_node_type_gtk_slider_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_GTK_SLIDER_OPTIONS_API_VERSION,
+        -EINVAL);
 
     if (opts) {
         min = opts->range.min;

--- a/src/modules/flow/gyroscope/gyroscope.c
+++ b/src/modules/flow/gyroscope/gyroscope.c
@@ -37,6 +37,7 @@
 #include "sol-i2c.h"
 #include "sol-mainloop.h"
 #include "sol-util-internal.h"
+#include "sol-flow-internal.h"
 
 /* speed only works for riot */
 #define I2C_SPEED SOL_I2C_SPEED_10KBIT
@@ -460,7 +461,9 @@ gyroscope_l3g4200d_open(struct sol_flow_node *node,
     const struct sol_flow_node_type_gyroscope_l3g4200d_options *opts =
         (const struct sol_flow_node_type_gyroscope_l3g4200d_options *)options;
 
-    SOL_NULL_CHECK(options, -EINVAL);
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_GYROSCOPE_L3G4200D_OPTIONS_API_VERSION,
+        -EINVAL);
 
     mdata->i2c = sol_i2c_open(opts->i2c_bus, I2C_SPEED);
     SOL_NULL_CHECK_MSG(mdata->i2c, -EIO, "Failed to open i2c bus");

--- a/src/modules/flow/http-server/http-server.c
+++ b/src/modules/flow/http-server/http-server.c
@@ -45,6 +45,7 @@
 #include "sol-mainloop.h"
 #include "sol-util-internal.h"
 #include "sol-vector.h"
+#include "sol-flow-internal.h"
 
 #define HTTP_HEADER_ACCEPT "Accept"
 #define HTTP_HEADER_CONTENT_TYPE "Content-Type"
@@ -317,6 +318,10 @@ int_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_opti
     struct sol_flow_node_type_http_server_int_options *opts =
         (struct sol_flow_node_type_http_server_int_options *)options;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_HTTP_SERVER_INT_OPTIONS_API_VERSION,
+        -EINVAL);
+
     r = start_server(mdata, node, opts->path, opts->port);
     SOL_INT_CHECK(r, < 0, r);
 
@@ -333,6 +338,10 @@ float_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_op
     struct http_data *mdata = data;
     struct sol_flow_node_type_http_server_float_options *opts =
         (struct sol_flow_node_type_http_server_float_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_HTTP_SERVER_FLOAT_OPTIONS_API_VERSION,
+        -EINVAL);
 
     r = start_server(mdata, node, opts->path, opts->port);
     SOL_INT_CHECK(r, < 0, r);
@@ -489,6 +498,10 @@ string_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_o
     struct sol_flow_node_type_http_server_string_options *opts =
         (struct sol_flow_node_type_http_server_string_options *)options;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_HTTP_SERVER_STRING_OPTIONS_API_VERSION,
+        -EINVAL);
+
     mdata->value.s = strdup(opts->value);
     SOL_NULL_CHECK(mdata->value.s, -ENOMEM);
 
@@ -642,6 +655,10 @@ static_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_o
     struct http_data *mdata = data;
     struct sol_flow_node_type_http_server_static_options *opts =
         (struct sol_flow_node_type_http_server_static_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_HTTP_SERVER_STATIC_OPTIONS_API_VERSION,
+        -EINVAL);
 
     mdata->sdata = server_ref(opts->port);
     SOL_NULL_CHECK(mdata->sdata, -ENOMEM);

--- a/src/modules/flow/int/int.c
+++ b/src/modules/flow/int/int.c
@@ -517,6 +517,9 @@ irange_constrain_open(struct sol_flow_node *node, void *data, const struct sol_f
     struct irange_constrain_data *mdata = data;
     const struct sol_flow_node_type_int_constrain_options *opts;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_INT_CONSTRAIN_OPTIONS_API_VERSION,
+        -EINVAL);
     opts = (const struct sol_flow_node_type_int_constrain_options *)options;
     mdata->range = opts->range;
     mdata->use_input_range = opts->use_input_range;

--- a/src/modules/flow/keyboard/keyboard.c
+++ b/src/modules/flow/keyboard/keyboard.c
@@ -49,6 +49,7 @@
 #include "sol-vector.h"
 #include "sol-util-internal.h"
 #include "sol-util-file.h"
+#include "sol-flow-internal.h"
 
 struct keyboard_common_data {
     struct sol_flow_node *node;
@@ -300,7 +301,9 @@ keyboard_boolean_open(struct sol_flow_node *node,
     const struct sol_flow_node_type_keyboard_boolean_options *opts =
         (const struct sol_flow_node_type_keyboard_boolean_options *)options;
 
-    SOL_NULL_CHECK(options, -EINVAL);
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_KEYBOARD_BOOLEAN_OPTIONS_API_VERSION,
+        -EINVAL);
 
     mdata->binary_code = opts->binary_code;
     mdata->toggle = opts->toggle;

--- a/src/modules/flow/led-strip/lpd8806.c
+++ b/src/modules/flow/led-strip/lpd8806.c
@@ -80,6 +80,10 @@ led_strip_controler_open(struct sol_flow_node *node, void *data, const struct so
     uint8_t latch_bytes;
     struct sol_spi_config spi_config;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_LED_STRIP_LPD8806_OPTIONS_API_VERSION,
+        -EINVAL);
+
     opts = (const struct sol_flow_node_type_led_strip_lpd8806_options *)options;
 
     SOL_INT_CHECK(opts->pixel_count, < 0, -EINVAL);

--- a/src/modules/flow/mqtt/mqtt.c
+++ b/src/modules/flow/mqtt/mqtt.c
@@ -82,6 +82,7 @@ publish(struct client_data *mdata)
     payload_buffer = SOL_BUFFER_INIT_CONST(mdata->payload->mem, mdata->payload->size);
 
     message = (struct sol_mqtt_message){
+        SOL_SET_API_VERSION(.api_version = SOL_MQTT_MESSAGE_API_VERSION, )
         .topic = mdata->topic,
         .payload = &payload_buffer,
         .qos = mdata->qos,
@@ -142,6 +143,9 @@ on_message(void *data, struct sol_mqtt *mqtt, const struct sol_mqtt_message *mes
     struct sol_blob *blob;
     char *payload;
 
+    SOL_NULL_CHECK(message);
+    SOL_MQTT_MESSAGE_CHECK_API_VERSION(message);
+
     payload = sol_util_memdup(message->payload->data, message->payload->used);
     SOL_NULL_CHECK(payload);
 
@@ -161,7 +165,7 @@ static void
 mqtt_init(struct client_data *mdata)
 {
     struct sol_mqtt_config config = {
-        .api_version = SOL_MQTT_CONFIG_API_VERSION,
+        SOL_SET_API_VERSION(.api_version = SOL_MQTT_CONFIG_API_VERSION, )
         .clean_session = mdata->clean_session,
         .keepalive = mdata->keepalive,
         .username = mdata->user,

--- a/src/modules/flow/network/network.c
+++ b/src/modules/flow/network/network.c
@@ -44,6 +44,7 @@
 #include "sol-network.h"
 #include "sol-util-internal.h"
 #include "sol-vector.h"
+#include "sol-flow-internal.h"
 
 struct network_data {
     struct sol_flow_node *node;
@@ -110,6 +111,8 @@ _on_network_event(void *data, const struct sol_network_link *link, enum sol_netw
     bool connected;
     uint16_t idx;
 
+    SOL_NETWORK_LINK_CHECK_VERSION(link);
+
     if (!_match_link(mdata, link))
         return;
 
@@ -149,6 +152,9 @@ network_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_
     const struct sol_flow_node_type_network_boolean_options *opts =
         (const struct sol_flow_node_type_network_boolean_options *)options;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_NETWORK_BOOLEAN_OPTIONS_API_VERSION, -EINVAL);
+
     SOL_NULL_CHECK(options, -EINVAL);
 
     if (!_compile_regex(&mdata->regex, opts->address))
@@ -168,6 +174,7 @@ network_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_
 
     if (links) {
         SOL_VECTOR_FOREACH_IDX (links, itr, idx) {
+            SOL_NETWORK_LINK_CHECK_VERSION(itr, -EINVAL);
             if (_match_link(mdata, itr)) {
                 sol_ptr_vector_append(&mdata->links, itr);
                 mdata->connected |= (itr->flags & SOL_NETWORK_LINK_RUNNING) &&

--- a/src/modules/flow/oauth/oauth.c
+++ b/src/modules/flow/oauth/oauth.c
@@ -48,6 +48,7 @@
 #include "sol-random.h"
 #include "sol-util-internal.h"
 #include "sol-vector.h"
+#include "sol-flow-internal.h"
 
 struct v1_data {
     struct sol_ptr_vector pending_conns;
@@ -272,6 +273,8 @@ v1_parse_response(struct v1_request_data *req_data, const struct sol_http_respon
         .param = SOL_HTTP_REQUEST_PARAMS_INIT,
         .response_code = SOL_HTTP_STATUS_FOUND,
     };
+
+    SOL_HTTP_RESPONSE_CHECK_API(response, -EINVAL);
 
     tokens = sol_str_slice_split(
         sol_str_slice_from_str(response->content.data), "&", 0);
@@ -593,6 +596,10 @@ v1_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_optio
     struct oauth_node_type *type;
     struct sol_flow_node_type_oauth_v1_options *opts =
         (struct sol_flow_node_type_oauth_v1_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_OAUTH_V1_OPTIONS_API_VERSION,
+        -EINVAL);
 
     type = (struct oauth_node_type *)sol_flow_node_get_type(node);
 

--- a/src/modules/flow/persistence/persistence.c
+++ b/src/modules/flow/persistence/persistence.c
@@ -39,6 +39,7 @@
 #include "sol-str-slice.h"
 #include "sol-str-table.h"
 #include "sol-util-internal.h"
+#include "sol-flow-internal.h"
 
 #ifdef USE_FILESYSTEM
 #include "sol-fs-storage.h"
@@ -393,6 +394,9 @@ persist_boolean_open(struct sol_flow_node *node,
     const struct sol_flow_node_type_persistence_boolean_options *opts =
         (const struct sol_flow_node_type_persistence_boolean_options *)options;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_PERSISTENCE_BOOLEAN_OPTIONS_API_VERSION, -EINVAL);
+
     mdata->base.packet_data_size = sizeof(bool);
     mdata->base.value_ptr = &mdata->last_value;
     mdata->base.packet_new_fn = persist_boolean_packet_new;
@@ -456,6 +460,9 @@ persist_byte_open(struct sol_flow_node *node,
     struct persist_byte_data *mdata = data;
     const struct sol_flow_node_type_persistence_byte_options *opts =
         (const struct sol_flow_node_type_persistence_byte_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_PERSISTENCE_BYTE_OPTIONS_API_VERSION, -EINVAL);
 
     mdata->base.packet_data_size = sizeof(unsigned char);
     mdata->base.value_ptr = &mdata->last_value;
@@ -541,6 +548,9 @@ persist_irange_open(struct sol_flow_node *node,
     const struct sol_flow_node_type_persistence_int_options *opts =
         (const struct sol_flow_node_type_persistence_int_options *)options;
     int r;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_PERSISTENCE_INT_OPTIONS_API_VERSION, -EINVAL);
 
     if (opts->store_only_val)
         mdata->base.packet_data_size = sizeof(int32_t);
@@ -637,6 +647,9 @@ persist_drange_open(struct sol_flow_node *node,
         (const struct sol_flow_node_type_persistence_float_options *)options;
     int r;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_PERSISTENCE_FLOAT_OPTIONS_API_VERSION, -EINVAL);
+
     if (opts->store_only_val)
         mdata->base.packet_data_size = sizeof(double);
     else
@@ -707,6 +720,8 @@ persist_string_open(struct sol_flow_node *node,
         (const struct sol_flow_node_type_persistence_string_options *)options;
     int r;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_PERSISTENCE_STRING_OPTIONS_API_VERSION, -EINVAL);
     mdata->base.packet_new_fn = persist_string_packet_new;
     mdata->base.packet_data_get_fn = persist_string_packet_data_get;
     mdata->base.packet_send_fn = persist_string_packet_send;

--- a/src/modules/flow/piezo-speaker/piezo-speaker.c
+++ b/src/modules/flow/piezo-speaker/piezo-speaker.c
@@ -44,6 +44,7 @@
 #include "sol-pwm.h"
 #include "sol-str-table.h"
 #include "sol-util-internal.h"
+#include "sol-flow-internal.h"
 
 static bool be_quiet(void *data);
 
@@ -392,6 +393,10 @@ piezo_speaker_open(struct sol_flow_node *node,
     const struct sol_flow_node_type_piezo_speaker_sound_options *opts =
         (const struct sol_flow_node_type_piezo_speaker_sound_options *)options;
     struct sol_pwm_config pwm_config = { 0 };
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_PIEZO_SPEAKER_SOUND_OPTIONS_API_VERSION,
+        -EINVAL);
 
     SOL_SET_API_VERSION(pwm_config.api_version = SOL_PWM_CONFIG_API_VERSION; )
     pwm_config.period_ns = -1;

--- a/src/modules/flow/platform/platform.c
+++ b/src/modules/flow/platform/platform.c
@@ -269,6 +269,9 @@ monitor_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_
     const struct monitor_node_type *monitor_type =
         (const struct monitor_node_type *)sol_flow_node_get_type(node);
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_PLATFORM_HOSTNAME_OPTIONS_API_VERSION, -EINVAL);
+
     opts = (const struct sol_flow_node_type_platform_hostname_options *)options;
 
     if (opts->send_initial_packet)
@@ -439,10 +442,13 @@ static int
 locale_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
 {
     int r;
-    const struct sol_flow_node_type_platform_hostname_options *opts;
+    const struct sol_flow_node_type_platform_locale_options *opts;
     enum sol_platform_locale_category i;
 
-    opts = (const struct sol_flow_node_type_platform_hostname_options *)options;
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_PLATFORM_LOCALE_OPTIONS_API_VERSION, -EINVAL);
+
+    opts = (const struct sol_flow_node_type_platform_locale_options *)options;
 
     if (!opts->send_initial_packet)
         return 0;

--- a/src/modules/flow/process/subprocess.c
+++ b/src/modules/flow/process/subprocess.c
@@ -35,6 +35,7 @@
 #include "sol-platform-linux.h"
 #include "sol-util-internal.h"
 #include "sol-util-file.h"
+#include "sol-flow-internal.h"
 
 #include <fcntl.h>
 #include <signal.h>
@@ -380,6 +381,10 @@ process_subprocess_open(struct sol_flow_node *node, void *data, const struct sol
     struct subprocess_data *mdata = data;
     struct sol_flow_node_type_process_subprocess_options *opts =
         (struct sol_flow_node_type_process_subprocess_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_PROCESS_SUBPROCESS_OPTIONS_API_VERSION,
+        -EINVAL);
 
     mdata->node = node;
     sol_vector_init(&mdata->write_data, sizeof(struct write_data));

--- a/src/modules/flow/random/random.c
+++ b/src/modules/flow/random/random.c
@@ -50,6 +50,9 @@ random_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_o
     struct random_node_data *mdata = data;
     const struct sol_flow_node_type_random_int_options *opts;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_RANDOM_INT_OPTIONS_API_VERSION, -EINVAL);
+
     /* TODO find some way to share the same options struct between
        multiple node types */
     opts = (const struct sol_flow_node_type_random_int_options *)options;

--- a/src/modules/flow/servo-motor/servo-motor.c
+++ b/src/modules/flow/servo-motor/servo-motor.c
@@ -39,6 +39,7 @@
 #include <stdlib.h>
 
 #include "sol-flow/servo-motor.h"
+#include "sol-flow-internal.h"
 
 struct servo_motor_data {
     struct sol_irange duty_cycle_range;
@@ -54,6 +55,9 @@ servo_motor_open(struct sol_flow_node *node, void *data, const struct sol_flow_n
     const struct sol_flow_node_type_servo_motor_controller_options *opts;
     struct servo_motor_data *mdata = data;
     struct sol_pwm_config pwm_config = { 0 };
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_SERVO_MOTOR_CONTROLLER_OPTIONS_API_VERSION, -EINVAL);
 
     opts = (const struct sol_flow_node_type_servo_motor_controller_options *)options;
 

--- a/src/modules/flow/test/blob-validator.c
+++ b/src/modules/flow/test/blob-validator.c
@@ -40,6 +40,7 @@
 
 #include "blob-validator.h"
 #include "sol-flow/test.h"
+#include "sol-flow-internal.h"
 
 int
 blob_validator_open(
@@ -50,6 +51,10 @@ blob_validator_open(
     struct blob_validator_data *mdata = data;
     const struct sol_flow_node_type_test_blob_validator_options *opts =
         (const struct sol_flow_node_type_test_blob_validator_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_TEST_BLOB_VALIDATOR_OPTIONS_API_VERSION,
+        -EINVAL);
 
     mdata->done = false;
 

--- a/src/modules/flow/test/boolean-generator.c
+++ b/src/modules/flow/test/boolean-generator.c
@@ -41,6 +41,7 @@
 #include "test-module.h"
 #include "boolean-generator.h"
 #include "sol-flow/test.h"
+#include "sol-flow-internal.h"
 
 static bool
 timer_tick(void *data)
@@ -77,6 +78,10 @@ boolean_generator_open(
     struct boolean_generator_data *mdata = data;
     const struct sol_flow_node_type_test_boolean_generator_options *opts =
         (const struct sol_flow_node_type_test_boolean_generator_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_TEST_BOOLEAN_GENERATOR_OPTIONS_API_VERSION,
+        -EINVAL);
 
     if (opts->sequence == NULL || *opts->sequence == '\0') {
         SOL_ERR("Option 'sequence' is either NULL or empty.");

--- a/src/modules/flow/test/boolean-validator.c
+++ b/src/modules/flow/test/boolean-validator.c
@@ -40,6 +40,7 @@
 
 #include "boolean-validator.h"
 #include "sol-flow/test.h"
+#include "sol-flow-internal.h"
 
 int
 boolean_validator_open(
@@ -51,6 +52,9 @@ boolean_validator_open(
     const struct sol_flow_node_type_test_boolean_validator_options *opts =
         (const struct sol_flow_node_type_test_boolean_validator_options *)options;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_TEST_BOOLEAN_VALIDATOR_OPTIONS_API_VERSION,
+        -EINVAL);
     mdata->done = false;
 
     if (opts->sequence == NULL || *opts->sequence == '\0') {

--- a/src/modules/flow/test/byte-generator.c
+++ b/src/modules/flow/test/byte-generator.c
@@ -42,6 +42,7 @@
 #include "test-module.h"
 #include "byte-generator.h"
 #include "sol-flow/test.h"
+#include "sol-flow-internal.h"
 
 static bool
 timer_tick(void *data)
@@ -69,6 +70,10 @@ byte_generator_open(struct sol_flow_node *node, void *data,
     const char *it;
     char *tail;
     unsigned char *val;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_TEST_BYTE_GENERATOR_OPTIONS_API_VERSION,
+        -EINVAL);
 
     if (opts->sequence == NULL || *opts->sequence == '\0') {
         SOL_ERR("Option 'sequence' is either NULL or empty.");

--- a/src/modules/flow/test/byte-validator.c
+++ b/src/modules/flow/test/byte-validator.c
@@ -41,6 +41,7 @@
 
 #include "byte-validator.h"
 #include "sol-flow/test.h"
+#include "sol-flow-internal.h"
 
 static int
 _populate_values(void *data, const char *sequence)
@@ -92,6 +93,9 @@ byte_validator_open(struct sol_flow_node *node, void *data,
     const struct sol_flow_node_type_test_byte_validator_options *opts =
         (const struct sol_flow_node_type_test_byte_validator_options *)options;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_TEST_BYTE_VALIDATOR_OPTIONS_API_VERSION,
+        -EINVAL);
     mdata->done = false;
 
     if (opts->sequence == NULL || opts->sequence == '\0') {

--- a/src/modules/flow/test/float-generator.c
+++ b/src/modules/flow/test/float-generator.c
@@ -41,6 +41,7 @@
 #include "test-module.h"
 #include "float-generator.h"
 #include "sol-flow/test.h"
+#include "sol-flow-internal.h"
 
 static bool
 timer_tick(void *data)
@@ -70,6 +71,10 @@ float_generator_open(
     const char *it;
     char *tail;
     double *val;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_TEST_FLOAT_GENERATOR_OPTIONS_API_VERSION,
+        -EINVAL);
 
     if (opts->sequence == NULL || *opts->sequence == '\0') {
         SOL_ERR("Option 'sequence' is either NULL or empty.");

--- a/src/modules/flow/test/float-validator.c
+++ b/src/modules/flow/test/float-validator.c
@@ -41,6 +41,7 @@
 #include "test-module.h"
 #include "float-validator.h"
 #include "sol-flow/test.h"
+#include "sol-flow-internal.h"
 
 int
 float_validator_open(
@@ -55,6 +56,9 @@ float_validator_open(
     char *tail;
     double *val;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_TEST_FLOAT_VALIDATOR_OPTIONS_API_VERSION,
+        -EINVAL);
     mdata->done = false;
 
     if (opts->sequence == NULL || *opts->sequence == '\0') {

--- a/src/modules/flow/test/int-generator.c
+++ b/src/modules/flow/test/int-generator.c
@@ -42,6 +42,7 @@
 #include "test-module.h"
 #include "int-generator.h"
 #include "sol-flow/test.h"
+#include "sol-flow-internal.h"
 
 static bool
 timer_tick(void *data)
@@ -72,6 +73,10 @@ int_generator_open(
     const char *it;
     char *tail;
     int32_t *val;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_TEST_INT_GENERATOR_OPTIONS_API_VERSION,
+        -EINVAL);
 
     if (opts->sequence == NULL || *opts->sequence == '\0') {
         SOL_ERR("Option 'sequence' is either NULL or empty.");

--- a/src/modules/flow/test/int-validator.c
+++ b/src/modules/flow/test/int-validator.c
@@ -41,6 +41,7 @@
 
 #include "int-validator.h"
 #include "sol-flow/test.h"
+#include "sol-flow-internal.h"
 
 static int
 _populate_values(void *data, const char *sequence)
@@ -87,6 +88,9 @@ int_validator_open(
     const struct sol_flow_node_type_test_int_validator_options *opts =
         (const struct sol_flow_node_type_test_int_validator_options *)options;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_TEST_INT_VALIDATOR_OPTIONS_API_VERSION,
+        -EINVAL);
     mdata->done = false;
 
     if (opts->sequence == NULL || opts->sequence == '\0') {

--- a/src/modules/flow/test/result.c
+++ b/src/modules/flow/test/result.c
@@ -39,6 +39,7 @@
 #include "test-module.h"
 #include "result.h"
 #include "sol-flow/test.h"
+#include "sol-flow-internal.h"
 
 static int node_count;
 
@@ -98,6 +99,10 @@ test_result_open(
     struct test_result_data *d = data;
     const struct sol_flow_node_type_test_result_options *opts =
         (const struct sol_flow_node_type_test_result_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_TEST_RESULT_OPTIONS_API_VERSION,
+        -EINVAL);
 
     d->timer = sol_timeout_add(opts->timeout, on_timeout, node);
     SOL_NULL_CHECK_GOTO(d->timer, error);

--- a/src/modules/flow/test/string-generator.c
+++ b/src/modules/flow/test/string-generator.c
@@ -42,6 +42,7 @@
 #include "test-module.h"
 #include "string-generator.h"
 #include "sol-flow/test.h"
+#include "sol-flow-internal.h"
 
 static bool
 timer_tick(void *data)
@@ -68,6 +69,9 @@ string_generator_open(
     const struct sol_flow_node_type_test_string_generator_options *opts =
         (const struct sol_flow_node_type_test_string_generator_options *)options;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_TEST_STRING_GENERATOR_OPTIONS_API_VERSION,
+        -EINVAL);
     sol_vector_init(&mdata->values, sizeof(struct sol_str_slice));
     if (opts->sequence == NULL || *opts->sequence == '\0') {
         SOL_ERR("Option 'sequence' is either NULL or empty.");

--- a/src/modules/flow/test/string-validator.c
+++ b/src/modules/flow/test/string-validator.c
@@ -42,6 +42,7 @@
 
 #include "string-validator.h"
 #include "sol-flow/test.h"
+#include "sol-flow-internal.h"
 
 static int
 _populate_values(void *data)
@@ -89,6 +90,9 @@ string_validator_open(
     const struct sol_flow_node_type_test_string_validator_options *opts =
         (const struct sol_flow_node_type_test_string_validator_options *)options;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_TEST_STRING_VALIDATOR_OPTIONS_API_VERSION,
+        -EINVAL);
     mdata->done = false;
 
     if (opts->sequence == NULL || *opts->sequence == '\0') {

--- a/src/modules/flow/twitter/twitter.c
+++ b/src/modules/flow/twitter/twitter.c
@@ -46,6 +46,7 @@
 #include "sol-random.h"
 #include "sol-util-internal.h"
 #include "sol-vector.h"
+#include "sol-flow-internal.h"
 
 #define BASE_POST_URL "https://api.twitter.com/1.1/statuses/update.json"
 #define BASE_TIMELINE_URL "https://api.twitter.com/1.1/statuses/home_timeline.json"
@@ -594,6 +595,9 @@ twitter_open(struct sol_flow_node *node, void *data,
     struct sol_buffer buf;
     struct sol_flow_node_type_twitter_client_options *opts =
         (struct sol_flow_node_type_twitter_client_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_TWITTER_CLIENT_OPTIONS_API_VERSION, -EINVAL);
 
     mdata->consumer_key = strdup(opts->consumer_key);
     SOL_NULL_CHECK(mdata->consumer_key, -ENOMEM);

--- a/src/modules/flow/udev/udev.c
+++ b/src/modules/flow/udev/udev.c
@@ -43,6 +43,7 @@
 #include "sol-mainloop.h"
 #include "sol-util-internal.h"
 #include "sol-vector.h"
+#include "sol-flow-internal.h"
 
 struct udev_data {
     struct sol_flow_node *node;
@@ -100,6 +101,9 @@ udev_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_opt
     bool value;
     const struct sol_flow_node_type_udev_boolean_options *opts =
         (const struct sol_flow_node_type_udev_boolean_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_UDEV_BOOLEAN_OPTIONS_API_VERSION, -EINVAL);
 
     mdata->udev = udev_new();
     SOL_NULL_CHECK(mdata->udev, -EINVAL);

--- a/src/modules/flow/unix-socket/unix-socket.c
+++ b/src/modules/flow/unix-socket/unix-socket.c
@@ -38,6 +38,7 @@
 
 #include "unix-socket.h"
 #include "sol-flow/unix-socket.h"
+#include "sol-flow-internal.h"
 #include "sol-buffer.h"
 #include "sol-flow.h"
 #include "sol-mainloop.h"
@@ -97,6 +98,10 @@ boolean_reader_open(struct sol_flow_node *node, void *data, const struct sol_flo
     struct sol_flow_node_type_unix_socket_boolean_reader_options *opts =
         (struct sol_flow_node_type_unix_socket_boolean_reader_options *)options;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_UNIX_SOCKET_BOOLEAN_READER_OPTIONS_API_VERSION,
+        -EINVAL);
+
     mdata->node = node;
     if (opts->server)
         mdata->un_socket = unix_socket_server_new(mdata, opts->path, boolean_read_data);
@@ -127,6 +132,12 @@ boolean_writer_open(struct sol_flow_node *node, void *data, const struct sol_flo
     struct unix_socket_data *mdata = data;
     struct sol_flow_node_type_unix_socket_boolean_writer_options *opts =
         (struct sol_flow_node_type_unix_socket_boolean_writer_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_API_CHECK(options,
+        SOL_FLOW_NODE_OPTIONS_API_VERSION, -EINVAL);
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_UNIX_SOCKET_BOOLEAN_WRITER_OPTIONS_API_VERSION,
+        -EINVAL);
 
     mdata->node = node;
     if (opts->server)
@@ -171,6 +182,10 @@ string_reader_open(struct sol_flow_node *node, void *data, const struct sol_flow
     struct sol_flow_node_type_unix_socket_string_reader_options *opts =
         (struct sol_flow_node_type_unix_socket_string_reader_options *)options;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_UNIX_SOCKET_STRING_READER_OPTIONS_API_VERSION,
+        -EINVAL);
+
     mdata->node = node;
     if (opts->server)
         mdata->un_socket = unix_socket_server_new(mdata, opts->path, string_read_data);
@@ -209,6 +224,10 @@ string_writer_open(struct sol_flow_node *node, void *data, const struct sol_flow
     struct sol_flow_node_type_unix_socket_string_writer_options *opts =
         (struct sol_flow_node_type_unix_socket_string_writer_options *)options;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_UNIX_SOCKET_STRING_WRITER_OPTIONS_API_VERSION,
+        -EINVAL);
+
     mdata->node = node;
     if (opts->server)
         mdata->un_socket = unix_socket_server_new(mdata, opts->path, NULL);
@@ -243,6 +262,10 @@ rgb_reader_open(struct sol_flow_node *node, void *data, const struct sol_flow_no
     struct sol_flow_node_type_unix_socket_rgb_reader_options *opts =
         (struct sol_flow_node_type_unix_socket_rgb_reader_options *)options;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_UNIX_SOCKET_RGB_READER_OPTIONS_API_VERSION,
+        -EINVAL);
+
     mdata->node = node;
     if (opts->server)
         mdata->un_socket = unix_socket_server_new(mdata, opts->path, rgb_read_data);
@@ -273,6 +296,10 @@ rgb_writer_open(struct sol_flow_node *node, void *data, const struct sol_flow_no
     struct unix_socket_data *mdata = data;
     struct sol_flow_node_type_unix_socket_rgb_writer_options *opts =
         (struct sol_flow_node_type_unix_socket_rgb_writer_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_UNIX_SOCKET_RGB_WRITER_OPTIONS_API_VERSION,
+        -EINVAL);
 
     mdata->node = node;
     if (opts->server)
@@ -308,6 +335,10 @@ direction_vector_reader_open(struct sol_flow_node *node, void *data, const struc
     struct sol_flow_node_type_unix_socket_direction_vector_reader_options *opts =
         (struct sol_flow_node_type_unix_socket_direction_vector_reader_options *)options;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_UNIX_SOCKET_DIRECTION_VECTOR_READER_OPTIONS_API_VERSION,
+        -EINVAL);
+
     mdata->node = node;
     if (opts->server)
         mdata->un_socket = unix_socket_server_new(mdata, opts->path, direction_vector_read_data);
@@ -338,6 +369,10 @@ direction_vector_writer_open(struct sol_flow_node *node, void *data, const struc
     struct unix_socket_data *mdata = data;
     struct sol_flow_node_type_unix_socket_direction_vector_writer_options *opts =
         (struct sol_flow_node_type_unix_socket_direction_vector_writer_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_UNIX_SOCKET_DIRECTION_VECTOR_WRITER_OPTIONS_API_VERSION,
+        -EINVAL);
 
     mdata->node = node;
     if (opts->server)
@@ -373,6 +408,10 @@ byte_reader_open(struct sol_flow_node *node, void *data, const struct sol_flow_n
     struct sol_flow_node_type_unix_socket_byte_reader_options *opts =
         (struct sol_flow_node_type_unix_socket_byte_reader_options *)options;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_UNIX_SOCKET_DIRECTION_VECTOR_READER_OPTIONS_API_VERSION,
+        -EINVAL);
+
     mdata->node = node;
     if (opts->server)
         mdata->un_socket = unix_socket_server_new(mdata, opts->path, byte_read_data);
@@ -403,6 +442,10 @@ byte_writer_open(struct sol_flow_node *node, void *data, const struct sol_flow_n
     struct unix_socket_data *mdata = data;
     struct sol_flow_node_type_unix_socket_byte_writer_options *opts =
         (struct sol_flow_node_type_unix_socket_byte_writer_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_UNIX_SOCKET_BYTE_WRITER_OPTIONS_API_VERSION,
+        -EINVAL);
 
     mdata->node = node;
     if (opts->server)
@@ -438,6 +481,10 @@ int_reader_open(struct sol_flow_node *node, void *data, const struct sol_flow_no
     struct sol_flow_node_type_unix_socket_int_reader_options *opts =
         (struct sol_flow_node_type_unix_socket_int_reader_options *)options;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_UNIX_SOCKET_INT_READER_OPTIONS_API_VERSION,
+        -EINVAL);
+
     mdata->node = node;
     if (opts->server)
         mdata->un_socket = unix_socket_server_new(mdata, opts->path, int_read_data);
@@ -468,6 +515,10 @@ int_writer_open(struct sol_flow_node *node, void *data, const struct sol_flow_no
     struct unix_socket_data *mdata = data;
     struct sol_flow_node_type_unix_socket_int_writer_options *opts =
         (struct sol_flow_node_type_unix_socket_int_writer_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_UNIX_SOCKET_INT_WRITER_OPTIONS_API_VERSION,
+        -EINVAL);
 
     mdata->node = node;
     if (opts->server)
@@ -503,6 +554,10 @@ float_reader_open(struct sol_flow_node *node, void *data, const struct sol_flow_
     struct sol_flow_node_type_unix_socket_float_reader_options *opts =
         (struct sol_flow_node_type_unix_socket_float_reader_options *)options;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_UNIX_SOCKET_FLOAT_READER_OPTIONS_API_VERSION,
+        -EINVAL);
+
     mdata->node = node;
     if (opts->server)
         mdata->un_socket = unix_socket_server_new(mdata, opts->path, float_read_data);
@@ -533,6 +588,10 @@ float_writer_open(struct sol_flow_node *node, void *data, const struct sol_flow_
     struct unix_socket_data *mdata = data;
     struct sol_flow_node_type_unix_socket_float_writer_options *opts =
         (struct sol_flow_node_type_unix_socket_float_writer_options *)options;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_UNIX_SOCKET_FLOAT_WRITER_OPTIONS_API_VERSION,
+        -EINVAL);
 
     mdata->node = node;
     if (opts->server)

--- a/src/modules/flow/wallclock/wallclock.c
+++ b/src/modules/flow/wallclock/wallclock.c
@@ -363,6 +363,10 @@ wallclock_second_open(struct sol_flow_node *node,
     struct wallclock_data *mdata = data;
     const struct sol_flow_node_type_wallclock_second_options *opts;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_WALLCLOCK_SECOND_OPTIONS_API_VERSION,
+        -EINVAL);
+
     opts = (const struct sol_flow_node_type_wallclock_second_options *)
         options;
     mdata->type = TIMEOUT_SECOND;
@@ -376,6 +380,10 @@ wallclock_minute_open(struct sol_flow_node *node,
 {
     struct wallclock_data *mdata = data;
     const struct sol_flow_node_type_wallclock_minute_options *opts;
+
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_WALLCLOCK_MINUTE_OPTIONS_API_VERSION,
+        -EINVAL);
 
     opts = (const struct sol_flow_node_type_wallclock_minute_options *)
         options;
@@ -391,6 +399,10 @@ wallclock_hour_open(struct sol_flow_node *node,
     struct wallclock_data *mdata = data;
     const struct sol_flow_node_type_wallclock_hour_options *opts;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_WALLCLOCK_HOUR_OPTIONS_API_VERSION,
+        -EINVAL);
+
     opts = (const struct sol_flow_node_type_wallclock_hour_options *)
         options;
     mdata->type = TIMEOUT_HOUR;
@@ -405,6 +417,9 @@ wallclock_weekday_open(struct sol_flow_node *node,
     struct wallclock_data *mdata = data;
     const struct sol_flow_node_type_wallclock_weekday_options *opts;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_WALLCLOCK_WEEKDAY_OPTIONS_API_VERSION,
+        -EINVAL);
     opts = (const struct sol_flow_node_type_wallclock_weekday_options *)
         options;
     mdata->type = TIMEOUT_WEEKDAY;
@@ -419,6 +434,9 @@ wallclock_monthday_open(struct sol_flow_node *node,
     struct wallclock_data *mdata = data;
     const struct sol_flow_node_type_wallclock_monthday_options *opts;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_WALLCLOCK_MONTHDAY_OPTIONS_API_VERSION,
+        -EINVAL);
     opts = (const struct sol_flow_node_type_wallclock_monthday_options *)
         options;
     mdata->type = TIMEOUT_MONTHDAY;
@@ -433,6 +451,9 @@ wallclock_month_open(struct sol_flow_node *node,
     struct wallclock_data *mdata = data;
     const struct sol_flow_node_type_wallclock_month_options *opts;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_WALLCLOCK_MONTH_OPTIONS_API_VERSION,
+        -EINVAL);
     opts = (const struct sol_flow_node_type_wallclock_month_options *)
         options;
     mdata->type = TIMEOUT_MONTH;
@@ -447,6 +468,9 @@ wallclock_year_open(struct sol_flow_node *node,
     struct wallclock_data *mdata = data;
     const struct sol_flow_node_type_wallclock_year_options *opts;
 
+    SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
+        SOL_FLOW_NODE_TYPE_WALLCLOCK_YEAR_OPTIONS_API_VERSION,
+        -EINVAL);
     opts = (const struct sol_flow_node_type_wallclock_year_options *)
         options;
     mdata->type = TIMEOUT_YEAR;

--- a/src/modules/linux-micro/network-up/network-up.c
+++ b/src/modules/linux-micro/network-up/network-up.c
@@ -45,6 +45,8 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "linux-micro-network-up");
 static void
 _network_event_cb(void *data, const struct sol_network_link *link, enum sol_network_event event)
 {
+    SOL_NETWORK_LINK_CHECK_VERSION(link);
+
     switch (event) {
     case SOL_NETWORK_LINK_ADDED:
         sol_network_link_up(link->index);
@@ -65,6 +67,7 @@ network_up_start(const struct sol_platform_linux_micro_module *mod, const char *
 
     links = sol_network_get_available_links();
     SOL_VECTOR_FOREACH_IDX (links, itr, idx) {
+        SOL_NETWORK_LINK_CHECK_VERSION(itr, -EINVAL);
         sol_network_link_up(itr->index);
     }
 

--- a/src/modules/update/update-common/http.c
+++ b/src/modules/update/update-common/http.c
@@ -109,6 +109,8 @@ task_get_metadata_response(void *data, const struct sol_http_client_connection *
     handle->conn = NULL;
     handle->on_callback = true;
 
+    SOL_HTTP_RESPONSE_CHECK_API(http_response);
+
     if (http_response->response_code != SOL_HTTP_STATUS_OK) {
         SOL_WRN("Invalid response code from [%s] when checking for update: %d",
             handle->url, http_response->response_code);
@@ -198,6 +200,8 @@ task_fetch_response(void *data, const struct sol_http_client_connection *conn,
 
     handle->conn = NULL;
     handle->on_callback = true;
+
+    SOL_HTTP_RESPONSE_CHECK_API(http_response);
 
     if (http_response->response_code != SOL_HTTP_STATUS_OK) {
         SOL_WRN("Invalid response code from [%s] when fetching update: %d",

--- a/src/samples/coap/iotivity-test-client.c
+++ b/src/samples/coap/iotivity-test-client.c
@@ -478,6 +478,18 @@ found_resource(struct sol_oic_client *cli, struct sol_oic_resource *res, void *d
     bool (*fill_repr_map)(void *data, struct sol_oic_map_writer *repr_map) = NULL;
     struct sol_str_slice href;
 
+    if (!res)
+        return false;
+
+#ifndef SOL_NO_API_VERSION
+    if (SOL_UNLIKELY(res->api_version != SOL_OIC_RESOURCE_API_VERSION)) {
+        SOL_WRN("Couldn't add resource_type with "
+            "version '%u'. Expected version '%u'.",
+            res->api_version, SOL_OIC_RESOURCE_API_VERSION);
+        return NULL;
+    }
+#endif
+
     if (!found_resource_print(cli, res, data))
         return false;
 

--- a/src/samples/coap/oic-client.c
+++ b/src/samples/coap/oic-client.c
@@ -111,6 +111,15 @@ found_resource(struct sol_oic_client *cli, struct sol_oic_resource *res, void *d
     if (!res)
         return false;
 
+#ifndef SOL_NO_API_VERSION
+    if (SOL_UNLIKELY(res->api_version != SOL_OIC_RESOURCE_API_VERSION)) {
+        SOL_WRN("Couldn't add resource_type with "
+            "version '%u'. Expected version '%u'.",
+            res->api_version, SOL_OIC_RESOURCE_API_VERSION);
+        return NULL;
+    }
+#endif
+
     if (!sol_network_addr_to_str(&res->addr, addr, sizeof(addr))) {
         SOL_WRN("Could not convert network address to string");
         return false;

--- a/src/samples/http/client.c
+++ b/src/samples/http/client.c
@@ -47,6 +47,7 @@
 #include "sol-mainloop.h"
 #include "sol-http.h"
 #include "sol-http-client.h"
+#include "sol-log.h"
 
 static bool verbose = false;
 
@@ -54,6 +55,10 @@ static void
 response_cb(void *userdata, const struct sol_http_client_connection *connection,
     struct sol_http_response *response)
 {
+
+    SOL_HTTP_RESPONSE_CHECK_API(response);
+    SOL_HTTP_PARAMS_CHECK_API_VERSION(&response->param);
+
     if (response->response_code != SOL_HTTP_STATUS_OK) {
         fprintf(stderr, "Finished with error, response code: %d\n",
             response->response_code);

--- a/src/samples/http/download.c
+++ b/src/samples/http/download.c
@@ -38,6 +38,7 @@
 #include "sol-mainloop.h"
 #include "sol-http.h"
 #include "sol-http-client.h"
+#include "sol-log.h"
 
 static FILE *fd;
 struct sol_http_client_connection *pending;
@@ -64,6 +65,8 @@ response_func(void *userdata, const struct sol_http_client_connection *connectio
     fclose(fd);
     fd = NULL;
     pending = NULL;
+
+    SOL_HTTP_RESPONSE_CHECK_API(response);
 
     if (response->response_code != SOL_HTTP_STATUS_OK) {
         fprintf(stderr, "ERROR: Finished with error, response code: %d\n", response->response_code);

--- a/src/samples/mavlink/basic.c
+++ b/src/samples/mavlink/basic.c
@@ -169,6 +169,7 @@ main(int argc, char *argv[])
 {
     struct sol_mavlink *mavlink;
     struct sol_mavlink_handlers mavlink_handlers = {
+        SOL_SET_API_VERSION(.api_version = SOL_MAVLINK_HANDLERS_API_VERSION, )
         .connect = mavlink_connect_cb,
         .position_changed = position_changed_cb,
         .mode_changed = mode_changed_cb,
@@ -177,6 +178,7 @@ main(int argc, char *argv[])
         .mission_reached = mission_reached_cb,
     };
     struct sol_mavlink_config config = {
+        SOL_SET_API_VERSION(.api_version = SOL_MAVLINK_CONFIG_API_VERSION, )
         .handlers = &mavlink_handlers,
     };
 

--- a/src/samples/mavlink/goto.c
+++ b/src/samples/mavlink/goto.c
@@ -195,6 +195,7 @@ main(int argc, char *argv[])
 {
     struct sol_mavlink *mavlink;
     struct sol_mavlink_handlers mavlink_handlers = {
+        SOL_SET_API_VERSION(.api_version = SOL_MAVLINK_HANDLERS_API_VERSION, )
         .connect = mavlink_connect_cb,
         .mode_changed = mode_changed_cb,
         .armed = armed_cb,
@@ -203,6 +204,7 @@ main(int argc, char *argv[])
         .mission_reached = mission_reached_cb,
     };
     struct sol_mavlink_config config = {
+        SOL_SET_API_VERSION(.api_version = SOL_MAVLINK_CONFIG_API_VERSION, )
         .handlers = &mavlink_handlers,
     };
 

--- a/src/samples/mqtt/mqtt-publish.c
+++ b/src/samples/mqtt/mqtt-publish.c
@@ -101,6 +101,7 @@ const struct sol_mqtt_config config = {
     .clean_session = true,
     .keepalive = 60,
     .handlers = {
+        SOL_SET_API_VERSION(.api_version = SOL_MQTT_HANDLERS_API_VERSION, )
         .connect = on_connect,
         .disconnect = on_disconnect,
     },
@@ -126,6 +127,7 @@ main(int argc, char *argv[])
     payload = SOL_BUFFER_INIT_CONST(argv[4], strlen(argv[4]));
 
     message = (struct sol_mqtt_message){
+        SOL_SET_API_VERSION(.api_version = SOL_MQTT_MESSAGE_API_VERSION, )
         .topic = topic,
         .payload = &payload,
         .qos = SOL_MQTT_QOS_EXACTLY_ONCE,

--- a/src/samples/mqtt/mqtt-subscribe.c
+++ b/src/samples/mqtt/mqtt-subscribe.c
@@ -51,6 +51,7 @@ static void
 on_message(void *data, struct sol_mqtt *mqtt, const struct sol_mqtt_message *message)
 {
     SOL_NULL_CHECK(message);
+    SOL_MQTT_MESSAGE_CHECK_API_VERSION(message);
 
     SOL_INF("%.*s", (int)message->payload->used, (char *)message->payload->data);
 }
@@ -86,6 +87,7 @@ const struct sol_mqtt_config config = {
     .clean_session = true,
     .keepalive = 60,
     .handlers = {
+        SOL_SET_API_VERSION(.api_version = SOL_MQTT_HANDLERS_API_VERSION, )
         .connect = on_connect,
         .disconnect = on_disconnect,
         .message = on_message,

--- a/src/samples/network/network-status.c
+++ b/src/samples/network/network-status.c
@@ -51,6 +51,7 @@
 #include "sol-mainloop.h"
 #include "sol-network.h"
 #include "sol-vector.h"
+#include "sol-log.h"
 
 static regex_t regex;
 
@@ -91,6 +92,8 @@ static void
 _on_network_event(void *data, const struct sol_network_link *link, enum sol_network_event event)
 {
     char *name;
+
+    SOL_NETWORK_LINK_CHECK_VERSION(link);
 
     if (!_match_link(link))
         return;

--- a/src/shared/sol-conffile.c
+++ b/src/shared/sol-conffile.c
@@ -376,7 +376,7 @@ _parse_maps(struct sol_json_token token)
         map = calloc(1, sizeof(struct sol_memmap_map) + entries_vector_size);
         SOL_NULL_CHECK_GOTO(map, error);
 
-        map->version = version;
+        map->api_version = version;
         map->timeout = timeout;
         r = sol_json_token_get_unescaped_string(&path, &path_buffer);
         SOL_INT_CHECK_GOTO(r, < 0, error);

--- a/src/test/test-persistence-memmap.c
+++ b/src/test/test-persistence-memmap.c
@@ -75,7 +75,7 @@ static const struct sol_str_table_ptr _memmap0_entries[] = {
 };
 
 static const struct sol_memmap_map _memmap0 = {
-    .version = 1,
+    .api_version = 1,
     .path = "memmap-test.bin",
     .entries = _memmap0_entries
 };
@@ -120,7 +120,7 @@ static const struct sol_str_table_ptr _memmap1_entries[] = {
 };
 
 static const struct sol_memmap_map _memmap1 = {
-    .version = 1,
+    .api_version = 1,
     .path = "memmap-test2.bin",
     .entries = _memmap1_entries
 };


### PR DESCRIPTION
They should be uint16_t and it's not necessary enforce a sub_api field.
This patch also add some API checks in some places.

Signed-off-by: Guilherme Iscaro <guilherme.iscaro@intel.com>