### PR TITLE
Fix check of snprintf() return value

### DIFF
--- a/src/lib/comms/sol-oic-client.c
+++ b/src/lib/comms/sol-oic-client.c
@@ -787,7 +787,7 @@ sol_oic_client_find_resource(struct sol_oic_client *client,
         char query[64];
 
         r = snprintf(query, sizeof(query), "rt=%s", resource_type);
-        if (r < 0 || r > (int)sizeof(query))
+        if (r < 0 || r >= (int)sizeof(query))
             goto out;
 
         sol_coap_add_option(req, SOL_COAP_OPTION_URI_QUERY, query, r);

--- a/src/lib/io/sol-gpio-impl-linux.c
+++ b/src/lib/io/sol-gpio-impl-linux.c
@@ -94,7 +94,7 @@ _gpio_export(uint32_t gpio, bool unexport)
         return true;
 
     len = snprintf(gpio_dir, sizeof(gpio_dir), GPIO_BASE "/gpio%u", gpio);
-    if (len < 0 || len > PATH_MAX)
+    if (len < 0 || len >= PATH_MAX)
         return false;
 
     /* busywait for the exported gpio's sysfs entry to be created. It's
@@ -134,7 +134,7 @@ _gpio_open_fd(struct sol_gpio *gpio, enum sol_gpio_direction dir)
     }
 
     len = snprintf(path, sizeof(path), GPIO_BASE "/gpio%u/value", gpio->pin);
-    if (len < 0 || len > PATH_MAX)
+    if (len < 0 || len >= PATH_MAX)
         return -ENAMETOOLONG;
 
     gpio->fp = fopen(path, mode);

--- a/src/lib/io/sol-pwm-impl-linux.c
+++ b/src/lib/io/sol-pwm-impl-linux.c
@@ -98,7 +98,7 @@ _pwm_export(int device, int channel, bool export)
         return true;
 
     len = snprintf(path, sizeof(path), PWM_BASE "/pwmchip%d/pwm%d", device, channel);
-    if (len < 0 || len > (int)sizeof(path))
+    if (len < 0 || len >= (int)sizeof(path))
         return false;
 
     /* busywait for the exported pwm's sysfs entry to be created. It's

--- a/src/modules/pin-mux/intel-common/intel-common.c
+++ b/src/modules/pin-mux/intel-common/intel-common.c
@@ -113,7 +113,7 @@ _set_gpio(uint32_t pin, enum sol_gpio_direction dir, int drive, bool val)
     // you used it and we have no way of differentiate those. So its ok to fail
     // to write
     len = snprintf(path, sizeof(path), BASE "/gpio%d/drive", pin);
-    if (len < 0 || len > PATH_MAX || stat(path, &st) == -1)
+    if (len < 0 || len >= PATH_MAX || stat(path, &st) == -1)
         goto end;
 
     switch (drive) {
@@ -144,7 +144,7 @@ _set_mode(uint32_t pin, int mode)
     char mode_str[] = "mode0";
 
     len = snprintf(path, sizeof(path), MODE_PATH, pin);
-    if (len < 0 || len > PATH_MAX || stat(path, &st) == -1)
+    if (len < 0 || len >= PATH_MAX || stat(path, &st) == -1)
         return -EINVAL;
 
     mode_str[4] = '0' + (mode - PIN_MODE_0);

--- a/src/shared/sol-util-file.c
+++ b/src/shared/sol-util-file.c
@@ -373,7 +373,7 @@ sol_util_get_rootdir(char *out, size_t size)
     }
 
     r = snprintf(out, size, "%.*s/", (int)(strlen(progname) - strlen(substr)), progname);
-    return (r < 0 || r > (int)size) ? -ENOMEM : r;
+    return (r < 0 || r >= (int)size) ? -ENOMEM : r;
 }
 
 SOL_API int


### PR DESCRIPTION
Patch made with Coccinelle using the following spatch:

    @@
    type T;
    T ret;
    expression size;
    @@

    <...
    ret = snprintf(...);
    ...
    (
    -ret < 0 || ret > size
    +ret < 0 || ret >= size
    )
    ...>

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>