### PR TITLE
oic: Make /oic/d and /oic/p resources discoverable - v2

### DIFF
--- a/src/lib/comms/include/sol-oic-server.h
+++ b/src/lib/comms/include/sol-oic-server.h
@@ -221,6 +221,13 @@ struct sol_oic_resource_type {
      */
     struct sol_str_slice interface;
 
+    /**
+     * @brief String representation of the path of this resource.
+     * If path.data == NULL or path.len == 0, a path will be generated
+     * automatically for this resource.
+     */
+    struct sol_str_slice path;
+
     struct {
         sol_coap_responsecode_t (*handle)(const struct sol_network_link_addr *cliaddr,
             const void *data, const struct sol_oic_map_reader *input, struct sol_oic_map_writer *output);

--- a/src/lib/comms/sol-oic-cbor.h
+++ b/src/lib/comms/sol-oic-cbor.h
@@ -68,6 +68,9 @@ enum sol_oic_payload_type {
     SOL_OIC_PAYLOAD_REPRESENTATION = 4,
 };
 
+#define SOL_OIC_DEVICE_PATH "/oic/d"
+#define SOL_OIC_PLATFORM_PATH "/oic/p"
+
 #define SOL_OIC_KEY_REPRESENTATION "rep"
 #define SOL_OIC_KEY_HREF "href"
 #define SOL_OIC_KEY_PLATFORM_ID "pi"

--- a/src/lib/comms/sol-oic-client.c
+++ b/src/lib/comms/sol-oic-client.c
@@ -474,7 +474,7 @@ sol_oic_client_get_platform_info(struct sol_oic_client *client,
     OIC_RESOURCE_CHECK_API(resource, false);
 
     server = _best_server_for_resource(client, resource,  &addr);
-    return client_get_info(client, server, &addr, "/oic/p",
+    return client_get_info(client, server, &addr, SOL_OIC_PLATFORM_PATH,
         _platform_info_reply_cb, info_received_cb, data);
 }
 
@@ -491,7 +491,7 @@ sol_oic_client_get_platform_info_by_addr(struct sol_oic_client *client,
     OIC_CLIENT_CHECK_API(client, false);
     SOL_NULL_CHECK(addr, false);
 
-    return client_get_info(client, client->server, addr, "/oic/p",
+    return client_get_info(client, client->server, addr, SOL_OIC_PLATFORM_PATH,
         _platform_info_reply_cb, info_received_cb, data);
 }
 
@@ -518,7 +518,7 @@ sol_oic_client_get_server_info(struct sol_oic_client *client,
         const struct sol_oic_platform_information *info, void *data))
         info_received_cb;
     server = _best_server_for_resource(client, resource,  &addr);
-    return client_get_info(client, server, &addr, "/oic/d",
+    return client_get_info(client, server, &addr, SOL_OIC_DEVICE_PATH,
         _server_info_reply_cb, cb, data);
 }
 
@@ -541,7 +541,7 @@ sol_oic_client_get_server_info_by_addr(struct sol_oic_client *client,
     cb = (void (*)(struct sol_oic_client *cli,
         const struct sol_oic_platform_information *info, void *data))
         info_received_cb;
-    return client_get_info(client, client->server, addr, "/oic/d",
+    return client_get_info(client, client->server, addr, SOL_OIC_DEVICE_PATH,
         _server_info_reply_cb, cb, data);
 }
 

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -530,19 +530,10 @@ sol_oic_server_shutdown(void)
         return;
 
     SOL_PTR_VECTOR_FOREACH_REVERSE_IDX (&oic_server.resources, res, idx)
-        sol_coap_server_unregister_resource(oic_server.server, res->coap);
-    if (oic_server.dtls_server) {
-        SOL_PTR_VECTOR_FOREACH_REVERSE_IDX (&oic_server.resources, res, idx)
-            sol_coap_server_unregister_resource(oic_server.dtls_server,
-                res->coap);
+        sol_oic_server_del_resource(res);
 
-        sol_coap_server_unregister_resource(oic_server.dtls_server, &oic_d_coap_resource);
-        sol_coap_server_unregister_resource(oic_server.dtls_server, &oic_p_coap_resource);
+    if (oic_server.dtls_server)
         sol_coap_server_unref(oic_server.dtls_server);
-    }
-    SOL_PTR_VECTOR_FOREACH_REVERSE_IDX (&oic_server.resources, res, idx)
-        free(res);
-    sol_ptr_vector_clear(&oic_server.resources);
 
     sol_coap_server_unregister_resource(oic_server.server, &oic_d_coap_resource);
     sol_coap_server_unregister_resource(oic_server.server, &oic_p_coap_resource);


### PR DESCRIPTION
Changelog from v2:
 - Use field from sol_oic_resource_type struct to inform resource's path to sol_oic_server_add_resource
 - Add overflow check in function that generates resource's name.
Replaces #1410