### PR TITLE
TEST, please ignore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,14 +31,9 @@ nodejs_bindings: $(SOL_LIB_OUTPUT)
 	# Build the package without clobbering build/
 	@ \
 		SOLETTA_CFLAGS="$(addprefix -I,$(abspath $(HEADERDIRS)))" \
-		SOLETTA_LIBS="$(FIND_LIBRARY_LDFLAGS)" \
-		NODE_GYP="$$(if test -x "$$(which node-gyp 2> /dev/null)"; then \
-				echo "$$(which node-gyp)"; \
-			elif test -x "$$(dirname $$(which node))/../lib/node_modules/npm/bin/node-gyp-bin/node-gyp"; then \
-				echo "$$(dirname $$(which node))/../lib/node_modules/npm/bin/node-gyp-bin/node-gyp"; \
-			fi)"; \
-		( SOLETTA_CFLAGS="$${SOLETTA_CFLAGS}" SOLETTA_LIBS="$${SOLETTA_LIBS}" $${NODE_GYP} configure && \
-		SOLETTA_CFLAGS="$${SOLETTA_CFLAGS}" SOLETTA_LIBS="$${SOLETTA_LIBS}" $${NODE_GYP} build )
+		SOLETTA_LIBS="$(FIND_LIBRARY_LDFLAGS)"; \
+		( SOLETTA_CFLAGS="$${SOLETTA_CFLAGS}" SOLETTA_LIBS="$${SOLETTA_LIBS}" $(NODE_GYP) $(NODE_GYP_FLAGS) configure && \
+		SOLETTA_CFLAGS="$${SOLETTA_CFLAGS}" SOLETTA_LIBS="$${SOLETTA_LIBS}" $(NODE_GYP) $(NODE_GYP_FLAGS) build )
 
 PHONY += nodejs_bindings
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -28,10 +28,7 @@
 						"action_name": "collectbindings",
 						"message": "Collecting bindings",
 						"outputs": [ "bindings/nodejs/generated/main.cc" ],
-						"inputs": [
-							"bindings/nodejs/generated/main.cc.prologue",
-							"bindings/nodejs/generated/main.cc.epilogue",
-						],
+						"inputs": [ "" ],
 						"action": [
 							"sh",
 							"-c",

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -486,3 +486,13 @@ $(top_srcdir)src/test-fbp/javascript.fbp-CFLAGS := -I$(top_srcdir)src/thirdparty
 else
 TEST_FBP_SCRIPT_SKIP_EXTRA := SKIP_JAVASCRIPT
 endif
+
+ifneq ($(USE_NODEJS),)
+NODE_GYP ?= $(shell \
+	if test -x "$$(which node-gyp 2> /dev/null)"; then \
+		which node-gyp; \
+	elif test -x "$$(dirname $$(which node))/../lib/node_modules/npm/bin/node-gyp-bin/node-gyp"; then \
+		echo "$$(dirname $$(which node))/../lib/node_modules/npm/bin/node-gyp-bin/node-gyp"; \
+	fi; \
+)
+endif


### PR DESCRIPTION
When building node.js bindings as part of a package it is important to have
provisions for allowing the integrator to specify the path to node-gyp and
additional flags with which it should run.

Signed-off-by: Gabriel Schulhof <gabriel.schulhof@intel.com>