### PR TITLE
oic: Fix uninitialized memory access in no-payload requests

### DIFF
--- a/src/lib/comms/include/sol-oic-server.h
+++ b/src/lib/comms/include/sol-oic-server.h
@@ -237,8 +237,8 @@ struct sol_oic_resource_type {
      *
      * @param cliaddr The client address.
      * @param data The user's data pointer.
-     * @param input Handler to read request packet data using, for example,
-     *        @ref SOL_OIC_MAP_LOOP() macro.
+     * @param input Always NULL because GET requests shouldn't cointain payload
+     *        data. Parameter kept for compatibility reasons.
      * @param output Handler to write data to response packet using, for
      *        example, @ref sol_oic_map_append().
      *
@@ -276,8 +276,8 @@ struct sol_oic_resource_type {
      *
      * @param cliaddr The client address.
      * @param data The user's data pointer.
-     * @param input Handler to read request packet data using, for example,
-     *        @ref SOL_OIC_MAP_LOOP() macro.
+     * @param input Always NULL because DELETE requests shouldn't cointain
+     *        payload data. Parameter kept for compatibility reasons.
      * @param output Handler to write data to response packet using, for
      *        example, @ref sol_oic_map_append().
      *

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -499,7 +499,7 @@ _sol_oic_resource_type_handle(
     struct sol_oic_server_resource *res, bool expect_payload)
 {
     struct sol_coap_packet *response;
-    struct sol_oic_map_reader input;
+    struct sol_oic_map_reader input, *input_ptr = NULL;
     struct sol_oic_map_writer output;
     sol_coap_responsecode_t code = SOL_COAP_RSPCODE_INTERNAL_ERROR;
     CborParser parser;
@@ -526,10 +526,11 @@ _sol_oic_resource_type_handle(
             code = SOL_COAP_RSPCODE_BAD_REQUEST;
             goto done;
         }
+        input_ptr = &input;
     }
 
     sol_oic_packet_cbor_create(response, res->href, &output);
-    code = handle_fn(cliaddr, res->callback.data, &input, &output);
+    code = handle_fn(cliaddr, res->callback.data, input_ptr, &output);
     if (sol_oic_packet_cbor_close(response, &output) != CborNoError)
         code = SOL_COAP_RSPCODE_INTERNAL_ERROR;
 
@@ -553,7 +554,7 @@ done:
 DEFINE_RESOURCE_TYPE_CALLBACK_FOR_METHOD(get, false)
 DEFINE_RESOURCE_TYPE_CALLBACK_FOR_METHOD(put, true)
 DEFINE_RESOURCE_TYPE_CALLBACK_FOR_METHOD(post, true)
-DEFINE_RESOURCE_TYPE_CALLBACK_FOR_METHOD(del, true)
+DEFINE_RESOURCE_TYPE_CALLBACK_FOR_METHOD(del, false)
 
 #undef DEFINE_RESOURCE_TYPE_CALLBACK_FOR_METHOD
 


### PR DESCRIPTION
Payload should be ignored for GET and DELETE requests, so we should use
NULL as the input parameter when calling the callback. Instead of
removing the input parameter, this approach was prefered so we can use
the same function was callback to multiple methods.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>