### PR TITLE
oic: Do not include platform specific network headers - v2

### DIFF
--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -961,14 +961,12 @@ def master_json_as_string(generated, json_name):
 
 def master_c_as_string(generated, oic_gen_c, oic_gen_h):
     generated = list(generated)
-    code = '''#include <arpa/inet.h>
+    code = '''
 #include <assert.h>
 #include <errno.h>
 #include <math.h>
-#include <netinet/in.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/socket.h>
 
 #include "%(oic_gen_h)s"
 

--- a/src/lib/comms/sol-oic-client.c
+++ b/src/lib/comms/sol-oic-client.c
@@ -30,15 +30,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <arpa/inet.h>
 #include <errno.h>
-#include <fcntl.h>
-#include <netinet/in.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/socket.h>
 
 #include "cbor.h"
 #include "sol-coap.h"

--- a/src/samples/coap/oic-client.c
+++ b/src/samples/coap/oic-client.c
@@ -31,7 +31,6 @@
  */
 
 #include <stdio.h>
-#include <arpa/inet.h>
 
 #include "sol-log.h"
 #include "sol-mainloop.h"

--- a/src/samples/coap/oic-server.c
+++ b/src/samples/coap/oic-server.c
@@ -33,13 +33,11 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/kd.h>
-#include <netinet/in.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
-#include <sys/socket.h>
 
 #include "sol-log.h"
 #include "sol-mainloop.h"


### PR DESCRIPTION
v2: Even less includes - on oic samples and lib.

They are not necessary and may break build on different platforms.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>
