### PR TITLE
Build: Enable fPIC for all builds

### DIFF
--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -259,9 +259,7 @@ DEP_RESOLVER_CFLAGS := $(CFLAGS) -Werror=implicit-function-declaration
 DEP_RESOLVER_LDFLAGS := $(LDFLAGS)
 MISSING_H := $(top_srcdir)src/lib/common/sol-missing.h
 
-ifeq (y,$(SHARED_LIBRARY))
 COMMON_CFLAGS += -fPIC
-endif
 
 ifeq (y,$(BUILD_TYPE_DEBUG))
 COMMON_CFLAGS += -g -fno-lto


### PR DESCRIPTION
Since our binaries are compiled with fPIE now, when compiling
Soletta as a static library the linker will complain that Soletta
is not linked with fPIC.

Hardening output as static lib:

hardening-check build/soletta_sysroot/usr/bin/sol-fbp-runner
build/soletta_sysroot/usr/bin/sol-fbp-runner:
 Position Independent Executable: yes
 Stack protected: yes
 Fortify Source functions: yes (some protected functions found)
 Read-only relocations: yes
 Immediate binding: yes

Signed-off-by: Guilherme Iscaro <guilherme.iscaro@intel.com>