### PR TITLE
build:mavlink: Fix dependency

### DIFF
--- a/src/lib/comms/Kconfig
+++ b/src/lib/comms/Kconfig
@@ -110,7 +110,7 @@ config MQTT
 config MAVLINK
 	bool "Mavlink"
 	default y
-    depends on NETWORK && HAVE_MAVLINK_SRC
+    depends on LINUX && NETWORK && HAVE_MAVLINK_SRC
     help
             MAVLink or Micro Air Vehicle Link is a protocol for communicating with
             small unmanned vehicle. It is designed as a header-only message marshaling


### PR DESCRIPTION
Makes mavlink depends on linux.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>