### PR TITLE
build: Set max log level to error on release mode

### DIFF
--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -327,6 +327,7 @@ config LOG
 
 choice
 	prompt "Maximum allowed log level"
+	default MAXIMUM_LOG_LEVEL_ERROR if BUILD_TYPE_RELEASE
 	default MAXIMUM_LOG_LEVEL_UNLIMITED
 	depends on LOG
 	help


### PR DESCRIPTION
If a user is building Soletta on release mode,
set max log level to error, so no debug or informative
messages are logged / displayed.

Otherwise sensitive information regarding their products
eventually would be displayed if the enviroment
variable that sets log levels were changed
by product users / attackers.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>