### PR TITLE
mavlink: protect against uninitialized fields on mavlink_message_t

### DIFF
--- a/src/lib/comms/sol-mavlink.c
+++ b/src/lib/comms/sol-mavlink.c
@@ -309,7 +309,7 @@ sol_mavlink_check_known_vehicle(uint8_t type)
 static bool
 sol_mavlink_request_home_position(struct sol_mavlink *mavlink)
 {
-    mavlink_message_t msg;
+    mavlink_message_t msg = { 0 };
     uint8_t buf[MAVLINK_MAX_PACKET_LEN];
     uint16_t len;
 
@@ -436,7 +436,7 @@ static bool
 sol_mavlink_fd_handler(void *data, int fd, uint32_t cond)
 {
     struct sol_mavlink *mavlink = data;
-    mavlink_message_t msg;
+    mavlink_message_t msg = { 0 };
     mavlink_status_t status;
     uint8_t buf[MAVLINK_MAX_PACKET_LEN] = { 0 };
     int i, res;
@@ -491,7 +491,7 @@ sol_mavlink_fd_handler(void *data, int fd, uint32_t cond)
 static bool
 setup_data_stream(struct sol_mavlink *mavlink)
 {
-    mavlink_message_t msg;
+    mavlink_message_t msg = { 0 };
     uint8_t buf[MAVLINK_MAX_PACKET_LEN];
     uint16_t len;
 
@@ -766,7 +766,7 @@ sol_mavlink_disconnect(struct sol_mavlink *mavlink)
 SOL_API int
 sol_mavlink_set_armed(struct sol_mavlink *mavlink, bool armed)
 {
-    mavlink_message_t msg;
+    mavlink_message_t msg = { 0 };
     uint8_t buf[MAVLINK_MAX_PACKET_LEN];
     uint16_t len, res;
     bool curr;
@@ -790,7 +790,7 @@ sol_mavlink_set_armed(struct sol_mavlink *mavlink, bool armed)
 SOL_API int
 sol_mavlink_takeoff(struct sol_mavlink *mavlink, struct sol_mavlink_position *pos)
 {
-    mavlink_message_t msg;
+    mavlink_message_t msg = { 0 };
     uint8_t buf[MAVLINK_MAX_PACKET_LEN];
     uint16_t len, res;
 
@@ -812,7 +812,7 @@ sol_mavlink_takeoff(struct sol_mavlink *mavlink, struct sol_mavlink_position *po
 SOL_API int
 sol_mavlink_land(struct sol_mavlink *mavlink, struct sol_mavlink_position *pos)
 {
-    mavlink_message_t msg;
+    mavlink_message_t msg = { 0 };
     uint8_t buf[MAVLINK_MAX_PACKET_LEN];
     uint16_t len, res;
 
@@ -834,7 +834,7 @@ sol_mavlink_land(struct sol_mavlink *mavlink, struct sol_mavlink_position *pos)
 SOL_API int
 sol_mavlink_set_mode(struct sol_mavlink *mavlink, enum sol_mavlink_mode mode)
 {
-    mavlink_message_t msg;
+    mavlink_message_t msg = { 0 };
     uint8_t buf[MAVLINK_MAX_PACKET_LEN], custom_mode;
     uint16_t len, res;
 
@@ -916,7 +916,7 @@ sol_mavlink_get_home_position(struct sol_mavlink *mavlink, struct sol_mavlink_po
 SOL_API int
 sol_mavlink_goto(struct sol_mavlink *mavlink, struct sol_mavlink_position *pos)
 {
-    mavlink_message_t msg;
+    mavlink_message_t msg = { 0 };
     uint8_t buf[MAVLINK_MAX_PACKET_LEN];
     uint16_t len, res;
 
@@ -938,7 +938,7 @@ sol_mavlink_goto(struct sol_mavlink *mavlink, struct sol_mavlink_position *pos)
 SOL_API int
 sol_mavlink_change_speed(struct sol_mavlink *mavlink, float speed, bool airspeed)
 {
-    mavlink_message_t msg;
+    mavlink_message_t msg = { 0 };
     uint8_t buf[MAVLINK_MAX_PACKET_LEN];
     uint16_t len, res;
     float speed_type = 1.f;


### PR DESCRIPTION
At least one of the mavlink API functions would not work well with
unitialized fields of that struct -- mavlink_msg_home_position_get_z():

      CC   build/stage/modules/pin-mux/intel-edison-rev-c/intel-edison-rev-c.o
./src/lib/comms/sol-mavlink.c: In function ‘sol_mavlink_fd_handler’:
./src/lib/comms/sol-mavlink.c:423:12: warning: ‘*((void *)&msg+28)’ may be used uninitialized in thi
s function [-Wmaybe-uninitialized]
     pos->z = mavlink_msg_home_position_get_z(msg);
            ^
./src/lib/comms/sol-mavlink.c:439:23: note: ‘*((void *)&msg+28)’ was declared here
     mavlink_message_t msg;
                       ^
In file included from <...>/soletta/src/thirdparty/mavlink/ardupilotmega/ardupilotme
ga.h:30:0,
                 from <...>/soletta/src/thirdparty/mavlink/ardupilotmega/mavlink.h:2
5,
                 from ./src/lib/comms/sol-mavlink.c:36:
<...>/soletta/src/thirdparty/mavlink/ardupilotmega/../protocol.h:281:95: warning: ‘*
((void *)&msg+24)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
./src/lib/comms/sol-mavlink.c:439:23: note: ‘*((void *)&msg+24)’ was declared here
     mavlink_message_t msg;
                       ^
In file included from <...>/soletta/src/thirdparty/mavlink/ardupilotmega/ardupilotme
ga.h:30:0,
                 from <...>/soletta/src/thirdparty/mavlink/ardupilotmega/mavlink.h:2
5,
                 from ./src/lib/comms/sol-mavlink.c:36:
<...>/soletta/src/thirdparty/mavlink/ardupilotmega/../protocol.h:281:95: warning: ‘*
((void *)&msg+20)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
./src/lib/comms/sol-mavlink.c:439:23: note: ‘*((void *)&msg+20)’ was declared here
     mavlink_message_t msg;
                       ^
./src/lib/comms/sol-mavlink.c:393:13: warning: ‘*((void *)&msg+16)’ may be used uninitialized in thi
s function [-Wmaybe-uninitialized]
     if (lat != pos->latitude || longi != pos->longitude || alt != pos->altitude) {
             ^
./src/lib/comms/sol-mavlink.c:439:23: note: ‘*((void *)&msg+16)’ was declared here
     mavlink_message_t msg;
                       ^
./src/lib/comms/sol-mavlink.c:258:14: warning: ‘*((void *)&msg+8)’ may be used uninitialized in this
 function [-Wmaybe-uninitialized]
         mode = mavlink_msg_heartbeat_get_custom_mode(msg);
              ^
./src/lib/comms/sol-mavlink.c:439:23: note: ‘*((void *)&msg+8)’ was declared here
     mavlink_message_t msg;
                       ^
./src/lib/comms/sol-mavlink.c:460:9: warning: ‘msg.msgid’ may be used uninitialized in this function
 [-Wmaybe-uninitialized]
         switch (msg.msgid) {
         ^
./src/lib/comms/sol-mavlink.c:439:23: note: ‘msg.msgid’ was declared here
     mavlink_message_t msg;
                       ^
In file included from <...>/soletta/src/thirdparty/mavlink/ardupilotmega/../protocol
.h:85:0,
                 from <...>/soletta/src/thirdparty/mavlink/ardupilotmega/ardupilotme
ga.h:30,
                 from <...>/soletta/src/thirdparty/mavlink/ardupilotmega/mavlink.h:2
5,
                 from ./src/lib/comms/sol-mavlink.c:36:
<...>/soletta/src/thirdparty/mavlink/ardupilotmega/../mavlink_helpers.h:79:14: warni
ng: ‘msg.compid’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  msg->compid = component_id;
              ^
./src/lib/comms/sol-mavlink.c:439:23: note: ‘msg.compid’ was declared here
     mavlink_message_t msg;
                       ^
./src/lib/comms/sol-mavlink.c:365:38: warning: ‘msg.sysid’ may be used uninitialized in this functio
n [-Wmaybe-uninitialized]
     if (mavlink->sysid != msg->sysid || mavlink->compid != msg->sysid)
                                      ^
./src/lib/comms/sol-mavlink.c:439:23: note: ‘msg.sysid’ was declared here
     mavlink_message_t msg;

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>