### PR TITLE
dep-resolver: show the proper python's version

### DIFF
--- a/data/scripts/dependency-resolver.py
+++ b/data/scripts/dependency-resolver.py
@@ -309,7 +309,7 @@ def handle_python_check(args, conf, context):
 
     if required and not success:
         req_label = context.find_makefile_var("NOT_FOUND")
-        req_label += "python module: %s\\n" % pkgname
+        req_label += "%s module: %s\\n" % (os.path.split(sys.executable)[-1], pkgname)
         context.add_append_makefile_var("NOT_FOUND", req_label, True)
 
     context.add_cond_makefile_var("HAVE_PYTHON_%s" % dep.upper(), "y" if success else "n")


### PR DESCRIPTION
This patch changes the dependency-resolver's python module handler to
show the python's version considered in the checks.

This was raised by issue #1469.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>