### PR TITLE
Change some apis to use struct sol_buffer insteand of char *buf, size_t buflen - V3

### DIFF
--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -1088,19 +1088,21 @@ state_changed(sol_coap_responsecode_t response_code, struct sol_oic_client *oic_
         return;
 
     if (!sol_network_link_addr_eq(cliaddr, &resource->resource->addr)) {
-        char resaddr[SOL_INET_ADDR_STRLEN] = {0};
-        char respaddr[SOL_INET_ADDR_STRLEN] = {0};
+        SOL_BUFFER_DECLARE_STATIC(resaddr, SOL_INET_ADDR_STRLEN);
+        SOL_BUFFER_DECLARE_STATIC(respaddr, SOL_INET_ADDR_STRLEN);
 
-        if (!sol_network_addr_to_str(&resource->resource->addr, resaddr, sizeof(resaddr))) {
+        if (!sol_network_addr_to_str(&resource->resource->addr, &resaddr)) {
             SOL_WRN("Could not convert network address to string");
             return;
         }
-        if (!sol_network_addr_to_str(cliaddr, respaddr, sizeof(respaddr))) {
+        if (!sol_network_addr_to_str(cliaddr, &respaddr)) {
             SOL_WRN("Could not convert network address to string");
             return;
         }
 
-        SOL_WRN("Expecting response from %%s, got from %%s, ignoring", resaddr, respaddr);
+        SOL_WRN("Expecting response from %%.*s, got from %%.*s, ignoring",
+            SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&resaddr)),
+            SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&respaddr)));
         return;
     }
 

--- a/src/lib/common/include/sol-power-supply.h
+++ b/src/lib/common/include/sol-power-supply.h
@@ -35,6 +35,7 @@
 #include <stdlib.h>
 
 #include <sol-vector.h>
+#include <sol-buffer.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -259,13 +260,13 @@ int sol_power_supply_get_capacity_level(const char *name, enum sol_power_supply_
  * @param name Name of power supply. A list of all board supplies names may be
  * fetched with sol_power_supply_get_list().
  *
- * @param model_name Model name of power supply will be set on
- * this pointer on success. It must be freed after usage.
+ * @param model_name_buf Model name of power supply will be appended
+ * to this buffer. The buffer must be already initialized.
  *
  * @return On success, it returns @c 0. On error, a negative value is returned
- * and properties won't be set (pointers won't be valid).
+ * and the property value will not be appended to @c model_name_buf
  */
-int sol_power_supply_get_model_name(const char *name, char **model_name);
+int sol_power_supply_get_model_name(const char *name, struct sol_buffer *model_name_buf);
 
 /**
  * Get manufacturer of a given power supply.
@@ -273,13 +274,13 @@ int sol_power_supply_get_model_name(const char *name, char **model_name);
  * @param name Name of power supply. A list of all board supplies names may be
  * fetched with sol_power_supply_get_list().
  *
- * @param manufacturer Manufacturer of power supply will be set on
- * this pointer on success. It must be freed after usage.
+ * @param manufacturer_buf Manufacturer of power supply will be appended to this
+ * buffer. The buffer must be already initialized.
  *
  * @return On success, it returns @c 0. On error, a negative value is returned
- * and properties won't be set (pointers won't be valid).
+ * and the property value will not be appended to @c manufacturer_buf.
  */
-int sol_power_supply_get_manufacturer(const char *name, char **manufacturer);
+int sol_power_supply_get_manufacturer(const char *name, struct sol_buffer *manufacturer_buf);
 
 /**
  * Get serial number of a given power supply.
@@ -287,13 +288,13 @@ int sol_power_supply_get_manufacturer(const char *name, char **manufacturer);
  * @param name Name of power supply. A list of all board supplies names may be
  * fetched with sol_power_supply_get_list().
  *
- * @param serial_number Serial number of power supply will be set on
- * this pointer on success. It must be freed after usage.
+ * @param serial_number_buf Serial number of power supply  will be appended
+ * to this buffer. The buffer must be already initialized.
  *
  * @return On success, it returns @c 0. On error, a negative value is returned
- * and properties won't be set (pointers won't be valid).
+ * and the property value will not be appended to @c serial_number_buf.
  */
-int sol_power_supply_get_serial_number(const char *name, char **serial_number);
+int sol_power_supply_get_serial_number(const char *name, struct sol_buffer *serial_number_buf);
 
 /**
  * Get current voltage.

--- a/src/lib/common/sol-mainloop-impl-posix.c
+++ b/src/lib/common/sol-mainloop-impl-posix.c
@@ -256,15 +256,15 @@ static void
 on_sig_debug(const siginfo_t *info)
 {
     if (SOL_LOG_LEVEL_POSSIBLE(SOL_LOG_LEVEL_DEBUG)) {
-        char errmsg[1024] = "Success";
+        SOL_BUFFER_DECLARE_STATIC(errmsg, 1024);
 
         if (info->si_errno)
-            sol_util_strerror(info->si_errno, errmsg, sizeof(errmsg));
+            sol_util_strerror(info->si_errno, &errmsg);
 
         SOL_DBG("got signal %d, errno %d (%s), code %d. ignored.",
             info->si_signo,
             info->si_errno,
-            errmsg,
+            info->si_errno ? "Success" : (char *)errmsg.data,
             info->si_code);
     }
 }

--- a/src/lib/common/sol-power-supply-impl-linux.c
+++ b/src/lib/common/sol-power-supply-impl-linux.c
@@ -100,26 +100,19 @@ _get_file_path(char *file_path, size_t size, const char *name,
 
 static int
 _get_string_prop(const char *name, enum sol_power_supply_prop prop,
-    char **value)
+    struct sol_buffer *buf)
 {
     char file_path[PATH_MAX];
-    char *str_value;
     int r;
 
     SOL_NULL_CHECK(name, -EINVAL);
-    SOL_NULL_CHECK(value, -EINVAL);
+    SOL_NULL_CHECK(buf, -EINVAL);
 
     r = _get_file_path(file_path, sizeof(file_path), name, prop);
     SOL_INT_CHECK(r, < 0, r);
 
-    errno = 0;
-    r = sol_util_read_file(file_path, "%ms", &str_value);
-    if (errno != 0)
-        return -errno;
-    if (r < 0)
-        return r;
-
-    *value = str_value;
+    r = sol_util_load_file_buffer(file_path, buf);
+    SOL_INT_CHECK(r, < 0, r);
 
     return 0;
 }
@@ -392,23 +385,27 @@ sol_power_supply_get_capacity_level(const char *name,
 }
 
 SOL_API int
-sol_power_supply_get_model_name(const char *name, char **model_name)
+sol_power_supply_get_model_name(const char *name,
+    struct sol_buffer *model_name_buf)
 {
-    return _get_string_prop(name, SOL_POWER_SUPPLY_PROP_MODEL_NAME, model_name);
+    return _get_string_prop(name, SOL_POWER_SUPPLY_PROP_MODEL_NAME,
+        model_name_buf);
 }
 
 SOL_API int
-sol_power_supply_get_manufacturer(const char *name, char **manufacturer)
+sol_power_supply_get_manufacturer(const char *name,
+    struct sol_buffer *manufacturer_buf)
 {
     return _get_string_prop(name,
-        SOL_POWER_SUPPLY_PROP_MANUFACTURER, manufacturer);
+        SOL_POWER_SUPPLY_PROP_MANUFACTURER, manufacturer_buf);
 }
 
 SOL_API int
-sol_power_supply_get_serial_number(const char *name, char **serial_number)
+sol_power_supply_get_serial_number(const char *name,
+    struct sol_buffer *serial_number_buf)
 {
     return _get_string_prop(name,
-        SOL_POWER_SUPPLY_PROP_SERIAL_NUMBER, serial_number);
+        SOL_POWER_SUPPLY_PROP_SERIAL_NUMBER, serial_number_buf);
 }
 
 SOL_API int

--- a/src/lib/comms/include/sol-http.h
+++ b/src/lib/comms/include/sol-http.h
@@ -528,7 +528,7 @@ void sol_http_params_clear(struct sol_http_params *params);
  * the slices content to the buffer and set
  * @c SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED.
  *
- * @param buf The buffer that will hold the encoded string.
+ * @param buf The buffer that will hold the encoded string - The buffer will be initialized by this function.
  * @param value A slice to be encoded.
  *
  * @note if it's required to keep or change the buffer contents
@@ -545,7 +545,7 @@ int sol_http_encode_slice(struct sol_buffer *buf, const struct sol_str_slice val
  * the slices contents to the buffer and set
  * @c SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED.
  *
- * @param buf The buffer that will hold the decoded string.
+ * @param buf The buffer that will hold the decoded string - The buffer will be initialized by this function.
  * @param value A slice to be decoded.
  *
  * @note if it's required to keep or change the buffer contents
@@ -558,25 +558,25 @@ int sol_http_decode_slice(struct sol_buffer *buf, const struct sol_str_slice val
 /**
  * @brief Creates an URI based on struct sol_http_url and its params
  *
- * @param uri_out The created URI - it should be freed using free().
+ * @param buf Where the create URI should be appended - The buffer must be already initialized.
  * @param url The url parameters.
  * @param params The query and cookies params.
  *
  * @return 0 on success, negative number on error.
  */
-int sol_http_create_uri(char **uri_out, const struct sol_http_url url, const struct sol_http_params *params);
+int sol_http_create_uri(struct sol_buffer *buf, const struct sol_http_url url, const struct sol_http_params *params);
 
 /**
  * @brief A simpler version of sol_http_create_uri().
  *
  *
- * @param uri The created URI - it should be freed using free().
+ * @param buf Where the create URI should be appended - The buffer must be already initialized.
  * @param base_uri The base uri to be used.
  * @param params The query and cookies params.
  *
  * @return 0 on success, negative number on error.
  */
-int sol_http_create_simple_uri(char **uri, const struct sol_str_slice base_uri, const struct sol_http_params *params);
+int sol_http_create_simple_uri(struct sol_buffer *buf, const struct sol_str_slice base_uri, const struct sol_http_params *params);
 
 /**
  * @brief Encodes http parameters of a given type.
@@ -622,16 +622,16 @@ int sol_http_split_uri(const struct sol_str_slice full_uri, struct sol_http_url 
 /**
  * @brief An wrapper of over sol_http_create_simple_uri()
  *
- * @param uri The created URI - it should be freed using free().
+ * @param buf Where the create URI should be appended - The buffer must be already initialized.
  * @param base_url The base uri to be used.
  * @param params The query and cookies params.
  *
  * @return 0 on success, negative number on error.
  */
 static inline int
-sol_http_create_simple_uri_from_str(char **uri, const char *base_url, const struct sol_http_params *params)
+sol_http_create_simple_uri_from_str(struct sol_buffer *buf, const char *base_url, const struct sol_http_params *params)
 {
-    return sol_http_create_simple_uri(uri, sol_str_slice_from_str(base_url ? base_url : ""), params);
+    return sol_http_create_simple_uri(buf, sol_str_slice_from_str(base_url ? base_url : ""), params);
 }
 
 /**

--- a/src/lib/comms/include/sol-network.h
+++ b/src/lib/comms/include/sol-network.h
@@ -37,6 +37,7 @@
 #include <sol-common-buildopts.h>
 #include <sol-vector.h>
 #include <sol-str-slice.h>
+#include <sol-buffer.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -182,15 +183,14 @@ struct sol_network_link {
  * @brief Converts a @c sol_network_link_addr to a string.
  *
  * @param addr The address to be converted.
- * @param buf The buffer where the converted string will be stored.
- * @param len The size of buf.
+ * @param buf The buffer where the converted string will be appended -
+ * It must be already initialized.
  *
  * @return a string with the network link address on success, @c NULL on error.
  *
  * @see sol_network_addr_from_str()
  */
-const char *sol_network_addr_to_str(const struct sol_network_link_addr *addr,
-    char *buf, uint32_t len);
+const char *sol_network_addr_to_str(const struct sol_network_link_addr *addr, struct sol_buffer *buf);
 
 /**
  * @brief Converts a string address to @c sol_network_link_addr.

--- a/src/lib/comms/sol-http-client-impl-curl.c
+++ b/src/lib/comms/sol-http-client-impl-curl.c
@@ -482,7 +482,7 @@ header_cb(char *data, size_t size, size_t nmemb, void *connp)
     if (!strncasecmp(data, "Set-Cookie:", key_size)) {
         param.type = SOL_HTTP_PARAM_COOKIE;
         cookie_name_size = 0;
-        while (sep[cookie_name_size++] != '=');
+        while (sep[cookie_name_size++] != '=') ;
         decoded_key = curl_easy_unescape(connection->curl, sep,
             cookie_name_size - 1, NULL);
         SOL_NULL_CHECK_GOTO(decoded_key, err_exit);
@@ -746,14 +746,14 @@ static bool
 set_uri_from_params(CURL *curl, const char *base,
     const struct sol_http_params *params)
 {
-    char *full_uri;
+    struct sol_buffer full_uri = SOL_BUFFER_INIT_EMPTY;
     int err;
     bool r;
 
     err = sol_http_create_simple_uri_from_str(&full_uri, base, params);
     SOL_INT_CHECK(err, < 0, false);
-    r = curl_easy_setopt(curl, CURLOPT_URL, full_uri) == CURLE_OK;
-    free(full_uri);
+    r = curl_easy_setopt(curl, CURLOPT_URL, full_uri.data) == CURLE_OK;
+    sol_buffer_fini(&full_uri);
     return r;
 }
 

--- a/src/lib/comms/sol-http-server-impl-microhttpd.c
+++ b/src/lib/comms/sol-http-server-impl-microhttpd.c
@@ -711,8 +711,7 @@ notify_connection_cb(void *data, struct MHD_Connection *connection, void **socke
     conn->watch = sol_fd_add(conn->fd, fd_flags, connection_watch_cb, server);
 
     if (!conn->watch) {
-        char error_str[128];
-        SOL_WRN("Could not watch file descriptor: %s", sol_util_strerror(errno, error_str, sizeof(error_str)));
+        SOL_WRN("Could not watch file descriptor: %s", sol_util_strerrora(errno));
         sol_vector_del_last(&server->fds);
     }
 }

--- a/src/lib/comms/sol-lwm2m.c
+++ b/src/lib/comms/sol-lwm2m.c
@@ -3413,8 +3413,9 @@ register_reply(struct sol_coap_server *server,
     struct server_conn_ctx *conn_ctx = data;
     struct sol_str_slice path[2];
     uint16_t code;
-    char addr[SOL_INET_ADDR_STRLEN] = { };
     int r;
+
+    SOL_BUFFER_DECLARE_STATIC(addr, SOL_INET_ADDR_STRLEN);
 
     sol_coap_packet_unref(conn_ctx->pending_pkt);
     conn_ctx->pending_pkt = NULL;
@@ -3431,7 +3432,7 @@ register_reply(struct sol_coap_server *server,
         return false;
     }
 
-    if (!sol_network_addr_to_str(server_addr, addr, sizeof(addr)))
+    if (!sol_network_addr_to_str(server_addr, &addr))
         SOL_WRN("Could not convert the server address to string");
 
     code = sol_coap_header_get_code(pkt);
@@ -3444,7 +3445,8 @@ register_reply(struct sol_coap_server *server,
     conn_ctx->location = sol_str_slice_to_string(path[1]);
     SOL_NULL_CHECK_GOTO(conn_ctx->location, err_exit);
 
-    SOL_DBG("Registered with server %s at location %s", addr,
+    SOL_DBG("Registered with server %.*s at location %s",
+        SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr)),
         conn_ctx->location);
 
     r = reschedule_client_timeout(conn_ctx->client);

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -332,10 +332,12 @@ _sol_oic_server_res(struct sol_coap_server *server,
 
 error:
     if (err != CborNoError) {
-        char addr[SOL_INET_ADDR_STRLEN];
-        sol_network_addr_to_str(cliaddr, addr, sizeof(addr));
-        SOL_WRN("Error building response for /oic/res, server %p client %s: %s",
-            oic_server.server, addr, cbor_error_string(err));
+        SOL_BUFFER_DECLARE_STATIC(addr, SOL_INET_ADDR_STRLEN);
+
+        sol_network_addr_to_str(cliaddr, &addr);
+        SOL_WRN("Error building response for /oic/res, server %p client %.*s: %s",
+            oic_server.server, SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr)),
+            cbor_error_string(err));
 
         sol_coap_header_set_code(resp, SOL_COAP_RSPCODE_INTERNAL_ERROR);
     } else {

--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -182,6 +182,25 @@ enum sol_decode_case {
 #define SOL_BUFFER_INIT_DATA(data_, size_) SOL_BUFFER_C_CAST { .data = data_, .capacity = size_, .used = size_, .flags = SOL_BUFFER_FLAGS_DEFAULT }
 
 /**
+ * @def SOL_BUFFER_DECLARE_STATIC(name_, size_)
+ *
+ * @brief A helper macro to create a static allocated buffer with a fixed capacity.
+ *
+ * This macro will expand into the following code:
+ * @code{.c}
+ * // SOL_BUFFER_DECLARE_STATIC(buf, 1024);
+ * uint8_t buf_storage[1024] = { 0 };
+ * struct sol_buffer buf = SOL_BUFFER_INIT_FLAGS(buf_storage, 1024, SOL_BUFFER_FLAGS_FIXED_CAPACITY);
+ * @endcode
+ *
+ * @param name_ The name of the struct sol_buffer variable
+ * @param size_ The capacity of the buffer
+ */
+#define SOL_BUFFER_DECLARE_STATIC(name_, size_) \
+    uint8_t name_ ## storage[(size_)] = { 0 }; \
+    struct sol_buffer name_ = SOL_BUFFER_INIT_FLAGS(name_ ## storage, (size_), SOL_BUFFER_FLAGS_FIXED_CAPACITY)
+
+/**
  * @brief Initializes a @c sol_buffer structure.
  *
  * flags are set to @c SOL_BUFFER_FLAGS_DEFAULT.

--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -270,6 +270,21 @@ sol_buffer_at_end(const struct sol_buffer *buf)
 int sol_buffer_resize(struct sol_buffer *buf, size_t new_size);
 
 /**
+ * @brief Increment the buffer capacity to fit the @c bytes.
+ *
+ * This function will increase the buffer capacity in order to
+ * be able to fit @c bytes.
+ *
+ * @param buf The buffer
+ * @param bytes The number of bytes that the buffer must fit.
+ *
+ * @return @c 0 on success, error code (always negative) otherwise
+ *
+ * @note Internally this function uses sol_buffer_ensure()
+ */
+int sol_buffer_expand(struct sol_buffer *buf, size_t bytes);
+
+/**
  * @brief Ensures that @c buf has at least @c min_size.
  *
  * It may allocate more than requested.

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -85,6 +85,27 @@ sol_buffer_ensure(struct sol_buffer *buf, size_t min_size)
 }
 
 SOL_API int
+sol_buffer_expand(struct sol_buffer *buf, size_t bytes)
+{
+    size_t new_size, available;
+    int err;
+
+    SOL_NULL_CHECK(buf, -EINVAL);
+
+    available = buf->capacity - buf->used;
+
+    if (available >= bytes)
+        return 0;
+
+    err = sol_util_size_add(buf->capacity, bytes - available, &new_size);
+    SOL_INT_CHECK(err, < 0, err);
+    err = sol_buffer_ensure(buf, new_size);
+    SOL_INT_CHECK(err, < 0, err);
+
+    return 0;
+}
+
+SOL_API int
 sol_buffer_set_slice(struct sol_buffer *buf, const struct sol_str_slice slice)
 {
     int err;

--- a/src/lib/parsers/include/sol-json.h
+++ b/src/lib/parsers/include/sol-json.h
@@ -684,33 +684,21 @@ size_t sol_json_calculate_escaped_string_len(const char *str) SOL_ATTR_NONNULL(1
  * @brief Escapes JSON special and control characters from the string content.
  *
  * @param str String to escape
- * @param buf Where to place the escaped string
- * @param len Buffer size in bytes
+ * @param buf Where to append the escaped string - It must be already initialized.
  *
  * @return The escaped string
  */
-char *sol_json_escape_string(const char *str, char *buf, size_t len) SOL_ATTR_NONNULL(1, 2);
-
-/**
- * @brief Helper macro to make easier to escape a string for use in a JSON document
- *
- * @param s String to escape
- */
-#define SOL_JSON_ESCAPE_STRING(s) ({ \
-        size_t str_len ## __COUNT__  = sol_json_calculate_escaped_string_len(s); \
-        sol_json_escape_string(s, (char *)alloca(str_len ## __COUNT__), str_len ## __COUNT__); \
-    })
+char *sol_json_escape_string(const char *str, struct sol_buffer *buf) SOL_ATTR_NONNULL(1, 2);
 
 /**
  * @brief Converts a double into a string suited for use in a JSON Document
  *
  * @param value Value to be converted
- * @param buf Where to place the converted value
- * @param buf_len Buffer size in bytes
+ * @param buf Where to append the converted value - It must be already initialized.
  *
  * @return @c 0 on success, error code (always negative) otherwise
  */
-int sol_json_double_to_str(const double value, char *buf, size_t buf_len);
+int sol_json_double_to_str(const double value, struct sol_buffer *buf);
 
 /**
  * @brief Check if @c scanner content is pointing to a valid JSON element of

--- a/src/modules/flow/http-client/http-client.c
+++ b/src/modules/flow/http-client/http-client.c
@@ -98,6 +98,8 @@ struct http_client_node_type {
         struct sol_http_response *response);
 };
 
+#define DOUBLE_STRING_LEN (64)
+
 static int
 set_basic_url_info(struct http_data *mdata, const char *full_uri)
 {
@@ -684,25 +686,29 @@ float_post_process(struct sol_flow_node *node, void *data, uint16_t port, uint16
 {
     int r;
     struct sol_drange value;
-    char val[100], min[100], max[100], step[100];
+
+    SOL_BUFFER_DECLARE_STATIC(val, DOUBLE_STRING_LEN);
+    SOL_BUFFER_DECLARE_STATIC(min, DOUBLE_STRING_LEN);
+    SOL_BUFFER_DECLARE_STATIC(max, DOUBLE_STRING_LEN);
+    SOL_BUFFER_DECLARE_STATIC(step, DOUBLE_STRING_LEN);
 
     r = sol_flow_packet_get_drange(packet, &value);
     SOL_INT_CHECK(r, < 0, r);
 
-    r = sol_json_double_to_str(value.val, val, 100);
+    r = sol_json_double_to_str(value.val, &val);
     SOL_INT_CHECK(r, < 0, r);
 
-    r = sol_json_double_to_str(value.min, min, 100);
+    r = sol_json_double_to_str(value.min, &min);
     SOL_INT_CHECK(r, < 0, r);
 
-    r = sol_json_double_to_str(value.max, max, 100);
+    r = sol_json_double_to_str(value.max, &max);
     SOL_INT_CHECK(r, < 0, r);
 
-    r = sol_json_double_to_str(value.step, step, 100);
+    r = sol_json_double_to_str(value.step, &step);
     SOL_INT_CHECK(r, < 0, r);
 
-    return common_post_process(node, data, "value", val, "min", min,
-        "max", max, "step", step, NULL);
+    return common_post_process(node, data, "value", val.data, "min", min.data,
+        "max", max.data, "step", step.data, NULL);
 }
 
 /*

--- a/src/modules/flow/http-client/http-client.c
+++ b/src/modules/flow/http-client/http-client.c
@@ -102,7 +102,7 @@ static int
 set_basic_url_info(struct http_data *mdata, const char *full_uri)
 {
     struct sol_http_url url, base_url;
-    char *new_url;
+    struct sol_buffer new_url = SOL_BUFFER_INIT_EMPTY;
     int r;
 
     r = sol_http_split_uri(sol_str_slice_from_str(full_uri), &url);
@@ -119,7 +119,7 @@ set_basic_url_info(struct http_data *mdata, const char *full_uri)
     SOL_INT_CHECK(r, < 0, r);
 
     free(mdata->url);
-    mdata->url = new_url;
+    mdata->url = sol_buffer_steal(&new_url, NULL);
 
     sol_http_params_clear(&mdata->url_params);
     r = sol_http_decode_params(url.query,
@@ -1801,7 +1801,7 @@ create_url_create_process(struct sol_flow_node *node, void *data,
 {
     struct create_url_data *mdata = data;
     int r;
-    char *uri;
+    struct sol_buffer uri = SOL_BUFFER_INIT_EMPTY;
     struct sol_http_url url;
 
     url.scheme = sol_str_slice_from_str(mdata->scheme ? : "http");
@@ -1814,9 +1814,9 @@ create_url_create_process(struct sol_flow_node *node, void *data,
 
     r = sol_http_create_uri(&uri, url, &mdata->params);
     SOL_INT_CHECK(r, < 0, r);
-    r = sol_flow_send_string_packet(node,
-        SOL_FLOW_NODE_TYPE_HTTP_CLIENT_CREATE_URL__OUT__OUT, uri);
-    free(uri);
+    r = sol_flow_send_string_take_packet(node,
+        SOL_FLOW_NODE_TYPE_HTTP_CLIENT_CREATE_URL__OUT__OUT,
+        sol_buffer_steal(&uri, NULL));
     return r;
 }
 

--- a/src/modules/flow/oauth/oauth.c
+++ b/src/modules/flow/oauth/oauth.c
@@ -356,16 +356,18 @@ end:
 static char *
 get_callback_url(const struct sol_http_request *request, const char *basename)
 {
-    char *url, buf[SOL_INET_ADDR_STRLEN];
+    SOL_BUFFER_DECLARE_STATIC(buf, SOL_INET_ADDR_STRLEN);
+    char *url;
     struct sol_network_link_addr addr;
     int r;
 
     r = sol_http_request_get_interface_address(request, &addr);
     SOL_INT_CHECK(r, < 0, NULL);
 
-    sol_network_addr_to_str(&addr, buf, sizeof(buf));
-    r = asprintf(&url, "http://%s:%d/%s/oauth_callback",
-        buf, addr.port, basename);
+    SOL_NULL_CHECK(sol_network_addr_to_str(&addr, &buf), NULL);
+
+    r = asprintf(&url, "http://%.*s:%d/%s/oauth_callback",
+        SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&buf)), addr.port, basename);
 
     SOL_INT_CHECK(r, < 0, NULL);
     return url;

--- a/src/modules/flow/power-supply/power-supply.c
+++ b/src/modules/flow/power-supply/power-supply.c
@@ -256,9 +256,9 @@ get_capacity(struct sol_flow_node *node, void *data, uint16_t port, uint16_t con
 }
 
 static int
-send_string_prop(struct sol_flow_node *node, const char *name, int (*func)(const char *name, char **prop), uint16_t port, const char *err_msg)
+send_string_prop(struct sol_flow_node *node, const char *name, int (*func)(const char *name, struct sol_buffer *prop), uint16_t port, const char *err_msg)
 {
-    char *prop;
+    struct sol_buffer prop = SOL_BUFFER_INIT_EMPTY;
     int r;
 
     r = func(name, &prop);
@@ -266,8 +266,7 @@ send_string_prop(struct sol_flow_node *node, const char *name, int (*func)(const
         r = sol_flow_send_error_packet_str(node, EINVAL, err_msg);
         SOL_INT_CHECK(r, < 0, r);
     } else {
-        r = sol_flow_send_string_packet(node, port, prop);
-        free(prop);
+        r = sol_flow_send_string_take_packet(node, port, sol_buffer_steal(&prop, NULL));
         SOL_INT_CHECK(r, < 0, r);
     }
 

--- a/src/samples/coap/oic-client.c
+++ b/src/samples/coap/oic-client.c
@@ -43,7 +43,8 @@ got_get_response(sol_coap_responsecode_t response_code, struct sol_oic_client *c
     struct sol_oic_repr_field field;
     enum sol_oic_map_loop_reason end_reason;
     struct sol_oic_map_reader iterator;
-    char addr[SOL_INET_ADDR_STRLEN];
+
+    SOL_BUFFER_DECLARE_STATIC(addr, SOL_INET_ADDR_STRLEN);
 
     if (!srv_addr) {
         SOL_WRN("Response timeout");
@@ -55,12 +56,12 @@ got_get_response(sol_coap_responsecode_t response_code, struct sol_oic_client *c
         return;
     }
 
-    if (!sol_network_addr_to_str(srv_addr, addr, sizeof(addr))) {
+    if (!sol_network_addr_to_str(srv_addr, &addr)) {
         SOL_WRN("Could not convert network address to string");
         return;
     }
 
-    printf("Dumping payload received from addr %s {\n", addr);
+    printf("Dumping payload received from addr %.*s {\n", SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr)));
     SOL_OIC_MAP_LOOP(map_reader, &field, &iterator, end_reason) {
         printf("\tkey: '%s', value: ", field.key);
 
@@ -105,7 +106,8 @@ found_resource(struct sol_oic_client *cli, struct sol_oic_resource *res, void *d
     static const char digits[] = "0123456789abcdef";
     struct sol_str_slice *slice;
     uint16_t idx;
-    char addr[SOL_INET_ADDR_STRLEN];
+
+    SOL_BUFFER_DECLARE_STATIC(addr, SOL_INET_ADDR_STRLEN);
 
     if (!res)
         return false;
@@ -119,12 +121,12 @@ found_resource(struct sol_oic_client *cli, struct sol_oic_resource *res, void *d
     }
 #endif
 
-    if (!sol_network_addr_to_str(&res->addr, addr, sizeof(addr))) {
+    if (!sol_network_addr_to_str(&res->addr, &addr)) {
         SOL_WRN("Could not convert network address to string");
         return false;
     }
 
-    printf("Found resource: coap://%s%.*s\n", addr,
+    printf("Found resource: coap://%.*s%.*s\n", SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr)),
         SOL_STR_SLICE_PRINT(res->href));
 
     printf("Flags:\n"

--- a/src/samples/coap/simple-client.c
+++ b/src/samples/coap/simple-client.c
@@ -81,16 +81,17 @@ reply_cb(struct sol_coap_server *server, struct sol_coap_packet *req,
 {
     struct sol_str_slice *path = data;
     static int count;
-    char addr[SOL_INET_ADDR_STRLEN];
     uint8_t *payload;
     uint16_t len;
+
+    SOL_BUFFER_DECLARE_STATIC(addr, SOL_INET_ADDR_STRLEN);
 
     if (!req || !cliaddr) //timeout
         return false;
 
-    sol_network_addr_to_str(cliaddr, addr, sizeof(addr));
+    sol_network_addr_to_str(cliaddr, &addr);
 
-    SOL_INF("Got response from %s", addr);
+    SOL_INF("Got response from %.*s", SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr)));
 
     sol_coap_packet_get_payload(req, &payload, &len);
     SOL_INF("Payload: %.*s", len, payload);

--- a/src/samples/network/network-status.c
+++ b/src/samples/network/network-status.c
@@ -122,13 +122,15 @@ _on_network_event(void *data, const struct sol_network_link *link, enum sol_netw
 
     if (link->flags & SOL_NETWORK_LINK_UP) {
         struct sol_network_link_addr *addr;
-        char addr_str[SOL_INET_ADDR_STRLEN];
         uint16_t i;
+
+        SOL_BUFFER_DECLARE_STATIC(addr_str, SOL_INET_ADDR_STRLEN);
 
         printf("\tUP ");
         SOL_VECTOR_FOREACH_IDX (&link->addrs, addr, i) {
-            sol_network_addr_to_str(addr, addr_str, sizeof(addr_str));
-            printf("%s ", addr_str);
+            addr_str.used = 0;
+            sol_network_addr_to_str(addr, &addr_str);
+            printf("%.*s ", SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr_str)));
         }
         printf("\n");
     } else {

--- a/src/shared/include/sol-util-file.h
+++ b/src/shared/include/sol-util-file.h
@@ -137,7 +137,7 @@ int sol_util_vread_file(const char *path, const char *fmt, va_list args) SOL_ATT
  *
  * @see sol_util_load_file_string
  */
-struct sol_buffer *sol_util_load_file_raw(const int fd) SOL_ATTR_WARN_UNUSED_RESULT;
+struct sol_buffer *sol_util_load_file_fd_raw(const int fd) SOL_ATTR_WARN_UNUSED_RESULT;
 
 /**
  * @brief Reads the contents of a file.
@@ -166,6 +166,26 @@ char *sol_util_load_file_string(const char *filename, size_t *size) SOL_ATTR_WAR
  * @see sol_util_load_file_string
  */
 char *sol_util_load_file_fd_string(const int fd, size_t *size) SOL_ATTR_WARN_UNUSED_RESULT;
+
+/**
+ * @brief Reads the contents of a file and append to a buffer.
+ *
+ * @param fd A valid file descriptor.
+ * @param buf A buffer to append the file contents - It must be initialized.
+ *
+ * @return 0 on success, negative errno otherwise.
+ */
+int sol_util_load_file_fd_buffer(int fd, struct sol_buffer *buf) SOL_ATTR_WARN_UNUSED_RESULT;
+
+/**
+ * @brief Reads the contents of a file and append to a buffer.
+ *
+ * @param filename THe file path to be read.
+ * @param buf A buffer to append the file contents - It must be initialized.
+ *
+ * @return 0 on success, negative errno otherwise.
+ */
+int sol_util_load_file_buffer(const char *filename, struct sol_buffer *buf) SOL_ATTR_WARN_UNUSED_RESULT;
 
 /**
  * @brief Gets the root directory.

--- a/src/shared/include/sol-util.h
+++ b/src/shared/include/sol-util.h
@@ -203,14 +203,13 @@ sol_util_msec_from_timespec(const struct timespec *ts)
  * code passed in the argument @c errnum.
  *
  * @param errnum The error code
- * @param buf Buffer used to store the store the string.
- * @param buflen The size of @c buf
+ * @param buf Buffer used to append error the string - It must be already initialized.
  *
  * @return return the appropriate error description string.
  *
  * @see sol_util_strerrora
  */
-char *sol_util_strerror(int errnum, char *buf, size_t buflen);
+char *sol_util_strerror(int errnum, struct sol_buffer *buf);
 
 /**
  * @brief Gets a string from a given error using the stack.
@@ -227,8 +226,8 @@ char *sol_util_strerror(int errnum, char *buf, size_t buflen);
  */
 #define sol_util_strerrora(errnum) \
     ({ \
-        char buf ## __COUNT__[512]; \
-        sol_util_strerror((errnum), buf ## __COUNT__, sizeof(buf ## __COUNT__)); \
+        SOL_BUFFER_DECLARE_STATIC(buf ## __COUNT__, 512); \
+        sol_util_strerror((errnum), &buf ## __COUNT__); \
     })
 
 /**

--- a/src/shared/sol-file-reader.c
+++ b/src/shared/sol-file-reader.c
@@ -90,7 +90,7 @@ sol_file_reader_from_fd(int fd)
         goto err;
     }
 
-    buffer = sol_util_load_file_raw(fd);
+    buffer = sol_util_load_file_fd_raw(fd);
     if (!buffer)
         goto err;
     fr->contents = sol_buffer_steal(buffer, &size);

--- a/src/test-cpp/headers.cc.in
+++ b/src/test-cpp/headers.cc.in
@@ -158,8 +158,6 @@ startup()
 
     SOL_JSON_TOKEN_STR_LITERAL_EQ(&token, "asd");
 
-    SOL_JSON_ESCAPE_STRING("my string");
-
     SOL_JSON_PATH_FOREACH(path_scanner, key_slice, json_reason);
 
     SOL_JSON_SCANNER_ARRAY_LOOP_NEST(&scanner, &token, elem_type, json_reason);

--- a/src/test/test-http.c
+++ b/src/test/test-http.c
@@ -93,7 +93,8 @@ test_split_urls(void)
     for (i = 0; i < SOL_UTIL_ARRAY_SIZE(test_split); i++) {
         struct sol_http_url splitted;
         struct sol_http_params params;
-        char *out_uri;
+        struct sol_buffer out_uri = SOL_BUFFER_INIT_EMPTY;
+
         r = sol_http_split_uri(test_split[i].url, &splitted);
         ASSERT_INT_EQ(r, test_split[i].result);
         if (test_split[i].result < 0)
@@ -113,9 +114,9 @@ test_split_urls(void)
         ASSERT_INT_EQ(r, 0);
         r = sol_http_create_uri(&out_uri, splitted, &params);
         ASSERT_INT_EQ(r, 0);
-        ASSERT(sol_str_slice_str_eq(test_split[i].url, out_uri));
+        ASSERT(sol_str_slice_eq(test_split[i].url, sol_buffer_get_slice(&out_uri)));
         sol_http_params_clear(&params);
-        free(out_uri);
+        sol_buffer_fini(&out_uri);
     }
 
 #undef SET_PARAMS


### PR DESCRIPTION
Fixed problems pointed by @barbieri 
Changes since v2:
* Removed SOL_JSON_ESCAPE_STRING macro
* sol_buffer_expand() will not only expand the mount necessary to fit the required bytes.