### PR TITLE
submodules: ignore dirty submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,16 @@
 [submodule "src/thirdparty/duktape"]
 	path = src/thirdparty/duktape
 	url = https://github.com/solettaproject/duktape-release.git
+	ignore = dirty
 [submodule "src/thirdparty/tinycbor"]
 	path = src/thirdparty/tinycbor
 	url = https://github.com/01org/tinycbor/
+	ignore = dirty
 [submodule "src/thirdparty/tinydtls"]
 	path = src/thirdparty/tinydtls
 	url = git://git.code.sf.net/p/tinydtls/code
+	ignore = dirty
 [submodule "src/thirdparty/mavlink"]
 	path = src/thirdparty/mavlink
 	url = https://github.com/mavlink/c_library.git
+	ignore = dirty


### PR DESCRIPTION
We shouldn't change submodules.

At the moment, they'll be showed as dirty,
listed as untracked content after a build, because
some of them will generate objects on these directories.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>