### PR TITLE
Support setting log levels at compile time

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ or by applications if they define that in some way. Then messages
 above that number will be compiled out and using `$SOL_LOG_LEVEL` or
 `$SOL_LOG_LEVELS` for those numbers won't have effect.
 
+On systems where setting environment variables is not an option, both
+`$SOL_LOG_LEVEL` and `$SOL_LOG_LEVELS` may be defined at build time by
+adding them to the application's `CFLAGS`.
+
+    CFLAGS += -DSOL_LOG_LEVEL=\"CRIT\"
+    CFLAGS += -DSOL_LOG_LEVELS=\"domain1:level1,domain2:level2,...\"
 
 ## Libraries
 

--- a/src/lib/common/include/sol-log.h
+++ b/src/lib/common/include/sol-log.h
@@ -361,11 +361,32 @@ extern struct sol_log_domain *sol_log_global_domain;
  */
 #ifdef SOL_LOG_ENABLED
 void sol_log_domain_init_level(struct sol_log_domain *domain);
+void sol_log_init_level_global(const char *str, size_t length);
+void sol_log_init_levels(const char *str, size_t length);
+
+#ifdef SOL_LOG_LEVEL
+#define SOL_LOG_LEVEL_INIT() \
+    sol_log_init_level_global(SOL_LOG_LEVEL, sizeof(SOL_LOG_LEVEL) - 1)
+#else
+#define SOL_LOG_LEVEL_INIT()
+#endif
+
+#ifdef SOL_LOG_LEVELS
+#define SOL_LOG_LEVELS_INIT() \
+    sol_log_init_levels(SOL_LOG_LEVELS, sizeof(SOL_LOG_LEVELS) - 1)
+#else
+#define SOL_LOG_LEVELS_INIT()
+#endif
+
 #else
 static inline void
 sol_log_domain_init_level(struct sol_log_domain *domain)
 {
 }
+
+#define SOL_LOG_LEVEL_INIT()
+#define SOL_LOG_LEVELS_INIT()
+
 #endif
 
 #ifndef SOL_LOG_DOMAIN

--- a/src/lib/common/include/sol-mainloop.h
+++ b/src/lib/common/include/sol-mainloop.h
@@ -39,6 +39,8 @@
 #include <stdlib.h>
 #include <time.h>
 
+#include <sol-log.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -1100,6 +1102,8 @@ struct sol_main_callbacks {
     AUTOSTART_PROCESSES(&soletta_app_process);            \
     PROCESS_THREAD(soletta_app_process, ev, data)         \
     {                                                     \
+        SOL_LOG_LEVEL_INIT();                             \
+        SOL_LOG_LEVELS_INIT();                            \
         sol_mainloop_contiki_event_set(ev, data);         \
         PROCESS_BEGIN();                                  \
         if (sol_init() < 0)                               \
@@ -1116,6 +1120,8 @@ struct sol_main_callbacks {
 #ifdef SOL_PLATFORM_RIOT
 #define SOL_MAIN(CALLBACKS) \
     int main(void) { \
+        SOL_LOG_LEVEL_INIT(); \
+        SOL_LOG_LEVELS_INIT(); \
         return sol_mainloop_default_main(&(CALLBACKS), 0, NULL); \
     }
 #elif defined SOL_PLATFORM_ZEPHYR
@@ -1128,11 +1134,15 @@ struct sol_main_callbacks {
 
 #define SOL_MAIN(CALLBACKS) \
     void main_task(void) { \
+        SOL_LOG_LEVEL_INIT(); \
+        SOL_LOG_LEVELS_INIT(); \
         sol_mainloop_default_main(&(CALLBACKS), 0, NULL); \
     }
 #else
 #define SOL_MAIN(CALLBACKS)                                          \
     int main(int argc, char *argv[]) {                              \
+        SOL_LOG_LEVEL_INIT(); \
+        SOL_LOG_LEVELS_INIT(); \
         return sol_mainloop_default_main(&(CALLBACKS), argc, argv);  \
     }
 #endif /* SOL_PLATFORM_RIOT */

--- a/src/lib/common/sol-log-impl-contiki.c
+++ b/src/lib/common/sol-log-impl-contiki.c
@@ -59,12 +59,6 @@ sol_log_impl_unlock(void)
 }
 
 void
-sol_log_impl_domain_init_level(struct sol_log_domain *domain)
-{
-    domain->level = _global_domain.level;
-}
-
-void
 sol_log_impl_print_function_stderr(void *data, const struct sol_log_domain *domain, uint8_t message_level, const char *file, const char *function, int line, const char *format, va_list args)
 {
     const char *name = domain->name ? domain->name : "";

--- a/src/lib/common/sol-log-impl-linux.c
+++ b/src/lib/common/sol-log-impl-linux.c
@@ -42,102 +42,17 @@
 #include <systemd/sd-journal.h>
 #endif
 
-#include "sol-str-table.h"
 #include "sol-log-impl.h"
 #include "sol-util-file.h"
 #include "sol-util-internal.h"
 
 static pid_t _main_pid;
-static struct sol_str_table *_env_levels = NULL;
-static char *_env_levels_str = NULL;
 
 #ifdef PTHREAD
 #include <pthread.h>
 static pthread_t _main_thread;
 static pthread_mutex_t _mutex = PTHREAD_MUTEX_INITIALIZER;
 #endif
-
-static bool
-_level_str_parse(const char *buf, size_t buflen, uint8_t *storage)
-{
-    int16_t found;
-    static const struct sol_str_table table[] = {
-        SOL_STR_TABLE_ITEM("CRI",      SOL_LOG_LEVEL_CRITICAL),
-        SOL_STR_TABLE_ITEM("CRIT",     SOL_LOG_LEVEL_CRITICAL),
-        SOL_STR_TABLE_ITEM("CRITICAL", SOL_LOG_LEVEL_CRITICAL),
-        SOL_STR_TABLE_ITEM("DBG",      SOL_LOG_LEVEL_DEBUG),
-        SOL_STR_TABLE_ITEM("DEBUG",    SOL_LOG_LEVEL_DEBUG),
-        SOL_STR_TABLE_ITEM("ERR",      SOL_LOG_LEVEL_ERROR),
-        SOL_STR_TABLE_ITEM("ERROR",    SOL_LOG_LEVEL_ERROR),
-        SOL_STR_TABLE_ITEM("INF",      SOL_LOG_LEVEL_INFO),
-        SOL_STR_TABLE_ITEM("INFO",     SOL_LOG_LEVEL_INFO),
-        SOL_STR_TABLE_ITEM("WARN",     SOL_LOG_LEVEL_WARNING),
-        SOL_STR_TABLE_ITEM("WARNING",  SOL_LOG_LEVEL_WARNING),
-        SOL_STR_TABLE_ITEM("WRN",      SOL_LOG_LEVEL_WARNING),
-        { }
-    };
-
-    if (!sol_str_table_lookup(table, SOL_STR_SLICE_STR(buf, buflen), &found))
-        return false;
-    *storage = found;
-    return true;
-}
-
-static bool
-_int32_parse(const char *str, size_t size, int32_t *storage)
-{
-    int64_t value = 0;
-    size_t i;
-    bool negative = false;
-
-    errno = 0;
-    for (i = 0; i < size; i++) {
-        const char c = str[i];
-        if (i == 0 && c == '-') {
-            negative = true;
-            continue;
-        }
-
-        if (c < '0' || c > '9')
-            break;
-        value = (value * 10) + (c - '0');
-        if (value > INT32_MAX) {
-            errno = ERANGE;
-            return false;
-        }
-    }
-    if (i == 0) {
-        errno = EINVAL;
-        return false;
-    }
-    if (negative) {
-        value = -value;
-        if (value < INT32_MIN) {
-            errno = ERANGE;
-            return false;
-        }
-    }
-    *storage = value;
-    return true;
-}
-
-static bool
-_level_parse(const char *str, size_t size, uint8_t *storage)
-{
-    int32_t i;
-    uint8_t level = 0;
-
-    if (size == 0)
-        return false;
-
-    if (_int32_parse(str, size, &i))
-        level = i;
-    else if (!_level_str_parse(str, size, &level))
-        return false;
-
-    *storage = level;
-    return true;
-}
 
 static bool
 _bool_parse(const char *str, size_t size, bool *storage)
@@ -165,89 +80,13 @@ _bool_parse(const char *str, size_t size, bool *storage)
     return true;
 }
 
-static bool
-_levels_parse(const char *str, size_t size)
-{
-    const char *str_end = str + size;
-    unsigned int count = 0;
-    struct sol_str_table *itr;
-    const char *p, *e;
-
-    for (p = str; p < str_end; p++) {
-        if (*p == ',')
-            count++;
-    }
-    if (p > str)
-        count++;
-
-    free(_env_levels);
-    free(_env_levels_str);
-    if (count == 0) {
-        _env_levels = NULL;
-        _env_levels_str = NULL;
-        return false;
-    }
-
-    _env_levels = malloc((count + 1) * sizeof(*_env_levels));
-    if (!_env_levels) {
-        _env_levels_str = NULL;
-        return false;
-    }
-
-    _env_levels_str = strndup(str, size);
-    if (!_env_levels_str) {
-        free(_env_levels);
-        _env_levels = NULL;
-        _env_levels_str = NULL;
-        return false;
-    }
-
-    itr = _env_levels;
-    e = NULL;
-    str = _env_levels_str;
-    str_end = str + size;
-    for (p = str;; p++) {
-        if (p < str_end && *p == ':')
-            e = p;
-        else if (p == str_end || *p == ',') {
-            if (e && str + 1 < e && e + 1 < p) {
-                uint8_t val;
-                itr->key = str;
-                itr->len = e - str;
-                if (_level_parse(e + 1, p - e - 1, &val)) {
-                    itr->val = val;
-                    itr++;
-                }
-            }
-
-            if (p == str_end)
-                break;
-            str = p + 1;
-            e = NULL;
-        }
-    }
-
-    if (itr == _env_levels) {
-        free(_env_levels);
-        free(_env_levels_str);
-        _env_levels = NULL;
-        _env_levels_str = NULL;
-        return false;
-    }
-
-    itr->key = NULL;
-    itr->len = 0;
-    itr->val = 0;
-    return true;
-}
-
 static void
 _env_level_get(const char *envvar, uint8_t *storage)
 {
     const char *s = getenv(envvar);
 
     if (!s) return;
-    _level_parse(s, strlen(s), storage);
+    sol_log_level_parse(s, strlen(s), storage);
 }
 
 static void
@@ -265,16 +104,7 @@ _env_levels_load(void)
     const char *s = getenv("SOL_LOG_LEVELS");
 
     if (!s) return;
-    _levels_parse(s, strlen(s));
-}
-
-static void
-_env_levels_unload(void)
-{
-    free(_env_levels);
-    free(_env_levels_str);
-    _env_levels = NULL;
-    _env_levels_str = NULL;
+    sol_log_levels_parse(s, strlen(s));
 }
 
 static void
@@ -286,13 +116,13 @@ _bool_parse_wrapper(const char *str, size_t size, void *data)
 static void
 _level_parse_wrapper(const char *str, size_t size, void *data)
 {
-    _level_parse(str, size, data);
+    sol_log_level_parse(str, size, data);
 }
 
 static void
 _levels_parse_wrapper(const char *str, size_t size, void *data)
 {
-    _levels_parse(str, size);
+    sol_log_levels_parse(str, size);
 }
 
 static void
@@ -447,7 +277,6 @@ sol_log_impl_init(void)
 void
 sol_log_impl_shutdown(void)
 {
-    _env_levels_unload();
     _main_pid = 0;
 #ifdef PTHREAD
     _main_thread = 0;
@@ -476,21 +305,6 @@ sol_log_impl_unlock(void)
 #ifdef PTHREAD
     pthread_mutex_unlock(&_mutex);
 #endif
-}
-
-void
-sol_log_impl_domain_init_level(struct sol_log_domain *domain)
-{
-    int16_t level;
-
-    if (_env_levels) {
-        level = sol_str_table_lookup_fallback(_env_levels,
-            sol_str_slice_from_str(domain->name),
-            _global_domain.level);
-    } else
-        level = _global_domain.level;
-
-    domain->level = level;
 }
 
 SOL_ATTR_PRINTF(7, 0)

--- a/src/lib/common/sol-log-impl-riot.c
+++ b/src/lib/common/sol-log-impl-riot.c
@@ -82,12 +82,6 @@ sol_log_impl_unlock(void)
 }
 
 void
-sol_log_impl_domain_init_level(struct sol_log_domain *domain)
-{
-    domain->level = _global_domain.level;
-}
-
-void
 sol_log_impl_print_function_stderr(void *data, const struct sol_log_domain *domain, uint8_t message_level, const char *file, const char *function, int line, const char *format, va_list args)
 {
     const char *name = domain->name ? domain->name : "";

--- a/src/lib/common/sol-log-impl-zephyr.c
+++ b/src/lib/common/sol-log-impl-zephyr.c
@@ -59,12 +59,6 @@ sol_log_impl_unlock(void)
 }
 
 void
-sol_log_impl_domain_init_level(struct sol_log_domain *domain)
-{
-    domain->level = _global_domain.level;
-}
-
-void
 sol_log_impl_print_function_stderr(void *data, const struct sol_log_domain *domain, uint8_t message_level, const char *file, const char *function, int line, const char *format, va_list args)
 {
     const char *name = domain->name ? domain->name : "";

--- a/src/lib/common/sol-log-impl.h
+++ b/src/lib/common/sol-log-impl.h
@@ -45,7 +45,8 @@ extern const void *_print_function_data;
 
 int sol_log_impl_init(void);
 void sol_log_impl_shutdown(void);
-void sol_log_impl_domain_init_level(struct sol_log_domain *domain);
 bool sol_log_impl_lock(void);
 void sol_log_impl_unlock(void);
+bool sol_log_level_parse(const char *str, size_t size, uint8_t *storage);
+bool sol_log_levels_parse(const char *str, size_t size);
 void sol_log_impl_print_function_stderr(void *data, const struct sol_log_domain *domain, uint8_t message_level, const char *file, const char *function, int line, const char *format, va_list args);

--- a/src/lib/common/sol-log.c
+++ b/src/lib/common/sol-log.c
@@ -38,6 +38,7 @@
 #include "sol-log.h"
 #include "sol-macros.h"
 #include "sol-log-impl.h"
+#include "sol-str-table.h"
 
 /* NOTE: these are not static since we share them with sol-log-impl-*.c
  * to make it simpler for those to change and check these variables
@@ -63,6 +64,8 @@ bool _show_line = true;
 void (*_print_function)(void *data, const struct sol_log_domain *domain, uint8_t message_level, const char *file, const char *function, int line, const char *format, va_list args) = sol_log_print_function_stderr;
 const void *_print_function_data = NULL;
 
+static struct sol_str_table *_env_levels = NULL;
+static char *_env_levels_str = NULL;
 static bool _inited = false;
 #define SOL_LOG_INIT_CHECK(fmt, ...) \
     do { \
@@ -95,18 +98,200 @@ void
 sol_log_shutdown(void)
 {
     sol_log_impl_shutdown();
+    free(_env_levels);
+    free(_env_levels_str);
+    _env_levels = NULL;
+    _env_levels_str = NULL;
     _inited = false;
+}
+
+static bool
+_level_str_parse(const char *buf, size_t buflen, uint8_t *storage)
+{
+    int16_t found;
+    static const struct sol_str_table table[] = {
+        SOL_STR_TABLE_ITEM("CRI",      SOL_LOG_LEVEL_CRITICAL),
+        SOL_STR_TABLE_ITEM("CRIT",     SOL_LOG_LEVEL_CRITICAL),
+        SOL_STR_TABLE_ITEM("CRITICAL", SOL_LOG_LEVEL_CRITICAL),
+        SOL_STR_TABLE_ITEM("DBG",      SOL_LOG_LEVEL_DEBUG),
+        SOL_STR_TABLE_ITEM("DEBUG",    SOL_LOG_LEVEL_DEBUG),
+        SOL_STR_TABLE_ITEM("ERR",      SOL_LOG_LEVEL_ERROR),
+        SOL_STR_TABLE_ITEM("ERROR",    SOL_LOG_LEVEL_ERROR),
+        SOL_STR_TABLE_ITEM("INF",      SOL_LOG_LEVEL_INFO),
+        SOL_STR_TABLE_ITEM("INFO",     SOL_LOG_LEVEL_INFO),
+        SOL_STR_TABLE_ITEM("WARN",     SOL_LOG_LEVEL_WARNING),
+        SOL_STR_TABLE_ITEM("WARNING",  SOL_LOG_LEVEL_WARNING),
+        SOL_STR_TABLE_ITEM("WRN",      SOL_LOG_LEVEL_WARNING),
+        { }
+    };
+
+    if (!sol_str_table_lookup(table, SOL_STR_SLICE_STR(buf, buflen), &found))
+        return false;
+    *storage = found;
+    return true;
+}
+
+static bool
+_int32_parse(const char *str, size_t size, int32_t *storage)
+{
+    int64_t value = 0;
+    size_t i;
+    bool negative = false;
+
+    errno = 0;
+    for (i = 0; i < size; i++) {
+        const char c = str[i];
+        if (i == 0 && c == '-') {
+            negative = true;
+            continue;
+        }
+
+        if (c < '0' || c > '9')
+            break;
+        value = (value * 10) + (c - '0');
+        if (value > INT32_MAX) {
+            errno = ERANGE;
+            return false;
+        }
+    }
+    if (i == 0) {
+        errno = EINVAL;
+        return false;
+    }
+    if (negative) {
+        value = -value;
+        if (value < INT32_MIN) {
+            errno = ERANGE;
+            return false;
+        }
+    }
+    *storage = value;
+    return true;
+}
+
+bool
+sol_log_level_parse(const char *str, size_t size, uint8_t *storage)
+{
+    int32_t i;
+    uint8_t level = 0;
+
+    if (size == 0)
+        return false;
+
+    if (_int32_parse(str, size, &i))
+        level = i;
+    else if (!_level_str_parse(str, size, &level))
+        return false;
+
+    *storage = level;
+    return true;
+}
+
+bool
+sol_log_levels_parse(const char *str, size_t size)
+{
+    const char *str_end = str + size;
+    unsigned int count = 0;
+    struct sol_str_table *itr;
+    const char *p, *e;
+
+    for (p = str; p < str_end; p++) {
+        if (*p == ',')
+            count++;
+    }
+    if (p > str)
+        count++;
+
+    free(_env_levels);
+    free(_env_levels_str);
+    if (count == 0) {
+        _env_levels = NULL;
+        _env_levels_str = NULL;
+        return false;
+    }
+
+    _env_levels = malloc((count + 1) * sizeof(*_env_levels));
+    if (!_env_levels) {
+        _env_levels_str = NULL;
+        return false;
+    }
+
+    _env_levels_str = strndup(str, size);
+    if (!_env_levels_str) {
+        free(_env_levels);
+        _env_levels = NULL;
+        _env_levels_str = NULL;
+        return false;
+    }
+
+    itr = _env_levels;
+    e = NULL;
+    str = _env_levels_str;
+    str_end = str + size;
+    for (p = str;; p++) {
+        if (p < str_end && *p == ':')
+            e = p;
+        else if (p == str_end || *p == ',') {
+            if (e && str + 1 < e && e + 1 < p) {
+                uint8_t val;
+                itr->key = str;
+                itr->len = e - str;
+                if (sol_log_level_parse(e + 1, p - e - 1, &val)) {
+                    itr->val = val;
+                    itr++;
+                }
+            }
+
+            if (p == str_end)
+                break;
+            str = p + 1;
+            e = NULL;
+        }
+    }
+
+    if (itr == _env_levels) {
+        free(_env_levels);
+        free(_env_levels_str);
+        _env_levels = NULL;
+        _env_levels_str = NULL;
+        return false;
+    }
+
+    itr->key = NULL;
+    itr->len = 0;
+    itr->val = 0;
+    return true;
+}
+
+SOL_API void
+sol_log_init_level_global(const char *str, size_t length)
+{
+    sol_log_level_parse(str, length, &_global_domain.level);
+}
+
+SOL_API void
+sol_log_init_levels(const char *str, size_t length)
+{
+    sol_log_levels_parse(str, length);
 }
 
 SOL_API void
 sol_log_domain_init_level(struct sol_log_domain *domain)
 {
+    int16_t level;
     SOL_LOG_INIT_CHECK("domain=%p", domain);
 
     if (!domain || !domain->name)
         return;
 
-    sol_log_impl_domain_init_level(domain);
+    if (_env_levels) {
+        level = sol_str_table_lookup_fallback(_env_levels,
+            sol_str_slice_from_str(domain->name),
+            _global_domain.level);
+    } else
+        level = _global_domain.level;
+
+    domain->level = level;
 }
 
 SOL_API void


### PR DESCRIPTION
In order to support changing log levels per domain on systems where
getenv() is not available, now we allow passing SOL_LOG_LEVEL and
SOL_LOG_LEVELS as compile time definitions.
They work the same way as the environment variables on Unix systems,
with the only caveat that SOL_LOG_LEVEL must always be defined as a
string.