### PR TITLE
check-fbp-bin: Fix building the javascript test

### DIFF
--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -294,7 +294,7 @@ $($(1)-out): $(SOL_LIB_OUTPUT) $($(1)-src) $(modules-out)
 	$(Q)echo "     " CC"   "$$@
 	$(Q)$(MKDIR) -p $(dir $($(1)-out))
 	$(Q)$(TARGETCC) $(SAMPLE_CFLAGS) $($(1)-CFLAGS) $(use-builtin-cflags) $($(1)-src) $($(1)-extra) -o $($(1)-out) \
-	$(SAMPLE_LDFLAGS) $(use-builtin-ldflags)
+	$(SAMPLE_LDFLAGS) $($(1)-LDFLAGS) $(use-builtin-ldflags)
 endef
 $(foreach test-fbp-bin,$(all-tests-fbp-bin),$(eval $(call make-test-fbp-bin,$(test-fbp-bin))))
 

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -488,6 +488,7 @@ tests-fbp-bin += $(top_srcdir)src/test-fbp/javascript.fbp
 $(top_srcdir)src/test-fbp/javascript.fbp-extra := $(top_srcdir)src/thirdparty/duktape/src/duktape.c
 $(top_srcdir)src/test-fbp/javascript.fbp-CFLAGS := -I$(top_srcdir)src/thirdparty/duktape/src/ -Wno-float-equal \
                                                 -Wno-format-nonliteral -Wno-suggest-attribute=noreturn
+$(top_srcdir)src/test-fbp/javascript.fbp-LDFLAGS := -lm
 else
 TEST_FBP_SCRIPT_SKIP_EXTRA := SKIP_JAVASCRIPT
 endif


### PR DESCRIPTION
Given how JS nodes, converted to C by sol-fbp-generator, require that
duktape.c is built along, we also need to pass appropriate LDFLAGS,
namely in this case, -lm.