### PR TITLE
Mem fixes

### DIFF
--- a/src/lib/comms/sol-http-common.c
+++ b/src/lib/comms/sol-http-common.c
@@ -494,8 +494,10 @@ sol_http_create_uri(struct sol_buffer *buf, const struct sol_http_url url,
         SOL_INT_CHECK_GOTO(r, < 0, err_exit);
     }
 
-    r = sol_buffer_ensure_nul_byte(buf);
-    SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+    if (SOL_BUFFER_NEEDS_NUL_BYTE(buf)) {
+        r = sol_buffer_ensure_nul_byte(buf);
+        SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+    }
 
     return 0;
 
@@ -564,8 +566,10 @@ sol_http_create_simple_uri(struct sol_buffer *buf, const struct sol_str_slice ba
         }
     }
 
-    r = sol_buffer_ensure_nul_byte(buf);
-    SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+    if (SOL_BUFFER_NEEDS_NUL_BYTE(buf)) {
+        r = sol_buffer_ensure_nul_byte(buf);
+        SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+    }
 
     return 0;
 

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -39,7 +39,7 @@
 #include "sol-util-internal.h"
 
 SOL_ATTR_PURE static inline size_t
-nul_byte_size(struct sol_buffer *buf)
+nul_byte_size(const struct sol_buffer *buf)
 {
     return (buf->flags & SOL_BUFFER_FLAGS_NO_NUL_BYTE) ? 0 : 1;
 }
@@ -70,15 +70,19 @@ SOL_API int
 sol_buffer_ensure(struct sol_buffer *buf, size_t min_size)
 {
     int err;
+    size_t nul_byte;
 
     SOL_NULL_CHECK(buf, -EINVAL);
 
-    if (min_size >= SIZE_MAX - nul_byte_size(buf))
+    nul_byte = nul_byte_size(buf);
+    if (min_size >= SIZE_MAX - nul_byte)
         return -EINVAL;
+
+    min_size += nul_byte;
     if (buf->capacity >= min_size)
         return 0;
 
-    err = sol_buffer_resize(buf, align_power2(min_size + nul_byte_size(buf)));
+    err = sol_buffer_resize(buf, align_power2(min_size));
     if (err == -EPERM)
         return -ENOMEM;
     return err;
@@ -94,7 +98,8 @@ sol_buffer_expand(struct sol_buffer *buf, size_t bytes)
 
     available = buf->capacity - buf->used;
 
-    if (available >= bytes)
+    /* only account null byte here since sol_buffer_ensure() already adds it */
+    if (available >= bytes + nul_byte_size(buf))
         return 0;
 
     err = sol_util_size_add(buf->capacity, bytes - available, &new_size);
@@ -112,10 +117,8 @@ sol_buffer_set_slice(struct sol_buffer *buf, const struct sol_str_slice slice)
 
     SOL_NULL_CHECK(buf, -EINVAL);
 
-    /* Extra room for the ending NUL-byte. */
-    if (slice.len >= SIZE_MAX - nul_byte_size(buf))
-        return -EOVERFLOW;
-    err = sol_buffer_ensure(buf, slice.len + nul_byte_size(buf));
+    /* ensure already handles the null-byte */
+    err = sol_buffer_ensure(buf, slice.len);
     if (err < 0)
         return err;
 
@@ -127,28 +130,19 @@ sol_buffer_set_slice(struct sol_buffer *buf, const struct sol_str_slice slice)
 SOL_API int
 sol_buffer_append_bytes(struct sol_buffer *buf, const uint8_t *bytes, size_t size)
 {
-    const size_t nul_size = nul_byte_size(buf);
     char *p;
-    size_t new_size;
     int err;
 
     SOL_NULL_CHECK(buf, -EINVAL);
 
-    err = sol_util_size_add(buf->used, size, &new_size);
-    if (err < 0)
-        return err;
-
-    /* Extra room for the ending NUL-byte. */
-    if (new_size >= SIZE_MAX - nul_size)
-        return -EOVERFLOW;
-    err = sol_buffer_ensure(buf, new_size + nul_size);
+    err = sol_buffer_expand(buf, size);
     if (err < 0)
         return err;
 
     p = sol_buffer_at_end(buf);
     memcpy(p, bytes, size);
 
-    if (nul_size)
+    if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
         p[size] = '\0';
     buf->used += size;
     return 0;
@@ -164,17 +158,20 @@ SOL_API int
 sol_buffer_set_slice_at(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice)
 {
     int err;
-    const size_t nul_size = nul_byte_size(buf);
+    size_t nul_size;
 
     SOL_NULL_CHECK(buf, -EINVAL);
     if (buf->used < pos) {
         return -EINVAL;
     }
 
+    nul_size = nul_byte_size(buf);
     /* Extra room for the ending NUL-byte. */
     if (slice.len >= SIZE_MAX - nul_size - pos)
         return -EOVERFLOW;
-    err = sol_buffer_ensure(buf, pos + slice.len + nul_size);
+
+    /* ensure already handles the null-byte */
+    err = sol_buffer_ensure(buf, pos + slice.len);
     if (err < 0)
         return err;
 
@@ -184,7 +181,8 @@ sol_buffer_set_slice_at(struct sol_buffer *buf, size_t pos, const struct sol_str
     if (pos + slice.len >= buf->used) {
         buf->used = pos + slice.len;
         /* only terminate if we're growing */
-        ((char *)buf->data)[buf->used] = 0;
+        if (nul_size)
+            ((char *)buf->data)[buf->used] = 0;
     }
 
     return 0;
@@ -194,17 +192,20 @@ SOL_API int
 sol_buffer_set_char_at(struct sol_buffer *buf, size_t pos, char c)
 {
     int err;
-    const size_t nul_size = nul_byte_size(buf);
+    size_t nul_size;
 
     SOL_NULL_CHECK(buf, -EINVAL);
     if (buf->used < pos) {
         return -EINVAL;
     }
 
+    nul_size = nul_byte_size(buf);
     /* Extra room for the ending NUL-byte. */
     if (1 >= SIZE_MAX - nul_size - pos)
         return -EOVERFLOW;
-    err = sol_buffer_ensure(buf, pos + 1 + nul_size);
+
+    /* ensure already handles the null-byte */
+    err = sol_buffer_ensure(buf, pos + 1);
     if (err < 0)
         return err;
 
@@ -213,7 +214,7 @@ sol_buffer_set_char_at(struct sol_buffer *buf, size_t pos, char c)
     if (pos + 1 >= buf->used)
         buf->used = pos + 1;
 
-    if (nul_byte_size(buf))
+    if (nul_size)
         return sol_buffer_ensure_nul_byte(buf);
 
     return 0;
@@ -222,9 +223,7 @@ sol_buffer_set_char_at(struct sol_buffer *buf, size_t pos, char c)
 SOL_API int
 sol_buffer_insert_bytes(struct sol_buffer *buf, size_t pos, const uint8_t *bytes, size_t size)
 {
-    const size_t nul_size = nul_byte_size(buf);
     char *p;
-    size_t new_size;
     int err;
 
     SOL_NULL_CHECK(buf, -EINVAL);
@@ -233,14 +232,7 @@ sol_buffer_insert_bytes(struct sol_buffer *buf, size_t pos, const uint8_t *bytes
     if (pos == buf->used)
         return sol_buffer_append_bytes(buf, bytes, size);
 
-    err = sol_util_size_add(buf->used, size, &new_size);
-    if (err < 0)
-        return err;
-
-    /* Extra room for the ending NUL-byte. */
-    if (new_size >= SIZE_MAX - nul_size)
-        return -EOVERFLOW;
-    err = sol_buffer_ensure(buf, new_size + nul_size);
+    err = sol_buffer_expand(buf, size);
     if (err < 0)
         return err;
 
@@ -249,10 +241,8 @@ sol_buffer_insert_bytes(struct sol_buffer *buf, size_t pos, const uint8_t *bytes
     memcpy(p, bytes, size);
     buf->used += size;
 
-    if (nul_size) {
-        p = sol_buffer_at_end(buf);
-        p[0] = '\0';
-    }
+    if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
+        return sol_buffer_ensure_nul_byte(buf);
 
     return 0;
 }
@@ -297,12 +287,20 @@ sol_buffer_append_vprintf(struct sol_buffer *buf, const char *fmt, va_list args)
         if (r < 0)
             goto end;
 
-        /* Extra room for the ending NUL-byte. */
-        if (new_size >= SIZE_MAX - 1) {
-            r = -EOVERFLOW;
-            goto end;
+        if (!SOL_BUFFER_NEEDS_NUL_BYTE(buf)) {
+            /* sol_buffer_ensure() will add the space for the
+             * null-byte only if the flag is set, however vsnprintf()
+             * needs it in all cases.
+             * Then if NO_NULL_BYTE is set, we need to manually add it.
+             */
+            if (new_size >= SIZE_MAX - 1) {
+                r = -EOVERFLOW;
+                goto end;
+            }
+            new_size++;
         }
-        r = sol_buffer_ensure(buf, new_size + 1);
+
+        r = sol_buffer_ensure(buf, new_size);
         if (r < 0)
             goto end;
 
@@ -379,7 +377,7 @@ sol_buffer_steal_or_copy(struct sol_buffer *buf, size_t *size)
 
     r = sol_buffer_steal(buf, size);
     if (!r) {
-        r = sol_util_memdup(buf->data, buf->used);
+        r = sol_util_memdup(buf->data, buf->used + nul_byte_size(buf));
         SOL_NULL_CHECK(r, NULL);
 
         if (size)
@@ -399,7 +397,7 @@ sol_buffer_copy(const struct sol_buffer *buf)
     b_copy = sol_util_memdup(buf, sizeof(*buf));
     if (!b_copy) return NULL;
 
-    b_copy->data = sol_util_memdup(buf->data, buf->used);
+    b_copy->data = sol_util_memdup(buf->data, buf->used + nul_byte_size(buf));
     if (!b_copy->data) {
         free(b_copy);
         return NULL;
@@ -434,16 +432,11 @@ SOL_API int
 sol_buffer_append_char(struct sol_buffer *buf, const char c)
 {
     char *p;
-    size_t new_size;
     int err;
 
     SOL_NULL_CHECK(buf, -EINVAL);
 
-    err = sol_util_size_add(buf->used, 1, &new_size);
-    if (err < 0)
-        return err;
-
-    err = sol_buffer_ensure(buf, new_size);
+    err = sol_buffer_expand(buf, 1);
     if (err < 0)
         return err;
 
@@ -460,7 +453,6 @@ SOL_API int
 sol_buffer_insert_char(struct sol_buffer *buf, size_t pos, const char c)
 {
     char *p;
-    size_t new_size;
     int err;
 
     SOL_NULL_CHECK(buf, -EINVAL);
@@ -469,11 +461,7 @@ sol_buffer_insert_char(struct sol_buffer *buf, size_t pos, const char c)
     if (pos == buf->used)
         return sol_buffer_append_char(buf, c);
 
-    err = sol_util_size_add(buf->used, 1, &new_size);
-    if (err < 0)
-        return err;
-
-    err = sol_buffer_ensure(buf, new_size);
+    err = sol_buffer_expand(buf, 1);
     if (err < 0)
         return err;
 
@@ -482,7 +470,7 @@ sol_buffer_insert_char(struct sol_buffer *buf, size_t pos, const char c)
     *p = c;
     buf->used++;
 
-    if (nul_byte_size(buf))
+    if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
         return sol_buffer_ensure_nul_byte(buf);
     return 0;
 }
@@ -493,9 +481,7 @@ SOL_API int
 sol_buffer_insert_as_base64(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)])
 {
     char *p;
-    size_t new_size;
     ssize_t encoded_size, r;
-    const size_t nul_size = nul_byte_size(buf);
     int err;
 
     SOL_NULL_CHECK(buf, -EINVAL);
@@ -511,17 +497,7 @@ sol_buffer_insert_as_base64(struct sol_buffer *buf, size_t pos, const struct sol
     if (encoded_size < 0)
         return encoded_size;
 
-    err = sol_util_size_add(buf->used, encoded_size, &new_size);
-    if (err < 0)
-        return err;
-
-    if (nul_size) {
-        err = sol_util_size_add(new_size, nul_size, &new_size);
-        if (err < 0)
-            return err;
-    }
-
-    err = sol_buffer_ensure(buf, new_size);
+    err = sol_buffer_expand(buf, encoded_size);
     if (err < 0)
         return err;
 
@@ -530,7 +506,7 @@ sol_buffer_insert_as_base64(struct sol_buffer *buf, size_t pos, const struct sol
     r = sol_util_base64_encode(p, encoded_size, slice, base64_map);
     if (r != encoded_size) {
         memmove(p, p + encoded_size, buf->used - pos);
-        if (nul_size)
+        if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
             sol_buffer_ensure_nul_byte(buf);
         if (r < 0)
             return r;
@@ -540,7 +516,7 @@ sol_buffer_insert_as_base64(struct sol_buffer *buf, size_t pos, const struct sol
 
     buf->used += encoded_size;
 
-    if (nul_size)
+    if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
         return sol_buffer_ensure_nul_byte(buf);
     return 0;
 }
@@ -549,9 +525,7 @@ SOL_API int
 sol_buffer_append_as_base64(struct sol_buffer *buf, const struct sol_str_slice slice, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)])
 {
     char *p;
-    size_t new_size;
     ssize_t encoded_size, r;
-    const size_t nul_size = nul_byte_size(buf);
     int err;
 
     SOL_NULL_CHECK(buf, -EINVAL);
@@ -563,24 +537,14 @@ sol_buffer_append_as_base64(struct sol_buffer *buf, const struct sol_str_slice s
     if (encoded_size < 0)
         return encoded_size;
 
-    err = sol_util_size_add(buf->used, encoded_size, &new_size);
-    if (err < 0)
-        return err;
-
-    if (nul_size) {
-        err = sol_util_size_add(new_size, nul_size, &new_size);
-        if (err < 0)
-            return err;
-    }
-
-    err = sol_buffer_ensure(buf, new_size);
+    err = sol_buffer_expand(buf, encoded_size);
     if (err < 0)
         return err;
 
     p = sol_buffer_at_end(buf);
     r = sol_util_base64_encode(p, encoded_size, slice, base64_map);
     if (r != encoded_size) {
-        if (nul_size)
+        if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
             sol_buffer_ensure_nul_byte(buf);
         if (r < 0)
             return r;
@@ -590,7 +554,7 @@ sol_buffer_append_as_base64(struct sol_buffer *buf, const struct sol_str_slice s
 
     buf->used += encoded_size;
 
-    if (nul_size)
+    if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
         return sol_buffer_ensure_nul_byte(buf);
     return 0;
 }
@@ -599,9 +563,7 @@ SOL_API int
 sol_buffer_insert_from_base64(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)])
 {
     char *p;
-    size_t new_size;
     ssize_t decoded_size, r;
-    const size_t nul_size = nul_byte_size(buf);
     int err;
 
     SOL_NULL_CHECK(buf, -EINVAL);
@@ -617,17 +579,7 @@ sol_buffer_insert_from_base64(struct sol_buffer *buf, size_t pos, const struct s
     if (decoded_size < 0)
         return decoded_size;
 
-    err = sol_util_size_add(buf->used, decoded_size, &new_size);
-    if (err < 0)
-        return err;
-
-    if (nul_size) {
-        err = sol_util_size_add(new_size, nul_size, &new_size);
-        if (err < 0)
-            return err;
-    }
-
-    err = sol_buffer_ensure(buf, new_size);
+    err = sol_buffer_expand(buf, decoded_size);
     if (err < 0)
         return err;
 
@@ -636,7 +588,7 @@ sol_buffer_insert_from_base64(struct sol_buffer *buf, size_t pos, const struct s
     r = sol_util_base64_decode(p, decoded_size, slice, base64_map);
     if (r != decoded_size) {
         memmove(p, p + decoded_size, buf->used - pos);
-        if (nul_size)
+        if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
             sol_buffer_ensure_nul_byte(buf);
         if (r < 0)
             return r;
@@ -646,7 +598,7 @@ sol_buffer_insert_from_base64(struct sol_buffer *buf, size_t pos, const struct s
 
     buf->used += decoded_size;
 
-    if (nul_size)
+    if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
         return sol_buffer_ensure_nul_byte(buf);
     return 0;
 }
@@ -655,9 +607,7 @@ SOL_API int
 sol_buffer_append_from_base64(struct sol_buffer *buf, const struct sol_str_slice slice, const char base64_map[SOL_STATIC_ARRAY_SIZE(65)])
 {
     char *p;
-    size_t new_size;
     ssize_t decoded_size, r;
-    const size_t nul_size = nul_byte_size(buf);
     int err;
 
     SOL_NULL_CHECK(buf, -EINVAL);
@@ -669,24 +619,14 @@ sol_buffer_append_from_base64(struct sol_buffer *buf, const struct sol_str_slice
     if (decoded_size < 0)
         return decoded_size;
 
-    err = sol_util_size_add(buf->used, decoded_size, &new_size);
-    if (err < 0)
-        return err;
-
-    if (nul_size) {
-        err = sol_util_size_add(new_size, nul_size, &new_size);
-        if (err < 0)
-            return err;
-    }
-
-    err = sol_buffer_ensure(buf, new_size);
+    err = sol_buffer_expand(buf, decoded_size);
     if (err < 0)
         return err;
 
     p = sol_buffer_at_end(buf);
     r = sol_util_base64_decode(p, decoded_size, slice, base64_map);
     if (r != decoded_size) {
-        if (nul_size)
+        if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
             sol_buffer_ensure_nul_byte(buf);
         if (r < 0)
             return r;
@@ -696,7 +636,7 @@ sol_buffer_append_from_base64(struct sol_buffer *buf, const struct sol_str_slice
 
     buf->used += decoded_size;
 
-    if (nul_size)
+    if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
         return sol_buffer_ensure_nul_byte(buf);
     return 0;
 }
@@ -705,9 +645,7 @@ SOL_API int
 sol_buffer_insert_as_base16(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice, bool uppercase)
 {
     char *p;
-    size_t new_size;
     ssize_t encoded_size, r;
-    const size_t nul_size = nul_byte_size(buf);
     int err;
 
     SOL_NULL_CHECK(buf, -EINVAL);
@@ -723,17 +661,7 @@ sol_buffer_insert_as_base16(struct sol_buffer *buf, size_t pos, const struct sol
     if (encoded_size < 0)
         return encoded_size;
 
-    err = sol_util_size_add(buf->used, encoded_size, &new_size);
-    if (err < 0)
-        return err;
-
-    if (nul_size) {
-        err = sol_util_size_add(new_size, nul_size, &new_size);
-        if (err < 0)
-            return err;
-    }
-
-    err = sol_buffer_ensure(buf, new_size);
+    err = sol_buffer_expand(buf, encoded_size);
     if (err < 0)
         return err;
 
@@ -742,7 +670,7 @@ sol_buffer_insert_as_base16(struct sol_buffer *buf, size_t pos, const struct sol
     r = sol_util_base16_encode(p, encoded_size, slice, uppercase);
     if (r != encoded_size) {
         memmove(p, p + encoded_size, buf->used - pos);
-        if (nul_size)
+        if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
             sol_buffer_ensure_nul_byte(buf);
         if (r < 0)
             return r;
@@ -752,7 +680,7 @@ sol_buffer_insert_as_base16(struct sol_buffer *buf, size_t pos, const struct sol
 
     buf->used += encoded_size;
 
-    if (nul_size)
+    if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
         return sol_buffer_ensure_nul_byte(buf);
     return 0;
 }
@@ -761,9 +689,7 @@ SOL_API int
 sol_buffer_append_as_base16(struct sol_buffer *buf, const struct sol_str_slice slice, bool uppercase)
 {
     char *p;
-    size_t new_size;
     ssize_t encoded_size, r;
-    const size_t nul_size = nul_byte_size(buf);
     int err;
 
     SOL_NULL_CHECK(buf, -EINVAL);
@@ -775,24 +701,14 @@ sol_buffer_append_as_base16(struct sol_buffer *buf, const struct sol_str_slice s
     if (encoded_size < 0)
         return encoded_size;
 
-    err = sol_util_size_add(buf->used, encoded_size, &new_size);
-    if (err < 0)
-        return err;
-
-    if (nul_size) {
-        err = sol_util_size_add(new_size, nul_size, &new_size);
-        if (err < 0)
-            return err;
-    }
-
-    err = sol_buffer_ensure(buf, new_size);
+    err = sol_buffer_expand(buf, encoded_size);
     if (err < 0)
         return err;
 
     p = sol_buffer_at_end(buf);
     r = sol_util_base16_encode(p, encoded_size, slice, uppercase);
     if (r != encoded_size) {
-        if (nul_size)
+        if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
             sol_buffer_ensure_nul_byte(buf);
         if (r < 0)
             return r;
@@ -802,7 +718,7 @@ sol_buffer_append_as_base16(struct sol_buffer *buf, const struct sol_str_slice s
 
     buf->used += encoded_size;
 
-    if (nul_size)
+    if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
         return sol_buffer_ensure_nul_byte(buf);
     return 0;
 }
@@ -811,9 +727,7 @@ SOL_API int
 sol_buffer_insert_from_base16(struct sol_buffer *buf, size_t pos, const struct sol_str_slice slice, enum sol_decode_case decode_case)
 {
     char *p;
-    size_t new_size;
     ssize_t decoded_size, r;
-    const size_t nul_size = nul_byte_size(buf);
     int err;
 
     SOL_NULL_CHECK(buf, -EINVAL);
@@ -829,17 +743,7 @@ sol_buffer_insert_from_base16(struct sol_buffer *buf, size_t pos, const struct s
     if (decoded_size < 0)
         return decoded_size;
 
-    err = sol_util_size_add(buf->used, decoded_size, &new_size);
-    if (err < 0)
-        return err;
-
-    if (nul_size) {
-        err = sol_util_size_add(new_size, nul_size, &new_size);
-        if (err < 0)
-            return err;
-    }
-
-    err = sol_buffer_ensure(buf, new_size);
+    err = sol_buffer_expand(buf, decoded_size);
     if (err < 0)
         return err;
 
@@ -848,7 +752,7 @@ sol_buffer_insert_from_base16(struct sol_buffer *buf, size_t pos, const struct s
     r = sol_util_base16_decode(p, decoded_size, slice, decode_case);
     if (r != decoded_size) {
         memmove(p, p + decoded_size, buf->used - pos);
-        if (nul_size)
+        if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
             sol_buffer_ensure_nul_byte(buf);
         if (r < 0)
             return r;
@@ -858,7 +762,7 @@ sol_buffer_insert_from_base16(struct sol_buffer *buf, size_t pos, const struct s
 
     buf->used += decoded_size;
 
-    if (nul_size)
+    if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
         return sol_buffer_ensure_nul_byte(buf);
     return 0;
 }
@@ -867,9 +771,7 @@ SOL_API int
 sol_buffer_append_from_base16(struct sol_buffer *buf, const struct sol_str_slice slice, enum sol_decode_case decode_case)
 {
     char *p;
-    size_t new_size;
     ssize_t decoded_size, r;
-    const size_t nul_size = nul_byte_size(buf);
     int err;
 
     SOL_NULL_CHECK(buf, -EINVAL);
@@ -881,24 +783,14 @@ sol_buffer_append_from_base16(struct sol_buffer *buf, const struct sol_str_slice
     if (decoded_size < 0)
         return decoded_size;
 
-    err = sol_util_size_add(buf->used, decoded_size, &new_size);
-    if (err < 0)
-        return err;
-
-    if (nul_size) {
-        err = sol_util_size_add(new_size, nul_size, &new_size);
-        if (err < 0)
-            return err;
-    }
-
-    err = sol_buffer_ensure(buf, new_size);
+    err = sol_buffer_expand(buf, decoded_size);
     if (err < 0)
         return err;
 
     p = sol_buffer_at_end(buf);
     r = sol_util_base16_decode(p, decoded_size, slice, decode_case);
     if (r != decoded_size) {
-        if (nul_size)
+        if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
             sol_buffer_ensure_nul_byte(buf);
         if (r < 0)
             return r;
@@ -908,7 +800,7 @@ sol_buffer_append_from_base16(struct sol_buffer *buf, const struct sol_str_slice
 
     buf->used += decoded_size;
 
-    if (nul_size)
+    if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
         return sol_buffer_ensure_nul_byte(buf);
     return 0;
 }
@@ -920,7 +812,6 @@ sol_buffer_remove_data(struct sol_buffer *buf, size_t size, size_t offset)
     size_t total;
 
     SOL_NULL_CHECK(buf, -EINVAL);
-    SOL_EXP_CHECK(buf->flags & SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED, -EPERM);
 
     if ((buf->used < offset))
         return -EINVAL;
@@ -937,6 +828,14 @@ sol_buffer_remove_data(struct sol_buffer *buf, size_t size, size_t offset)
 
     buf->used -= size;
 
+    if (!(buf->flags & SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED)) {
+        r = sol_buffer_resize(buf, align_power2(buf->used + nul_byte_size(buf)));
+        if (r < 0)
+            return r;
+    }
+
+    if (SOL_BUFFER_NEEDS_NUL_BYTE(buf))
+        return sol_buffer_ensure_nul_byte(buf);
     return 0;
 }
 

--- a/src/lib/io/sol-efivarfs-storage.c
+++ b/src/lib/io/sol-efivarfs-storage.c
@@ -247,24 +247,16 @@ sol_efivars_read_raw(const char *name, struct sol_buffer *buffer)
     }
 
     /* Read (to discard) the first uint32_t containing the attributes */
-    r = sol_util_fill_buffer(fd, &attr, sizeof(uint32_t));
+    r = sol_util_fill_buffer_exactly(fd, &attr, sizeof(uint32_t));
     if (r < 0) {
         SOL_WRN("Could not read persistence file [%s] attributes", path);
         goto end;
     }
 
     if (buffer->capacity) {
-        r = sol_util_fill_buffer(fd, buffer, buffer->capacity);
+        r = sol_util_fill_buffer_exactly(fd, buffer, buffer->capacity);
     } else {
-        size_t size;
-        char *data = sol_util_load_file_fd_string(fd, &size);
-        if (data) {
-            buffer->capacity = size;
-            buffer->used = size;
-            buffer->data = data;
-            r = size;
-        } else
-            r = -errno;
+        r = sol_util_load_file_fd_buffer(fd, buffer);
     }
 
 end:

--- a/src/lib/io/sol-fs-storage.c
+++ b/src/lib/io/sol-fs-storage.c
@@ -187,17 +187,9 @@ sol_fs_read_raw(const char *name, struct sol_buffer *buffer)
     }
 
     if (buffer->capacity) {
-        r = sol_util_fill_buffer(fd, buffer, buffer->capacity);
+        r = sol_util_fill_buffer_exactly(fd, buffer, buffer->capacity);
     } else {
-        size_t size = 0;
-        char *data = sol_util_load_file_fd_string(fd, &size);
-        if (data) {
-            buffer->capacity = size;
-            buffer->used = size;
-            buffer->data = data;
-            r = size;
-        } else
-            r = -errno;
+        r = sol_util_load_file_fd_buffer(fd, buffer);
     }
 
     close(fd);

--- a/src/lib/io/sol-iio.c
+++ b/src/lib/io/sol-iio.c
@@ -418,7 +418,6 @@ device_reader_cb(void *data, int fd, uint32_t active_flags)
         result = false;
     }
 
-    sol_buffer_reset(&device->buffer);
     ret = sol_util_fill_buffer(fd, &device->buffer, device->buffer_size);
     if (ret <= 0) {
         result = false;
@@ -426,6 +425,7 @@ device_reader_cb(void *data, int fd, uint32_t active_flags)
         if (device->reader_cb) {
             device->reader_cb((void *)device->reader_cb_data, device);
         }
+        sol_buffer_reset(&device->buffer);
     }
 
     if (!result) {

--- a/src/lib/io/sol-memmap-storage.c
+++ b/src/lib/io/sol-memmap-storage.c
@@ -127,7 +127,7 @@ sol_memmap_read_raw_do(const char *path, const struct sol_memmap_entry *entry, u
     if (lseek(fd, entry->offset, SEEK_SET) < 0)
         goto error;
 
-    if ((ret = sol_util_fill_buffer(fd, buffer, entry->size)) < 0)
+    if ((ret = sol_util_fill_buffer_exactly(fd, buffer, entry->size)) < 0)
         goto error;
 
     if (mask) {

--- a/src/shared/sol-util-file.c
+++ b/src/shared/sol-util-file.c
@@ -161,12 +161,11 @@ sol_util_fill_buffer(const int fd, struct sol_buffer *buffer, const size_t size)
     if (ret > 0)
         ret = bytes_read;
 
-    if (!(buffer->flags & SOL_BUFFER_FLAGS_NO_NUL_BYTE)) {
-        if (buffer->used == buffer->capacity)
-            SOL_WRN("sol_buffer %p asks for terminating NUL byte, but doesn't have space for it",
-                buffer);
-        else
-            *((char *)buffer->data + buffer->used) = '\0';
+    if (SOL_BUFFER_NEEDS_NUL_BYTE(buffer)) {
+        int err;
+
+        err = sol_buffer_ensure_nul_byte(buffer);
+        SOL_INT_CHECK(err, < 0, err);
     }
 
     return ret;

--- a/src/shared/sol-util-file.c
+++ b/src/shared/sol-util-file.c
@@ -221,8 +221,6 @@ sol_util_load_file_fd_buffer(int fd, struct sol_buffer *buf)
 
     r = (int)ret;
     SOL_INT_CHECK(r, < 0, r);
-    r = sol_buffer_trim(buf);
-    SOL_INT_CHECK(r, < 0, r);
 
     return 0;
 }
@@ -237,6 +235,8 @@ sol_util_load_file_fd_string(int fd, size_t *size)
 
     r = sol_util_load_file_fd_buffer(fd, &buf);
     SOL_INT_CHECK_GOTO(r, < 0, err);
+    r = sol_buffer_trim(buf);
+    SOL_INT_CHECK(r, < 0, r);
     data = sol_buffer_steal(&buf, &size_read);
     SOL_NULL_CHECK_GOTO(data, err);
 

--- a/src/shared/sol-util-file.c
+++ b/src/shared/sol-util-file.c
@@ -181,7 +181,7 @@ sol_util_load_file_fd_raw(const int fd)
     buf = sol_buffer_new();
     SOL_NULL_CHECK(buf, NULL);
 
-    buf->flags = SOL_BUFFER_FLAGS_NO_NUL_BYTE;
+    buf->flags |= SOL_BUFFER_FLAGS_NO_NUL_BYTE;
 
     r = sol_util_load_file_fd_buffer(fd, buf);
     SOL_INT_CHECK_GOTO(r, < 0, err_exit);

--- a/src/test/test-buffer.c
+++ b/src/test/test-buffer.c
@@ -263,6 +263,76 @@ test_set_slice_at(void)
     ASSERT_INT_EQ(err, -EINVAL);
 
     sol_buffer_fini(&buf);
+
+    sol_buffer_init(&buf);
+    slice = sol_str_slice_from_str("abcd");
+    err = sol_buffer_set_slice(&buf, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("abcd"));
+    ASSERT_STR_EQ(buf.data, "abcd");
+
+    slice = sol_str_slice_from_str("XY");
+    err = sol_buffer_set_slice_at(&buf, 4, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("abcdXY"));
+    ASSERT_STR_EQ(buf.data, "abcdXY");
+    sol_buffer_fini(&buf);
+
+    sol_buffer_init(&buf);
+    slice = sol_str_slice_from_str("abcd");
+    err = sol_buffer_set_slice(&buf, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("abcd"));
+    ASSERT_STR_EQ(buf.data, "abcd");
+
+    slice = sol_str_slice_from_str("XY");
+    err = sol_buffer_set_slice_at(&buf, 3, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("abcXY"));
+    ASSERT_STR_EQ(buf.data, "abcXY");
+    sol_buffer_fini(&buf);
+
+    sol_buffer_init(&buf);
+    slice = sol_str_slice_from_str("abcd");
+    err = sol_buffer_set_slice(&buf, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("abcd"));
+    ASSERT_STR_EQ(buf.data, "abcd");
+
+    slice = sol_str_slice_from_str("XY");
+    err = sol_buffer_set_slice_at(&buf, 2, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("abXY"));
+    ASSERT_STR_EQ(buf.data, "abXY");
+    sol_buffer_fini(&buf);
+
+    sol_buffer_init(&buf);
+    slice = sol_str_slice_from_str("abcd");
+    err = sol_buffer_set_slice(&buf, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("abcd"));
+    ASSERT_STR_EQ(buf.data, "abcd");
+
+    slice = sol_str_slice_from_str("XY");
+    err = sol_buffer_set_slice_at(&buf, 1, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("aXYd"));
+    ASSERT_STR_EQ(buf.data, "aXYd");
+    sol_buffer_fini(&buf);
+
+    sol_buffer_init(&buf);
+    slice = sol_str_slice_from_str("abcd");
+    err = sol_buffer_set_slice(&buf, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("abcd"));
+    ASSERT_STR_EQ(buf.data, "abcd");
+
+    slice = sol_str_slice_from_str("XY");
+    err = sol_buffer_set_slice_at(&buf, 0, slice);
+    ASSERT_INT_EQ(err, 0);
+    ASSERT_INT_EQ(buf.used, strlen("XYcd"));
+    ASSERT_STR_EQ(buf.data, "XYcd");
+    sol_buffer_fini(&buf);
 }
 
 DEFINE_TEST(test_set_char_at);
@@ -369,7 +439,8 @@ test_memory_not_owned(void)
     err = sol_buffer_ensure(&buf, 0);
     ASSERT_INT_EQ(err, 0);
 
-    err = sol_buffer_ensure(&buf, sizeof(backend));
+    /* ensure considers null-byte, so we use sizeof - 1 */
+    err = sol_buffer_ensure(&buf, sizeof(backend) - 1);
     ASSERT_INT_EQ(err, 0);
 
     err = sol_buffer_ensure(&buf, sizeof(backend) * 2);


### PR DESCRIPTION
wow, this was huge... started by me going back to master to valgrind http-client sample to understand if my #1494 introduced regressions.

I've found that new helpers introduced by @cabelitos in sol-buffer were missing some trailing null-bytes, but then I reviewed the whole sol-buffer and found many other issues, most were harmless since they were adding one more byte than was needed, but some were actually bugs by failing to copy or account that byte.

By checking that I also found that some code were using `sol_util_fill_buffer()` but were not checking if the requested amount was read, in the case of less bytes read it would proceed with garbage. This was the case with @ceolin unix-socket and @edersondisouza persistence. Likely the original versions didn't had problems, but when the sol-util-file helpers were added the details were "lost in translation".

That said, please @cabelitos, @edersondisouza and @ceolin review and test this PR extensively using valgrind, try to break it... if you do, introduce more tests so we avoid to introduce more bugs in the future. I didn't add new tests for null-byte, so it could be a nice addition from you.