### PR TITLE
comms: replace sol_buffet_at_end to sol_buffer_at_end

### DIFF
--- a/src/lib/comms/sol-network-impl-riot.c
+++ b/src/lib/comms/sol-network-impl-riot.c
@@ -66,7 +66,7 @@ sol_network_addr_to_str(const struct sol_network_link_addr *addr,
         SOL_INT_CHECK(err, < 0, NULL);
     }
 
-    r = ipv6_addr_to_str(sol_buffet_at_end(buf), (ipv6_addr_t *)&addr->addr,
+    r = ipv6_addr_to_str(sol_buffer_at_end(buf), (ipv6_addr_t *)&addr->addr,
         IPV6_ADDR_MAX_STR_LEN);
 
     if (r)


### PR DESCRIPTION
There is no such function sol_buffet_at_end in Soletta

Signed-off-by: Bruno Bottazzini <bruno.bottazzini@intel.com>