### PR TITLE
Sol-monitors: Fix infinite loop while iterating over a sol-monitor ca…

### DIFF
--- a/src/lib/datatypes/include/sol-vector.h
+++ b/src/lib/datatypes/include/sol-vector.h
@@ -239,6 +239,20 @@ sol_vector_take_data(struct sol_vector *v)
         idx++)
 
 /**
+ * @def SOL_VECTOR_FOREACH_IDX_UNTIL(vector, itrvar, idx, until)
+ * @brief Macro to iterate over the vector until a index.
+ *
+ * @param vector The vector to iterate over
+ * @param itrvar Variable pointing to the current element's data on each iteration
+ * @param idx Index integer variable that is increased while iterating
+ * @param until The index that the iteration should stop
+ */
+#define SOL_VECTOR_FOREACH_IDX_UNTIL(vector, itrvar, idx, until) \
+    for (idx = 0; \
+        idx < until && (itrvar = (__typeof__(itrvar))sol_vector_get_nocheck((vector), idx), true); \
+        idx++)
+
+/**
  * @def SOL_VECTOR_FOREACH_REVERSE_IDX(vector, itrvar, idx)
  * @brief Macro to iterate over the vector easily in the reverse order.
  *
@@ -587,6 +601,21 @@ sol_ptr_vector_take_data(struct sol_ptr_vector *pv)
 #define SOL_PTR_VECTOR_FOREACH_IDX(vector, itrvar, idx) \
     for (idx = 0; \
         idx < (vector)->base.len && \
+        ((itrvar = (__typeof__(itrvar))sol_ptr_vector_get_nocheck((vector), idx)), true); \
+        idx++)
+
+/**
+ * @def SOL_PTR_VECTOR_FOREACH_IDX_UNTIL(vector, itrvar, idx, until)
+ * @brief Macro to iterate over the pointer vector until a index.
+ *
+ * @param vector The pointer vector to iterate over
+ * @param itrvar Variable pointing to the current element's data on each iteration
+ * @param idx Index integer variable that is increased while iterating
+ * @param until The index that the iteration should stop
+ */
+#define SOL_PTR_VECTOR_FOREACH_IDX_UNTIL(vector, itrvar, idx, until) \
+    for (idx = 0; \
+        idx < until && \
         ((itrvar = (__typeof__(itrvar))sol_ptr_vector_get_nocheck((vector), idx)), true); \
         idx++)
 

--- a/src/shared/sol-monitors.h
+++ b/src/shared/sol-monitors.h
@@ -128,11 +128,12 @@ void sol_monitors_end_walk(struct sol_monitors *ms);
 
 #define _SOL_MONITORS_WALK_VAR(X) walk__var__ ## X
 
-#define __SOL_MONITORS_WALK(ms, itrvar, idx, executed)                    \
-    for (bool executed = ({ sol_monitors_begin_walk(ms); false; });      \
-        !executed;                                                     \
-        executed = ({ sol_monitors_end_walk(ms); true; }))              \
-        SOL_VECTOR_FOREACH_IDX (&(ms)->entries, itrvar, idx)
+#define __SOL_MONITORS_WALK(ms, itrvar, idx, executed) \
+    for (uint16_t executed = ({ sol_monitors_begin_walk(ms); 0; }), \
+        entries_len = sol_monitors_count(ms); \
+        !executed; \
+        executed = ({ sol_monitors_end_walk(ms); 1; })) \
+        SOL_VECTOR_FOREACH_IDX_UNTIL (&(ms)->entries, itrvar, idx, entries_len)
 
 #define _SOL_MONITORS_WALK(ms, itrvar, idx, executed) \
     __SOL_MONITORS_WALK(ms, itrvar, idx, _SOL_MONITORS_WALK_VAR(executed))


### PR DESCRIPTION
…llbacks.

The following code would lead soletta to an infinite loop:

static void
my_monitor_cb(void *data)
{
    struct sol_monitors *ms = data;

    sol_monitors_append(my_monitor_cb, ms);
}

// C code...

SOL_MONITORS_WALK(sol_monitor, cb, i)
	cb(sol_monitor);

//More C code...

This happens because sol_monitors_append() does not care if
the sol_monitor is walking. In order to prevent an infinite
loop, __SOL_MONITORS_WALK() should save how many monitors
are registered before the walk starts and walk until that number is reached.

Signed-off-by: Guilherme Iscaro <guilherme.iscaro@intel.com>