### PR TITLE
Remove platform dependent code from coap.c

### DIFF
--- a/src/lib/comms/coap.c
+++ b/src/lib/comms/coap.c
@@ -30,7 +30,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <arpa/inet.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>


### PR DESCRIPTION
Signed-off-by: Bruno Bottazzini <bruno.bottazzini@intel.com>

@ceolin, could you verify this? It is related to your PR https://github.com/solettaproject/soletta/pull/1515