### PR TITLE
coap: change it to handle payload in sol_buffers.

### DIFF
--- a/src/lib/comms/coap.c
+++ b/src/lib/comms/coap.c
@@ -97,51 +97,53 @@ decode_delta(int num, const uint8_t *buf, int16_t buflen, uint16_t *decoded)
 }
 
 int
-coap_parse_option(const struct sol_coap_packet *pkt, struct option_context *context,
+coap_parse_option(struct option_context *context,
     uint8_t **value, uint16_t *vlen)
 {
     uint16_t delta, len;
     int r;
 
-    if (context->buflen < 1)
+    if (context->buf->used - context->pos < 1)
         return 0;
 
     /* This indicates that options have ended */
-    if (context->buf[0] == COAP_MARKER)
+    if (((uint8_t *)sol_buffer_at(context->buf, context->pos))[0] ==
+        COAP_MARKER)
         return 0;
 
-    delta = coap_option_header_get_delta(context->buf[0]);
-    len = coap_option_header_get_len(context->buf[0]);
-    context->buf += 1;
+    delta = coap_option_header_get_delta((((uint8_t *)sol_buffer_at
+            (context->buf, context->pos))[0]));
+    len = coap_option_header_get_len((((uint8_t *)sol_buffer_at
+            (context->buf, context->pos))[0]));
+    context->pos += 1;
     context->used += 1;
-    context->buflen -= 1;
 
     /* In case 'delta' doesn't fit the option fixed header. */
-    r = decode_delta(delta, context->buf, context->buflen, &delta);
+    r = decode_delta(delta, sol_buffer_at(context->buf, context->pos),
+        context->buf->used - context->pos, &delta);
     if (r < 0)
-        return -EINVAL;
+        return r;
 
-    context->buf += r;
+    context->pos += r;
     context->used += r;
-    context->buflen -= r;
 
     /* In case 'len' doesn't fit the option fixed header. */
-    r = decode_delta(len, context->buf, context->buflen, &len);
+    r = decode_delta(len, sol_buffer_at(context->buf, context->pos),
+        context->buf->used - context->pos, &len);
     if (r < 0)
-        return -EINVAL;
+        return r;
 
-    if (context->buflen < r + len)
+    if (context->buf->used - context->pos < (size_t)(r + len))
         return -EINVAL;
 
     if (value)
-        *value = context->buf + r;
+        *value = sol_buffer_at(context->buf, context->pos + r);
 
     if (vlen)
         *vlen = len;
 
-    context->buf += r + len;
+    context->pos += r + len;
     context->used += r + len;
-    context->buflen -= r + len;
 
     context->delta += delta;
 
@@ -153,11 +155,11 @@ coap_parse_options(struct sol_coap_packet *pkt, unsigned int offset)
 {
     struct option_context context = { .delta = 0,
                                       .used = 0,
-                                      .buflen = pkt->payload.size - offset,
-                                      .buf = &pkt->buf[offset] };
+                                      .buf = &pkt->buf,
+                                      .pos = offset };
 
     while (true) {
-        int r = coap_parse_option(pkt, &context, NULL, NULL);
+        int r = coap_parse_option(&context, NULL, NULL);
         if (r < 0)
             return -EINVAL;
 
@@ -176,17 +178,17 @@ coap_get_header_len(const struct sol_coap_packet *pkt)
 
     hdrlen = sizeof(struct coap_header);
 
-    if (pkt->payload.size < hdrlen)
+    if (pkt->buf.used < hdrlen)
         return -EINVAL;
 
-    hdr = (struct coap_header *)pkt->buf;
+    hdr = (struct coap_header *)sol_buffer_at(&pkt->buf, 0);
     tkl = hdr->tkl;
 
     // Token lenghts 9-15 are reserved.
     if (tkl > 8)
         return -EINVAL;
 
-    if (pkt->payload.size < hdrlen + tkl)
+    if (pkt->buf.used < hdrlen + tkl)
         return -EINVAL;
 
     return hdrlen + tkl;
@@ -201,33 +203,33 @@ coap_packet_parse(struct sol_coap_packet *pkt)
 
     hdrlen = coap_get_header_len(pkt);
     if (hdrlen < 0)
-        return -EINVAL;
+        return hdrlen;
 
     optlen = coap_parse_options(pkt, hdrlen);
     if (optlen < 0)
+        return optlen;
+
+    if (pkt->buf.used < (size_t)(hdrlen + optlen))
         return -EINVAL;
 
-    if (pkt->payload.size < hdrlen + optlen)
+    if (pkt->buf.used > COAP_UDP_MTU)
         return -EINVAL;
 
-    if (pkt->payload.size > COAP_UDP_MTU)
-        return -EINVAL;
-
-    if (pkt->payload.size <= hdrlen + optlen + 1) {
-        pkt->payload.start = NULL;
-        pkt->payload.used = pkt->payload.size;
+    /* +1 for COAP_MARKER */
+    if (pkt->buf.used <= (size_t)(hdrlen + optlen + 1)) {
+        pkt->payload_start = 0;
         return 0;
     }
 
-    pkt->payload.start = pkt->buf + hdrlen + optlen + 1;
-    pkt->payload.used = hdrlen + optlen + 1;
+    pkt->payload_start = hdrlen + optlen + 1;
     return 0;
 }
 
 static int
-delta_encode(int num, uint8_t *value, uint8_t *buf, size_t buflen)
+delta_encode(int num, uint8_t *value, struct sol_buffer *buf, size_t offset)
 {
     uint16_t v;
+    int r;
 
     if (num < 13) {
         *value = num;
@@ -235,21 +237,19 @@ delta_encode(int num, uint8_t *value, uint8_t *buf, size_t buflen)
     }
 
     if (num < 269) {
-        if (buflen < 1)
-            return -EINVAL;
-
         *value = 13;
-        *buf = num - 13;
+        r = sol_buffer_insert_char(buf, offset, num - 13);
+        SOL_INT_CHECK(r, < 0, r);
+
         return 1;
     }
-
-    if (buflen < 2)
-        return -EINVAL;
 
     *value = 14;
 
     v = sol_util_cpu_to_be16(num - 269);
-    memcpy(buf, &v, sizeof(v));
+
+    r = sol_buffer_insert_bytes(buf, offset, (uint8_t *)&v, sizeof(v));
+    SOL_INT_CHECK(r, < 0, r);
 
     return 2;
 }
@@ -265,24 +265,27 @@ coap_option_encode(struct option_context *context, uint16_t code,
 
     offset = 1;
 
-    r = delta_encode(delta, &data, context->buf + offset, context->buflen - offset);
+    /* write zero on this reserved space, just to advance buffer's 'used' */
+    r = sol_buffer_set_char_at(context->buf, context->pos, 0);
+    SOL_INT_CHECK(r, < 0, r);
+
+    r = delta_encode(delta, &data, context->buf, context->pos + offset);
     if (r < 0)
         return -EINVAL;
 
     offset += r;
-    coap_option_header_set_delta(context->buf, data);
+    coap_option_header_set_delta(sol_buffer_at(context->buf, context->pos),
+        data);
 
-    r = delta_encode(len, &data, context->buf + offset, context->buflen - offset);
-    if (r < 0)
-        return -EINVAL;
+    r = delta_encode(len, &data, context->buf, context->pos + offset);
+    SOL_INT_CHECK(r, < 0, r);
 
     offset += r;
-    coap_option_header_set_len(context->buf, data);
-
-    if (context->buflen < offset + len)
-        return -EINVAL;
-
-    memcpy(context->buf + offset, value, len);
+    coap_option_header_set_len(sol_buffer_at(context->buf, context->pos),
+        data);
+    r = sol_buffer_insert_bytes(context->buf,
+        context->pos + offset, value, len);
+    SOL_INT_CHECK(r, < 0, r);
 
     return offset + len;
 }

--- a/src/lib/comms/coap.h
+++ b/src/lib/comms/coap.h
@@ -32,6 +32,9 @@
 
 #pragma once
 
+#include <inttypes.h>
+#include "sol-buffer.h"
+
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 struct coap_header {
     uint8_t ver : 2;
@@ -56,19 +59,15 @@ struct coap_header {
 
 struct sol_coap_packet {
     int refcnt;
-    struct {
-        uint8_t *start;
-        uint16_t size;
-        uint16_t used;
-    } payload;
-    uint8_t buf[COAP_UDP_MTU];
+    struct sol_buffer buf;
+    size_t payload_start;
 };
 
 struct option_context {
-    uint8_t *buf;
+    struct sol_buffer *buf;
+    size_t pos; /* current position on buf */
     int delta;
-    int used;
-    int buflen;
+    int used; /* size used of options */
 };
 
 #define COAP_VERSION 1
@@ -79,8 +78,7 @@ int coap_get_header_len(const struct sol_coap_packet *pkt);
 
 struct sol_coap_packet *coap_new_packet(struct sol_coap_packet *old);
 
-int coap_parse_option(const struct sol_coap_packet *pkt, struct option_context *context,
-    uint8_t **value, uint16_t *vlen);
+int coap_parse_option(struct option_context *context, uint8_t **value, uint16_t *vlen);
 
 int coap_option_encode(struct option_context *context, uint16_t code,
     const void *value, uint16_t len);

--- a/src/lib/comms/sol-oic-common.c
+++ b/src/lib/comms/sol-oic-common.c
@@ -132,22 +132,23 @@ sol_oic_payload_debug(struct sol_coap_packet *pkt)
     SOL_NULL_CHECK(pkt);
 
 #ifdef HAVE_STDOUT
-    uint8_t *payload;
-    uint16_t payload_len;
+    struct sol_buffer *buf;
     CborParser parser;
-    CborError err;
     CborValue root;
+    CborError err;
+    size_t offset;
 
     if (!sol_oic_pkt_has_cbor_content(pkt) ||
         !sol_coap_packet_has_payload(pkt)) {
         return;
     }
-    if (sol_coap_packet_get_payload(pkt, &payload, &payload_len) < 0) {
+    if (sol_coap_packet_get_payload(pkt, &buf, &offset) < 0) {
         SOL_DBG("Failed to get packet payload");
         return;
     }
 
-    err = cbor_parser_init(payload, payload_len, 0, &parser, &root);
+    err = cbor_parser_init(sol_buffer_at(buf, offset),
+        buf->used - offset, 0, &parser, &root);
     if (err != CborNoError) {
         SOL_DBG("Failed to get cbor payload");
         return;


### PR DESCRIPTION
This is the 1st iteration of trying to use less memory on CoAP buffers.
sol_coap will now, on packet creation, use a sol_buffer to handle all
the payload, and not allocate a blob with COAP_UDP_MTU bytes right away
anymore. This way, the user is able to append on that buffer to make the
user payload, so that less data hangs around at least on the sending
side. All places where a minimum amount of sending bytes could be
assured now do so.

We still have to think on how to proceed on some of the OIC/cbor paths,
since the involve users callbacks appending cbor data to a packet's
buffer (and issuing the callback *twice* just to have the cbor
phony-size-calculating calls to take place would be bad). At the
receiving side, we still allocate COAP_UDP_MTU bytes to the buffer. We
can make this better from here as well. On Linux, at least, we have the
MSG_TRUNC recvmsg() flag.

Also, the next iteration of this work will be to change de
sol_coap_packet_new() to receive a possible user-allocated buffer to use
as payload (at the receiving side this could be used as well). So, on
small OSs the direct network buffers could be passed around -- we'll
surely evolve from here.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>

----

This was tested extensively, but of couse more testing is welcome. @otaviobp, would you help by exercising this on all your tests too? I will now check how do we perform memory-wise with the lwm2m RIOT's sample app.