### PR TITLE
Enable Soletta running over Zephyr's nanokernel

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -273,10 +273,15 @@
       ]
     },
     {
+      "dependency": "zephyr_micro",
+      "type": "ccode",
+      "fragment": "#ifndef CONFIG_MICROKERNEL\n#error \"Microkernel not supported\"\n#endif\n"
+    },
+    {
       "dependency": "zephyr",
       "type": "ccode",
       "headers": [
-        "<microkernel.h>"
+        "<nanokernel.h>"
       ]
     },
     {

--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -160,6 +160,12 @@ config SOL_BUS
 
 source "src/modules/linux-micro/Kconfig"
 
+config MAINLOOP_ZEPHYR_NANO
+	bool
+
+config MAINLOOP_ZEPHYR_MICRO
+	bool
+
 choice
 	prompt "Mainloop"
 	default MAINLOOP_POSIX if LINUX
@@ -243,6 +249,8 @@ config MAINLOOP_CONTIKI
 config MAINLOOP_ZEPHYR
 	bool "zephyr"
 	depends on ZEPHYR
+	select MAINLOOP_ZEPHYR_NANO if !FEATURE_ZEPHYR_MICROKERNEL
+	select MAINLOOP_ZEPHYR_MICRO if FEATURE_ZEPHYR_MICROKERNEL
 	help
             The mainloop to be used in Zephyr platform.
 

--- a/src/lib/common/Makefile
+++ b/src/lib/common/Makefile
@@ -54,7 +54,13 @@ obj-core-$(MAINLOOP_CONTIKI) += \
 
 obj-core-$(MAINLOOP_ZEPHYR) += \
     sol-mainloop-common.o \
-    sol-mainloop-impl-zephyr.o
+    sol-mainloop-impl-zephyr-common.o
+
+obj-core-$(MAINLOOP_ZEPHYR_NANO) += \
+    sol-mainloop-impl-zephyr-nano.o
+
+obj-core-$(MAINLOOP_ZEPHYR_MICRO) += \
+    sol-mainloop-impl-zephyr-micro.o
 
 obj-core-$(PLATFORM_LINUX_MICRO) += \
     sol-platform-impl-linux-micro.o

--- a/src/lib/common/include/soletta.h
+++ b/src/lib/common/include/soletta.h
@@ -110,7 +110,7 @@ extern "C" {
 #include <zephyr.h>
 
 #define SOL_MAIN(CALLBACKS) \
-    void main_task(void) { \
+    void main(void) { \
         SOL_LOG_LEVEL_INIT(); \
         SOL_LOG_LEVELS_INIT(); \
         sol_mainloop_default_main(&(CALLBACKS), 0, NULL); \

--- a/src/lib/common/sol-mainloop-impl-zephyr-micro.c
+++ b/src/lib/common/sol-mainloop-impl-zephyr-micro.c
@@ -30,13 +30,51 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include <errno.h>
 
-struct mainloop_event {
-    void (*cb)(void *data);
-    const void *data;
-};
+#include <microkernel.h>
 
-int sol_mainloop_zephyr_common_init(void);
-int sol_mainloop_event_post(const struct mainloop_event *me);
-void sol_mainloop_events_process(int32_t sleeptime);
+#include "sol-log.h"
+#include "sol-mainloop-zephyr.h"
+
+#define MAX_QUEUED_EVENTS 8
+#define PIPE_BUFFER_SIZE (MAX_QUEUED_EVENTS * sizeof(struct mainloop_event))
+DEFINE_PIPE(_sol_mainloop_pipe, PIPE_BUFFER_SIZE)
+
+int
+sol_mainloop_impl_platform_init(void)
+{
+    return sol_mainloop_zephyr_common_init();
+}
+
+int
+sol_mainloop_event_post(const struct mainloop_event *me)
+{
+    int bytes_written, ret;
+    ret = task_pipe_put(_sol_mainloop_pipe, (void *)me, sizeof(*me), &bytes_written, 0, TICKS_NONE);
+    SOL_INT_CHECK(ret, != RC_OK, -ENOMEM);
+
+    return 0;
+}
+
+void
+sol_mainloop_events_process(int32_t sleeptime)
+{
+    char buf[PIPE_BUFFER_SIZE];
+    struct mainloop_event *p;
+    int bytes_read, count, ret;
+
+    ret = task_pipe_get(_sol_mainloop_pipe, buf, PIPE_BUFFER_SIZE, &bytes_read,
+            0, sleeptime);
+
+    if (ret == RC_OK) {
+        p = (struct mainloop_event *)buf;
+        count = bytes_read / sizeof(*p);
+        while (count) {
+            if (p->cb)
+                p->cb((void *)p->data);
+            count--;
+            p++;
+        }
+    }
+}

--- a/src/lib/common/sol-mainloop-impl-zephyr-nano.c
+++ b/src/lib/common/sol-mainloop-impl-zephyr-nano.c
@@ -30,13 +30,69 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include <nanokernel.h>
 
-struct mainloop_event {
-    void (*cb)(void *data);
-    const void *data;
+#include "sol-log.h"
+#include "sol-mainloop-zephyr.h"
+#include "sol-util.h"
+
+struct me_fifo_entry {
+    void *reserved_for_fifo;
+    struct mainloop_event me;
 };
 
-int sol_mainloop_zephyr_common_init(void);
-int sol_mainloop_event_post(const struct mainloop_event *me);
-void sol_mainloop_events_process(int32_t sleeptime);
+static struct nano_fifo _sol_mainloop_pending_events;
+static struct nano_fifo _sol_mainloop_free_events;
+
+#define MAX_QUEUED_EVENTS 8
+#define EVENTS_BUF_SIZE (MAX_QUEUED_EVENTS * sizeof(struct me_fifo_entry))
+static struct me_fifo_entry _events[EVENTS_BUF_SIZE];
+
+int
+sol_mainloop_impl_platform_init(void)
+{
+    int i;
+
+    sol_mainloop_zephyr_common_init();
+
+    nano_fifo_init(&_sol_mainloop_pending_events);
+    nano_fifo_init(&_sol_mainloop_free_events);
+    for (i = 0; i < SOL_UTIL_ARRAY_SIZE(_events); i++) {
+        struct me_fifo_entry *mfe;
+
+        mfe = &_events[i];
+        nano_fifo_put(&_sol_mainloop_free_events, mfe);
+    }
+
+    return 0;
+}
+
+int
+sol_mainloop_event_post(const struct mainloop_event *me)
+{
+    struct me_fifo_entry *mfe;
+
+    mfe = nano_fifo_get(&_sol_mainloop_free_events, TICKS_NONE);
+    SOL_NULL_CHECK(mfe, -ENOMEM);
+
+    mfe->me = *me;
+    nano_fifo_put(&_sol_mainloop_pending_events, mfe);
+
+    return 0;
+}
+
+void
+sol_mainloop_events_process(int32_t sleeptime)
+{
+    struct me_fifo_entry *mfe;
+
+    mfe = nano_task_fifo_get(&_sol_mainloop_pending_events, sleeptime);
+    if (!mfe)
+        return;
+
+    do {
+        if (mfe->me.cb)
+            mfe->me.cb((void *)mfe->me.data);
+        nano_task_fifo_put(&_sol_mainloop_free_events, mfe);
+    } while ((mfe = nano_task_fifo_get(&_sol_mainloop_pending_events, TICKS_NONE)));
+}

--- a/src/lib/io/sol-gpio-impl-zephyr.c
+++ b/src/lib/io/sol-gpio-impl-zephyr.c
@@ -87,7 +87,7 @@ sol_gpio_interrupt_process(void *data)
 static void
 gpio_isr_cb(struct device *port, uint32_t pin)
 {
-    struct mainloop_wake_data w = {
+    struct mainloop_event w = {
         .cb = sol_gpio_interrupt_process,
         .data = NULL
     };
@@ -97,7 +97,7 @@ gpio_isr_cb(struct device *port, uint32_t pin)
     if (!atomic_cas(&int_flag, 0, 1))
         return;
 
-    sol_mainloop_wakeup(&w);
+    sol_mainloop_event_post(&w);
 }
 
 SOL_API struct sol_gpio *

--- a/tools/build/Kconfig.zephyr
+++ b/tools/build/Kconfig.zephyr
@@ -1,3 +1,6 @@
+config FEATURE_ZEPHYR_MICROKERNEL
+    bool
+
 config ZEPHYR
     def_bool y
     select FEATURE_HW_AIO
@@ -6,3 +9,4 @@ config ZEPHYR
     select FEATURE_HW_PWM
     select FEATURE_HW_SPI
     select FEATURE_FLOW
+    select FEATURE_ZEPHYR_MICROKERNEL if HAVE_ZEPHYR_MICRO

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -276,7 +276,7 @@ COMMON_CFLAGS += -fprofile-arcs -ftest-coverage
 COMMON_LDFLAGS += -lgcov
 endif
 
-DEP_RESOLVER_CFLAGS := $(CFLAGS) -Werror=implicit-function-declaration
+DEP_RESOLVER_CFLAGS := $(CFLAGS) -std=gnu99 -Werror=implicit-function-declaration
 DEP_RESOLVER_LDFLAGS := $(LDFLAGS)
 MISSING_H := $(top_srcdir)src/lib/common/sol-missing.h
 


### PR DESCRIPTION
Also wake up the mainloop when timeouts/idlers are added.