### PR TITLE
Arduino breakout

### DIFF
--- a/src/modules/pin-mux/intel-common/intel-common.c
+++ b/src/modules/pin-mux/intel-common/intel-common.c
@@ -152,8 +152,8 @@ _set_mode(uint32_t pin, int mode)
     return sol_util_write_file(path, "%s", mode_str);
 }
 
-static int
-_apply_mux_desc(struct mux_description *desc, unsigned int mode)
+int
+apply_mux_desc(struct mux_description *desc, unsigned int mode)
 {
     int ret;
 
@@ -262,7 +262,7 @@ mux_set_aio(const int device, const int pin, const struct mux_controller *ctl_li
     if (pin >= (int)ctl->len || !ctl->recipe[pin])
         return 0;
 
-    return _apply_mux_desc(ctl->recipe[pin], MODE_ANALOG);
+    return apply_mux_desc(ctl->recipe[pin], MODE_ANALOG);
 }
 
 int
@@ -272,7 +272,7 @@ mux_set_gpio(const uint32_t pin, const enum sol_gpio_direction dir,
     if (pin >= s || !desc_list[pin])
         return 0;
 
-    return _apply_mux_desc(desc_list[pin], dir == SOL_GPIO_DIR_OUT ?
+    return apply_mux_desc(desc_list[pin], dir == SOL_GPIO_DIR_OUT ?
         MODE_GPIO_OUTPUT : MODE_GPIO_INPUT_PULLUP);
 }
 
@@ -284,12 +284,12 @@ mux_set_i2c(const uint8_t bus, struct mux_description * (*const desc_list)[2], c
     if (bus >= s || (!desc_list[bus][0] && !desc_list[bus][1]))
         return 0;
 
-    ret = _apply_mux_desc(desc_list[bus][0], MODE_I2C);
+    ret = apply_mux_desc(desc_list[bus][0], MODE_I2C);
 
     if (ret < 0)
         return ret;
 
-    return _apply_mux_desc(desc_list[bus][1], MODE_I2C);
+    return apply_mux_desc(desc_list[bus][1], MODE_I2C);
 }
 
 int
@@ -314,5 +314,5 @@ mux_set_pwm(const int device, const int channel, const struct mux_controller *ct
     if (channel >= (int)ctl->len || !ctl->recipe[channel])
         return 0;
 
-    return _apply_mux_desc(ctl->recipe[channel], MODE_PWM);
+    return apply_mux_desc(ctl->recipe[channel], MODE_PWM);
 }

--- a/src/modules/pin-mux/intel-common/intel-common.h
+++ b/src/modules/pin-mux/intel-common/intel-common.h
@@ -102,6 +102,8 @@ struct mux_pin_map {
     } aio, pwm; /**< AIO and PWM mapping */
 };
 
+int apply_mux_desc(struct mux_description *desc, unsigned int mode);
+
 void mux_shutdown(void);
 
 int mux_pin_map(const struct mux_pin_map *map, const char *label, const enum sol_io_protocol prot,

--- a/src/modules/pin-mux/intel-edison-rev-c/intel-edison-rev-c.c
+++ b/src/modules/pin-mux/intel-edison-rev-c/intel-edison-rev-c.c
@@ -399,39 +399,67 @@ static struct mux_pin_map pin_map[] = {
 };
 
 // =============================================================================
+static bool ardu_breakout = false;
+
+static int
+_mux_init(void)
+{
+    //Try to detect the Arduino Breakout
+    if (sol_util_write_file("/sys/class/gpio/export", "214") >= 0) {
+        ardu_breakout = true;
+    }
+
+    return 0;
+}
 
 static int
 _pin_map(const char *label, const enum sol_io_protocol prot, va_list args)
 {
-    return mux_pin_map(pin_map, label, prot, args);
+    if (ardu_breakout)
+        return mux_pin_map(pin_map, label, prot, args);
+
+    return -EINVAL;
 }
 
 static int
 _set_aio(const int device, const int pin)
 {
-    return mux_set_aio(device, pin, aio_controller_list, (int)SOL_UTIL_ARRAY_SIZE(aio_controller_list));
+    if (ardu_breakout)
+        return mux_set_aio(device, pin, aio_controller_list, (int)SOL_UTIL_ARRAY_SIZE(aio_controller_list));
+
+    return 0;
 }
 
 static int
 _set_gpio(const uint32_t pin, const enum sol_gpio_direction dir)
 {
-    return mux_set_gpio(pin, dir, gpio_dev_0, (uint32_t)SOL_UTIL_ARRAY_SIZE(gpio_dev_0));
+    if (ardu_breakout)
+        return mux_set_gpio(pin, dir, gpio_dev_0, (uint32_t)SOL_UTIL_ARRAY_SIZE(gpio_dev_0));
+
+    return 0;
 }
 
 static int
 _set_i2c(const uint8_t bus)
 {
-    return mux_set_i2c(bus, i2c_dev_0, SOL_UTIL_ARRAY_SIZE(i2c_dev_0));
+    if (ardu_breakout)
+        return mux_set_i2c(bus, i2c_dev_0, SOL_UTIL_ARRAY_SIZE(i2c_dev_0));
+
+    return 0;
 }
 
 static int
 _set_pwm(const int device, const int channel)
 {
-    return mux_set_pwm(device, channel, pwm_controller_list, (int)SOL_UTIL_ARRAY_SIZE(pwm_controller_list));
+    if (ardu_breakout)
+        return mux_set_pwm(device, channel, pwm_controller_list, (int)SOL_UTIL_ARRAY_SIZE(pwm_controller_list));
+
+    return 0;
 }
 
 SOL_PIN_MUX_DECLARE(INTEL_EDISON_REV_C,
     .plat_name = "intel-edison-rev-c",
+    .init = _mux_init,
     .shutdown = mux_shutdown,
     .pin_map = _pin_map,
     .aio = _set_aio,

--- a/src/modules/pin-mux/intel-edison-rev-c/intel-edison-rev-c.c
+++ b/src/modules/pin-mux/intel-edison-rev-c/intel-edison-rev-c.c
@@ -38,6 +38,21 @@
 // Edison Multiplexer Descriptions
 // =============================================================================
 
+static struct mux_description init_board[] = {
+    { 214, PIN_LOW, MODE_GPIO },
+    { 240, PIN_LOW, MODE_GPIO },
+    { 241, PIN_LOW, MODE_GPIO },
+    { 242, PIN_LOW, MODE_GPIO },
+    { 243, PIN_LOW, MODE_GPIO },
+    { 262, PIN_HIGH, MODE_GPIO },
+    { 263, PIN_HIGH, MODE_GPIO },
+    { 109, PIN_MODE_1, MODE_GPIO },
+    { 114, PIN_MODE_1, MODE_GPIO },
+    { 115, PIN_MODE_1, MODE_GPIO },
+    { 214, PIN_HIGH, MODE_GPIO },
+    { }
+};
+
 static struct mux_description desc_0[] = {
     { 214, PIN_LOW, MODE_GPIO | MODE_UART },
     { 248, PIN_HIGH, MODE_GPIO_OUTPUT },
@@ -407,6 +422,7 @@ _mux_init(void)
     //Try to detect the Arduino Breakout
     if (sol_util_write_file("/sys/class/gpio/export", "214") >= 0) {
         ardu_breakout = true;
+        apply_mux_desc(init_board, MODE_GPIO);
     }
 
     return 0;


### PR DESCRIPTION
- Only apply edison mux if the breakout is detected
- If edison breakout is found, run steps to reset the mux hardware.