### PR TITLE
Sol-platform: Remove the '\"' and '\'' characters from the locale v4

### DIFF
--- a/src/lib/common/sol-platform-linux-common.c
+++ b/src/lib/common/sol-platform-linux-common.c
@@ -970,12 +970,12 @@ sol_platform_impl_load_locales(char **locale_cache)
     }
 
     line = NULL;
-    r = -EINVAL;
     while (fscanf(f, "%m[^\n]\n", &line) != EOF) {
         sep = strchr(line, '=');
         if (!sep) {
             SOL_WRN("The locale entry: %s does not have the separator '='",
                 line);
+            r = -EINVAL;
             goto err_val;
         }
 
@@ -986,7 +986,12 @@ sol_platform_impl_load_locales(char **locale_cache)
 
         category = system_locale_to_sol_locale(key);
         if (category != SOL_PLATFORM_LOCALE_UNKNOWN) {
-            locale_cache[category] = sol_str_slice_to_string(value);
+            struct sol_buffer buf;
+
+            r = sol_util_unescape_quotes(value, &buf);
+            SOL_INT_CHECK_GOTO(r, < 0, err_val);
+            locale_cache[category] = sol_buffer_steal_or_copy(&buf, NULL);
+            sol_buffer_fini(&buf);
             SOL_NULL_CHECK_GOTO(locale_cache[category], err_nomem);
         }
         free(line);

--- a/src/shared/include/sol-util.h
+++ b/src/shared/include/sol-util.h
@@ -1039,6 +1039,22 @@ sol_util_le64_to_cpu(uint64_t val)
 }
 
 /**
+ * @brief Unescape a string removing quotes from it.
+ *
+ * This function will unescape single quotes (\') and double quotes (\") from the slice,
+ * it will also remove single and double quotes from the string if they are not escaped.
+ * The number of quotes that are not escaped must match, otherwise it will be considered a
+ * malformed slice and it will return an error.
+ * Trying to unespace a character that is not a single quote or double quote it is also
+ * considered an error.
+ *
+ * @param slice The slice to be escaped
+ * @param buf - The buffer to hold the unescaped string - It will be initialized by this function.
+ * @return 0 on success, negative errno otherwise.
+ */
+int sol_util_unescape_quotes(const struct sol_str_slice slice, struct sol_buffer *buf);
+
+/**
  * @}
  */
 


### PR DESCRIPTION
Changes since v3:
* Properly unescape the locale string