### PR TITLE
glima	coap: change it to handle payload in sol_buffers [v3]

### DIFF
--- a/src/lib/comms/coap.c
+++ b/src/lib/comms/coap.c
@@ -97,51 +97,53 @@ decode_delta(int num, const uint8_t *buf, int16_t buflen, uint16_t *decoded)
 }
 
 int
-coap_parse_option(const struct sol_coap_packet *pkt, struct option_context *context,
+coap_parse_option(struct option_context *context,
     uint8_t **value, uint16_t *vlen)
 {
     uint16_t delta, len;
+    uint8_t start;
     int r;
 
-    if (context->buflen < 1)
+    if (context->buf->used - context->pos < 1)
         return 0;
+
+    start = ((uint8_t *)sol_buffer_at(context->buf, context->pos))[0];
 
     /* This indicates that options have ended */
-    if (context->buf[0] == COAP_MARKER)
+    if (start == COAP_MARKER)
         return 0;
 
-    delta = coap_option_header_get_delta(context->buf[0]);
-    len = coap_option_header_get_len(context->buf[0]);
-    context->buf += 1;
+    delta = coap_option_header_get_delta(start);
+    len = coap_option_header_get_len(start);
+    context->pos += 1;
     context->used += 1;
-    context->buflen -= 1;
 
     /* In case 'delta' doesn't fit the option fixed header. */
-    r = decode_delta(delta, context->buf, context->buflen, &delta);
+    r = decode_delta(delta, sol_buffer_at(context->buf, context->pos),
+        context->buf->used - context->pos, &delta);
     if (r < 0)
-        return -EINVAL;
+        return r;
 
-    context->buf += r;
+    context->pos += r;
     context->used += r;
-    context->buflen -= r;
 
     /* In case 'len' doesn't fit the option fixed header. */
-    r = decode_delta(len, context->buf, context->buflen, &len);
+    r = decode_delta(len, sol_buffer_at(context->buf, context->pos),
+        context->buf->used - context->pos, &len);
     if (r < 0)
-        return -EINVAL;
+        return r;
 
-    if (context->buflen < r + len)
+    if (context->buf->used - context->pos < (size_t)(r + len))
         return -EINVAL;
 
     if (value)
-        *value = context->buf + r;
+        *value = sol_buffer_at(context->buf, context->pos + r);
 
     if (vlen)
         *vlen = len;
 
-    context->buf += r + len;
+    context->pos += r + len;
     context->used += r + len;
-    context->buflen -= r + len;
 
     context->delta += delta;
 
@@ -153,11 +155,11 @@ coap_parse_options(struct sol_coap_packet *pkt, unsigned int offset)
 {
     struct option_context context = { .delta = 0,
                                       .used = 0,
-                                      .buflen = pkt->payload.size - offset,
-                                      .buf = &pkt->buf[offset] };
+                                      .buf = &pkt->buf,
+                                      .pos = offset };
 
     while (true) {
-        int r = coap_parse_option(pkt, &context, NULL, NULL);
+        int r = coap_parse_option(&context, NULL, NULL);
         if (r < 0)
             return -EINVAL;
 
@@ -176,17 +178,17 @@ coap_get_header_len(const struct sol_coap_packet *pkt)
 
     hdrlen = sizeof(struct coap_header);
 
-    if (pkt->payload.size < hdrlen)
+    if (pkt->buf.used < hdrlen)
         return -EINVAL;
 
-    hdr = (struct coap_header *)pkt->buf;
+    hdr = (struct coap_header *)sol_buffer_at(&pkt->buf, 0);
     tkl = hdr->tkl;
 
     // Token lenghts 9-15 are reserved.
     if (tkl > 8)
         return -EINVAL;
 
-    if (pkt->payload.size < hdrlen + tkl)
+    if (pkt->buf.used < hdrlen + tkl)
         return -EINVAL;
 
     return hdrlen + tkl;
@@ -201,33 +203,33 @@ coap_packet_parse(struct sol_coap_packet *pkt)
 
     hdrlen = coap_get_header_len(pkt);
     if (hdrlen < 0)
-        return -EINVAL;
+        return hdrlen;
 
     optlen = coap_parse_options(pkt, hdrlen);
     if (optlen < 0)
+        return optlen;
+
+    if (pkt->buf.used < (size_t)(hdrlen + optlen))
         return -EINVAL;
 
-    if (pkt->payload.size < hdrlen + optlen)
+    if (pkt->buf.used > COAP_UDP_MTU)
         return -EINVAL;
 
-    if (pkt->payload.size > COAP_UDP_MTU)
-        return -EINVAL;
-
-    if (pkt->payload.size <= hdrlen + optlen + 1) {
-        pkt->payload.start = NULL;
-        pkt->payload.used = pkt->payload.size;
+    /* +1 for COAP_MARKER */
+    if (pkt->buf.used <= (size_t)(hdrlen + optlen + 1)) {
+        pkt->payload_start = 0;
         return 0;
     }
 
-    pkt->payload.start = pkt->buf + hdrlen + optlen + 1;
-    pkt->payload.used = hdrlen + optlen + 1;
+    pkt->payload_start = hdrlen + optlen + 1;
     return 0;
 }
 
 static int
-delta_encode(int num, uint8_t *value, uint8_t *buf, size_t buflen)
+delta_encode(int num, uint8_t *value, struct sol_buffer *buf, size_t offset)
 {
     uint16_t v;
+    int r;
 
     if (num < 13) {
         *value = num;
@@ -235,21 +237,19 @@ delta_encode(int num, uint8_t *value, uint8_t *buf, size_t buflen)
     }
 
     if (num < 269) {
-        if (buflen < 1)
-            return -EINVAL;
-
         *value = 13;
-        *buf = num - 13;
+        r = sol_buffer_insert_char(buf, offset, num - 13);
+        SOL_INT_CHECK(r, < 0, r);
+
         return 1;
     }
-
-    if (buflen < 2)
-        return -EINVAL;
 
     *value = 14;
 
     v = sol_util_cpu_to_be16(num - 269);
-    memcpy(buf, &v, sizeof(v));
+
+    r = sol_buffer_insert_bytes(buf, offset, (uint8_t *)&v, sizeof(v));
+    SOL_INT_CHECK(r, < 0, r);
 
     return 2;
 }
@@ -265,24 +265,27 @@ coap_option_encode(struct option_context *context, uint16_t code,
 
     offset = 1;
 
-    r = delta_encode(delta, &data, context->buf + offset, context->buflen - offset);
+    /* write zero on this reserved space, just to advance buffer's 'used' */
+    r = sol_buffer_set_char_at(context->buf, context->pos, 0);
+    SOL_INT_CHECK(r, < 0, r);
+
+    r = delta_encode(delta, &data, context->buf, context->pos + offset);
     if (r < 0)
         return -EINVAL;
 
     offset += r;
-    coap_option_header_set_delta(context->buf, data);
+    coap_option_header_set_delta(sol_buffer_at(context->buf, context->pos),
+        data);
 
-    r = delta_encode(len, &data, context->buf + offset, context->buflen - offset);
-    if (r < 0)
-        return -EINVAL;
+    r = delta_encode(len, &data, context->buf, context->pos + offset);
+    SOL_INT_CHECK(r, < 0, r);
 
     offset += r;
-    coap_option_header_set_len(context->buf, data);
-
-    if (context->buflen < offset + len)
-        return -EINVAL;
-
-    memcpy(context->buf + offset, value, len);
+    coap_option_header_set_len(sol_buffer_at(context->buf, context->pos),
+        data);
+    r = sol_buffer_insert_bytes(context->buf,
+        context->pos + offset, value, len);
+    SOL_INT_CHECK(r, < 0, r);
 
     return offset + len;
 }

--- a/src/lib/comms/coap.h
+++ b/src/lib/comms/coap.h
@@ -32,6 +32,9 @@
 
 #pragma once
 
+#include <inttypes.h>
+#include "sol-buffer.h"
+
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 struct coap_header {
     uint8_t ver : 2;
@@ -56,19 +59,15 @@ struct coap_header {
 
 struct sol_coap_packet {
     int refcnt;
-    struct {
-        uint8_t *start;
-        uint16_t size;
-        uint16_t used;
-    } payload;
-    uint8_t buf[COAP_UDP_MTU];
+    struct sol_buffer buf;
+    size_t payload_start;
 };
 
 struct option_context {
-    uint8_t *buf;
+    struct sol_buffer *buf;
+    size_t pos; /* current position on buf */
     int delta;
-    int used;
-    int buflen;
+    int used; /* size used of options */
 };
 
 #define COAP_VERSION 1
@@ -79,8 +78,7 @@ int coap_get_header_len(const struct sol_coap_packet *pkt);
 
 struct sol_coap_packet *coap_new_packet(struct sol_coap_packet *old);
 
-int coap_parse_option(const struct sol_coap_packet *pkt, struct option_context *context,
-    uint8_t **value, uint16_t *vlen);
+int coap_parse_option(struct option_context *context, uint8_t **value, uint16_t *vlen);
 
 int coap_option_encode(struct option_context *context, uint16_t code,
     const void *value, uint16_t len);

--- a/src/lib/comms/sol-oic-cbor.c
+++ b/src/lib/comms/sol-oic-cbor.c
@@ -30,6 +30,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/* FIXME: this layer should not be aware of coap.h, it's just here
+ * because of the FIXME below */
+#include "coap.h"
 #include "sol-log.h"
 #include "sol-oic-cbor.h"
 #include "sol-oic-common.h"
@@ -38,21 +41,34 @@ static CborError
 initialize_cbor_payload(struct sol_oic_map_writer *encoder)
 {
     int r;
-    uint16_t size;
+    size_t offset;
+    struct sol_buffer *buf;
     const uint8_t format_cbor = SOL_COAP_CONTENTTYPE_APPLICATION_CBOR;
 
     r = sol_coap_add_option(encoder->pkt, SOL_COAP_OPTION_CONTENT_FORMAT,
         &format_cbor, sizeof(format_cbor));
     SOL_INT_CHECK(r, < 0, CborUnknownError);
 
-    if (sol_coap_packet_get_payload(encoder->pkt, &encoder->payload, &size) < 0) {
+    r = sol_coap_packet_get_payload(encoder->pkt, &buf, &offset);
+    if (r < 0) {
         SOL_WRN("Could not get CoAP payload");
         return CborUnknownError;
     }
 
-    cbor_encoder_init(&encoder->encoder, encoder->payload, size, 0);
+    /* FIXME: Because we can't now make phony cbor calls to calculate
+     * the exact payload in the contexts this call is issued (they
+     * involve user callbacks to append cbor data), we ensure this
+     * hardcoded size */
+    r = sol_buffer_ensure(buf, COAP_UDP_MTU);
+    SOL_INT_CHECK(r, < 0, CborErrorOutOfMemory);
+
+    encoder->payload = sol_buffer_at(buf, offset);
+
+    cbor_encoder_init(&encoder->encoder, encoder->payload,
+        buf->capacity - offset, 0);
 
     encoder->type = SOL_OIC_MAP_CONTENT;
+
     return cbor_encoder_create_map(&encoder->encoder, &encoder->rep_map,
         CborIndefiniteLength);
 }
@@ -78,11 +94,16 @@ sol_oic_packet_cbor_close(struct sol_coap_packet *pkt, struct sol_oic_map_writer
     }
 
     err = cbor_encoder_close_container(&encoder->encoder, &encoder->rep_map);
+    if (err == CborNoError) {
+        /* Ugly, but since tinycbor operates on memory slices
+         * directly, we have to resort to that */
+        struct sol_buffer *buf;
+        int r = sol_coap_packet_get_payload(pkt, &buf, NULL);
+        SOL_INT_CHECK_GOTO(r, < 0, error);
+        buf->used += encoder->encoder.ptr - encoder->payload;
+    }
 
-    if (err == CborNoError)
-        sol_coap_packet_set_payload_used(pkt,
-            encoder->encoder.ptr - encoder->payload);
-
+error:
     return err;
 }
 
@@ -201,13 +222,14 @@ CborError
 sol_oic_packet_cbor_extract_repr_map(struct sol_coap_packet *pkt, CborParser *parser, CborValue *repr_map)
 {
     CborError err;
-    uint8_t *payload;
-    uint16_t size;
+    size_t offset;
+    struct sol_buffer *buf;
 
-    if (sol_coap_packet_get_payload(pkt, &payload, &size) < 0)
-        return CborErrorUnknownLength;
+    err = sol_coap_packet_get_payload(pkt, &buf, &offset);
+    SOL_INT_CHECK(err, < 0, CborErrorUnknownLength);
 
-    err = cbor_parser_init(payload, size, 0, parser, repr_map);
+    err = cbor_parser_init(sol_buffer_at(buf, offset),
+        buf->used - offset, 0, parser, repr_map);
     if (err != CborNoError)
         return err;
 

--- a/src/lib/comms/sol-oic-common.c
+++ b/src/lib/comms/sol-oic-common.c
@@ -132,22 +132,23 @@ sol_oic_payload_debug(struct sol_coap_packet *pkt)
     SOL_NULL_CHECK(pkt);
 
 #ifdef HAVE_STDOUT
-    uint8_t *payload;
-    uint16_t payload_len;
+    struct sol_buffer *buf;
     CborParser parser;
-    CborError err;
     CborValue root;
+    CborError err;
+    size_t offset;
 
     if (!sol_oic_pkt_has_cbor_content(pkt) ||
         !sol_coap_packet_has_payload(pkt)) {
         return;
     }
-    if (sol_coap_packet_get_payload(pkt, &payload, &payload_len) < 0) {
+    if (sol_coap_packet_get_payload(pkt, &buf, &offset) < 0) {
         SOL_DBG("Failed to get packet payload");
         return;
     }
 
-    err = cbor_parser_init(payload, payload_len, 0, &parser, &root);
+    err = cbor_parser_init(sol_buffer_at(buf, offset),
+        buf->used - offset, 0, &parser, &root);
     if (err != CborNoError) {
         SOL_DBG("Failed to get cbor payload");
         return;

--- a/src/lib/comms/sol-socket-dtls-impl-tinydtls.c
+++ b/src/lib/comms/sol-socket-dtls-impl-tinydtls.c
@@ -230,7 +230,7 @@ remove_item_from_vector(struct sol_vector *vec, struct queue_item *item,
     return retval;
 }
 
-static int
+static ssize_t
 sol_socket_dtls_recvmsg(struct sol_socket *socket, void *buf, size_t len, struct sol_network_link_addr *cliaddr)
 {
     struct sol_socket_dtls *s = (struct sol_socket_dtls *)socket;
@@ -254,7 +254,7 @@ sol_socket_dtls_recvmsg(struct sol_socket *socket, void *buf, size_t len, struct
     if (item->buffer.used <= len) {
         memcpy(buf, item->buffer.data, item->buffer.used);
         return remove_item_from_vector(&s->read.queue, item,
-            (int)item->buffer.used);
+            item->buffer.used);
     }
 
     memcpy(buf, item->buffer.data, len);
@@ -270,7 +270,7 @@ sol_socket_dtls_recvmsg(struct sol_socket *socket, void *buf, size_t len, struct
     sol_buffer_fini(&item->buffer);
     item->buffer = new_buf;
 
-    return (int)len;
+    return len;
 
 clear_buf:
     SOL_WRN("Could not copy buffer for short read, discarding unencrypted data");

--- a/src/lib/comms/sol-socket-impl-riot.c
+++ b/src/lib/comms/sol-socket-impl-riot.c
@@ -56,7 +56,7 @@ struct sol_socket_riot {
 
 static struct sol_ptr_vector ipv6_udp_bound_sockets = SOL_PTR_VECTOR_INIT;
 
-static int
+static ssize_t
 ipv6_udp_recvmsg(struct sol_socket_riot *s, void *buf, size_t len, struct sol_network_link_addr *cliaddr)
 {
     gnrc_pktsnip_t *pkt = s->curr_pkt, *udp, *ipv6;
@@ -65,6 +65,9 @@ ipv6_udp_recvmsg(struct sol_socket_riot *s, void *buf, size_t len, struct sol_ne
     size_t copysize;
 
     SOL_NULL_CHECK(pkt, -EAGAIN);
+
+    if (!buf)
+        return pkt->size;
 
     LL_SEARCH_SCALAR(pkt, ipv6, type, GNRC_NETTYPE_IPV6);
     iphdr = ipv6->data;
@@ -301,7 +304,7 @@ sol_socket_riot_set_on_write(struct sol_socket *s, bool (*cb)(void *data, struct
     return 0;
 }
 
-static int
+static ssize_t
 sol_socket_riot_recvmsg(struct sol_socket *s, void *buf, size_t len, struct sol_network_link_addr *cliaddr)
 {
     struct sol_socket_riot *socket = (struct sol_socket_riot *)s;

--- a/src/lib/comms/sol-socket-impl.h
+++ b/src/lib/comms/sol-socket-impl.h
@@ -42,7 +42,12 @@ struct sol_socket_impl {
     int (*set_on_read)(struct sol_socket *s, bool (*cb)(void *data, struct sol_socket *s), const void *data);
     int (*set_on_write)(struct sol_socket *s, bool (*cb)(void *data, struct sol_socket *s), const void *data);
 
-    int (*recvmsg)(struct sol_socket *s, void *buf, size_t len, struct sol_network_link_addr *cliaddr);
+    /* If buf is NULL, it will only peek the incoming packet queue
+     * (not removing data from it), returning the number of bytes
+     * needed to store the next datagram and ignoring the cliaddr
+     * argument. This way, the user may allocate the exact number of
+     * bytes to hold the message contents. */
+    ssize_t (*recvmsg)(struct sol_socket *s, void *buf, size_t len, struct sol_network_link_addr *cliaddr);
 
     int (*sendmsg)(struct sol_socket *s, const void *buf, size_t len,
         const struct sol_network_link_addr *cliaddr);

--- a/src/lib/comms/sol-socket.c
+++ b/src/lib/comms/sol-socket.c
@@ -113,7 +113,7 @@ sol_socket_set_on_write(struct sol_socket *s, bool (*cb)(void *data, struct sol_
     return s->impl->set_on_write(s, cb, data);
 }
 
-SOL_API int
+SOL_API ssize_t
 sol_socket_recvmsg(struct sol_socket *s, void *buf, size_t len, struct sol_network_link_addr *cliaddr)
 {
     SOL_NULL_CHECK(s, -EINVAL);

--- a/src/lib/comms/sol-socket.h
+++ b/src/lib/comms/sol-socket.h
@@ -64,7 +64,7 @@ void sol_socket_del(struct sol_socket *s);
 int sol_socket_set_on_read(struct sol_socket *s, bool (*cb)(void *data, struct sol_socket *s), const void *data);
 int sol_socket_set_on_write(struct sol_socket *s, bool (*cb)(void *data, struct sol_socket *s), const void *data);
 
-int sol_socket_recvmsg(struct sol_socket *s, void *buf, size_t len, struct sol_network_link_addr *cliaddr);
+ssize_t sol_socket_recvmsg(struct sol_socket *s, void *buf, size_t len, struct sol_network_link_addr *cliaddr);
 
 int sol_socket_sendmsg(struct sol_socket *s, const void *buf, size_t len,
     const struct sol_network_link_addr *cliaddr);

--- a/src/samples/coap/simple-client.c
+++ b/src/samples/coap/simple-client.c
@@ -57,15 +57,17 @@ disable_observing(struct sol_coap_packet *req, struct sol_coap_server *server,
 {
     struct sol_coap_packet *pkt = sol_coap_packet_new(req);
     uint8_t observe = 1;
-    int i;
+    int i, r;
 
     if (!pkt)
         return;
 
-    sol_coap_header_set_code(pkt, SOL_COAP_METHOD_GET);
-    sol_coap_header_set_type(pkt, SOL_COAP_TYPE_CON);
-
-    sol_coap_add_option(pkt, SOL_COAP_OPTION_OBSERVE, &observe, sizeof(observe));
+    r = sol_coap_header_set_code(pkt, SOL_COAP_METHOD_GET);
+    SOL_INT_CHECK_GOTO(r, < 0, err);
+    r = sol_coap_header_set_type(pkt, SOL_COAP_TYPE_CON);
+    SOL_INT_CHECK_GOTO(r, < 0, err);
+    r = sol_coap_add_option(pkt, SOL_COAP_OPTION_OBSERVE, &observe, sizeof(observe));
+    SOL_INT_CHECK_GOTO(r, < 0, err);
 
     for (i = 0; path[i].data; i++)
         sol_coap_add_option(pkt, SOL_COAP_OPTION_URI_PATH, path[i].data, path[i].len);
@@ -73,6 +75,11 @@ disable_observing(struct sol_coap_packet *req, struct sol_coap_server *server,
     sol_coap_send_packet(server, pkt, cliaddr);
 
     SOL_INF("Disabled observing");
+
+    return;
+
+err:
+    sol_coap_packet_unref(pkt);
 }
 
 static bool
@@ -81,8 +88,8 @@ reply_cb(struct sol_coap_server *server, struct sol_coap_packet *req,
 {
     struct sol_str_slice *path = data;
     static int count;
-    uint8_t *payload;
-    uint16_t len;
+    struct sol_buffer *buf;
+    size_t offset;
 
     SOL_BUFFER_DECLARE_STATIC(addr, SOL_INET_ADDR_STRLEN);
 
@@ -91,10 +98,11 @@ reply_cb(struct sol_coap_server *server, struct sol_coap_packet *req,
 
     sol_network_addr_to_str(cliaddr, &addr);
 
-    SOL_INF("Got response from %.*s", SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr)));
+    SOL_INF("Got response from %.*s\n", SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr)));
 
-    sol_coap_packet_get_payload(req, &payload, &len);
-    SOL_INF("Payload: %.*s", len, payload);
+    sol_coap_packet_get_payload(req, &buf, &offset);
+    SOL_INF("Payload: %.*s\n", (int)(buf->used - offset),
+        (char *)sol_buffer_at(buf, offset));
 
     if (++count == 10)
         disable_observing(req, server, path, cliaddr);
@@ -110,7 +118,7 @@ main(int argc, char *argv[])
     struct sol_network_link_addr cliaddr = { };
     struct sol_coap_packet *req;
     uint8_t observe = 0;
-    int i;
+    int i, r;
     struct sol_network_link_addr servaddr = { .family = SOL_NETWORK_FAMILY_INET6,
                                               .port = 0 };
 
@@ -119,7 +127,7 @@ main(int argc, char *argv[])
     sol_init();
 
     if (argc < 3) {
-        SOL_INF("Usage: %s <address> <path> [path]\n", argv[0]);
+        printf("Usage: %s <address> <path> [path]\n", argv[0]);
         return 0;
     }
 
@@ -135,7 +143,11 @@ main(int argc, char *argv[])
         return -1;
     }
 
-    sol_coap_header_set_token(req, token, sizeof(token));
+    r = sol_coap_header_set_token(req, token, sizeof(token));
+    if (r < 0) {
+        SOL_WRN("Could not set coap header token.");
+        return -1;
+    }
 
     path = calloc(argc - 1, sizeof(*path));
     if (!path) {


### PR DESCRIPTION
Changes since #1540:
- finally removed the submodule change
- suggestions by @vcgomes done
- new patch handling exact buffer size at the receiving side for coap (linux & riot)

----

The Zephyr part of the second patch is locally written and should be fine, for the record.