### PR TITLE
coap-tests: no reason to link against sol-socket.o [v2]

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -3,7 +3,7 @@ test-test-arena-$(TEST_ARENA) := test.c test-arena.c
 
 test-internal-$(TEST_COAP) += test-coap
 test-internal-test-coap-$(TEST_COAP) := test.c test-coap.c
-test-internal-test-coap-$(TEST_COAP)-deps := lib/comms/coap.o lib/comms/sol-coap.o
+test-internal-test-coap-$(TEST_COAP)-deps := lib/comms/coap.o
 
 test-$(TEST_FBP) += test-fbp
 test-test-fbp-$(TEST_FBP) := test.c test-fbp.c


### PR DESCRIPTION
sol-coap.o is there because that API is not exported on the final lib.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>