### PR TITLE
Sol-platform: Remove the '\"' and '\'' characters from the locale v5

### DIFF
--- a/src/lib/common/sol-platform-linux-common.c
+++ b/src/lib/common/sol-platform-linux-common.c
@@ -970,12 +970,12 @@ sol_platform_impl_load_locales(char **locale_cache)
     }
 
     line = NULL;
-    r = -EINVAL;
     while (fscanf(f, "%m[^\n]\n", &line) != EOF) {
         sep = strchr(line, '=');
         if (!sep) {
             SOL_WRN("The locale entry: %s does not have the separator '='",
                 line);
+            r = -EINVAL;
             goto err_val;
         }
 
@@ -986,7 +986,12 @@ sol_platform_impl_load_locales(char **locale_cache)
 
         category = system_locale_to_sol_locale(key);
         if (category != SOL_PLATFORM_LOCALE_UNKNOWN) {
-            locale_cache[category] = sol_str_slice_to_string(value);
+            struct sol_buffer buf;
+
+            r = sol_util_unescape_quotes(value, &buf);
+            SOL_INT_CHECK_GOTO(r, < 0, err_val);
+            locale_cache[category] = sol_buffer_steal_or_copy(&buf, NULL);
+            sol_buffer_fini(&buf);
             SOL_NULL_CHECK_GOTO(locale_cache[category], err_nomem);
         }
         free(line);

--- a/src/shared/include/sol-util.h
+++ b/src/shared/include/sol-util.h
@@ -1039,6 +1039,20 @@ sol_util_le64_to_cpu(uint64_t val)
 }
 
 /**
+ * @brief Unescape a string removing quotes from it.
+ *
+ * This function will unescape single quotes (\') and double quotes (\") from the slice,
+ * it will also remove single and double quotes from the string if they are not escaped.
+ * Trying to unescape a character that is not a single quote or double quote it is also
+ * considered an error.
+ *
+ * @param slice The slice to be escaped
+ * @param buf - The buffer to hold the unescaped string - It will be initialized by this function.
+ * @return 0 on success, negative errno otherwise.
+ */
+int sol_util_unescape_quotes(const struct sol_str_slice slice, struct sol_buffer *buf);
+
+/**
  * @}
  */
 

--- a/src/test/test-util.c
+++ b/src/test/test-util.c
@@ -522,4 +522,89 @@ test_unicode_utf_conversion(void)
     }
 }
 
+DEFINE_TEST(test_escape_quotes);
+
+static void
+test_escape_quotes(void)
+{
+    static const struct {
+        const struct sol_str_slice input;
+        const struct sol_str_slice output;
+        ssize_t int_result;
+        enum sol_buffer_flags flags;
+    } escape_tests[] = {
+        //Cases where that copy is not necessary.
+        { SOL_STR_SLICE_LITERAL("x"), SOL_STR_SLICE_LITERAL("x"), 0,
+          SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE },
+        { SOL_STR_SLICE_LITERAL("    x"), SOL_STR_SLICE_LITERAL("x"), 0,
+          SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE },
+        { SOL_STR_SLICE_LITERAL("x    "), SOL_STR_SLICE_LITERAL("x"), 0,
+          SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE },
+        { SOL_STR_SLICE_LITERAL("'x'"), SOL_STR_SLICE_LITERAL("x"), 0,
+          SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE },
+        { SOL_STR_SLICE_LITERAL("\"x\""), SOL_STR_SLICE_LITERAL("x"), 0,
+          SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE },
+        { SOL_STR_SLICE_LITERAL("    \"x\""), SOL_STR_SLICE_LITERAL("x"), 0,
+          SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE },
+        { SOL_STR_SLICE_LITERAL("\"x\"     "), SOL_STR_SLICE_LITERAL("x"), 0,
+          SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE },
+        { SOL_STR_SLICE_LITERAL("    \"x\"    "), SOL_STR_SLICE_LITERAL("x"), 0,
+          SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE },
+        { SOL_STR_SLICE_LITERAL("'Locale'"), SOL_STR_SLICE_LITERAL("Locale"), 0,
+          SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE },
+        { SOL_STR_SLICE_LITERAL("\"My String\""), SOL_STR_SLICE_LITERAL("My String"), 0,
+          SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE },
+        { SOL_STR_SLICE_LITERAL("      \"My Stri    ng\" "), SOL_STR_SLICE_LITERAL("My Stri    ng"), 0,
+          SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE },
+        { SOL_STR_SLICE_LITERAL("       "), SOL_STR_SLICE_LITERAL(""), 0,
+          SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE },
+        { SOL_STR_SLICE_LITERAL("I'm good"), SOL_STR_SLICE_LITERAL("I'm good"), 0,
+          SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE },
+        { SOL_STR_SLICE_LITERAL("Hello"), SOL_STR_SLICE_LITERAL("Hello"), 0,
+          SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE },
+
+        { SOL_STR_SLICE_LITERAL("I 'like' you"), SOL_STR_SLICE_LITERAL("I like you"), 0,
+          SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("x'y'"), SOL_STR_SLICE_LITERAL("xy"), 0, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("x\\\"y"), SOL_STR_SLICE_LITERAL("x\"y"), 0, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("\\\'x"), SOL_STR_SLICE_LITERAL("'x"), 0, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("\\\"x"), SOL_STR_SLICE_LITERAL("\"x"), 0, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("    \\\"x"), SOL_STR_SLICE_LITERAL("\"x"), 0, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("x\\\'y\\\"zd"), SOL_STR_SLICE_LITERAL("x'y\"zd"), 0, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("x\"y\""), SOL_STR_SLICE_LITERAL("xy"), 0, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("x\"y\"z\\\"f"), SOL_STR_SLICE_LITERAL("xyz\"f"), 0, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("\\'Locale\\'"), SOL_STR_SLICE_LITERAL("'Locale'"), 0, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("MyQuo\\\"tes"), SOL_STR_SLICE_LITERAL("MyQuo\"tes"), 0, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("MyQuo\\'tes2"), SOL_STR_SLICE_LITERAL("MyQuo'tes2"), 0, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("\\\"Hi, I'm good\\\"   "), SOL_STR_SLICE_LITERAL("\"Hi, I'm good\""), 0, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("    \\\"Hi, I'm good\\\"   "), SOL_STR_SLICE_LITERAL("\"Hi, I'm good\""), 0, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("   \\\"Hi, I'm good\\\"   "), SOL_STR_SLICE_LITERAL("\"Hi, I'm good\""), 0, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("\\\"Hi, I'm good\\\""), SOL_STR_SLICE_LITERAL("\"Hi, I'm good\""), 0, SOL_BUFFER_FLAGS_DEFAULT },
+
+        //Cases that should fail
+        { SOL_STR_SLICE_LITERAL("Wrong\\a"), SOL_STR_SLICE_LITERAL(""), -EINVAL, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("Wrong\\ba"), SOL_STR_SLICE_LITERAL(""), -EINVAL, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("'x\""), SOL_STR_SLICE_LITERAL(""), -EINVAL, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("\"x'"), SOL_STR_SLICE_LITERAL(""), -EINVAL, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("\"x'"), SOL_STR_SLICE_LITERAL(""), -EINVAL, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("'x\""), SOL_STR_SLICE_LITERAL(""), -EINVAL, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("'x"), SOL_STR_SLICE_LITERAL(""), -EINVAL, SOL_BUFFER_FLAGS_DEFAULT },
+        { SOL_STR_SLICE_LITERAL("\"x"), SOL_STR_SLICE_LITERAL(""), -EINVAL, SOL_BUFFER_FLAGS_DEFAULT },
+    };
+    size_t i;
+
+    for (i = 0; i < SOL_UTIL_ARRAY_SIZE(escape_tests); i++) {
+        struct sol_buffer buf;
+        int r;
+
+        r = sol_util_unescape_quotes(escape_tests[i].input, &buf);
+        ASSERT_INT_EQ(r, escape_tests[i].int_result);
+        if (r < 0)
+            continue;
+        ASSERT(sol_str_slice_eq(escape_tests[i].output, sol_buffer_get_slice(&buf)));
+        ASSERT(buf.flags == escape_tests[i].flags);
+        sol_buffer_fini(&buf);
+    }
+}
+
 TEST_MAIN();


### PR DESCRIPTION
Changes since v4:
* Fixed problem pointed by @ederson