### PR TITLE
coap: Limit packet size to COAP_UDP_MTU when reading from socket

### DIFF
--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -1430,7 +1430,7 @@ on_can_read(void *data, struct sol_socket *s)
      * have to change on those cases. */
 
     /* calculate exact needed size */
-    len = sol_socket_recvmsg(s, NULL, 0, NULL);
+    len = sol_socket_recvmsg(s, NULL, COAP_UDP_MTU, NULL);
     SOL_INT_CHECK_GOTO(len, < 0, err_recv);
 
     SOL_DBG("allocating %zd bytes for pkt", len);

--- a/src/lib/comms/sol-socket-dtls-impl-tinydtls.c
+++ b/src/lib/comms/sol-socket-dtls-impl-tinydtls.c
@@ -249,6 +249,9 @@ sol_socket_dtls_recvmsg(struct sol_socket *socket, void *buf, size_t len, struct
         return -EAGAIN;
     }
 
+    if (!buf)
+        return item->buffer.used < len ? item->buffer.used : len;
+
     memcpy(cliaddr, &item->addr, sizeof(*cliaddr));
 
     if (item->buffer.used <= len) {

--- a/src/lib/comms/sol-socket-impl-linux.c
+++ b/src/lib/comms/sol-socket-impl-linux.c
@@ -248,7 +248,10 @@ sol_socket_linux_recvmsg(struct sol_socket *socket, void *buf, size_t len, struc
      * remember to err if !buf && type != DGRAM */
     if (!buf) {
         msg.msg_iov->iov_len = 0;
-        return recvmsg(s->fd, &msg, MSG_TRUNC | MSG_PEEK);
+        r = recvmsg(s->fd, &msg, MSG_TRUNC | MSG_PEEK);
+        if (r < 0)
+            return -errno;
+        return (size_t)r < len ? r : (ssize_t)len;
     } else
         r = recvmsg(s->fd, &msg, 0);
 

--- a/src/lib/comms/sol-socket-impl-riot.c
+++ b/src/lib/comms/sol-socket-impl-riot.c
@@ -69,7 +69,7 @@ ipv6_udp_recvmsg(struct sol_socket_riot *s, void *buf, size_t len, struct sol_ne
     /* When more types of sockets (not just datagram) are accepted,
      * remember to err if !buf && type != DGRAM */
     if (!buf)
-        return pkt->size;
+        return pkt->size < len ? pkt->size : len;
 
     LL_SEARCH_SCALAR(pkt, ipv6, type, GNRC_NETTYPE_IPV6);
     iphdr = ipv6->data;


### PR DESCRIPTION
When calling sol_socket_recvmsg with empty buffer, socket will return
the size of packet read. This can be larger than COAP_UDP_MTU when not
using a real udp socket (tinydtls socket wrapper, for example).

This patch also fixes sol_socket_dtls_recvmsg behavior when calling it
with empty buffer.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>