### PR TITLE
dtls: Don't crash when calling recvmsg to calculate packet size

### DIFF
--- a/src/lib/comms/sol-socket-dtls-impl-tinydtls.c
+++ b/src/lib/comms/sol-socket-dtls-impl-tinydtls.c
@@ -249,6 +249,9 @@ sol_socket_dtls_recvmsg(struct sol_socket *socket, void *buf, size_t len, struct
         return -EAGAIN;
     }
 
+    if (!buf)
+        return item->buffer.used;
+
     memcpy(cliaddr, &item->addr, sizeof(*cliaddr));
 
     if (item->buffer.used <= len) {


### PR DESCRIPTION
sol_socket_dtls_recvmsg was crashing if buf or cliaddr were NULL and
this is used to calculate the packet size.

@glima and @vcgomes: This replaces my fix in commit #1576

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>