### PR TITLE
coap: finally get rid of hardcoded packet sizes at sending side.

### DIFF
--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -658,7 +658,9 @@ on_can_write(void *data, struct sol_socket *s)
     if (err == -EAGAIN)
         return true;
 
-    SOL_DBG("pkt sent:");
+    SOL_DBG("CoAP packet sent (payload of %zu bytes, "
+        "buffer holding it with %zu bytes)",
+        outgoing->pkt->buf.used, outgoing->pkt->buf.capacity);
     sol_coap_packet_debug(outgoing->pkt);
     if (err < 0) {
         SOL_BUFFER_DECLARE_STATIC(addr, SOL_INET_ADDR_STRLEN);

--- a/src/lib/comms/sol-oic-cbor.c
+++ b/src/lib/comms/sol-oic-cbor.c
@@ -30,19 +30,34 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* FIXME: this layer should not be aware of coap.h, it's just here
- * because of the FIXME below */
-#include "coap.h"
 #include "sol-log.h"
 #include "sol-oic-cbor.h"
 #include "sol-oic-common.h"
+
+#define TYPICAL_OIC_PAYLOAD_SZ (64)
+
+static inline int
+buffer_used_bump(struct sol_oic_map_writer *writer, size_t inc)
+{
+    struct sol_buffer *buf;
+    int r = sol_coap_packet_get_payload(writer->pkt, &buf, NULL);
+
+    SOL_INT_CHECK(r, < 0, r);
+    /* Ugly, but since tinycbor operates on memory slices directly, we
+     * have to resort to that */
+    buf->used += inc;
+
+    return 0;
+}
 
 static CborError
 initialize_cbor_payload(struct sol_oic_map_writer *encoder)
 {
     int r;
+    CborError err;
     size_t offset;
     struct sol_buffer *buf;
+    uint8_t *old_ptr, *new_ptr;
     const uint8_t format_cbor = SOL_COAP_CONTENTTYPE_APPLICATION_CBOR;
 
     r = sol_coap_add_option(encoder->pkt, SOL_COAP_OPTION_CONTENT_FORMAT,
@@ -55,22 +70,30 @@ initialize_cbor_payload(struct sol_oic_map_writer *encoder)
         return CborUnknownError;
     }
 
-    /* FIXME: Because we can't now make phony cbor calls to calculate
-     * the exact payload in the contexts this call is issued (they
-     * involve user callbacks to append cbor data), we ensure this
-     * hardcoded size */
-    r = sol_buffer_ensure(buf, COAP_UDP_MTU);
+    r = sol_buffer_ensure(buf, offset + TYPICAL_OIC_PAYLOAD_SZ);
     SOL_INT_CHECK(r, < 0, CborErrorOutOfMemory);
+    printf("buffer initialized with %zu\n", buf->capacity);
 
     encoder->payload = sol_buffer_at(buf, offset);
 
     cbor_encoder_init(&encoder->encoder, encoder->payload,
         buf->capacity - offset, 0);
+    old_ptr = encoder->encoder.ptr;
 
     encoder->type = SOL_OIC_MAP_CONTENT;
 
-    return cbor_encoder_create_map(&encoder->encoder, &encoder->rep_map,
+    /* With the call to sol_buffer_ensure() before, we're safe to open
+     * a container */
+    err = cbor_encoder_create_map(&encoder->encoder, &encoder->rep_map,
         CborIndefiniteLength);
+    if (err == CborNoError) {
+        new_ptr = encoder->rep_map.ptr;
+        r = buffer_used_bump(encoder, new_ptr - old_ptr);
+        if (r < 0)
+            err = CborErrorUnknownType;
+    }
+
+    return err;
 }
 
 void
@@ -81,81 +104,220 @@ sol_oic_packet_cbor_create(struct sol_coap_packet *pkt, struct sol_oic_map_write
     encoder->type = SOL_OIC_MAP_NO_CONTENT;
 }
 
-CborError
-sol_oic_packet_cbor_close(struct sol_coap_packet *pkt, struct sol_oic_map_writer *encoder)
+/* Enlarge a CoAP packet's buffer and update CoAP encoder states
+ * accordingly */
+static inline int
+enlarge_buffer(struct sol_oic_map_writer *writer,
+    CborEncoder orig_encoder,
+    CborEncoder orig_map,
+    size_t needed)
 {
-    CborError err;
+    uint8_t *old_payload = writer->payload;
+    struct sol_buffer *buf;
+    size_t offset;
+    int r;
 
-    if (!encoder->payload) {
-        if (encoder->type == SOL_OIC_MAP_NO_CONTENT)
+    r = sol_coap_packet_get_payload(writer->pkt, &buf, &offset);
+    SOL_INT_CHECK(r, < 0, r);
+
+    r = sol_buffer_ensure(buf, buf->capacity + needed);
+    SOL_INT_CHECK(r, < 0, r);
+
+    /* restore state */
+    writer->encoder = orig_encoder;
+    writer->rep_map = orig_map;
+
+    /* update all encoder states */
+    writer->payload = writer->encoder.ptr = sol_buffer_at(buf, offset);
+    /* sol_buffer_at() directly to somewhere past the used portion fails*/
+    writer->encoder.end = (uint8_t *)sol_buffer_at(buf, 0) + buf->capacity;
+
+    /* new offset + how much it had progressed so far */
+    writer->rep_map.ptr = writer->payload + (orig_map.ptr - old_payload);
+    writer->rep_map.end = writer->encoder.end;
+
+    return 0;
+}
+
+CborError
+sol_oic_packet_cbor_close(struct sol_coap_packet *pkt,
+    struct sol_oic_map_writer *writer)
+{
+    int r;
+    CborError err;
+    uint8_t *old_ptr, *new_ptr;
+    CborEncoder orig_encoder, orig_map;
+
+    if (!writer->payload) {
+        if (writer->type == SOL_OIC_MAP_NO_CONTENT)
             return CborNoError;
-        err = initialize_cbor_payload(encoder);
+        err = initialize_cbor_payload(writer);
         SOL_INT_CHECK(err, != CborNoError, err);
     }
 
-    err = cbor_encoder_close_container(&encoder->encoder, &encoder->rep_map);
-    if (err == CborNoError) {
-        /* Ugly, but since tinycbor operates on memory slices
-         * directly, we have to resort to that */
-        struct sol_buffer *buf;
-        int r = sol_coap_packet_get_payload(pkt, &buf, NULL);
-        SOL_INT_CHECK_GOTO(r, < 0, error);
-        buf->used += encoder->encoder.ptr - encoder->payload;
-    }
+close_container:
+    orig_encoder = writer->encoder, orig_map = writer->rep_map;
 
-error:
+    /* When you close an encoder, it will get its ptr set to the
+     * topmost container's. Also, this would append one byte to the
+     * payload, thus '1' below */
+    old_ptr = writer->rep_map.ptr;
+    err = cbor_encoder_close_container(&writer->encoder, &writer->rep_map);
+    if (err == CborErrorOutOfMemory) {
+        r = enlarge_buffer(writer, orig_encoder, orig_map, 1);
+        SOL_INT_CHECK_GOTO(r, < 0, end);
+        goto close_container;
+    } else if (err != CborNoError)
+        goto end;
+
+    new_ptr = writer->encoder.ptr;
+    r = buffer_used_bump(writer, new_ptr - old_ptr);
+    if (r < 0)
+        err = CborErrorUnknownType;
+
+end:
     return err;
 }
 
 CborError
-sol_oic_packet_cbor_append(struct sol_oic_map_writer *encoder, struct sol_oic_repr_field *repr)
+sol_oic_packet_cbor_append(struct sol_oic_map_writer *writer,
+    struct sol_oic_repr_field *repr)
 {
-    CborError err;
+    CborError err = CborNoError, old_err;
+    CborEncoder orig_encoder, orig_map;
+    int r;
 
-    if (!encoder->payload) {
-        err = initialize_cbor_payload(encoder);
+    if (!writer->payload) {
+        err = initialize_cbor_payload(writer);
         SOL_INT_CHECK(err, != CborNoError, err);
     }
 
-    err = cbor_encode_text_stringz(&encoder->rep_map, repr->key);
+    /* All enlarge_buffer() invocations pass sizeof(uint64_t) because,
+     * according to tinycbor's code:
+     * i) all scalar types should fit to it and
+     * ii) strings and byte arrays get a size sentinel, also with
+     * that maximum size, encoded together.
+     */
+encode_key:
+    orig_encoder = writer->encoder, orig_map = writer->rep_map;
+    old_err = err;
+    err |= cbor_encode_text_stringz(&writer->rep_map, repr->key);
+    if (err & CborErrorOutOfMemory) {
+        r = enlarge_buffer(writer, orig_encoder, orig_map, strlen(repr->key) +
+            sizeof(uint64_t));
+        SOL_INT_CHECK_GOTO(r, < 0, end);
+        err = old_err;
+        goto encode_key;
+    } else if (err != CborNoError)
+        goto end;
+    r = buffer_used_bump(writer, writer->rep_map.ptr - orig_map.ptr);
+    if (r < 0) {
+        err = CborErrorUnknownType;
+        goto end;
+    }
+
+#define TYPE_DO(_cbor_func, _type) \
+    encode_ ## _type : \
+    old_err = err; \
+    orig_encoder = writer->encoder, orig_map = writer->rep_map; \
+    err |= cbor_encode_ ## _cbor_func(&writer->rep_map, repr->v_ ## _type); \
+    do { \
+        if (err & CborErrorOutOfMemory) { \
+            r = enlarge_buffer(writer, orig_encoder, \
+                orig_map, sizeof(uint64_t)); \
+            SOL_INT_CHECK_GOTO(r, < 0, end); \
+            err = old_err; \
+            goto encode_ ## _type; \
+        } else if (err != CborNoError) \
+            goto end; \
+        r = buffer_used_bump(writer, \
+            writer->rep_map.ptr - orig_map.ptr); \
+        if (r < 0) { \
+            err = CborErrorUnknownType; \
+            goto end; \
+        } \
+    } while (0)
+
     switch (repr->type) {
     case SOL_OIC_REPR_TYPE_UINT:
-        err |= cbor_encode_uint(&encoder->rep_map, repr->v_uint);
+        TYPE_DO(uint, uint);
         break;
     case SOL_OIC_REPR_TYPE_INT:
-        err |= cbor_encode_int(&encoder->rep_map, repr->v_int);
+        TYPE_DO(int, int);
         break;
     case SOL_OIC_REPR_TYPE_SIMPLE:
-        err |= cbor_encode_simple_value(&encoder->rep_map, repr->v_simple);
+        TYPE_DO(simple_value, simple);
         break;
-    case SOL_OIC_REPR_TYPE_TEXT_STRING: {
-        const char *p = repr->v_slice.data ? repr->v_slice.data : "";
-
-        err |= cbor_encode_text_string(&encoder->rep_map, p, repr->v_slice.len);
+    case SOL_OIC_REPR_TYPE_TEXT_STRING:
+encode_string:
+        {
+            const char *p;
+            old_err = err;
+            orig_encoder = writer->encoder, orig_map = writer->rep_map;
+            p = repr->v_slice.data ? repr->v_slice.data : "";
+            err |= cbor_encode_text_string
+                    (&writer->rep_map, p, repr->v_slice.len);
+            if (err & CborErrorOutOfMemory) {
+                r = enlarge_buffer(writer, orig_encoder,
+                    orig_map, repr->v_slice.len +
+                    sizeof(uint64_t));
+                SOL_INT_CHECK_GOTO(r, < 0, end);
+                err = old_err;
+                goto encode_string;
+            } else if (err != CborNoError)
+                goto end;
+            r = buffer_used_bump(writer,
+                writer->rep_map.ptr - orig_map.ptr);
+            if (r < 0) {
+                err = CborErrorUnknownType;
+                goto end;
+            }
+        }
         break;
-    }
-    case SOL_OIC_REPR_TYPE_BYTE_STRING: {
-        const uint8_t *empty = (const uint8_t *)"";
-        const uint8_t *p = repr->v_slice.data ? (const uint8_t *)repr->v_slice.data : empty;
-
-        err |= cbor_encode_byte_string(&encoder->rep_map, p, repr->v_slice.len);
+    case SOL_OIC_REPR_TYPE_BYTE_STRING:
+encode_byte_stream:
+        {
+            const uint8_t *empty = (const uint8_t *)"";
+            const uint8_t *p = repr->v_slice.data ?
+                (const uint8_t *)repr->v_slice.data : empty;
+            old_err = err;
+            orig_encoder = writer->encoder, orig_map = writer->rep_map;
+            err |= cbor_encode_byte_string
+                    (&writer->rep_map, p, repr->v_slice.len);
+            if (err & CborErrorOutOfMemory) {
+                r = enlarge_buffer(writer, orig_encoder,
+                    orig_map, repr->v_slice.len +
+                    sizeof(uint64_t));
+                SOL_INT_CHECK_GOTO(r, < 0, end);
+                goto encode_byte_stream;
+            } else if (err != CborNoError)
+                goto end;
+            r = buffer_used_bump(writer,
+                writer->rep_map.ptr - orig_map.ptr);
+            if (r < 0) {
+                err = CborErrorUnknownType;
+                goto end;
+            }
+        }
         break;
-    }
     case SOL_OIC_REPR_TYPE_HALF_FLOAT:
-        err |= cbor_encode_half_float(&encoder->rep_map, repr->v_voidptr);
+        TYPE_DO(half_float, voidptr);
         break;
     case SOL_OIC_REPR_TYPE_FLOAT:
-        err |= cbor_encode_float(&encoder->rep_map, repr->v_float);
+        TYPE_DO(float, float);
         break;
     case SOL_OIC_REPR_TYPE_DOUBLE:
-        err |= cbor_encode_double(&encoder->rep_map, repr->v_double);
+        TYPE_DO(double, double);
         break;
     case SOL_OIC_REPR_TYPE_BOOLEAN:
-        err |= cbor_encode_boolean(&encoder->rep_map, repr->v_boolean);
+        TYPE_DO(boolean, boolean);
         break;
     default:
         err |= CborErrorUnknownType;
     }
+#undef TYPE_DO
+
+end:
 
     return err;
 }


### PR DESCRIPTION
We're abusing tinycbor's API, but at least we get to incrementally bump
a CoAP packet's buffer size (that should not happen frequently, since
the growth is exponential and it starts with a guessed typical OIC/cbor
payload size).

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>

----------------

@otaviobp: help with testing still welcome :)