### PR TITLE
coap: finally get rid of hardcoded packet sizes at sending side [v2]

### DIFF
--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -235,13 +235,13 @@ def object_to_repr_vec_fn_server_c(state_struct_name, name, props):
     return object_to_repr_vec_fn_common_c(state_struct_name, name, props, False)
 
 def get_field_integer_client_c(id, name, prop):
-    return '''if (decode_mask & (1<<%(id)d) && streq(field.key, "%(field_name)s")) {
+    return '''if (decode_mask & (1<<%(id)d) && streq(field.f_key, "%(field_name)s")) {
     if (field.type == SOL_OIC_REPR_TYPE_UINT)
-        fields.%(field_name)s = field.v_uint;
+        fields.%(field_name)s = field.f_uint;
     else if (field.type == SOL_OIC_REPR_TYPE_INT)
-        fields.%(field_name)s = field.v_int;
+        fields.%(field_name)s = field.f_int;
     else if (field.type == SOL_OIC_REPR_TYPE_SIMPLE)
-        fields.%(field_name)s = field.v_simple;
+        fields.%(field_name)s = field.f_simple;
     else
         RETURN_ERROR(-EINVAL);
     decode_mask &= ~(1<<%(id)d);
@@ -254,11 +254,11 @@ def get_field_integer_client_c(id, name, prop):
     }
 
 def get_field_number_client_c(id, name, prop):
-    return '''if (decode_mask & (1<<%(id)d) && streq(field.key, "%(field_name)s")) {
+    return '''if (decode_mask & (1<<%(id)d) && streq(field.f_key, "%(field_name)s")) {
     if (field.type == SOL_OIC_REPR_TYPE_DOUBLE)
-        fields.%(field_name)s = field.v_double;
+        fields.%(field_name)s = field.f_double;
     else if (field.type == SOL_OIC_REPR_TYPE_FLOAT)
-        fields.%(field_name)s = field.v_float;
+        fields.%(field_name)s = field.f_float;
     else
         RETURN_ERROR(-EINVAL);
     decode_mask &= ~(1<<%(id)d);
@@ -271,11 +271,11 @@ def get_field_number_client_c(id, name, prop):
     }
 
 def get_field_string_client_c(id, name, prop):
-    return '''if (decode_mask & (1<<%(id)d) && streq(field.key, "%(field_name)s")) {
+    return '''if (decode_mask & (1<<%(id)d) && streq(field.f_key, "%(field_name)s")) {
     if (field.type != SOL_OIC_REPR_TYPE_TEXT_STRING)
         RETURN_ERROR(-EINVAL);
     free(fields.%(field_name)s);
-    fields.%(field_name)s = strndup(field.v_slice.data, field.v_slice.len);
+    fields.%(field_name)s = strndup(field.f_slice.data, field.f_slice.len);
     if (!fields.%(field_name)s)
         RETURN_ERROR(-EINVAL);
     decode_mask &= ~(1<<%(id)d);
@@ -288,10 +288,10 @@ def get_field_string_client_c(id, name, prop):
     }
 
 def get_field_boolean_client_c(id, name, prop):
-    return '''if (decode_mask & (1<<%(id)d) && streq(field.key, "%(field_name)s")) {
+    return '''if (decode_mask & (1<<%(id)d) && streq(field.f_key, "%(field_name)s")) {
     if (field.type != SOL_OIC_REPR_TYPE_BOOLEAN)
         RETURN_ERROR(-EINVAL);
-    fields.%(field_name)s = field.v_boolean;
+    fields.%(field_name)s = field.f_boolean;
     decode_mask &= ~(1<<%(id)d);
     continue;
 }
@@ -302,14 +302,14 @@ def get_field_boolean_client_c(id, name, prop):
     }
 
 def get_field_enum_client_c(id, struct_name, name, prop):
-    return '''if (decode_mask & (1<<%(id)d) && streq(field.key, "%(field_name)s")) {
+    return '''if (decode_mask & (1<<%(id)d) && streq(field.f_key, "%(field_name)s")) {
     int val;
 
     if (field.type != SOL_OIC_REPR_TYPE_TEXT_STRING)
         RETURN_ERROR(-EINVAL);
 
     val = sol_str_table_lookup_fallback(%(struct_name)s_%(field_name)s_tbl,
-        field.v_slice, -1);
+        field.f_slice, -1);
     if (val < 0)
         RETURN_ERROR(-EINVAL);
     fields.%(field_name)s = (enum %(struct_name)s_%(field_name)s)val;
@@ -457,7 +457,7 @@ def object_inform_flow_fn_common_c(state_struct_name, name, props, client):
     for field_name, field_props in props.items():
         if 'enum' in field_props:
             fn = 'sol_flow_send_string_packet'
-            val = '%(struct_name)s_%(field_name)s_tbl[state->state.%(field_name)s].key' % {
+            val = '%(struct_name)s_%(field_name)s_tbl[state->state.%(field_name)s].f_key' % {
                 'struct_name': state_struct_name,
                 'field_name': field_name
             }

--- a/src/lib/comms/coap.c
+++ b/src/lib/comms/coap.c
@@ -212,9 +212,6 @@ coap_packet_parse(struct sol_coap_packet *pkt)
     if (pkt->buf.used < (size_t)(hdrlen + optlen))
         return -EINVAL;
 
-    if (pkt->buf.used > COAP_UDP_MTU)
-        return -EINVAL;
-
     /* +1 for COAP_MARKER */
     if (pkt->buf.used <= (size_t)(hdrlen + optlen + 1)) {
         pkt->payload_start = 0;

--- a/src/lib/comms/coap.h
+++ b/src/lib/comms/coap.h
@@ -55,8 +55,6 @@ struct coap_header {
 #error "Unknown byte order"
 #endif
 
-#define COAP_UDP_MTU (576)
-
 struct sol_coap_packet {
     int refcnt;
     struct sol_buffer buf;

--- a/src/lib/comms/include/sol-oic-common.h
+++ b/src/lib/comms/include/sol-oic-common.h
@@ -239,7 +239,7 @@ struct sol_oic_repr_field {
     /**
      * @brief Field's key as a string.
      */
-    const char *key;
+    const char *f_key;
     /**
      * @brief Union used to access field's data in correct format specified by
      * @a type
@@ -248,36 +248,36 @@ struct sol_oic_repr_field {
         /**
          * @brief Field's data if type is SOL_OIC_REPR_TYPE_UINT.
          */
-        uint64_t v_uint;
+        uint64_t f_uint;
         /**
          * @brief Field's data if type is SOL_OIC_REPR_TYPE_INT.
          */
-        int64_t v_int;
+        int64_t f_int;
         /**
          * @brief Field's data if type is SOL_OIC_REPR_TYPE_SIMPLE.
          */
-        uint8_t v_simple;
+        uint8_t f_simple;
         /**
          * @brief Field's data if type is SOL_OIC_REPR_TYPE_TEXT_STRING or
          * SOL_OIC_REPR_TYPE_BYTE_STRING.
          */
-        struct sol_str_slice v_slice;
+        struct sol_str_slice f_slice;
         /**
          * @brief Field's data if type is SOL_OIC_REPR_TYPE_FLOAT.
          */
-        float v_float;
+        float f_float;
         /**
          * @brief Field's data if type is SOL_OIC_REPR_TYPE_DOUBLE.
          */
-        double v_double;
+        double f_double;
         /**
          * @brief Field's data if type is SOL_OIC_REPR_TYPE_HALF_FLOAT.
          */
-        void *v_voidptr;
+        void *f_voidptr;
         /**
          * @brief Field's data if type is SOL_OIC_REPR_TYPE_BOOLEAN.
          */
-        bool v_boolean;
+        bool f_boolean;
     };
 };
 
@@ -289,7 +289,7 @@ struct sol_oic_repr_field {
  * @param ... Extra structure initialization commands.
  */
 #define SOL_OIC_REPR_FIELD(key_, type_, ...) \
-    (struct sol_oic_repr_field){.type = (type_), .key = (key_), { __VA_ARGS__ } }
+    (struct sol_oic_repr_field){.type = (type_), .f_key = (key_), { __VA_ARGS__ } }
 
 /**
  * @brief Helper macro to create an unsigned integer sol_oic_repr_field.
@@ -298,7 +298,7 @@ struct sol_oic_repr_field {
  * @param value_ The unsigned int value of this field.
  */
 #define SOL_OIC_REPR_UINT(key_, value_) \
-    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_UINT, .v_uint = (value_))
+    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_UINT, .f_uint = (value_))
 
 /**
  * @brief Helper macro to create an signed integer sol_oic_repr_field.
@@ -307,7 +307,7 @@ struct sol_oic_repr_field {
  * @param value_ The signed int value of this field.
  */
 #define SOL_OIC_REPR_INT(key_, value_) \
-    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_INT, .v_int = (value_))
+    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_INT, .f_int = (value_))
 
 /**
  * @brief Helper macro to create an boolean sol_oic_repr_field.
@@ -316,7 +316,7 @@ struct sol_oic_repr_field {
  * @param value_ The boolean value of this field.
  */
 #define SOL_OIC_REPR_BOOLEAN(key_, value_) \
-    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_BOOLEAN, .v_boolean = !!(value_))
+    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_BOOLEAN, .f_boolean = !!(value_))
 
 /**
  * @brief Helper macro to create an simple integer sol_oic_repr_field.
@@ -325,7 +325,7 @@ struct sol_oic_repr_field {
  * @param value_ The 8-bit integer value of this field.
  */
 #define SOL_OIC_REPR_SIMPLE(key_, value_) \
-    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_SIMPLE, .v_simple = (value_))
+    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_SIMPLE, .f_simple = (value_))
 
 /**
  * @brief Helper macro to create a text string sol_oic_repr_field.
@@ -336,7 +336,7 @@ struct sol_oic_repr_field {
  * @param len_ The length of the string pointed by @a value.
  */
 #define SOL_OIC_REPR_TEXT_STRING(key_, value_, len_) \
-    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_TEXT_STRING, .v_slice = SOL_STR_SLICE_STR((value_), (len_)))
+    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_TEXT_STRING, .f_slice = SOL_STR_SLICE_STR((value_), (len_)))
 
 /**
  * @brief Helper macro to create a byte string sol_oic_repr_field.
@@ -347,7 +347,7 @@ struct sol_oic_repr_field {
  * @param len_ The length of the string pointed by @a value.
  */
 #define SOL_OIC_REPR_BYTE_STRING(key_, value_, len_) \
-    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_BYTE_STRING, .v_slice = SOL_STR_SLICE_STR((value_), (len_)))
+    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_BYTE_STRING, .f_slice = SOL_STR_SLICE_STR((value_), (len_)))
 
 /**
  * @brief Helper macro to create a half-precision float number
@@ -357,7 +357,7 @@ struct sol_oic_repr_field {
  * @param value_ The value of the float number.
  */
 #define SOL_OIC_REPR_HALF_FLOAT(key_, value_) \
-    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_HALF_FLOAT, .v_voidptr = (void *)(value_))
+    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_HALF_FLOAT, .f_voidptr = (void *)(value_))
 
 /**
  * @brief Helper macro to create a single-precision float number
@@ -367,7 +367,7 @@ struct sol_oic_repr_field {
  * @param value_ The value of the float number.
  */
 #define SOL_OIC_REPR_FLOAT(key_, value_) \
-    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_FLOAT, .v_float = (value_))
+    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_FLOAT, .f_float = (value_))
 
 /**
  * @brief Helper macro to create a double-precision float sol_oic_repr_field.
@@ -376,7 +376,7 @@ struct sol_oic_repr_field {
  * @param value_ The value of the float number.
  */
 #define SOL_OIC_REPR_DOUBLE(key_, value_) \
-    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_DOUBLE, .v_double = (value_))
+    SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_DOUBLE, .f_double = (value_))
 
 /**
  * @struct sol_oic_map_writer

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -658,7 +658,9 @@ on_can_write(void *data, struct sol_socket *s)
     if (err == -EAGAIN)
         return true;
 
-    SOL_DBG("pkt sent:");
+    SOL_DBG("CoAP packet sent (payload of %zu bytes, "
+        "buffer holding it with %zu bytes)",
+        outgoing->pkt->buf.used, outgoing->pkt->buf.capacity);
     sol_coap_packet_debug(outgoing->pkt);
     if (err < 0) {
         SOL_BUFFER_DECLARE_STATIC(addr, SOL_INET_ADDR_STRLEN);

--- a/src/lib/comms/sol-oic-cbor.c
+++ b/src/lib/comms/sol-oic-cbor.c
@@ -30,19 +30,34 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* FIXME: this layer should not be aware of coap.h, it's just here
- * because of the FIXME below */
-#include "coap.h"
 #include "sol-log.h"
 #include "sol-oic-cbor.h"
 #include "sol-oic-common.h"
+
+#define TYPICAL_OIC_PAYLOAD_SZ (64)
+
+static inline int
+buffer_used_bump(struct sol_oic_map_writer *writer, size_t inc)
+{
+    struct sol_buffer *buf;
+    int r = sol_coap_packet_get_payload(writer->pkt, &buf, NULL);
+
+    SOL_INT_CHECK(r, < 0, r);
+    /* Ugly, but since tinycbor operates on memory slices directly, we
+     * have to resort to that */
+    buf->used += inc;
+
+    return 0;
+}
 
 static CborError
 initialize_cbor_payload(struct sol_oic_map_writer *encoder)
 {
     int r;
+    CborError err;
     size_t offset;
     struct sol_buffer *buf;
+    uint8_t *old_ptr, *new_ptr;
     const uint8_t format_cbor = SOL_COAP_CONTENTTYPE_APPLICATION_CBOR;
 
     r = sol_coap_add_option(encoder->pkt, SOL_COAP_OPTION_CONTENT_FORMAT,
@@ -55,22 +70,30 @@ initialize_cbor_payload(struct sol_oic_map_writer *encoder)
         return CborUnknownError;
     }
 
-    /* FIXME: Because we can't now make phony cbor calls to calculate
-     * the exact payload in the contexts this call is issued (they
-     * involve user callbacks to append cbor data), we ensure this
-     * hardcoded size */
-    r = sol_buffer_ensure(buf, COAP_UDP_MTU);
+    r = sol_buffer_ensure(buf, offset + TYPICAL_OIC_PAYLOAD_SZ);
     SOL_INT_CHECK(r, < 0, CborErrorOutOfMemory);
+    printf("buffer initialized with %zu\n", buf->capacity);
 
     encoder->payload = sol_buffer_at(buf, offset);
 
     cbor_encoder_init(&encoder->encoder, encoder->payload,
         buf->capacity - offset, 0);
+    old_ptr = encoder->encoder.ptr;
 
     encoder->type = SOL_OIC_MAP_CONTENT;
 
-    return cbor_encoder_create_map(&encoder->encoder, &encoder->rep_map,
+    /* With the call to sol_buffer_ensure() before, we're safe to open
+     * a container */
+    err = cbor_encoder_create_map(&encoder->encoder, &encoder->rep_map,
         CborIndefiniteLength);
+    if (err == CborNoError) {
+        new_ptr = encoder->rep_map.ptr;
+        r = buffer_used_bump(encoder, new_ptr - old_ptr);
+        if (r < 0)
+            err = CborErrorUnknownType;
+    }
+
+    return err;
 }
 
 void
@@ -81,81 +104,204 @@ sol_oic_packet_cbor_create(struct sol_coap_packet *pkt, struct sol_oic_map_write
     encoder->type = SOL_OIC_MAP_NO_CONTENT;
 }
 
-CborError
-sol_oic_packet_cbor_close(struct sol_coap_packet *pkt, struct sol_oic_map_writer *encoder)
+/* Enlarge a CoAP packet's buffer and update CoAP encoder states
+ * accordingly */
+static inline int
+enlarge_buffer(struct sol_oic_map_writer *writer,
+    CborEncoder orig_encoder,
+    CborEncoder orig_map,
+    size_t needed)
 {
-    CborError err;
+    uint8_t *old_payload = writer->payload;
+    struct sol_buffer *buf;
+    size_t offset;
+    int r;
 
-    if (!encoder->payload) {
-        if (encoder->type == SOL_OIC_MAP_NO_CONTENT)
+    r = sol_coap_packet_get_payload(writer->pkt, &buf, &offset);
+    SOL_INT_CHECK(r, < 0, r);
+
+    r = sol_buffer_ensure(buf, buf->capacity + needed);
+    SOL_INT_CHECK(r, < 0, r);
+
+    /* restore state */
+    writer->encoder = orig_encoder;
+    writer->rep_map = orig_map;
+
+    /* update all encoder states */
+    writer->payload = writer->encoder.ptr = sol_buffer_at(buf, offset);
+    /* sol_buffer_at() directly to somewhere past the used portion fails*/
+    writer->encoder.end = (uint8_t *)sol_buffer_at(buf, 0) + buf->capacity;
+
+    /* new offset + how much it had progressed so far */
+    writer->rep_map.ptr = writer->payload + (orig_map.ptr - old_payload);
+    writer->rep_map.end = writer->encoder.end;
+
+    return 0;
+}
+
+CborError
+sol_oic_packet_cbor_close(struct sol_coap_packet *pkt,
+    struct sol_oic_map_writer *writer)
+{
+    int r;
+    CborError err;
+    uint8_t *old_ptr, *new_ptr;
+    CborEncoder orig_encoder, orig_map;
+
+    if (!writer->payload) {
+        if (writer->type == SOL_OIC_MAP_NO_CONTENT)
             return CborNoError;
-        err = initialize_cbor_payload(encoder);
+        err = initialize_cbor_payload(writer);
         SOL_INT_CHECK(err, != CborNoError, err);
     }
 
-    err = cbor_encoder_close_container(&encoder->encoder, &encoder->rep_map);
-    if (err == CborNoError) {
-        /* Ugly, but since tinycbor operates on memory slices
-         * directly, we have to resort to that */
-        struct sol_buffer *buf;
-        int r = sol_coap_packet_get_payload(pkt, &buf, NULL);
-        SOL_INT_CHECK_GOTO(r, < 0, error);
-        buf->used += encoder->encoder.ptr - encoder->payload;
-    }
+close_container:
+    orig_encoder = writer->encoder, orig_map = writer->rep_map;
 
-error:
+    /* When you close an encoder, it will get its ptr set to the
+     * topmost container's. Also, this would append one byte to the
+     * payload, thus '1' below */
+    old_ptr = writer->rep_map.ptr;
+    err = cbor_encoder_close_container(&writer->encoder, &writer->rep_map);
+    if (err == CborErrorOutOfMemory) {
+        r = enlarge_buffer(writer, orig_encoder, orig_map, 1);
+        SOL_INT_CHECK_GOTO(r, < 0, end);
+        goto close_container;
+    } else if (err != CborNoError)
+        goto end;
+
+    new_ptr = writer->encoder.ptr;
+    r = buffer_used_bump(writer, new_ptr - old_ptr);
+    if (r < 0)
+        err = CborErrorUnknownType;
+
+end:
     return err;
 }
 
 CborError
-sol_oic_packet_cbor_append(struct sol_oic_map_writer *encoder, struct sol_oic_repr_field *repr)
+sol_oic_packet_cbor_append(struct sol_oic_map_writer *writer,
+    struct sol_oic_repr_field *repr)
 {
-    CborError err;
+    CborError err = CborNoError, old_err;
+    CborEncoder orig_encoder, orig_map;
+    size_t next_buf_sz = 0;
+    bool key_done = false;
+    int r;
 
-    if (!encoder->payload) {
-        err = initialize_cbor_payload(encoder);
+    if (!writer->payload) {
+        err = initialize_cbor_payload(writer);
         SOL_INT_CHECK(err, != CborNoError, err);
     }
 
-    err = cbor_encode_text_stringz(&encoder->rep_map, repr->key);
+#define TYPE_DO(_cbor_func, _type, _next_buf_sz) \
+    do { \
+        old_err = err; \
+        orig_encoder = writer->encoder, orig_map = writer->rep_map; \
+        err |= cbor_encode_ ## _cbor_func(&writer->rep_map, \
+            repr->f_ ## _type); \
+        if (err & CborErrorOutOfMemory) { \
+            next_buf_sz = _next_buf_sz; \
+            goto enlarge_buffer; \
+        } else if (err != CborNoError) \
+            goto end; \
+        r = buffer_used_bump(writer, \
+            writer->rep_map.ptr - orig_map.ptr); \
+        if (r < 0) { \
+            err = CborErrorUnknownType; \
+            goto end; \
+        } \
+    } while (0)
+
+encode_key:
+    TYPE_DO(text_stringz, key, strlen(repr->f_key) + sizeof(uint64_t));
+    key_done = true;
+    goto encode_payload;
+
+/* The next_buf_sz argument of enlarge_buffer() are like so because,
+ * according to tinycbor's code: i) all scalar types should fit to it
+ * and ii) strings and byte arrays get a size sentinel, also with that
+ * maximum size, encoded together.
+ */
+enlarge_buffer:
+    r = enlarge_buffer(writer, orig_encoder, orig_map, next_buf_sz);
+    SOL_INT_CHECK_GOTO(r, < 0, end);
+    err = old_err;
+    if (!key_done)
+        goto encode_key;
+
+encode_payload:
     switch (repr->type) {
     case SOL_OIC_REPR_TYPE_UINT:
-        err |= cbor_encode_uint(&encoder->rep_map, repr->v_uint);
+        TYPE_DO(uint, uint, sizeof(uint64_t));
         break;
     case SOL_OIC_REPR_TYPE_INT:
-        err |= cbor_encode_int(&encoder->rep_map, repr->v_int);
+        TYPE_DO(int, int, sizeof(uint64_t));
         break;
     case SOL_OIC_REPR_TYPE_SIMPLE:
-        err |= cbor_encode_simple_value(&encoder->rep_map, repr->v_simple);
+        TYPE_DO(simple_value, simple, sizeof(uint64_t));
         break;
-    case SOL_OIC_REPR_TYPE_TEXT_STRING: {
-        const char *p = repr->v_slice.data ? repr->v_slice.data : "";
-
-        err |= cbor_encode_text_string(&encoder->rep_map, p, repr->v_slice.len);
-        break;
+    case SOL_OIC_REPR_TYPE_TEXT_STRING:
+    {
+        const char *p;
+        old_err = err;
+        orig_encoder = writer->encoder, orig_map = writer->rep_map;
+        p = repr->f_slice.data ? repr->f_slice.data : "";
+        err |= cbor_encode_text_string
+                (&writer->rep_map, p, repr->f_slice.len);
+        if (err & CborErrorOutOfMemory) {
+            next_buf_sz = repr->f_slice.len + sizeof(uint64_t);
+            goto enlarge_buffer;
+        } else if (err != CborNoError)
+            goto end;
+        r = buffer_used_bump(writer,
+            writer->rep_map.ptr - orig_map.ptr);
+        if (r < 0) {
+            err = CborErrorUnknownType;
+            goto end;
+        }
     }
-    case SOL_OIC_REPR_TYPE_BYTE_STRING: {
+    break;
+    case SOL_OIC_REPR_TYPE_BYTE_STRING:
+    {
         const uint8_t *empty = (const uint8_t *)"";
-        const uint8_t *p = repr->v_slice.data ? (const uint8_t *)repr->v_slice.data : empty;
-
-        err |= cbor_encode_byte_string(&encoder->rep_map, p, repr->v_slice.len);
-        break;
+        const uint8_t *p = repr->f_slice.data ?
+            (const uint8_t *)repr->f_slice.data : empty;
+        old_err = err;
+        orig_encoder = writer->encoder, orig_map = writer->rep_map;
+        err |= cbor_encode_byte_string
+                (&writer->rep_map, p, repr->f_slice.len);
+        if (err & CborErrorOutOfMemory) {
+            next_buf_sz = repr->f_slice.len + sizeof(uint64_t);
+            goto enlarge_buffer;
+        } else if (err != CborNoError)
+            goto end;
+        r = buffer_used_bump(writer,
+            writer->rep_map.ptr - orig_map.ptr);
+        if (r < 0) {
+            err = CborErrorUnknownType;
+            goto end;
+        }
     }
+    break;
     case SOL_OIC_REPR_TYPE_HALF_FLOAT:
-        err |= cbor_encode_half_float(&encoder->rep_map, repr->v_voidptr);
+        TYPE_DO(half_float, voidptr, sizeof(uint64_t));
         break;
     case SOL_OIC_REPR_TYPE_FLOAT:
-        err |= cbor_encode_float(&encoder->rep_map, repr->v_float);
+        TYPE_DO(float, float, sizeof(uint64_t));
         break;
     case SOL_OIC_REPR_TYPE_DOUBLE:
-        err |= cbor_encode_double(&encoder->rep_map, repr->v_double);
+        TYPE_DO(double, double, sizeof(uint64_t));
         break;
     case SOL_OIC_REPR_TYPE_BOOLEAN:
-        err |= cbor_encode_boolean(&encoder->rep_map, repr->v_boolean);
+        TYPE_DO(boolean, boolean, sizeof(uint64_t));
         break;
     default:
         err |= CborErrorUnknownType;
     }
+#undef TYPE_DO
+
+end:
 
     return err;
 }
@@ -166,40 +312,40 @@ sol_oic_cbor_repr_map_get_next_field(CborValue *value, struct sol_oic_repr_field
     CborError err;
     size_t len;
 
-    err = cbor_value_dup_text_string(value, (char **)&repr->key, &len, NULL);
+    err = cbor_value_dup_text_string(value, (char **)&repr->f_key, &len, NULL);
     err |= cbor_value_advance(value);
 
     switch (cbor_value_get_type(value)) {
     case CborIntegerType:
-        err |= cbor_value_get_int64(value, &repr->v_int);
+        err |= cbor_value_get_int64(value, &repr->f_int);
         repr->type = SOL_OIC_REPR_TYPE_INT;
         break;
     case CborTextStringType:
-        err |= cbor_value_dup_text_string(value, (char **)&repr->v_slice.data, &repr->v_slice.len, NULL);
+        err |= cbor_value_dup_text_string(value, (char **)&repr->f_slice.data, &repr->f_slice.len, NULL);
         if (err != CborNoError)
             goto harmless;
         repr->type = SOL_OIC_REPR_TYPE_TEXT_STRING;
         break;
     case CborByteStringType:
-        err |= cbor_value_dup_byte_string(value, (uint8_t **)&repr->v_slice.data, &repr->v_slice.len, NULL);
+        err |= cbor_value_dup_byte_string(value, (uint8_t **)&repr->f_slice.data, &repr->f_slice.len, NULL);
         if (err != CborNoError)
             goto harmless;
         repr->type = SOL_OIC_REPR_TYPE_BYTE_STRING;
         break;
     case CborDoubleType:
-        err |= cbor_value_get_double(value, &repr->v_double);
+        err |= cbor_value_get_double(value, &repr->f_double);
         repr->type = SOL_OIC_REPR_TYPE_DOUBLE;
         break;
     case CborFloatType:
-        err |= cbor_value_get_float(value, &repr->v_float);
+        err |= cbor_value_get_float(value, &repr->f_float);
         repr->type = SOL_OIC_REPR_TYPE_FLOAT;
         break;
     case CborHalfFloatType:
-        err |= cbor_value_get_half_float(value, &repr->v_voidptr);
+        err |= cbor_value_get_half_float(value, &repr->f_voidptr);
         repr->type = SOL_OIC_REPR_TYPE_HALF_FLOAT;
         break;
     case CborBooleanType:
-        err |= cbor_value_get_boolean(value, &repr->v_boolean);
+        err |= cbor_value_get_boolean(value, &repr->f_boolean);
         repr->type = SOL_OIC_REPR_TYPE_BOOLEAN;
         break;
     default:
@@ -210,7 +356,7 @@ sol_oic_cbor_repr_map_get_next_field(CborValue *value, struct sol_oic_repr_field
 
 harmless:
         /* Initialize repr with harmless data so cleanup works. */
-        repr->v_boolean = false;
+        repr->f_boolean = false;
         repr->type = SOL_OIC_REPR_TYPE_BOOLEAN;
     }
     err |= cbor_value_advance(value);

--- a/src/lib/comms/sol-oic-client.c
+++ b/src/lib/comms/sol-oic-client.c
@@ -930,9 +930,6 @@ _resource_request(struct sol_oic_client *client, struct sol_oic_resource *res,
         goto out;
     }
 
-    /* FIXME: We can't make phony cbor calls to calculate the exact
-     * payload here because it involves an user callback
-     * (fill_repr_map). */
     if (fill_repr_map) {
         sol_oic_packet_cbor_create(req, &map_encoder);
         if (!fill_repr_map(fill_repr_map_data, &map_encoder))

--- a/src/lib/comms/sol-oic-common.c
+++ b/src/lib/comms/sol-oic-common.c
@@ -56,7 +56,7 @@ sol_oic_map_loop_init(const struct sol_oic_map_reader *map, struct sol_oic_map_r
 
     /* Initialize repr with harmless data so cleanup works. */
     repr->type = SOL_OIC_REPR_TYPE_BOOLEAN;
-    repr->key = NULL;
+    repr->f_key = NULL;
     return SOL_OIC_MAP_LOOP_OK;
 }
 
@@ -65,9 +65,9 @@ repr_field_free(struct sol_oic_repr_field *field)
 {
     if (field->type == SOL_OIC_REPR_TYPE_TEXT_STRING ||
         field->type == SOL_OIC_REPR_TYPE_BYTE_STRING)
-        free((char *)field->v_slice.data);
+        free((char *)field->f_slice.data);
 
-    free((char *)field->key);
+    free((char *)field->f_key);
 }
 
 SOL_API bool

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -584,9 +584,6 @@ _sol_oic_resource_type_handle(
         input_ptr = &input;
     }
 
-    /* FIXME: We can't make phony cbor calls to calculate the exact
-     * payload here because it involves an user callback
-     * (handle_fn). */
     sol_oic_packet_cbor_create(response, &output);
     code = handle_fn(cliaddr, res->callback.data, input_ptr, &output);
     if (sol_oic_packet_cbor_close(response, &output) != CborNoError)
@@ -793,9 +790,6 @@ send_notification_to_server(struct sol_oic_server_resource *resource,
     pkt = sol_coap_packet_notification_new(oic_server.server, resource->coap);
     SOL_NULL_CHECK(pkt, false);
 
-    /* FIXME: We can't make phony cbor calls to calculate the exact
-     * payload here because it involves an user callback
-     * (fill_repr_map). */
     sol_oic_packet_cbor_create(pkt, &oic_map_writer);
     if (!fill_repr_map((void *)data, &oic_map_writer))
         goto end;

--- a/src/samples/coap/iotivity-test-client.c
+++ b/src/samples/coap/iotivity-test-client.c
@@ -151,18 +151,18 @@ fill_info(const struct sol_oic_map_reader *map_reader, bool *state, int32_t *pow
     struct sol_oic_map_reader iterator;
 
     SOL_OIC_MAP_LOOP(map_reader, &field, &iterator, end_reason) {
-        if (state && streq(field.key, "state") &&
+        if (state && streq(field.f_key, "state") &&
             field.type == SOL_OIC_REPR_TYPE_BOOLEAN) {
-            *state = field.v_boolean;
+            *state = field.f_boolean;
             continue;
         }
-        if (power && streq(field.key, "power")) {
+        if (power && streq(field.f_key, "power")) {
             if (field.type == SOL_OIC_REPR_TYPE_UINT)
-                *power = field.v_uint;
+                *power = field.f_uint;
             else if (field.type == SOL_OIC_REPR_TYPE_INT)
-                *power = field.v_int;
+                *power = field.f_int;
             else if (field.type == SOL_OIC_REPR_TYPE_SIMPLE)
-                *power = field.v_simple;
+                *power = field.f_simple;
             continue;
         }
     }
@@ -349,46 +349,46 @@ print_response(sol_coap_responsecode_t response_code, struct sol_oic_client *cli
 
             switch (field.type) {
             case SOL_OIC_REPR_TYPE_UINT:
-                SOL_DBG("\tkey: '%s', value: uint(%" PRIu64 ")", field.key,
-                    field.v_uint);
+                SOL_DBG("\tkey: '%s', value: uint(%" PRIu64 ")", field.f_key,
+                    field.f_uint);
                 break;
             case SOL_OIC_REPR_TYPE_INT:
-                SOL_DBG("\tkey: '%s', value: int(%" PRIi64 ")", field.key,
-                    field.v_int);
+                SOL_DBG("\tkey: '%s', value: int(%" PRIi64 ")", field.f_key,
+                    field.f_int);
                 break;
             case SOL_OIC_REPR_TYPE_SIMPLE:
-                SOL_DBG("\tkey: '%s', value: simple(%d)", field.key,
-                    field.v_simple);
+                SOL_DBG("\tkey: '%s', value: simple(%d)", field.f_key,
+                    field.f_simple);
                 break;
             case SOL_OIC_REPR_TYPE_TEXT_STRING:
-                SOL_DBG("\tkey: '%s', value: str(%.*s)", field.key,
-                    (int)field.v_slice.len, field.v_slice.data);
+                SOL_DBG("\tkey: '%s', value: str(%.*s)", field.f_key,
+                    (int)field.f_slice.len, field.f_slice.data);
                 break;
             case SOL_OIC_REPR_TYPE_BYTE_STRING:
-                dump_byte_string(&buf, field.v_slice);
-                SOL_DBG("\tkey: '%s', value: bytestr{%.*s}", field.key,
+                dump_byte_string(&buf, field.f_slice);
+                SOL_DBG("\tkey: '%s', value: bytestr{%.*s}", field.f_key,
                     SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&buf)));
 
                 sol_buffer_fini(&buf);
                 break;
             case SOL_OIC_REPR_TYPE_HALF_FLOAT:
-                SOL_DBG("\tkey: '%s', value: hfloat(%p)", field.key,
-                    field.v_voidptr);
+                SOL_DBG("\tkey: '%s', value: hfloat(%p)", field.f_key,
+                    field.f_voidptr);
                 break;
             case SOL_OIC_REPR_TYPE_FLOAT:
-                SOL_DBG("\tkey: '%s', value: float(%f)", field.key,
-                    field.v_float);
+                SOL_DBG("\tkey: '%s', value: float(%f)", field.f_key,
+                    field.f_float);
                 break;
             case SOL_OIC_REPR_TYPE_DOUBLE:
-                SOL_DBG("\tkey: '%s', value: float(%g)", field.key,
-                    field.v_double);
+                SOL_DBG("\tkey: '%s', value: float(%g)", field.f_key,
+                    field.f_double);
                 break;
             case SOL_OIC_REPR_TYPE_BOOLEAN:
-                SOL_DBG("\tkey: '%s', value: boolean(%s)", field.key,
-                    field.v_boolean ? "true" : "false");
+                SOL_DBG("\tkey: '%s', value: boolean(%s)", field.f_key,
+                    field.f_boolean ? "true" : "false");
                 break;
             default:
-                SOL_DBG("\tkey: '%s', value: unknown(%d)", field.key, field.type);
+                SOL_DBG("\tkey: '%s', value: unknown(%d)", field.f_key, field.type);
             }
         }
         SOL_DBG("}\n");

--- a/src/samples/coap/oic-client.c
+++ b/src/samples/coap/oic-client.c
@@ -63,35 +63,35 @@ got_get_response(sol_coap_responsecode_t response_code, struct sol_oic_client *c
 
     printf("Dumping payload received from addr %.*s {\n", SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr)));
     SOL_OIC_MAP_LOOP(map_reader, &field, &iterator, end_reason) {
-        printf("\tkey: '%s', value: ", field.key);
+        printf("\tkey: '%s', value: ", field.f_key);
 
         switch (field.type) {
         case SOL_OIC_REPR_TYPE_UINT:
-            printf("uint(%" PRIu64 ")\n", field.v_uint);
+            printf("uint(%" PRIu64 ")\n", field.f_uint);
             break;
         case SOL_OIC_REPR_TYPE_INT:
-            printf("int(%" PRIi64 ")\n", field.v_int);
+            printf("int(%" PRIi64 ")\n", field.f_int);
             break;
         case SOL_OIC_REPR_TYPE_SIMPLE:
-            printf("simple(%d)\n", field.v_simple);
+            printf("simple(%d)\n", field.f_simple);
             break;
         case SOL_OIC_REPR_TYPE_TEXT_STRING:
-            printf("str(%.*s)\n", (int)field.v_slice.len, field.v_slice.data);
+            printf("str(%.*s)\n", (int)field.f_slice.len, field.f_slice.data);
             break;
         case SOL_OIC_REPR_TYPE_BYTE_STRING:
             printf("bytestr() [not dumping]\n");
             break;
         case SOL_OIC_REPR_TYPE_HALF_FLOAT:
-            printf("hfloat(%p)\n", field.v_voidptr);
+            printf("hfloat(%p)\n", field.f_voidptr);
             break;
         case SOL_OIC_REPR_TYPE_FLOAT:
-            printf("float(%f)\n", field.v_float);
+            printf("float(%f)\n", field.f_float);
             break;
         case SOL_OIC_REPR_TYPE_DOUBLE:
-            printf("float(%g)\n", field.v_double);
+            printf("float(%g)\n", field.f_double);
             break;
         case SOL_OIC_REPR_TYPE_BOOLEAN:
-            printf("boolean(%s)\n", field.v_boolean ? "true" : "false");
+            printf("boolean(%s)\n", field.f_boolean ? "true" : "false");
             break;
         default:
             printf("unknown(%d)\n", field.type);

--- a/src/samples/coap/oic-server.c
+++ b/src/samples/coap/oic-server.c
@@ -118,8 +118,8 @@ user_handle_put(const struct sol_network_link_addr *cliaddr, const void *data,
     struct sol_oic_map_reader iter;
 
     SOL_OIC_MAP_LOOP(input, &field, &iter, reason) {
-        if (!strcmp(field.key, "state") && field.type == SOL_OIC_REPR_TYPE_BOOLEAN) {
-            if (set_scrolllock_led(field.v_boolean))
+        if (!strcmp(field.f_key, "state") && field.type == SOL_OIC_REPR_TYPE_BOOLEAN) {
+            if (set_scrolllock_led(field.f_boolean))
                 return SOL_COAP_RSPCODE_OK;
 
             return SOL_COAP_RSPCODE_INTERNAL_ERROR;

--- a/src/test-cpp/headers.cc.in
+++ b/src/test-cpp/headers.cc.in
@@ -190,7 +190,7 @@ startup()
     struct sol_oic_repr_field rep_field8 = SOL_OIC_REPR_HALF_FLOAT("8", &f);
     struct sol_oic_repr_field rep_field9 = SOL_OIC_REPR_FLOAT("9", 2.3);
     struct sol_oic_repr_field rep_field10 = SOL_OIC_REPR_DOUBLE("10", 2.3);
-    struct sol_oic_repr_field rep_field11 = SOL_OIC_REPR_FIELD("131231", SOL_OIC_REPR_TYPE_UINT, .v_uint = 123);
+    struct sol_oic_repr_field rep_field11 = SOL_OIC_REPR_FIELD("131231", SOL_OIC_REPR_TYPE_UINT, .f_uint = 123);
     SOL_OIC_MAP_LOOP(&map, &rep_field1, &iterator, end_reason);
 #endif
 


### PR DESCRIPTION
We're abusing tinycbor's API, but at least we get to incrementally bump
a CoAP packet's buffer size (that should not happen frequently, since
the growth is exponential and it starts with a guessed typical OIC/cbor
payload size).

I chose to change struct sol_oic_repr_field field names so that a macro
could handle both scalar field and key cases of cbor encoding.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>

----

Changes since #1579:
 - enlarge_buffer() code got slightly smaller, with the switch() being possibly evaluated more than once
 - struct sol_oic_repr_field had to have fields renamed to ease my life

@vcgomes: better now? 