### PR TITLE
network: Fix api name

### DIFF
--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -1044,17 +1044,17 @@ initialize_multicast_addresses_once(void)
         return true;
 
     multicast_ipv4 = (struct sol_network_link_addr) { .family = SOL_NETWORK_FAMILY_INET, .port = DEFAULT_UDP_PORT };
-    if (!sol_network_addr_from_str(&multicast_ipv4, MULTICAST_ADDRESS_IPv4)) {
+    if (!sol_network_link_addr_from_str(&multicast_ipv4, MULTICAST_ADDRESS_IPv4)) {
         SOL_WRN("Could not parse multicast IP address");
         return false;
     }
     multicast_ipv6_local = (struct sol_network_link_addr) { .family = SOL_NETWORK_FAMILY_INET6, .port = DEFAULT_UDP_PORT };
-    if (!sol_network_addr_from_str(&multicast_ipv6_local, MULTICAST_ADDRESS_IPv6_LOCAL)) {
+    if (!sol_network_link_addr_from_str(&multicast_ipv6_local, MULTICAST_ADDRESS_IPv6_LOCAL)) {
         SOL_WRN("Could not parse multicast IP address");
         return false;
     }
     multicast_ipv6_site = (struct sol_network_link_addr) { .family = SOL_NETWORK_FAMILY_INET6, .port = DEFAULT_UDP_PORT };
-    if (!sol_network_addr_from_str(&multicast_ipv6_site, MULTICAST_ADDRESS_IPv6_SITE)) {
+    if (!sol_network_link_addr_from_str(&multicast_ipv6_site, MULTICAST_ADDRESS_IPv6_SITE)) {
         SOL_WRN("Could not parse multicast IP address");
         return false;
     }
@@ -1091,11 +1091,11 @@ state_changed(sol_coap_responsecode_t response_code, struct sol_oic_client *oic_
         SOL_BUFFER_DECLARE_STATIC(resaddr, SOL_INET_ADDR_STRLEN);
         SOL_BUFFER_DECLARE_STATIC(respaddr, SOL_INET_ADDR_STRLEN);
 
-        if (!sol_network_addr_to_str(&resource->resource->addr, &resaddr)) {
+        if (!sol_network_link_addr_to_str(&resource->resource->addr, &resaddr)) {
             SOL_WRN("Could not convert network address to string");
             return;
         }
-        if (!sol_network_addr_to_str(cliaddr, &respaddr)) {
+        if (!sol_network_link_addr_to_str(cliaddr, &respaddr)) {
             SOL_WRN("Could not convert network address to string");
             return;
         }

--- a/src/lib/comms/include/sol-network.h
+++ b/src/lib/comms/include/sol-network.h
@@ -188,9 +188,9 @@ struct sol_network_link {
  *
  * @return a string with the network link address on success, @c NULL on error.
  *
- * @see sol_network_addr_from_str()
+ * @see sol_network_link_addr_from_str()
  */
-const char *sol_network_addr_to_str(const struct sol_network_link_addr *addr, struct sol_buffer *buf);
+const char *sol_network_link_addr_to_str(const struct sol_network_link_addr *addr, struct sol_buffer *buf);
 
 /**
  * @brief Converts a string address to @c sol_network_link_addr.
@@ -200,9 +200,9 @@ const char *sol_network_addr_to_str(const struct sol_network_link_addr *addr, st
  *
  * @return the network link address on success, @c NULL on error.
  *
- * @see sol_network_addr_to_str()
+ * @see sol_network_link_addr_to_str()
  */
-const struct sol_network_link_addr *sol_network_addr_from_str(struct sol_network_link_addr *addr, const char *buf);
+const struct sol_network_link_addr *sol_network_link_addr_from_str(struct sol_network_link_addr *addr, const char *buf);
 
 /**
  * @brief Checks if two address are equal.

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -552,7 +552,7 @@ timeout_cb(void *data)
 
     sol_socket_set_on_write(server->socket, on_can_write, server);
 
-    sol_network_addr_to_str(&outgoing->cliaddr, &addr);
+    sol_network_link_addr_to_str(&outgoing->cliaddr, &addr);
 
     SOL_DBG("server %p retrying packet id %d to client %.*s",
         server, sol_coap_header_get_id(outgoing->pkt),
@@ -663,7 +663,7 @@ on_can_write(void *data, struct sol_socket *s)
     if (err < 0) {
         SOL_BUFFER_DECLARE_STATIC(addr, SOL_INET_ADDR_STRLEN);
 
-        sol_network_addr_to_str(&outgoing->cliaddr, &addr);
+        sol_network_link_addr_to_str(&outgoing->cliaddr, &addr);
         SOL_WRN("Could not send packet %d to %.*s (%d): %s", sol_coap_header_get_id(outgoing->pkt),
             SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr)), -err, sol_util_strerrora(-err));
         return false;
@@ -762,7 +762,7 @@ done:
     if (err < 0) {
         SOL_BUFFER_DECLARE_STATIC(addr, SOL_INET_ADDR_STRLEN);
 
-        sol_network_addr_to_str(cliaddr, &addr);
+        sol_network_link_addr_to_str(cliaddr, &addr);
         SOL_WRN("Could not enqueue packet %p to %.*s (%d): %s", pkt,
             SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr)), -err,
             sol_util_strerrora(-err));
@@ -846,7 +846,7 @@ sol_coap_packet_send_notification(struct sol_coap_server *server,
         if (r < 0) {
             SOL_BUFFER_DECLARE_STATIC(addr, SOL_INET_ADDR_STRLEN);
 
-            sol_network_addr_to_str(&o->cliaddr, &addr);
+            sol_network_link_addr_to_str(&o->cliaddr, &addr);
             SOL_WRN("Failed to enqueue packet %p to %.*s", p,
                 SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr)));
             goto done;
@@ -1552,18 +1552,18 @@ join_mcast_groups(struct sol_socket *s, const struct sol_network_link *link)
         groupaddr.family = addr->family;
 
         if (addr->family == SOL_NETWORK_FAMILY_INET) {
-            sol_network_addr_from_str(&groupaddr, IPV4_ALL_COAP_NODES_GROUP);
+            sol_network_link_addr_from_str(&groupaddr, IPV4_ALL_COAP_NODES_GROUP);
             if (sol_socket_join_group(s, link->index, &groupaddr) < 0)
                 return -errno;
 
             continue;
         }
 
-        sol_network_addr_from_str(&groupaddr, IPV6_ALL_COAP_NODES_SCOPE_LOCAL);
+        sol_network_link_addr_from_str(&groupaddr, IPV6_ALL_COAP_NODES_SCOPE_LOCAL);
         if (sol_socket_join_group(s, link->index, &groupaddr) < 0)
             return -errno;
 
-        sol_network_addr_from_str(&groupaddr, IPV6_ALL_COAP_NODES_SCOPE_SITE);
+        sol_network_link_addr_from_str(&groupaddr, IPV6_ALL_COAP_NODES_SCOPE_SITE);
         if (sol_socket_join_group(s, link->index, &groupaddr) < 0)
             return -errno;
     }

--- a/src/lib/comms/sol-lwm2m.c
+++ b/src/lib/comms/sol-lwm2m.c
@@ -3442,7 +3442,7 @@ register_reply(struct sol_coap_server *server,
         return false;
     }
 
-    if (!sol_network_addr_to_str(server_addr, &addr))
+    if (!sol_network_link_addr_to_str(server_addr, &addr))
         SOL_WRN("Could not convert the server address to string");
 
     code = sol_coap_header_get_code(pkt);

--- a/src/lib/comms/sol-network-impl-linux.c
+++ b/src/lib/comms/sol-network-impl-linux.c
@@ -90,7 +90,7 @@ struct sol_network {
 static struct sol_network *network = NULL;
 
 SOL_API const char *
-sol_network_addr_to_str(const struct sol_network_link_addr *addr,
+sol_network_link_addr_to_str(const struct sol_network_link_addr *addr,
     struct sol_buffer *buf)
 {
     const char *r;
@@ -117,7 +117,7 @@ sol_network_addr_to_str(const struct sol_network_link_addr *addr,
 }
 
 SOL_API const struct sol_network_link_addr *
-sol_network_addr_from_str(struct sol_network_link_addr *addr, const char *buf)
+sol_network_link_addr_from_str(struct sol_network_link_addr *addr, const char *buf)
 {
     SOL_NULL_CHECK(addr, NULL);
     SOL_NULL_CHECK(buf, NULL);

--- a/src/lib/comms/sol-network-impl-riot.c
+++ b/src/lib/comms/sol-network-impl-riot.c
@@ -47,7 +47,7 @@
 static struct sol_vector links = SOL_VECTOR_INIT(struct sol_network_link);
 
 SOL_API const char *
-sol_network_addr_to_str(const struct sol_network_link_addr *addr,
+sol_network_link_addr_to_str(const struct sol_network_link_addr *addr,
     struct sol_buffer *buf)
 {
 #if MODULE_GNRC_IPV6_NETIF
@@ -80,7 +80,7 @@ sol_network_addr_to_str(const struct sol_network_link_addr *addr,
 }
 
 SOL_API const struct sol_network_link_addr *
-sol_network_addr_from_str(struct sol_network_link_addr *addr, const char *buf)
+sol_network_link_addr_from_str(struct sol_network_link_addr *addr, const char *buf)
 {
 #if MODULE_GNRC_IPV6_NETIF
     SOL_NULL_CHECK(addr, NULL);

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -381,7 +381,7 @@ err:
     if (err != CborNoError) {
         SOL_BUFFER_DECLARE_STATIC(addr, SOL_INET_ADDR_STRLEN);
 
-        sol_network_addr_to_str(cliaddr, &addr);
+        sol_network_link_addr_to_str(cliaddr, &addr);
         SOL_WRN("Error building response for /oic/res, server %p client %.*s: %s",
             oic_server.server, SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr)),
             cbor_error_string(err));

--- a/src/modules/flow/oauth/oauth.c
+++ b/src/modules/flow/oauth/oauth.c
@@ -364,7 +364,7 @@ get_callback_url(const struct sol_http_request *request, const char *basename)
     r = sol_http_request_get_interface_address(request, &addr);
     SOL_INT_CHECK(r, < 0, NULL);
 
-    SOL_NULL_CHECK(sol_network_addr_to_str(&addr, &buf), NULL);
+    SOL_NULL_CHECK(sol_network_link_addr_to_str(&addr, &buf), NULL);
 
     r = asprintf(&url, "http://%.*s:%d/%s/oauth_callback",
         SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&buf)), addr.port, basename);

--- a/src/samples/coap/iotivity-test-client.c
+++ b/src/samples/coap/iotivity-test-client.c
@@ -115,7 +115,7 @@ found_resource_print(struct sol_oic_client *cli, struct sol_oic_resource *res, v
         return false;
     }
 
-    if (!sol_network_addr_to_str(&res->addr, &addr)) {
+    if (!sol_network_link_addr_to_str(&res->addr, &addr)) {
         SOL_WRN("Could not convert network address to string");
         return false;
     }
@@ -271,7 +271,7 @@ resource_notify(sol_coap_responsecode_t response_code, struct sol_oic_client *cl
         return;
     }
 
-    if (!sol_network_addr_to_str(cliaddr, &addr)) {
+    if (!sol_network_link_addr_to_str(cliaddr, &addr)) {
         SOL_WRN("Could not convert network address to string");
         sol_quit_with_code(EXIT_FAILURE);
         return;
@@ -324,7 +324,7 @@ print_response(sol_coap_responsecode_t response_code, struct sol_oic_client *cli
         return;
     }
 
-    if (!sol_network_addr_to_str(cliaddr, &addr)) {
+    if (!sol_network_link_addr_to_str(cliaddr, &addr)) {
         SOL_WRN("Could not convert network address to string");
         sol_quit_with_code(EXIT_FAILURE);
         return;
@@ -646,7 +646,7 @@ main(int argc, char *argv[])
     if (argc >= 3)
         resource_type = argv[2];
 
-    if (!sol_network_addr_from_str(&cliaddr, "224.0.1.187")) {
+    if (!sol_network_link_addr_from_str(&cliaddr, "224.0.1.187")) {
         SOL_WRN("could not convert multicast ip address to sockaddr_in");
         return 1;
     }

--- a/src/samples/coap/oic-client.c
+++ b/src/samples/coap/oic-client.c
@@ -56,7 +56,7 @@ got_get_response(sol_coap_responsecode_t response_code, struct sol_oic_client *c
         return;
     }
 
-    if (!sol_network_addr_to_str(srv_addr, &addr)) {
+    if (!sol_network_link_addr_to_str(srv_addr, &addr)) {
         SOL_WRN("Could not convert network address to string");
         return;
     }
@@ -121,7 +121,7 @@ found_resource(struct sol_oic_client *cli, struct sol_oic_resource *res, void *d
     }
 #endif
 
-    if (!sol_network_addr_to_str(&res->addr, &addr)) {
+    if (!sol_network_link_addr_to_str(&res->addr, &addr)) {
         SOL_WRN("Could not convert network address to string");
         return false;
     }
@@ -179,7 +179,7 @@ main(int argc, char *argv[])
     if (!strchr(argv[1], ':'))
         srv_addr.family = SOL_NETWORK_FAMILY_INET;
 
-    if (!sol_network_addr_from_str(&srv_addr, argv[1])) {
+    if (!sol_network_link_addr_from_str(&srv_addr, argv[1])) {
         printf("Could not convert IP address to sockaddr_in\n");
         return 1;
     }

--- a/src/samples/coap/simple-client.c
+++ b/src/samples/coap/simple-client.c
@@ -96,7 +96,7 @@ reply_cb(struct sol_coap_server *server, struct sol_coap_packet *req,
     if (!req || !cliaddr) //timeout
         return false;
 
-    sol_network_addr_to_str(cliaddr, &addr);
+    sol_network_link_addr_to_str(cliaddr, &addr);
 
     SOL_INF("Got response from %.*s\n", SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr)));
 
@@ -165,7 +165,7 @@ main(int argc, char *argv[])
         sol_coap_add_option(req, SOL_COAP_OPTION_URI_PATH, path[i].data, path[i].len);
 
     cliaddr.family = SOL_NETWORK_FAMILY_INET6;
-    if (!sol_network_addr_from_str(&cliaddr, argv[1])) {
+    if (!sol_network_link_addr_from_str(&cliaddr, argv[1])) {
         SOL_WRN("%s is an invalid IPv6 address", argv[1]);
         free(path);
         sol_coap_packet_unref(req);

--- a/src/samples/network/network-status.c
+++ b/src/samples/network/network-status.c
@@ -128,7 +128,7 @@ _on_network_event(void *data, const struct sol_network_link *link, enum sol_netw
         printf("\tUP ");
         SOL_VECTOR_FOREACH_IDX (&link->addrs, addr, i) {
             addr_str.used = 0;
-            sol_network_addr_to_str(addr, &addr_str);
+            sol_network_link_addr_to_str(addr, &addr_str);
             printf("%.*s ", SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr_str)));
         }
         printf("\n");


### PR DESCRIPTION
sol_network_addr_to/from are functions of the sol_network_link_addr
family, the namespace should tell it. Also, it was inconsistent with
sol_network_link_addr_eq().

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>