### PR TITLE
coap: Fix wrong unref

### DIFF
--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -1235,7 +1235,7 @@ resource_not_found(struct sol_coap_packet *req,
     return sol_coap_send_packet(server, resp, cliaddr);
 
 err:
-    sol_coap_packet_unref(req);
+    sol_coap_packet_unref(resp);
     return r;
 }
 


### PR DESCRIPTION
It was unref the wrong variable and this could cause double free and
leakings.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>