### PR TITLE
coap: finally get rid of hardcoded packet sizes at sending side [v3]

### DIFF
--- a/src/lib/comms/coap.c
+++ b/src/lib/comms/coap.c
@@ -212,9 +212,6 @@ coap_packet_parse(struct sol_coap_packet *pkt)
     if (pkt->buf.used < (size_t)(hdrlen + optlen))
         return -EINVAL;
 
-    if (pkt->buf.used > COAP_UDP_MTU)
-        return -EINVAL;
-
     /* +1 for COAP_MARKER */
     if (pkt->buf.used <= (size_t)(hdrlen + optlen + 1)) {
         pkt->payload_start = 0;

--- a/src/lib/comms/coap.h
+++ b/src/lib/comms/coap.h
@@ -55,8 +55,6 @@ struct coap_header {
 #error "Unknown byte order"
 #endif
 
-#define COAP_UDP_MTU (576)
-
 struct sol_coap_packet {
     int refcnt;
     struct sol_buffer buf;

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -658,7 +658,9 @@ on_can_write(void *data, struct sol_socket *s)
     if (err == -EAGAIN)
         return true;
 
-    SOL_DBG("pkt sent:");
+    SOL_DBG("CoAP packet sent (payload of %zu bytes, "
+        "buffer holding it with %zu bytes)",
+        outgoing->pkt->buf.used, outgoing->pkt->buf.capacity);
     sol_coap_packet_debug(outgoing->pkt);
     if (err < 0) {
         SOL_BUFFER_DECLARE_STATIC(addr, SOL_INET_ADDR_STRLEN);

--- a/src/lib/comms/sol-oic-client.c
+++ b/src/lib/comms/sol-oic-client.c
@@ -930,9 +930,6 @@ _resource_request(struct sol_oic_client *client, struct sol_oic_resource *res,
         goto out;
     }
 
-    /* FIXME: We can't make phony cbor calls to calculate the exact
-     * payload here because it involves an user callback
-     * (fill_repr_map). */
     if (fill_repr_map) {
         sol_oic_packet_cbor_create(req, &map_encoder);
         if (!fill_repr_map(fill_repr_map_data, &map_encoder))

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -584,9 +584,6 @@ _sol_oic_resource_type_handle(
         input_ptr = &input;
     }
 
-    /* FIXME: We can't make phony cbor calls to calculate the exact
-     * payload here because it involves an user callback
-     * (handle_fn). */
     sol_oic_packet_cbor_create(response, &output);
     code = handle_fn(cliaddr, res->callback.data, input_ptr, &output);
     if (sol_oic_packet_cbor_close(response, &output) != CborNoError)
@@ -793,9 +790,6 @@ send_notification_to_server(struct sol_oic_server_resource *resource,
     pkt = sol_coap_packet_notification_new(oic_server.server, resource->coap);
     SOL_NULL_CHECK(pkt, false);
 
-    /* FIXME: We can't make phony cbor calls to calculate the exact
-     * payload here because it involves an user callback
-     * (fill_repr_map). */
     sol_oic_packet_cbor_create(pkt, &oic_map_writer);
     if (!fill_repr_map((void *)data, &oic_map_writer))
         goto end;


### PR DESCRIPTION
Changes since #1588:
- buffer realloc loop changed to look nicer/simpler