### PR TITLE
coap: Separate transport from coap logic

### DIFF
--- a/src/lib/comms/Makefile
+++ b/src/lib/comms/Makefile
@@ -33,7 +33,9 @@ obj-networking-$(PLATFORM_LINUX) += \
 
 obj-networking-$(COAP) += \
     coap.o \
-    sol-coap.o
+    sol-coap.o \
+    sol-coap-transport.o \
+    sol-coap-transport-ip.o
 
 obj-networking-$(OIC) += \
     sol-oic-cbor.o \
@@ -101,7 +103,9 @@ headers-$(NETWORK) += \
     include/sol-network.h
 
 headers-$(COAP) += \
-    include/sol-coap.h
+    include/sol-coap.h \
+    include/sol-coap-transport.h \
+    include/sol-coap-transport-ip.h
 
 headers-$(OIC) += \
     include/sol-oic-common.h \

--- a/src/lib/comms/include/sol-coap-transport-ip.h
+++ b/src/lib/comms/include/sol-coap-transport-ip.h
@@ -1,0 +1,100 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2016 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <sol-coap-transport.h>
+#include <sol-network.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file
+ * @brief Routines to use CoAP protocol IP transport.
+ */
+
+/**
+ * @defgroup CoAP_Transport_IP CoAP_Transport_IP
+ * @ingroup CoAP_Transport
+ *
+ * @{
+ */
+
+/**
+ * @brief Creates a new CoAP transport over UDP.
+ *
+ * This function will create a new CoAP transport using UDP socket.
+ *
+ * @param addr The address to be used (where the socket will be bound).
+ * @return A CoAP transport handle or @c NULL on error
+ *
+ * @see sol_coap_server_new()
+ * @see sol_coap_transport_ip_secure_new()
+ * @see sol_coap_transport_del()
+ */
+struct sol_coap_transport *sol_coap_transport_ip_new(const struct sol_network_link_addr *addr);
+
+/**
+ * @brief Creates a new CoAP transport over UDP using a DTLS socket.
+ *
+ * This function will create a new CoAP transport using UDP socket and all the
+ * traffic will be encrypted.
+ *
+ * @param addr The address to be used (where the socket will be bound).
+ * @return A CoAP transport handle or @c NULL on error
+ *
+ * @see sol_coap_server_new()
+ * @see sol_coap_transport_ip_new()
+ * @see sol_coap_transport_del()
+ */
+struct sol_coap_transport *sol_coap_transport_ip_secure_new(const struct sol_network_link_addr *addr);
+
+/**
+ * @brief Deletes a CoAP transport created with @c sol_coap_transport_ip_secure_new() or
+ * @c sol_coap_transport_ip_new()
+ *
+ * @param transport The transport to be deleted.
+ *
+ * @see sol_coap_transport_ip_secure_new()
+ * @see sol_coap_transport_ip_new()
+ */
+void sol_coap_transport_ip_del(struct sol_coap_transport *transport);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/lib/comms/include/sol-coap-transport.h
+++ b/src/lib/comms/include/sol-coap-transport.h
@@ -1,0 +1,197 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2016 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <sol-buffer.h>
+#include <sol-network.h>
+#include <sol-vector.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file
+ * @brief Routines to handle a CoAP transport.
+ *
+ * It declares a way to create a transport for Constrained
+ * Application Protocol (CoAP).
+ */
+
+/**
+ * @defgroup CoAP_Transport CoAP_Transport
+ * @ingroup Coap
+ *
+ * @{
+ */
+
+/**
+ * @brief Struct that represents CoAP transport.
+ *
+ * It declares a required interface that CoAP uses to communicate.
+ * One can create a new transport filling this struct with the
+ * proper methods.
+ *
+ * @see sol_coap_server_new()
+ */
+struct sol_coap_transport {
+#ifndef SOL_NO_API_VERSION
+#define SOL_COAP_TRANSPORT_API_VERSION (1)
+    /** @brief API version */
+    uint16_t api_version;
+#endif
+
+    /**
+     * @brief Sends data
+     *
+     * @param transport The pointer to this struct (self).
+     * @param buf The data that is wanted to be sent.
+     * @param len The size of the given data's buffer.
+     * @param addr The address that will be sent.
+     * @return 0 on success, -errno on error.
+     */
+    int (*sendmsg)(struct sol_coap_transport *transport,
+        const void *buf, size_t len, const struct sol_network_link_addr *addr);
+
+    /**
+     * @brief Receives data
+     *
+     * @param transport The pointer to this struct (self).
+     * @param buf The buffer that will be used to store the received data.
+     * @param len The size of the given data's buffer.
+     * @param addr The address from where the data came.
+     * @return 0 on success, -errno on error.
+     */
+    int (*recvmsg)(struct sol_coap_transport *transport,
+        void *buf, size_t len, struct sol_network_link_addr *addr);
+
+    /**
+     * @brief Set a callback to be called when is possible to send data.
+     *
+     * @param transport The pointer to this struct (self).
+     * @param on_can_write The callback to be called.
+     * @param user_data The data that will be given when the callback be called.
+     * @return 0 on success, -errno on error.
+     */
+    int (*set_on_write)(struct sol_coap_transport *transport,
+        bool (*on_can_write)(void *data, struct sol_coap_transport *transport),
+        const void *user_data);
+
+    /**
+     * @brief Set a callback to be called when there is available data to read.
+     *
+     * @param transport The pointer to this struct (self).
+     * @param on_can_read The callback to be called.
+     * @param user_data The data that will be given when the callback be called.
+     * @return 0 on success, -errno on error.
+     */
+    int (*set_on_read)(struct sol_coap_transport *transport,
+        bool (*on_can_read)(void *data, struct sol_coap_transport *transport),
+        const void *user_data);
+};
+
+/**
+ * @brief Sends data through a CoAP transport.
+ *
+ * This function is wrapper over the @c sendmsg method of the @c sol_coap_transport
+ * struct. It checks the parameters and the API version of the transport.
+ *
+ * @param transport The pointer to this struct (self).
+ * @param buf The data that is wanted to be sent.
+ * @param len The size of the given data's buffer.
+ * @param addr The address that will be sent.
+ * @return 0 on success, -errno on error.
+ *
+ * @see sol_coap_transport_set_on_write()
+ */
+int sol_coap_transport_sendmsg(struct sol_coap_transport *transport, const void *buf, size_t len,
+    const struct sol_network_link_addr *addr);
+
+/**
+ * @brief Receives data using from a CoAP transport.
+ *
+ * This function is wrapper over the @c recvmsg method of the @c sol_coap_transport
+ * struct. It checks the parameters and the API version of the transport.
+ *
+ * @param transport The pointer to this struct (self).
+ * @param buf The buffer that will be used to store the received data.
+ * @param len The size of the given data's buffer.
+ * @param addr The address from where the data came.
+ * @return 0 on success, -errno on error.
+ *
+ * @see sol_coap_transport_set_on_read()
+ */
+int sol_coap_transport_recvmsg(struct sol_coap_transport *transport, void *buf, size_t len,
+    struct sol_network_link_addr *addr);
+
+/**
+ * @brief Receives data using from a CoAP transport.
+ *
+ * This function is wrapper over the @c set_on_write method of the @c sol_coap_transport
+ * struct. It checks the parameters and the API version of the transport.
+ *
+ * @param transport The pointer to this struct (self).
+ * @param on_can_write The callback to be called.
+ * @param user_data The data that will be given when the callback be called.
+ * @return 0 on success, -errno on error.
+ *
+ * @see sol_coap_transport_sendmsg()
+ */
+int sol_coap_transport_set_on_write(struct sol_coap_transport *transport,
+    bool (*on_can_write)(void *data, struct sol_coap_transport *transport),
+    const void *user_data);
+
+/**
+ * @brief Set a callback to be called when there is available data to read.
+ *
+ * This function is wrapper over the @c set_on_read method of the @c sol_coap_transport
+ * struct. It checks the parameters and the API version of the transport.
+ *
+ * @param transport The pointer to this struct (self).
+ * @param on_can_read The callback to be called.
+ * @param user_data The data that will be given when the callback be called.
+ * @return 0 on success, -errno on error.
+ *
+ * @see sol_coap_transport_recvmsg()
+ */
+int sol_coap_transport_set_on_read(struct sol_coap_transport *transport,
+    bool (*on_can_read)(void *data, struct sol_coap_transport *transport),
+    const void *user_data);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -32,7 +32,7 @@
 
 #pragma once
 
-#include <sol-network.h>
+#include <sol-coap-transport.h>
 #include <sol-str-slice.h>
 
 #ifdef __cplusplus
@@ -480,29 +480,11 @@ int sol_coap_header_set_id(struct sol_coap_packet *pkt, uint16_t id);
  * @a addr. If the server cannot be created, NULL will be returned and
  * errno will be set to indicate the reason.
  *
- * @param addr The address where the server will listen on.
+ * @param transport The transport that will be used.
  *
  * @return A new server instance, or NULL in case of failure.
- *
- * @see sol_coap_secure_server_new()
  */
-struct sol_coap_server *sol_coap_server_new(const struct sol_network_link_addr *addr);
-
-/**
- * @brief Creates a new secure CoAP server instance.
- *
- * Creates a new, unsecured, CoAP server instance listening on address
- * @a addr. This server will encrypt communication with its endpoints
- * using DTLS. If the server cannot be created, NULL will be returned
- * and errno will be set to indicate the reason.
- *
- * @param addr The address where the server will listen on.
- *
- * @return A new server instance, or NULL in case of failure.
- *
- * @see sol_coap_server_new()
- */
-struct sol_coap_server *sol_coap_secure_server_new(const struct sol_network_link_addr *addr);
+struct sol_coap_server *sol_coap_server_new(struct sol_coap_transport *transport);
 
 /**
  * @brief Take a reference of the given server.

--- a/src/lib/comms/sol-coap-transport-ip.c
+++ b/src/lib/comms/sol-coap-transport-ip.c
@@ -1,0 +1,310 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2016 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+
+#define SOL_LOG_DOMAIN &_log_domain
+#include "sol-log-internal.h"
+#include "sol-coap-transport.h"
+#include "sol-coap-transport-ip.h"
+#include "sol-network.h"
+#include "sol-socket.h"
+#include "sol-util-internal.h"
+
+SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "coap-transport-ip");
+
+#define IPV4_ALL_COAP_NODES_GROUP "224.0.1.187"
+
+#define IPV6_ALL_COAP_NODES_SCOPE_LOCAL "ff02::fd"
+#define IPV6_ALL_COAP_NODES_SCOPE_SITE "ff05::fd"
+
+struct sol_coap_transport_ip {
+    struct sol_coap_transport base;
+    struct sol_socket *sock;
+    struct {
+        bool (*cb)(void *data, struct sol_coap_transport *transport);
+        const void *cb_data;
+    } on_can_read;
+
+    struct {
+        bool (*cb)(void *data, struct sol_coap_transport *transport);
+        const void *cb_data;
+    } on_can_write;
+};
+
+static bool
+transport_ip_on_can_read(void *data, struct sol_socket *s)
+{
+    struct sol_coap_transport_ip *tip = data;
+
+    if (tip->on_can_read.cb)
+        return tip->on_can_read.cb((void *)tip->on_can_read.cb_data, data);
+
+    return true;
+}
+
+static bool
+transport_ip_on_can_write(void *data, struct sol_socket *s)
+{
+    struct sol_coap_transport_ip *tip = data;
+
+    if (tip->on_can_write.cb)
+        return tip->on_can_write.cb((void *)tip->on_can_write.cb_data, data);
+
+    return true;
+}
+
+static int
+join_mcast_groups(struct sol_socket *s, const struct sol_network_link *link)
+{
+    struct sol_network_link_addr groupaddr = { };
+    struct sol_network_link_addr *addr;
+    uint16_t i;
+
+    if (!(link->flags & SOL_NETWORK_LINK_RUNNING) && !(link->flags & SOL_NETWORK_LINK_MULTICAST))
+        return 0;
+
+    SOL_VECTOR_FOREACH_IDX (&link->addrs, addr, i) {
+        groupaddr.family = addr->family;
+
+        if (addr->family == SOL_NETWORK_FAMILY_INET) {
+            sol_network_link_addr_from_str(&groupaddr, IPV4_ALL_COAP_NODES_GROUP);
+            if (sol_socket_join_group(s, link->index, &groupaddr) < 0)
+                return -errno;
+
+            continue;
+        }
+
+        sol_network_link_addr_from_str(&groupaddr, IPV6_ALL_COAP_NODES_SCOPE_LOCAL);
+        if (sol_socket_join_group(s, link->index, &groupaddr) < 0)
+            return -errno;
+
+        sol_network_link_addr_from_str(&groupaddr, IPV6_ALL_COAP_NODES_SCOPE_SITE);
+        if (sol_socket_join_group(s, link->index, &groupaddr) < 0)
+            return -errno;
+    }
+
+    return 0;
+}
+
+static void
+network_event(void *data, const struct sol_network_link *link, enum sol_network_event event)
+{
+    struct sol_coap_transport_ip *transport = data;
+
+    if (event != SOL_NETWORK_LINK_ADDED && event != SOL_NETWORK_LINK_CHANGED)
+        return;
+
+    if (!(link->flags & SOL_NETWORK_LINK_RUNNING) && !(link->flags & SOL_NETWORK_LINK_MULTICAST))
+        return;
+
+    join_mcast_groups(transport->sock, link);
+}
+
+static int
+transport_ip_sendmsg(struct sol_coap_transport *transport, const void *buf,
+    size_t len, const struct sol_network_link_addr *addr)
+{
+    struct sol_coap_transport_ip *tip;
+
+    SOL_NULL_CHECK(transport, -EINVAL);
+
+    tip = (struct sol_coap_transport_ip *)transport;
+
+    return sol_socket_sendmsg(tip->sock, buf, len, addr);
+}
+
+static int
+transport_ip_recvmsg(struct sol_coap_transport *transport, void *buf,
+    size_t len, struct sol_network_link_addr *addr)
+{
+    int ret;
+    struct sol_coap_transport_ip *tip;
+
+    SOL_NULL_CHECK(transport, -EINVAL);
+
+    tip = (struct sol_coap_transport_ip *)transport;
+    ret = sol_socket_recvmsg(tip->sock, buf, len, addr);
+
+    return ret;
+}
+
+static int
+transport_ip_set_on_read(struct sol_coap_transport *transport,
+    bool (*on_can_read)(void *data, struct sol_coap_transport *transport),
+    const void *user_data)
+{
+    int err;
+    struct sol_coap_transport_ip *tip;
+
+    SOL_NULL_CHECK(transport, -EINVAL);
+
+    tip = (struct sol_coap_transport_ip *)transport;
+    tip->on_can_read.cb = on_can_read;
+    tip->on_can_read.cb_data = user_data;
+
+    err = sol_socket_set_on_read(tip->sock, transport_ip_on_can_read, tip);
+    SOL_INT_CHECK_GOTO(err, < 0, err);
+
+    return 0;
+
+err:
+    tip->on_can_read.cb = NULL;
+    return err;
+}
+
+static int
+transport_ip_set_on_write(struct sol_coap_transport *transport,
+    bool (*on_can_write)(void *data, struct sol_coap_transport *transport),
+    const void *user_data)
+{
+    int err;
+    struct sol_coap_transport_ip *tip;
+
+    SOL_NULL_CHECK(transport, -EINVAL);
+
+    tip = (struct sol_coap_transport_ip *)transport;
+    tip->on_can_write.cb = on_can_write;
+    tip->on_can_write.cb_data = user_data;
+
+    err = sol_socket_set_on_write(tip->sock, transport_ip_on_can_write, tip);
+    SOL_INT_CHECK_GOTO(err, < 0, err);
+
+    return 0;
+
+err:
+    tip->on_can_read.cb = NULL;
+    return err;
+}
+
+static struct sol_coap_transport *
+sol_coap_transport_ip_new_full(enum sol_socket_type type, const struct sol_network_link_addr *addr)
+{
+    struct sol_coap_transport_ip *transport;
+
+    errno = EINVAL;
+    SOL_NULL_CHECK(addr, NULL);
+
+    errno = ENOMEM;
+    transport = sol_util_memdup(&(struct sol_coap_transport_ip) {
+        .base = {
+            SOL_SET_API_VERSION(.api_version = SOL_COAP_TRANSPORT_API_VERSION, )
+            .sendmsg = transport_ip_sendmsg,
+            .recvmsg = transport_ip_recvmsg,
+            .set_on_read = transport_ip_set_on_read,
+            .set_on_write = transport_ip_set_on_write,
+        }
+    }, sizeof(*transport));
+    SOL_NULL_CHECK(transport, NULL);
+
+    transport->sock = sol_socket_new(addr->family, type, 0);
+    SOL_NULL_CHECK_GOTO(transport->sock, err);
+
+    if (sol_socket_bind(transport->sock, addr) < 0) {
+        SOL_WRN("Could not bind socket (%d): %s", errno, sol_util_strerrora(errno));
+        goto bind_err;
+    }
+
+    if (type == SOL_SOCKET_UDP && addr->port) {
+        const struct sol_vector *links;
+        struct sol_network_link *link;
+        uint16_t i;
+
+        /* From man 7 ip:
+         *
+         *   imr_address is the address of the local interface with which the
+         *   system should join the  multicast  group;  if  it  is  equal  to
+         *   INADDR_ANY,  an  appropriate  interface is chosen by the system.
+         *
+         * We can't join a multicast group on every interface. In the future
+         * we may want to add a default multicast route to the system and use
+         * that interface.
+         */
+        links = sol_network_get_available_links();
+
+        if (links) {
+            SOL_VECTOR_FOREACH_IDX (links, link, i) {
+                /* Not considering an error,
+                 * because direct packets will work still.
+                 */
+                if (join_mcast_groups(transport->sock, link) < 0) {
+                    char *name = sol_network_link_get_name(link);
+                    SOL_WRN("Could not join multicast group, iface %s (%d): %s",
+                        name, errno, sol_util_strerrora(errno));
+                    free(name);
+                }
+            }
+        }
+    }
+    sol_network_subscribe_events(network_event, transport);
+
+    SOL_DBG("New coap transport %p on port %d%s", transport, addr->port,
+        type == SOL_SOCKET_UDP ? "" : " (secure)");
+
+    errno = 0;
+    return &transport->base;
+
+bind_err:
+    sol_socket_del(transport->sock);
+err:
+    free(transport);
+    return NULL;
+}
+
+SOL_API struct sol_coap_transport *
+sol_coap_transport_ip_secure_new(const struct sol_network_link_addr *addr)
+{
+#ifdef DTLS
+    return sol_coap_transport_ip_new_full(SOL_SOCKET_DTLS, addr);
+#else
+    errno = ENOSYS;
+    return NULL;
+#endif
+}
+
+SOL_API struct sol_coap_transport *
+sol_coap_transport_ip_new(const struct sol_network_link_addr *addr)
+{
+    return sol_coap_transport_ip_new_full(SOL_SOCKET_UDP, addr);
+}
+
+SOL_API void
+sol_coap_transport_ip_del(struct sol_coap_transport *transport)
+{
+    struct sol_coap_transport_ip *t = (struct sol_coap_transport_ip *)transport;
+
+    SOL_NULL_CHECK(t);
+
+    sol_socket_del(t->sock);
+    free(t);
+}

--- a/src/lib/comms/sol-coap-transport.c
+++ b/src/lib/comms/sol-coap-transport.c
@@ -1,0 +1,100 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2016 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define SOL_LOG_DOMAIN &_log_domain
+#include "sol-log-internal.h"
+#include "sol-macros.h"
+#include "sol-coap-transport.h"
+
+SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "coap-transport");
+
+#ifndef SOL_NO_API_VERSION
+#define SOL_COAP_TRANSPORT_API_CHECK(transport, expected, ...) \
+    do { \
+        if (((const struct sol_coap_transport *)transport)->api_version != (expected)) { \
+            SOL_WRN("Invalid " # transport " %p API version(%hu), " \
+                "expected " # expected "(%hu)", \
+                (transport), \
+                ((const struct sol_coap_transport *)transport)->api_version, \
+                (expected)); \
+            return __VA_ARGS__; \
+        } \
+    } while (0)
+#else
+#define SOL_COAP_TRANSPORT_API_CHECK(transport, expected, ...)
+#endif
+
+SOL_API int
+sol_coap_transport_sendmsg(struct sol_coap_transport *transport, const void *buf, size_t len,
+    const struct sol_network_link_addr *addr)
+{
+    SOL_NULL_CHECK(transport, -EINVAL);
+    SOL_COAP_TRANSPORT_API_CHECK(transport, SOL_COAP_TRANSPORT_API_VERSION, -EINVAL);
+    SOL_NULL_CHECK(transport->sendmsg, -EINVAL);
+
+    return transport->sendmsg(transport, buf, len, addr);
+}
+
+SOL_API int
+sol_coap_transport_recvmsg(struct sol_coap_transport *transport, void *buf, size_t len,
+    struct sol_network_link_addr *addr)
+{
+    SOL_NULL_CHECK(transport, -EINVAL);
+    SOL_COAP_TRANSPORT_API_CHECK(transport, SOL_COAP_TRANSPORT_API_VERSION, -EINVAL);
+    SOL_NULL_CHECK(transport->recvmsg, -EINVAL);
+
+    return transport->recvmsg(transport, buf, len, addr);
+}
+
+SOL_API int
+sol_coap_transport_set_on_write(struct sol_coap_transport *transport,
+    bool (*on_can_write)(void *data, struct sol_coap_transport *transport),
+    const void *user_data)
+{
+    SOL_NULL_CHECK(transport, -EINVAL);
+    SOL_COAP_TRANSPORT_API_CHECK(transport, SOL_COAP_TRANSPORT_API_VERSION, -EINVAL);
+    SOL_NULL_CHECK(transport->set_on_write, -EINVAL);
+
+    return transport->set_on_write(transport, on_can_write, user_data);
+}
+
+SOL_API int
+sol_coap_transport_set_on_read(struct sol_coap_transport *transport,
+    bool (*on_can_read)(void *data, struct sol_coap_transport *transport),
+    const void *user_data)
+{
+    SOL_NULL_CHECK(transport, -EINVAL);
+    SOL_COAP_TRANSPORT_API_CHECK(transport, SOL_COAP_TRANSPORT_API_VERSION, -EINVAL);
+    SOL_NULL_CHECK(transport->set_on_read, -EINVAL);
+
+    return transport->set_on_read(transport, on_can_read, user_data);
+}

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -39,6 +39,8 @@
 
 #include "cbor.h"
 #include "sol-coap.h"
+#include "sol-coap-transport.h"
+#include "sol-coap-transport-ip.h"
 #include "sol-json.h"
 #include "sol-log-internal.h"
 #include "sol-macros.h"
@@ -55,7 +57,9 @@ SOL_LOG_INTERNAL_DECLARE(_sol_oic_server_log_domain, "oic-server");
 
 struct sol_oic_server {
     struct sol_coap_server *server;
+    struct sol_coap_transport *transport;
     struct sol_coap_server *dtls_server;
+    struct sol_coap_transport *dtls_transport;
     struct sol_ptr_vector resources;
     struct sol_oic_platform_information *plat_info;
     struct sol_oic_server_information *server_info;
@@ -470,22 +474,29 @@ sol_oic_server_init(void)
     server_info = init_static_server_info();
     SOL_NULL_CHECK_GOTO(server_info, error);
 
-    oic_server.server = sol_coap_server_new(&servaddr);
-    if (!oic_server.server) {
-        r = -ENOMEM;
-        goto error;
-    }
+    oic_server.transport = sol_coap_transport_ip_new(&servaddr);
+    SOL_NULL_CHECK_GOTO(oic_server.transport, error);
+
+    oic_server.server = sol_coap_server_new(oic_server.transport);
+    SOL_NULL_CHECK_GOTO(oic_server.transport, error);
 
     r = sol_coap_server_register_resource(oic_server.server,
         &oic_res_coap_resource, NULL);
     SOL_INT_CHECK_GOTO(r, < 0, error);
 
     servaddr.port = OIC_COAP_SERVER_DTLS_PORT;
-    oic_server.dtls_server = sol_coap_secure_server_new(&servaddr);
-    if (!oic_server.dtls_server) {
+
+    oic_server.dtls_transport = sol_coap_transport_ip_secure_new(&servaddr);
+    if (!oic_server.dtls_transport) {
         if (errno == ENOSYS) {
             SOL_INF("DTLS support not built in, OIC server running in insecure mode");
         } else {
+            SOL_INF("DTLS server could not be created for OIC server: %s",
+                sol_util_strerrora(errno));
+        }
+    } else {
+        oic_server.dtls_server = sol_coap_server_new(oic_server.dtls_transport);
+        if (!oic_server.dtls_transport) {
             SOL_INF("DTLS server could not be created for OIC server: %s",
                 sol_util_strerrora(errno));
         }
@@ -509,6 +520,10 @@ sol_oic_server_init(void)
 error:
     if (oic_server.server)
         sol_coap_server_unref(oic_server.server);
+    if (oic_server.transport)
+        sol_coap_transport_ip_del(oic_server.transport);
+    if (oic_server.dtls_transport)
+        sol_coap_transport_ip_del(oic_server.dtls_transport);
 
     free(server_info);
     free(plat_info);
@@ -540,6 +555,11 @@ sol_oic_server_shutdown(void)
         &oic_res_coap_resource);
 
     sol_coap_server_unref(oic_server.server);
+
+    if (oic_server.transport)
+        sol_coap_transport_ip_del(oic_server.transport);
+    if (oic_server.dtls_transport)
+        sol_coap_transport_ip_del(oic_server.dtls_transport);
 
     free(oic_server.server_info);
     free(oic_server.plat_info);

--- a/src/samples/coap/simple-client.c
+++ b/src/samples/coap/simple-client.c
@@ -39,7 +39,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
-#include <sys/socket.h>
 
 #include "sol-log.h"
 #include "sol-mainloop.h"
@@ -48,6 +47,7 @@
 #include "sol-vector.h"
 
 #include "sol-coap.h"
+#include "sol-coap-transport-ip.h"
 
 #define DEFAULT_UDP_PORT 5683
 
@@ -114,6 +114,7 @@ int
 main(int argc, char *argv[])
 {
     struct sol_coap_server *server;
+    struct sol_coap_transport *transport;
     struct sol_str_slice *path;
     struct sol_network_link_addr cliaddr = { };
     struct sol_coap_packet *req;
@@ -131,7 +132,13 @@ main(int argc, char *argv[])
         return 0;
     }
 
-    server = sol_coap_server_new(&servaddr);
+    transport = sol_coap_transport_ip_new(&servaddr);
+    if (!transport) {
+        SOL_WRN("Could not create a coap transport.");
+        return -1;
+    }
+
+    server = sol_coap_server_new(transport);
     if (!server) {
         SOL_WRN("Could not create a coap server.");
         return -1;
@@ -180,6 +187,7 @@ main(int argc, char *argv[])
     sol_run();
 
     sol_coap_server_unref(server);
+    sol_coap_transport_ip_del(transport);
     free(path);
 
     return 0;

--- a/src/samples/coap/simple-server.c
+++ b/src/samples/coap/simple-server.c
@@ -39,7 +39,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
-#include <sys/socket.h>
 
 #include "sol-log.h"
 #include "sol-mainloop.h"
@@ -48,6 +47,8 @@
 #include "sol-vector.h"
 
 #include "sol-coap.h"
+#include "sol-coap-transport.h"
+#include "sol-coap-transport-ip.h"
 
 #define DEFAULT_UDP_PORT 5683
 
@@ -256,13 +257,15 @@ main(int argc, char *argv[])
 {
     struct light_context context = { .resource = &light };
     struct sol_coap_server *server;
+    struct sol_coap_transport *transport;
     char old_led_state;
     struct sol_network_link_addr servaddr = { .family = SOL_NETWORK_FAMILY_INET6,
                                               .port = DEFAULT_UDP_PORT };
 
     sol_init();
 
-    server = sol_coap_server_new(&servaddr);
+    transport = sol_coap_transport_ip_new(&servaddr);
+    server = sol_coap_server_new(transport);
     if (!server) {
         SOL_WRN("Could not create a coap server using port %d.", DEFAULT_UDP_PORT);
         return -1;


### PR DESCRIPTION
This is probably the most straightforward way to separate the  coap from the transport. 
It defines a basic interface that coap will use to send and received data.

Now it look likes another abstraction over socket but it will allows using bluetooth as transport. The fact of each transport has its header and its own api will allows the oic implementation uses bluetooth as the transport easily.

Once we have mapped all the necessity of different transports we can improve this api.