### PR TITLE
run-fbp-tests: Add test PASS/FAIL info to be compatible to ptest log format definition

### DIFF
--- a/tools/run-fbp-tests
+++ b/tools/run-fbp-tests
@@ -241,6 +241,7 @@ def run_tests(args):
         if curr.should_skip(skips):
             logging.debug("SKIPPED running %s: %s" % (t, curr.skip_msg))
             status["skipped"] += 1
+            logging.info("SKIP: %s" % path["file"])
             continue
 
         if not args.compiled:
@@ -269,6 +270,7 @@ def run_tests(args):
                 logging.warning("Dependence test %s for test %s failed. Skipping it",
                         curr.depends, curr.test_file)
                 status["skipped"] += 1
+                logging.info("SKIP: %s" % path["file"])
                 continue
 
             out, code = sh(cmd, cwd=test_cwd)
@@ -277,8 +279,10 @@ def run_tests(args):
         status[result] += 1
         if result == "failed":
             failures = True
+            logging.info("FAIL: %s" % path["file"])
         else:
             successful.append(path['file'])
+            logging.info("PASS: %s" % path["file"])
 
     for k,v in status.items():
         if v > 0:


### PR DESCRIPTION

    According to package test (ptest) log format definition, the test case result recorded in log as
        PASS: <case name>
        FAIL: <case name>
    The patch prints more output to be compatible to ptest log format when execute Soletta FBP tests
    The Soletta test result mapping to ptest output logic is:
        Soletta test pass -> ptest output PASS
        Soletta test fail -> ptest output FAIL
        Soletta test skip by dependence test fail -> ptest output FAIL
        Soletta test skip by user specified       -> ptest output SKIP

Signed-off-by: Lei Yang <lei.a.yang@intel.com>