### PR TITLE
nodejs: Add NODE_GYP_FLAGS to specify additional flags to node-gyp

### DIFF
--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -204,8 +204,8 @@ bindings-nodejs: $(SOL_LIB_OUTPUT)
 	$(Q) \
 		SOLETTA_CFLAGS="$(addprefix -I,$(abspath $(HEADERDIRS)))" \
 		SOLETTA_LIBS="$(FIND_LIBRARY_LDFLAGS)" \
-               SOLETTA_CFLAGS="$${SOLETTA_CFLAGS}" SOLETTA_LIBS="$${SOLETTA_LIBS}" $(NODE_GYP) configure && \
-               SOLETTA_CFLAGS="$${SOLETTA_CFLAGS}" SOLETTA_LIBS="$${SOLETTA_LIBS}" $(NODE_GYP) build
+               SOLETTA_CFLAGS="$${SOLETTA_CFLAGS}" SOLETTA_LIBS="$${SOLETTA_LIBS}" $(NODE_GYP) $(NODE_GYP_FLAGS) configure && \
+               SOLETTA_CFLAGS="$${SOLETTA_CFLAGS}" SOLETTA_LIBS="$${SOLETTA_LIBS}" $(NODE_GYP) $(NODE_GYP_FLAGS) build
 
 PHONY += bindings-nodejs
 


### PR DESCRIPTION
Additional flags like --arch and --proxy needs to passed to node-gyp
when building JS bindings for different targets inside Yocto. So, adding
NODE_GYP_FLAGS to specify those additional flags.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>