### PR TITLE
nodejs: Set NODE_GYP only if it doesn't have a value already

### DIFF
--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -194,7 +194,7 @@ PHONY += cheat-sheet
 ifneq ($(USE_NODEJS),)
 
 bins-out += bindings-nodejs
-NODE_GYP=$(NODE_GYP_PATH)/node-gyp
+NODE_GYP ?= $(NODE_GYP_PATH)/node-gyp
 
 bindings-nodejs: $(SOL_LIB_OUTPUT)
 	# Install dependencies without building the package


### PR DESCRIPTION
This helps us to specify additional flags that are needed for building JS bindings for different targets using node-gyp.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>