### PR TITLE
Fixes v2 - Invalid memory access 

### DIFF
--- a/src/modules/flow/oauth/oauth.c
+++ b/src/modules/flow/oauth/oauth.c
@@ -50,30 +50,29 @@ struct v1_request_data {
     char *timestamp, *nonce, *callback_url;
 };
 
-struct oauth_node_type {
-    struct sol_flow_node_type base;
+static struct {
     struct sol_http_server *server;
-    uint16_t server_ref;
-};
+    uint16_t ref;
+} oauth;
 
 static int
-server_ref(struct oauth_node_type *oauth)
+ref(void)
 {
-    if (!oauth->server) {
-        oauth->server = sol_http_server_new(HTTP_SERVER_PORT);
-        SOL_NULL_CHECK(oauth->server, -ENOMEM);
+    if (!oauth.server) {
+        oauth.server = sol_http_server_new(HTTP_SERVER_PORT);
+        SOL_NULL_CHECK(oauth.server, -ENOMEM);
     }
-    oauth->server_ref++;
+    oauth.ref++;
     return 0;
 }
 
 static void
-server_unref(struct oauth_node_type *oauth)
+server_unref(void)
 {
-    oauth->server_ref--;
-    if (!oauth->server_ref) {
-        sol_http_server_del(oauth->server);
-        oauth->server = NULL;
+    oauth.ref--;
+    if (!oauth.ref) {
+        sol_http_server_del(oauth.server);
+        oauth.server = NULL;
     }
 }
 
@@ -219,15 +218,12 @@ v1_close(struct sol_flow_node *node, void *data)
 {
     struct sol_http_client_connection *connection;
     struct sol_message_digest *digest;
-    struct oauth_node_type *type;
     struct v1_data *mdata = data;
     uint16_t i;
 
-    type = (struct oauth_node_type *)sol_flow_node_get_type(node);
-
-    sol_http_server_unregister_handler(type->server, mdata->start_handler_url);
-    sol_http_server_unregister_handler(type->server, mdata->callback_handler_url);
-    server_unref(type);
+    sol_http_server_unregister_handler(oauth.server, mdata->start_handler_url);
+    sol_http_server_unregister_handler(oauth.server, mdata->callback_handler_url);
+    server_unref();
 
     free(mdata->start_handler_url);
     free(mdata->callback_handler_url);
@@ -583,7 +579,6 @@ v1_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_optio
 {
     int r;
     struct v1_data *mdata = data;
-    struct oauth_node_type *type;
     struct sol_flow_node_type_oauth_v1_options *opts =
         (struct sol_flow_node_type_oauth_v1_options *)options;
 
@@ -591,9 +586,7 @@ v1_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_optio
         SOL_FLOW_NODE_TYPE_OAUTH_V1_OPTIONS_API_VERSION,
         -EINVAL);
 
-    type = (struct oauth_node_type *)sol_flow_node_get_type(node);
-
-    r = server_ref(type);
+    r = ref();
     SOL_INT_CHECK(r, < 0, r);
 
     mdata->request_token_url = strdup(opts->request_token_url);
@@ -623,18 +616,18 @@ v1_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_optio
     r = asprintf(&mdata->callback_handler_url, "%s/oauth_callback", mdata->basename);
     SOL_INT_CHECK_GOTO(r, < 0, err_callback);
 
-    r = sol_http_server_register_handler(type->server, mdata->start_handler_url,
+    r = sol_http_server_register_handler(oauth.server, mdata->start_handler_url,
         v1_request_start_cb, node);
     SOL_INT_CHECK_GOTO(r, < 0, err_register_handler);
 
-    r = sol_http_server_register_handler(type->server, mdata->callback_handler_url,
+    r = sol_http_server_register_handler(oauth.server, mdata->callback_handler_url,
         v1_authorize_response_cb, node);
     SOL_INT_CHECK_GOTO(r, < 0, err);
 
     return 0;
 
 err:
-    sol_http_server_unregister_handler(type->server,
+    sol_http_server_unregister_handler(oauth.server,
         mdata->start_handler_url);
 err_register_handler:
     free(mdata->callback_handler_url);
@@ -653,7 +646,7 @@ access_err:
 authorize_err:
     free(mdata->request_token_url);
 url_err:
-    server_unref(type);
+    server_unref();
     return r;
 }
 

--- a/src/modules/flow/oauth/oauth.json
+++ b/src/modules/flow/oauth/oauth.json
@@ -15,12 +15,6 @@
         "close": "v1_close",
         "open": "v1_open"
       },
-      "node_type": {
-        "access": [
-          "base"
-        ],
-        "data_type": "struct oauth_node_type"
-      },
       "options": {
 	"members": [
 	  {

--- a/src/modules/flow/update/update.c
+++ b/src/modules/flow/update/update.c
@@ -38,17 +38,6 @@ struct update_node_type {
 };
 
 static int
-check_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
-{
-    struct update_node_type *type;
-
-    type = (struct update_node_type *)sol_flow_node_get_type(node);
-    type->progress_port = SOL_FLOW_NODE_TYPE_UPDATE_CHECK__OUT__PROGRESS;
-
-    return 0;
-}
-
-static int
 cancel_check_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet)
 {
     struct update_data *mdata = data;
@@ -117,17 +106,6 @@ check_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t co
     return 0;
 }
 
-static int
-fetch_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
-{
-    struct update_node_type *type;
-
-    type = (struct update_node_type *)sol_flow_node_get_type(node);
-    type->progress_port = SOL_FLOW_NODE_TYPE_UPDATE_FETCH__OUT__PROGRESS;
-
-    return 0;
-}
-
 static void
 common_close(struct sol_flow_node *node, void *data)
 {
@@ -190,17 +168,6 @@ fetch_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t co
         sol_flow_send_error_packet(node, EINVAL, "Could not fetch update file");
         return -EINVAL;
     }
-
-    return 0;
-}
-
-static int
-install_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_options *options)
-{
-    struct update_node_type *type;
-
-    type = (struct update_node_type *)sol_flow_node_get_type(node);
-    type->progress_port = SOL_FLOW_NODE_TYPE_UPDATE_INSTALL__OUT__PROGRESS;
 
     return 0;
 }

--- a/src/modules/flow/update/update.json
+++ b/src/modules/flow/update/update.json
@@ -37,14 +37,16 @@
         }
       ],
       "methods": {
-        "close": "common_close",
-        "open": "check_open"
+        "close": "common_close"
       },
       "node_type": {
         "access": [
           "base"
         ],
-        "data_type": "struct update_node_type"
+        "data_type": "struct update_node_type",
+        "extra_methods": {
+          "progress_port": "SOL_FLOW_NODE_TYPE_UPDATE_CHECK__OUT__PROGRESS"
+	}
       },
       "name": "update/check",
       "out_ports": [
@@ -102,14 +104,16 @@
         }
       ],
       "methods": {
-        "close": "common_close",
-        "open": "fetch_open"
+        "close": "common_close"
       },
       "node_type": {
         "access": [
           "base"
         ],
-        "data_type": "struct update_node_type"
+        "data_type": "struct update_node_type",
+        "extra_methods": {
+          "progress_port": "SOL_FLOW_NODE_TYPE_UPDATE_FETCH__OUT__PROGRESS"
+	}
       },
       "name": "update/fetch",
       "out_ports": [
@@ -156,14 +160,16 @@
         }
       ],
       "methods": {
-        "close": "common_close",
-        "open": "install_open"
+        "close": "common_close"
       },
       "node_type": {
         "access": [
           "base"
         ],
-        "data_type": "struct update_node_type"
+        "data_type": "struct update_node_type",
+        "extra_methods": {
+          "progress_port": "SOL_FLOW_NODE_TYPE_UPDATE_INSTALL__OUT__PROGRESS"
+	}
       },
       "name": "update/install",
       "out_ports": [


### PR DESCRIPTION
from v1:
 - use `extra_methods` to set the progress port in update nodes