### PR TITLE
Coap mem improvements [v7]

### DIFF
--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -60,6 +60,12 @@ extern "C" {
  * as multicast support, very low overhead, and simplicity
  * for constrained environments.
  *
+ * Relevant RFCs:
+ * - https://tools.ietf.org/html/rfc7252: The Constrained Application
+ *   Protocol (CoAP)
+ * - https://tools.ietf.org/html/rfc7641: Observing Resources in the
+ *   Constrained Application Protocol (CoAP)
+ *
  * @{
  */
 

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -703,20 +703,24 @@ int sol_coap_send_packet(struct sol_coap_server *server, struct sol_coap_packet 
 /**
  * @brief Sends a packet to the given address.
  *
- * Sends the packet @a pkt to the destination address especified by @a cliaddr,
- * which may be a multicast address for discovery purposes.
+ * Sends the packet @a pkt to the destination address especified by @a
+ * cliaddr, which may be a multicast address for discovery purposes,
+ * and issues a given callback when a response arrives.
  *
- * When a response is received, the function @a reply_cb will be called.
- * As long as this function returns @c true, @a server will continue waiting
- * for more responses. When the function returns @c false, the internal response
- * handler will be freed and any new replies that arrive for this request
- * will be ignored. For unobserving packets server will also be notified using
- * an unobserve packet.
- * After internal timeout is reached reply_cb will be called with @c NULL
- * req and cliaddr. The same behavior is expected for reply_cb return, if
- * reply_cb returns @c true, @a server will continue waiting responses until
- * next timeout. If reply_cb returns @c false, @a server will terminate
- * response waiting.
+ * If @a reply_cb is @c NULL, this function will behave exactly like
+ * sol_coap_send_packet(). If a valid function is passed, when a
+ * response is received, the function @a reply_cb will be called. As
+ * long as this function returns @c true, @a server will continue
+ * waiting for more responses. When it returns @c false, the internal
+ * response handler will be freed and any new reply that may arrive
+ * for this request will be ignored. For unobserving packets, @a
+ * server will also be notified using an unobserve packet.
+ *
+ * After an internal timeout is reached, @a reply_cb will be called
+ * with @c NULL @c req and @c cliaddr. The same behavior is expected
+ * for its return: if @c true, @a server will issue a new timeout and
+ * continue waiting responses until it ends, otherwise @a server will
+ * terminate response waiting.
  *
  * @note This function will take the reference of the given @a pkt.
  *
@@ -726,7 +730,7 @@ int sol_coap_send_packet(struct sol_coap_server *server, struct sol_coap_packet 
  * @param reply_cb The function to call when a response is received.
  * @param data The user data pointer to pass to the @a reply_cb function.
  *
- * @return 0 on success, -errno otherwise.
+ * @return 0 on success, a negative error code otherwise.
  */
 int sol_coap_send_packet_with_reply(struct sol_coap_server *server, struct sol_coap_packet *pkt,
     const struct sol_network_link_addr *cliaddr,

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -106,6 +106,8 @@ struct pending_reply {
 struct outgoing {
     struct sol_coap_server *server;
     struct sol_coap_packet *pkt;
+    /* When present this header will overwrite the header from 'pkt'. */
+    struct sol_coap_packet *header;
     struct sol_timeout *timeout;
     struct sol_network_link_addr cliaddr;
     int counter; /* How many times this packet was retransmited. */
@@ -566,6 +568,10 @@ outgoing_free(struct outgoing *outgoing)
         sol_timeout_del(outgoing->timeout);
 
     sol_coap_packet_unref(outgoing->pkt);
+
+    if (outgoing->header)
+        sol_coap_packet_unref(outgoing->header);
+
     free(outgoing);
 }
 
@@ -690,11 +696,57 @@ timeout_expired(struct sol_coap_server *server, struct outgoing *outgoing)
     return expired;
 }
 
+static int
+prepare_buffer(struct outgoing *outgoing, struct sol_buffer *buffer)
+{
+    struct sol_coap_packet *header = outgoing->header;
+    struct sol_coap_packet *payload = outgoing->pkt;
+    uint16_t new_size, new_offset, old_offset;
+    uint8_t new_tkl, old_tkl;
+    uint8_t *buf_data;
+    int r;
+
+    if (!header) {
+        sol_buffer_init_flags(buffer, payload->buf.data, payload->buf.used,
+            SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+        buffer->used = payload->buf.used;
+        return 0;
+    }
+
+    (void)sol_coap_header_get_token(payload, &old_tkl);
+    (void)sol_coap_header_get_token(header, &new_tkl);
+
+    new_size = payload->buf.used + (new_tkl - old_tkl);
+
+    buf_data = malloc(new_size);
+    SOL_NULL_CHECK(buf_data, -ENOMEM);
+
+    sol_buffer_init_flags(buffer, buf_data, new_size,
+        SOL_BUFFER_FLAGS_FIXED_CAPACITY | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+
+    new_offset = sizeof(struct coap_header) + new_tkl;
+    old_offset = sizeof(struct coap_header) + old_tkl;
+
+    r = sol_buffer_append_bytes(buffer, header->buf.data, new_offset);
+    SOL_INT_CHECK_GOTO(r, < 0, error);
+
+    r = sol_buffer_append_bytes(buffer, sol_buffer_at(&payload->buf, old_offset),
+        payload->buf.used - old_offset);
+    SOL_INT_CHECK_GOTO(r, < 0, error);
+
+    return 0;
+
+error:
+    sol_buffer_fini(buffer);
+    return -ENOMEM;
+}
+
 static bool
 on_can_write(void *data, struct sol_socket *s)
 {
     struct sol_coap_server *server = data;
     struct outgoing *outgoing;
+    struct sol_buffer buf;
     int err;
     int idx;
 
@@ -708,9 +760,14 @@ on_can_write(void *data, struct sol_socket *s)
     if (!outgoing)
         return false;
 
-    err = sol_socket_sendmsg(s, outgoing->pkt->buf.data,
-        outgoing->pkt->buf.used, &outgoing->cliaddr);
+    err = prepare_buffer(outgoing, &buf);
+    if (err)
+        return true;
+
+    err = sol_socket_sendmsg(s, buf.data, buf.used, &outgoing->cliaddr);
     /* Eventually we are going to re-send it. */
+    sol_buffer_fini(&buf);
+
     if (err == -EAGAIN)
         return true;
 
@@ -737,6 +794,7 @@ on_can_write(void *data, struct sol_socket *s)
 
 static int
 enqueue_packet(struct sol_coap_server *server, struct sol_coap_packet *pkt,
+    struct sol_coap_packet *header,
     const struct sol_network_link_addr *cliaddr)
 {
     struct outgoing *outgoing;
@@ -759,6 +817,8 @@ enqueue_packet(struct sol_coap_server *server, struct sol_coap_packet *pkt,
     memcpy(&outgoing->cliaddr, cliaddr, sizeof(*cliaddr));
 
     outgoing->pkt = sol_coap_packet_ref(pkt);
+    if (header)
+        outgoing->header = sol_coap_packet_ref(header);
 
     sol_socket_set_on_write(server->socket, on_can_write, server);
 
@@ -822,7 +882,7 @@ sol_coap_send_packet_with_reply(struct sol_coap_server *server, struct sol_coap_
     }
 
 done:
-    err = enqueue_packet(server, pkt, cliaddr);
+    err = enqueue_packet(server, pkt, NULL, cliaddr);
     if (err < 0) {
         SOL_BUFFER_DECLARE_STATIC(addr, SOL_INET_ADDR_STRLEN);
 
@@ -870,8 +930,7 @@ sol_coap_packet_send_notification(struct sol_coap_server *server,
 {
     struct resource_observer *o;
     struct resource_context *c;
-    struct sol_coap_packet *p;
-    uint8_t tkl;
+    struct sol_coap_packet *header;
     uint16_t i;
     int r = 0;
 
@@ -884,43 +943,32 @@ sol_coap_packet_send_notification(struct sol_coap_server *server,
     c = find_context(server, resource);
     SOL_NULL_CHECK(c, -ENOENT);
 
-    sol_coap_header_get_token(pkt, &tkl);
-
     SOL_PTR_VECTOR_FOREACH_IDX (&c->observers, o, i) {
         uint8_t type, code;
 
-        p = sol_coap_packet_new(NULL);
-        SOL_NULL_CHECK(p, -ENOMEM);
+        header = sol_coap_packet_new(NULL);
+        SOL_NULL_CHECK(header, -ENOMEM);
 
         sol_coap_header_get_code(pkt, &code);
-        r = sol_coap_header_set_code(p, code);
+        r = sol_coap_header_set_code(header, code);
         SOL_INT_CHECK_GOTO(r, < 0, err);
         sol_coap_header_get_type(pkt, &type);
-        r = sol_coap_header_set_type(p, type);
+        r = sol_coap_header_set_type(header, type);
         SOL_INT_CHECK_GOTO(r, < 0, err);
-        r = sol_coap_header_set_token(p, o->token, o->tkl);
-        SOL_INT_CHECK_GOTO(r, < 0, err);
-
-        /*
-         * Copying the options + payload from the notification packet to
-         * every packet that will be sent.
-         */
-        r = sol_buffer_append_bytes(&p->buf,
-            (uint8_t *)pkt->buf.data + sizeof(struct coap_header) + tkl,
-            pkt->buf.used - sizeof(struct coap_header) - tkl);
+        r = sol_coap_header_set_token(header, o->token, o->tkl);
         SOL_INT_CHECK_GOTO(r, < 0, err);
 
-        r = enqueue_packet(server, p, &o->cliaddr);
+        r = enqueue_packet(server, pkt, header, &o->cliaddr);
         if (r < 0) {
             SOL_BUFFER_DECLARE_STATIC(addr, SOL_INET_ADDR_STRLEN);
 
             sol_network_link_addr_to_str(&o->cliaddr, &addr);
-            SOL_WRN("Failed to enqueue packet %p to %.*s", p,
+            SOL_WRN("Failed to enqueue packet %p to %.*s", header,
                 SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr)));
             goto done;
         }
 
-        sol_coap_packet_unref(p);
+        sol_coap_packet_unref(header);
     }
 
 done:
@@ -928,7 +976,7 @@ done:
     return r;
 
 err:
-    sol_coap_packet_unref(p);
+    sol_coap_packet_unref(header);
     sol_coap_packet_unref(pkt);
     return r;
 }


### PR DESCRIPTION
Some memory usage revamps.

-----------

Changes since v1:
- bad mem access fixed (ptr vector instead of vector for contexts)

Changes since v2:
- early continue on a func, to diminish nesting.

Changes since v3:
- Fixed the way new tokens were written to the original packet
- Kept a way to send notifications *with* confirmation, if the user wants to

Changes since v4:
- @vcgomes's approach to notifications packet reuse was taken
- fixed keeping context for ack/reset packets
- we don't keep context for noncon packts anymore

Changes since v5:
- new patch dealing with NONCON but with reply messages.

Changes since v6:
- new approach by @vcgomes on pending timeouts, with fixes

@edersondisouza's code sending a lot of con packets was his timers on neighbour discovery/scan. Those are being acked at least, so we're fine. What was not escalating in any way were the non-con messages on both directions which would blow the memory usage very quickly.
