### PR TITLE
platform-linux: Fix not handling empty locales

### DIFF
--- a/src/lib/common/sol-platform-linux-common.c
+++ b/src/lib/common/sol-platform-linux-common.c
@@ -969,6 +969,8 @@ sol_platform_impl_load_locales(char **locale_cache)
         value.data = sep + 1;
         key.len = sep - key.data;
         value.len = strlen(line) - key.len - 1;
+        if (!value.len)
+            goto ignore;
 
         category = system_locale_to_sol_locale(key);
         if (category != SOL_PLATFORM_LOCALE_UNKNOWN) {
@@ -980,6 +982,8 @@ sol_platform_impl_load_locales(char **locale_cache)
             sol_buffer_fini(&buf);
             SOL_NULL_CHECK_GOTO(locale_cache[category], err_nomem);
         }
+
+ignore:
         free(line);
         line = NULL;
     }


### PR DESCRIPTION
This fixes an invalid memory access when encountering an empty locale
variable, for example:

LANG=

Valgrind log:
==8712==
==8712== Invalid read of size 1
==8712==    at 0x4C2D9E0: memcpy@@GLIBC_2.14 (vg_replace_strmem.c:1018)
==8712==    by 0x5441DE2: sol_util_memdup (sol-util.c:72)
==8712==    by 0x53CAAF3: sol_buffer_steal_or_copy (sol-buffer.c:366)
==8712==    by 0x538BDB6: sol_platform_impl_load_locales (sol-platform-linux-common.c:979)
==8712==    by 0x538C179: sol_platform_init (sol-platform.c:93)
==8712==    by 0x538415F: sol_init (sol-mainloop.c:137)
==8712==    by 0x112D26: main (main.c:2535)
==8712==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==8712==
==8712==
==8712== Process terminating with default action of signal 11 (SIGSEGV)
==8712==  Access not within mapped region at address 0x0
==8712==    at 0x4C2D9E0: memcpy@@GLIBC_2.14 (vg_replace_strmem.c:1018)
==8712==    by 0x5441DE2: sol_util_memdup (sol-util.c:72)
==8712==    by 0x53CAAF3: sol_buffer_steal_or_copy (sol-buffer.c:366)
==8712==    by 0x538BDB6: sol_platform_impl_load_locales (sol-platform-linux-common.c:979)
==8712==    by 0x538C179: sol_platform_init (sol-platform.c:93)
==8712==    by 0x538415F: sol_init (sol-mainloop.c:137)
==8712==    by 0x112D26: main (main.c:2535)
==8712==  If you believe this happened as a result of a stack
==8712==  overflow in your program's main thread (unlikely but
==8712==  possible), you can try to increase the size of the
==8712==  main thread stack using the --main-stacksize= flag.
==8712==  The main thread stack size used in this run was 8388608.
==8712==

Signed-off-by: Vinicius Costa Gomes <vinicius.gomes@intel.com>