### PR TITLE
buffer: Don't use implicit flags when setting secure clear

### DIFF
--- a/src/lib/comms/sol-socket-dtls-impl-tinydtls.c
+++ b/src/lib/comms/sol-socket-dtls-impl-tinydtls.c
@@ -242,7 +242,8 @@ sol_socket_dtls_recvmsg(struct sol_socket *socket, void *buf, size_t len, struct
     SOL_NULL_CHECK_GOTO(buf_copy, clear_buf);
 
     sol_buffer_init_flags(&new_buf, buf_copy, len,
-        SOL_BUFFER_FLAGS_CLEAR_MEMORY | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+        SOL_BUFFER_FLAGS_CLEAR_MEMORY | SOL_BUFFER_FLAGS_NO_NUL_BYTE |
+        SOL_BUFFER_FLAGS_FIXED_CAPACITY);
     new_buf.used = item->buffer.used - len;
 
     sol_buffer_fini(&item->buffer);
@@ -276,7 +277,8 @@ sol_socket_dtls_sendmsg(struct sol_socket *socket, const void *buf, size_t len,
 
     item->addr = *cliaddr;
     sol_buffer_init_flags(&item->buffer, buf_copy, len,
-        SOL_BUFFER_FLAGS_CLEAR_MEMORY | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+        SOL_BUFFER_FLAGS_CLEAR_MEMORY | SOL_BUFFER_FLAGS_NO_NUL_BYTE |
+        SOL_BUFFER_FLAGS_FIXED_CAPACITY);
     item->buffer.used = len;
 
     encrypt_payload(s);
@@ -363,7 +365,8 @@ call_user_read_cb(struct dtls_context_t *ctx, session_t *session, uint8_t *buf, 
 
     item->addr = addr;
     sol_buffer_init_flags(&item->buffer, buf_copy, len,
-        SOL_BUFFER_FLAGS_CLEAR_MEMORY | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
+        SOL_BUFFER_FLAGS_CLEAR_MEMORY | SOL_BUFFER_FLAGS_NO_NUL_BYTE |
+        SOL_BUFFER_FLAGS_FIXED_CAPACITY);
     item->buffer.used = len;
 
     if (!socket->read.cb) {

--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -90,10 +90,12 @@ enum sol_buffer_flags {
      */
     SOL_BUFFER_FLAGS_NO_NUL_BYTE = (1 << 2),
     /**
-     * @brief Securely clear buffer data before finishing; this implies the flag
-     * SOL_BUFFER_FLAGS_FIXED_CAPACITY, so buffer data won't be reallocated.
+     * @brief Securely clear buffer data before finishing. Prefer using this
+     * flag combined with SOL_BUFFER_FLAGS_FIXED_CAPACITY, because of resizing
+     * overhead: everytime buffer is resized, new memory is allocated, old
+     * memory is copied to new destination and old memory is cleared.
      */
-    SOL_BUFFER_FLAGS_CLEAR_MEMORY = (1 << 3) | SOL_BUFFER_FLAGS_FIXED_CAPACITY,
+    SOL_BUFFER_FLAGS_CLEAR_MEMORY = (1 << 3),
 };
 
 /**

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -30,6 +30,23 @@ nul_byte_size(const struct sol_buffer *buf)
     return (buf->flags & SOL_BUFFER_FLAGS_NO_NUL_BYTE) ? 0 : 1;
 }
 
+static void *
+secure_realloc(struct sol_buffer *buf, size_t new_size)
+{
+    char *new_data = NULL;
+
+    if (!new_size)
+        goto end;
+
+    new_data = malloc(new_size);
+    memcpy(new_data, buf->data, sol_min(new_size, buf->capacity));
+
+end:
+    sol_util_secure_clear_memory(buf->data, buf->capacity);
+    free(buf->data);
+    return new_data;
+}
+
 SOL_API int
 sol_buffer_resize(struct sol_buffer *buf, size_t new_size)
 {
@@ -41,7 +58,11 @@ sol_buffer_resize(struct sol_buffer *buf, size_t new_size)
     if (buf->capacity == new_size)
         return 0;
 
-    new_data = realloc(buf->data, new_size);
+    if (buf->flags & SOL_BUFFER_FLAGS_CLEAR_MEMORY)
+        new_data = secure_realloc(buf, new_size);
+    else
+        new_data = realloc(buf->data, new_size);
+
     if (!new_data && new_size)
         return -errno;
 
@@ -830,7 +851,7 @@ sol_buffer_fini(struct sol_buffer *buf)
 {
     if (!buf)
         return;
-    if ((buf->flags & SOL_BUFFER_FLAGS_CLEAR_MEMORY) == SOL_BUFFER_FLAGS_CLEAR_MEMORY)
+    if (buf->flags & SOL_BUFFER_FLAGS_CLEAR_MEMORY)
         sol_util_secure_clear_memory(buf->data, buf->capacity);
     if (!(buf->flags & SOL_BUFFER_FLAGS_NO_FREE))
         free(buf->data);


### PR DESCRIPTION
Supports in buffer to use SOL_BUFFER_FLAGS_CLEAR_MEMORY for memory owned
by buffer. This was, SOL_BUFFER_FLAGS_CLEAR_MEMORY wont enforce
SOL_BUFFER_FLAGS_FIXED_CAPACITY flag.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>