### PR TITLE
generator and flow: Add indirection when getting node type

### DIFF
--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -1655,15 +1655,15 @@ generate(struct sol_vector *fbp_data_vector)
         "static bool\n"
         "initialize_types(void)\n"
         "{\n"
-        "    const struct sol_flow_node_type *t;\n"
+        "    const struct sol_flow_node_type **t;\n"
         "    int i = 0;\n\n");
     SOL_VECTOR_FOREACH_IDX (&ctx->types_to_initialize, type, i) {
         out(
             "    if (sol_flow_get_node_type(\"%.*s\", %.*s, &t) < 0)\n"
             "        return false;\n"
-            "    if (t->init_type)\n"
-            "        t->init_type();\n"
-            "    external_types[i++] = t;\n",
+            "    if ((*t)->init_type)\n"
+            "        (*t)->init_type();\n"
+            "    external_types[i++] = *t;\n",
             SOL_STR_SLICE_PRINT(type->module),
             SOL_STR_SLICE_PRINT(type->symbol));
     }

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -1053,14 +1053,14 @@ struct sol_flow_port_type_in {
 
 #define sol_flow_get_node_type(_mod, _type, _var) sol_flow_internal_get_node_type(_mod, #_type, _var)
 
-int sol_flow_internal_get_node_type(const char *module, const char *symbol, const struct sol_flow_node_type **type);
+int sol_flow_internal_get_node_type(const char *modname, const char *symbol, const struct sol_flow_node_type ***type);
 
 #define sol_flow_get_packet_type(_mod, _type, _var) sol_flow_internal_get_packet_type(_mod, #_type, _var)
 
 int sol_flow_internal_get_packet_type(const char *module, const char *symbol, const struct sol_flow_packet_type **type);
 
 #else
-#define sol_flow_get_node_type(_mod, _type, _var) ({ (*(_var)) = _type; 0; })
+#define sol_flow_get_node_type(_mod, _type, _var) ({ (*(_var)) = &_type; 0; })
 #define sol_flow_get_packet_type(_mod, _type, _var) ({ (*(_var)) = _type; 0; })
 #endif /* SOL_DYNAMIC_MODULES */
 

--- a/src/lib/flow/sol-flow-modules.c
+++ b/src/lib/flow/sol-flow-modules.c
@@ -22,7 +22,7 @@
 #include "sol-modules.h"
 
 SOL_API int
-sol_flow_internal_get_node_type(const char *modname, const char *symbol, const struct sol_flow_node_type **type)
+sol_flow_internal_get_node_type(const char *modname, const char *symbol, const struct sol_flow_node_type ***type)
 {
     const struct sol_flow_node_type **ret;
 
@@ -30,7 +30,7 @@ sol_flow_internal_get_node_type(const char *modname, const char *symbol, const s
     if (!ret || !*ret)
         return -errno;
 
-    *type = *ret;
+    *type = ret;
     return 0;
 }
 

--- a/src/modules/flow/calamari/calamari.c
+++ b/src/modules/flow/calamari/calamari.c
@@ -233,7 +233,7 @@ static void
 calamari_7seg_new_type(const struct sol_flow_node_type **current)
 {
     struct sol_flow_node_type *type;
-    const struct sol_flow_node_type *gpio_writer;
+    const struct sol_flow_node_type **gpio_writer, **ctl;
 
     static struct sol_flow_static_node_spec nodes[] = {
         [SEG_CTL] = { NULL, "segments-ctl", NULL },
@@ -270,9 +270,15 @@ calamari_7seg_new_type(const struct sol_flow_node_type **current)
         *current = NULL;
         return;
     }
+    if ((*gpio_writer)->init_type)
+        (*gpio_writer)->init_type();
 
-    nodes[SEG_CTL].type = SOL_FLOW_NODE_TYPE_CALAMARI_SEGMENTS_CTL;
-    nodes[SEG_CLEAR].type = nodes[SEG_LATCH].type = nodes[SEG_CLOCK].type = nodes[SEG_DATA].type = gpio_writer;
+    ctl = &SOL_FLOW_NODE_TYPE_CALAMARI_SEGMENTS_CTL;
+    if ((*ctl)->init_type)
+        (*ctl)->init_type();
+
+    nodes[SEG_CTL].type = *ctl;
+    nodes[SEG_CLEAR].type = nodes[SEG_LATCH].type = nodes[SEG_CLOCK].type = nodes[SEG_DATA].type = *gpio_writer;
 
     type = sol_flow_static_new_type(&spec);
     SOL_NULL_CHECK(type);
@@ -582,7 +588,7 @@ static void
 calamari_rgb_led_new_type(const struct sol_flow_node_type **current)
 {
     struct sol_flow_node_type *type;
-    const struct sol_flow_node_type *gpio_writer;
+    const struct sol_flow_node_type **gpio_writer, **ctl;
 
     static struct sol_flow_static_node_spec nodes[] = {
         [RGB_LED_CTL] = { NULL, "rgb-ctl", NULL },
@@ -618,9 +624,15 @@ calamari_rgb_led_new_type(const struct sol_flow_node_type **current)
         *current = NULL;
         return;
     }
+    if ((*gpio_writer)->init_type)
+        (*gpio_writer)->init_type();
 
-    nodes[RGB_LED_CTL].type = SOL_FLOW_NODE_TYPE_CALAMARI_RGB_CTL;
-    nodes[RGB_LED_RED].type = nodes[RGB_LED_GREEN].type = nodes[RGB_LED_BLUE].type = gpio_writer;
+    ctl = &SOL_FLOW_NODE_TYPE_CALAMARI_RGB_CTL;
+    if ((*ctl)->init_type)
+        (*ctl)->init_type();
+
+    nodes[RGB_LED_CTL].type = *ctl;
+    nodes[RGB_LED_RED].type = nodes[RGB_LED_GREEN].type = nodes[RGB_LED_BLUE].type = *gpio_writer;
 
     type = sol_flow_static_new_type(&spec);
     SOL_NULL_CHECK(type);

--- a/src/modules/flow/grove/grove.c
+++ b/src/modules/flow/grove/grove.c
@@ -70,7 +70,7 @@ static void
 grove_rotary_sensor_new_type(const struct sol_flow_node_type **current)
 {
     struct sol_flow_node_type *type;
-    const struct sol_flow_node_type *aio_reader;
+    const struct sol_flow_node_type **aio_reader, **ctl;
 
     static struct sol_flow_static_node_spec nodes[] = {
         { NULL, "rotary-converter", NULL },
@@ -103,8 +103,12 @@ grove_rotary_sensor_new_type(const struct sol_flow_node_type **current)
         return;
     }
 
-    nodes[0].type = SOL_FLOW_NODE_TYPE_GROVE_ROTARY_CONVERTER;
-    nodes[1].type = aio_reader;
+    ctl = &SOL_FLOW_NODE_TYPE_GROVE_ROTARY_CONVERTER;
+    if ((*ctl)->init_type)
+        (*ctl)->init_type();
+
+    nodes[0].type = *ctl;
+    nodes[1].type = *aio_reader;
 
     type = sol_flow_static_new_type(&spec);
     SOL_NULL_CHECK(type);
@@ -210,7 +214,7 @@ static void
 grove_light_sensor_new_type(const struct sol_flow_node_type **current)
 {
     struct sol_flow_node_type *type;
-    const struct sol_flow_node_type *aio_reader;
+    const struct sol_flow_node_type **aio_reader, **ctl;
 
     static struct sol_flow_static_node_spec nodes[] = {
         { NULL, "light-converter", NULL },
@@ -242,8 +246,12 @@ grove_light_sensor_new_type(const struct sol_flow_node_type **current)
         return;
     }
 
-    nodes[0].type = SOL_FLOW_NODE_TYPE_GROVE_LIGHT_CONVERTER;
-    nodes[1].type = aio_reader;
+    ctl = &SOL_FLOW_NODE_TYPE_GROVE_LIGHT_CONVERTER;
+    if ((*ctl)->init_type)
+        (*ctl)->init_type();
+
+    nodes[0].type = *ctl;
+    nodes[1].type = *aio_reader;
 
     type = sol_flow_static_new_type(&spec);
     SOL_NULL_CHECK(type);
@@ -395,7 +403,7 @@ static void
 grove_temperature_sensor_new_type(const struct sol_flow_node_type **current)
 {
     struct sol_flow_node_type *type;
-    const struct sol_flow_node_type *aio_reader;
+    const struct sol_flow_node_type **aio_reader, **ctl;
 
     static struct sol_flow_static_node_spec nodes[] = {
         { NULL, "temperature-converter", NULL },
@@ -427,8 +435,12 @@ grove_temperature_sensor_new_type(const struct sol_flow_node_type **current)
         return;
     }
 
-    nodes[0].type = SOL_FLOW_NODE_TYPE_GROVE_TEMPERATURE_CONVERTER;
-    nodes[1].type = aio_reader;
+    ctl = &SOL_FLOW_NODE_TYPE_GROVE_TEMPERATURE_CONVERTER;
+    if ((*ctl)->init_type)
+        (*ctl)->init_type();
+
+    nodes[0].type = *ctl;
+    nodes[1].type = *aio_reader;
 
     type = sol_flow_static_new_type(&spec);
     SOL_NULL_CHECK(type);

--- a/src/samples/flow/c-api/lowlevel.c
+++ b/src/samples/flow/c-api/lowlevel.c
@@ -106,7 +106,7 @@ static struct sol_flow_node *flow;
 static void
 startup(void)
 {
-    const struct sol_flow_node_type *console_type;
+    const struct sol_flow_node_type **console_type;
 
     if (sol_flow_get_node_type("console", SOL_FLOW_NODE_TYPE_CONSOLE, &console_type) < 0)
         return;
@@ -119,7 +119,7 @@ startup(void)
     nodes[0 /* reader */].type = SOL_FLOW_NODE_TYPE_CUSTOM_NODE_TYPES_READER;
     nodes[1 /* logic */].type = SOL_FLOW_NODE_TYPE_CUSTOM_NODE_TYPES_LOGIC;
     nodes[2 /* writer */].type = SOL_FLOW_NODE_TYPE_CUSTOM_NODE_TYPES_WRITER;
-    nodes[3 /* console */].type = console_type;
+    nodes[3 /* console */].type = *console_type;
 
     flow = sol_flow_static_new(NULL, nodes, conns);
 }

--- a/src/samples/flow/c-api/single-node.c
+++ b/src/samples/flow/c-api/single-node.c
@@ -131,7 +131,7 @@ on_seconds_packet(void *data, struct sol_flow_node *n, uint16_t port, const stru
 static void
 create_minutes(void)
 {
-    const struct sol_flow_node_type *type;
+    const struct sol_flow_node_type **type;
     struct sol_flow_node_named_options named_opts = {};
     const char *strv_opts[] = {
         "send_initial_packet=1",
@@ -161,13 +161,13 @@ create_minutes(void)
      * sol-flow/wallclock.h such as
      * SOL_FLOW_NODE_TYPE_WALLCLOCK_MINUTE__OUT__OUT.
      */
-    minutes_port_enabled = sol_flow_node_find_port_in(type, "ENABLED");
+    minutes_port_enabled = sol_flow_node_find_port_in(*type, "ENABLED");
     if (minutes_port_enabled == UINT16_MAX) {
         fputs("ERROR: couldn't find ouput port by name: ENABLED\n", stderr);
         sol_quit_with_code(EXIT_FAILURE);
         return;
     }
-    minutes_port_out = sol_flow_node_find_port_out(type, "OUT");
+    minutes_port_out = sol_flow_node_find_port_out(*type, "OUT");
     if (minutes_port_out == UINT16_MAX) {
         fputs("ERROR: couldn't find ouput port by name: OUT\n", stderr);
         sol_quit_with_code(EXIT_FAILURE);
@@ -210,7 +210,7 @@ create_minutes(void)
      * should go with option #2 and those that want to squeeze the
      * size and get performance should consider #1.
      */
-    err = sol_flow_node_named_options_init_from_strv(&named_opts, type, strv_opts);
+    err = sol_flow_node_named_options_init_from_strv(&named_opts, *type, strv_opts);
     if (err < 0) {
         fputs("could not parse options for wallclock/minute\n", stderr);
         sol_quit_with_code(EXIT_FAILURE);
@@ -218,7 +218,7 @@ create_minutes(void)
     }
 
     /* convert the named options in the actual options structure */
-    err = sol_flow_node_options_new(type, &named_opts, &opts);
+    err = sol_flow_node_options_new(*type, &named_opts, &opts);
     sol_flow_node_named_options_fini(&named_opts);
     if (err < 0) {
         fputs("could not create options for wallclock/minute\n", stderr);
@@ -242,18 +242,18 @@ create_minutes(void)
      * sol_flow_single_port_in_connect() and
      * sol_flow_single_port_out_connect().
      */
-    minutes = sol_flow_single_new("minutes", type, opts,
+    minutes = sol_flow_single_new("minutes", *type, opts,
         SOL_FLOW_SINGLE_CONNECTIONS(minutes_port_enabled),
         SOL_FLOW_SINGLE_CONNECTIONS(minutes_port_out),
         on_minutes_packet, NULL);
-    sol_flow_node_options_del(type, opts);
+    sol_flow_node_options_del(*type, opts);
 }
 
 
 static void
 create_seconds(void)
 {
-    const struct sol_flow_node_type *type;
+    const struct sol_flow_node_type **type;
     struct sol_flow_node_named_options named_opts = {};
     const char *strv_opts[] = {
         "send_initial_packet=1",
@@ -270,27 +270,27 @@ create_seconds(void)
         return;
     }
 
-    seconds_port_enabled = sol_flow_node_find_port_in(type, "ENABLED");
+    seconds_port_enabled = sol_flow_node_find_port_in(*type, "ENABLED");
     if (seconds_port_enabled == UINT16_MAX) {
         fputs("ERROR: couldn't find ouput port by name: ENABLED\n", stderr);
         sol_quit_with_code(EXIT_FAILURE);
         return;
     }
-    seconds_port_out = sol_flow_node_find_port_out(type, "OUT");
+    seconds_port_out = sol_flow_node_find_port_out(*type, "OUT");
     if (seconds_port_out == UINT16_MAX) {
         fputs("ERROR: couldn't find ouput port by name: OUT\n", stderr);
         sol_quit_with_code(EXIT_FAILURE);
         return;
     }
 
-    err = sol_flow_node_named_options_init_from_strv(&named_opts, type, strv_opts);
+    err = sol_flow_node_named_options_init_from_strv(&named_opts, *type, strv_opts);
     if (err < 0) {
         fputs("could not parse options for wallclock/second\n", stderr);
         sol_quit_with_code(EXIT_FAILURE);
         return;
     }
 
-    err = sol_flow_node_options_new(type, &named_opts, &opts);
+    err = sol_flow_node_options_new(*type, &named_opts, &opts);
     sol_flow_node_named_options_fini(&named_opts);
     if (err < 0) {
         fputs("could not create options for wallclock/second\n", stderr);
@@ -298,11 +298,11 @@ create_seconds(void)
         return;
     }
 
-    seconds = sol_flow_single_new("seconds", type, opts,
+    seconds = sol_flow_single_new("seconds", *type, opts,
         SOL_FLOW_SINGLE_CONNECTIONS(seconds_port_enabled),
         SOL_FLOW_SINGLE_CONNECTIONS(seconds_port_out),
         on_seconds_packet, NULL);
-    sol_flow_node_options_del(type, opts);
+    sol_flow_node_options_del(*type, opts);
 }
 
 static void

--- a/src/test/test-flow.c
+++ b/src/test/test-flow.c
@@ -1140,14 +1140,14 @@ named_options_init_from_strv(void)
 {
     struct sol_flow_node_named_options named_opts;
     struct sol_flow_node_named_options_member *m;
-    const struct sol_flow_node_type *node_type;
+    const struct sol_flow_node_type **node_type;
     int r;
 
     ASSERT(sol_flow_get_node_type("int", SOL_FLOW_NODE_TYPE_INT_ACCUMULATOR, &node_type) == 0);
     {
         const char *strv[] = { "initial_value=1000", NULL };
 
-        r = sol_flow_node_named_options_init_from_strv(&named_opts, node_type,
+        r = sol_flow_node_named_options_init_from_strv(&named_opts, *node_type,
             strv);
         ASSERT(r >= 0);
         ASSERT_INT_EQ(named_opts.count, SOL_UTIL_ARRAY_SIZE(strv) - 1);
@@ -1163,7 +1163,7 @@ named_options_init_from_strv(void)
     {
         const char *strv[] = { "setup_value=20|60|2", NULL };
 
-        r = sol_flow_node_named_options_init_from_strv(&named_opts, node_type,
+        r = sol_flow_node_named_options_init_from_strv(&named_opts, *node_type,
             strv);
         ASSERT(r >= 0);
         ASSERT_INT_EQ(named_opts.count, SOL_UTIL_ARRAY_SIZE(strv) - 1);
@@ -1181,7 +1181,7 @@ named_options_init_from_strv(void)
     {
         const char *strv[] = { "setup_value=min:10|max:200|step:5", NULL };
 
-        r = sol_flow_node_named_options_init_from_strv(&named_opts, node_type,
+        r = sol_flow_node_named_options_init_from_strv(&named_opts, *node_type,
             strv);
         ASSERT(r >= 0);
         ASSERT_INT_EQ(named_opts.count, SOL_UTIL_ARRAY_SIZE(strv) - 1);
@@ -1199,7 +1199,7 @@ named_options_init_from_strv(void)
     {
         const char *strv[] = { "this_is_not_a_valid_field=100", NULL };
 
-        r = sol_flow_node_named_options_init_from_strv(&named_opts, node_type,
+        r = sol_flow_node_named_options_init_from_strv(&named_opts, *node_type,
             strv);
         ASSERT(r < 0);
     }
@@ -1207,7 +1207,7 @@ named_options_init_from_strv(void)
     {
         const char *wrong_formatting_strv[] = { "initial_value = 1000", NULL };
 
-        r = sol_flow_node_named_options_init_from_strv(&named_opts, node_type,
+        r = sol_flow_node_named_options_init_from_strv(&named_opts, *node_type,
             wrong_formatting_strv);
         ASSERT(r < 0);
     }
@@ -1217,7 +1217,7 @@ named_options_init_from_strv(void)
     {
         const char *strv[] = { "pin=2 7", "raw=true", "enabled=true", "period=42", "duty_cycle=88", NULL };
 
-        r = sol_flow_node_named_options_init_from_strv(&named_opts, node_type, strv);
+        r = sol_flow_node_named_options_init_from_strv(&named_opts, *node_type, strv);
         ASSERT(r >= 0);
         ASSERT_INT_EQ(named_opts.count, SOL_UTIL_ARRAY_SIZE(strv) - 1);
 
@@ -1254,7 +1254,7 @@ named_options_init_from_strv(void)
     {
         const char *strv[] = { "prefix=console prefix:", "suffix=. suffix!", "output_on_stdout=true", NULL };
 
-        r = sol_flow_node_named_options_init_from_strv(&named_opts, node_type, strv);
+        r = sol_flow_node_named_options_init_from_strv(&named_opts, *node_type, strv);
         ASSERT(r >= 0);
         ASSERT_INT_EQ(named_opts.count, SOL_UTIL_ARRAY_SIZE(strv) - 1);
 
@@ -1319,29 +1319,29 @@ node_options_new(void)
     struct sol_flow_node_type_console_options *console_opts;
     struct sol_flow_node_options *opts;
     struct sol_flow_node_named_options named_opts;
-    const struct sol_flow_node_type *node_type;
+    const struct sol_flow_node_type **node_type;
     int r;
 
     /* One option */
     ASSERT(sol_flow_get_node_type("timer", SOL_FLOW_NODE_TYPE_TIMER, &node_type) == 0);
     named_opts.members = one_option;
     named_opts.count = SOL_UTIL_ARRAY_SIZE(one_option);
-    r = sol_flow_node_options_new(node_type, &named_opts, &opts);
+    r = sol_flow_node_options_new(*node_type, &named_opts, &opts);
     ASSERT(r >= 0);
     timer_opts = (struct sol_flow_node_type_timer_options *)opts;
     ASSERT_INT_EQ(timer_opts->interval, 1000);
-    sol_flow_node_options_del(node_type, opts);
+    sol_flow_node_options_del(*node_type, opts);
 
     /* Unknown option */
     named_opts.members = unknown_option;
     named_opts.count = SOL_UTIL_ARRAY_SIZE(unknown_option);
-    r = sol_flow_node_options_new(node_type, &named_opts, &opts);
+    r = sol_flow_node_options_new(*node_type, &named_opts, &opts);
     ASSERT(r < 0);
 
     /* Wrong type */
     named_opts.members = wrong_type;
     named_opts.count = SOL_UTIL_ARRAY_SIZE(wrong_type);
-    r = sol_flow_node_options_new(node_type, &named_opts, &opts);
+    r = sol_flow_node_options_new(*node_type, &named_opts, &opts);
     ASSERT(r < 0);
 
 #ifdef USE_PWM
@@ -1349,7 +1349,7 @@ node_options_new(void)
     ASSERT(sol_flow_get_node_type("pwm", SOL_FLOW_NODE_TYPE_PWM, &node_type) == 0);
     named_opts.members = multiple_options;
     named_opts.count = SOL_UTIL_ARRAY_SIZE(multiple_options);
-    r = sol_flow_node_options_new(node_type, &named_opts, &opts);
+    r = sol_flow_node_options_new(*node_type, &named_opts, &opts);
     ASSERT(r >= 0);
     pwm_opts = (struct sol_flow_node_type_pwm_options *)opts;
     ASSERT_STR_EQ(pwm_opts->pin, "2 7");
@@ -1357,20 +1357,20 @@ node_options_new(void)
     ASSERT_INT_EQ(pwm_opts->enabled, true);
     ASSERT_INT_EQ(pwm_opts->period, 42);
     ASSERT_INT_EQ(pwm_opts->duty_cycle, 88);
-    sol_flow_node_options_del(node_type, opts);
+    sol_flow_node_options_del(*node_type, opts);
 #endif
 
     /* String options */
     ASSERT(sol_flow_get_node_type("console", SOL_FLOW_NODE_TYPE_CONSOLE, &node_type) == 0);
     named_opts.members = string_options;
     named_opts.count = SOL_UTIL_ARRAY_SIZE(string_options);
-    r = sol_flow_node_options_new(node_type, &named_opts, &opts);
+    r = sol_flow_node_options_new(*node_type, &named_opts, &opts);
     ASSERT(r >= 0);
     console_opts = (struct sol_flow_node_type_console_options *)opts;
     ASSERT(streq(console_opts->prefix, "console prefix:"));
     ASSERT(streq(console_opts->suffix, ". suffix!"));
     ASSERT_INT_EQ(console_opts->output_on_stdout, true);
-    sol_flow_node_options_del(node_type, opts);
+    sol_flow_node_options_del(*node_type, opts);
 }
 #endif
 
@@ -1406,47 +1406,47 @@ DEFINE_TEST(test_find_port);
 static void
 test_find_port(void)
 {
-    const struct sol_flow_node_type *node_type;
+    const struct sol_flow_node_type **node_type;
     uint16_t idx;
 
     ASSERT(sol_flow_get_node_type("boolean", SOL_FLOW_NODE_TYPE_BOOLEAN_AND, &node_type) == 0);
 
-    idx = sol_flow_node_find_port_out(node_type, "OUT");
+    idx = sol_flow_node_find_port_out(*node_type, "OUT");
     ASSERT_INT_EQ(idx, 0);
 
-    idx = sol_flow_node_find_port_out(node_type, "NON-EXISTENT");
+    idx = sol_flow_node_find_port_out(*node_type, "NON-EXISTENT");
     ASSERT_INT_EQ(idx, UINT16_MAX);
 
-    idx = sol_flow_node_find_port_in(node_type, "IN");
+    idx = sol_flow_node_find_port_in(*node_type, "IN");
     ASSERT_INT_EQ(idx, UINT16_MAX);
 
-    idx = sol_flow_node_find_port_in(node_type, "OUT[0]");
+    idx = sol_flow_node_find_port_in(*node_type, "OUT[0]");
     ASSERT_INT_EQ(idx, UINT16_MAX);
 
-    idx = sol_flow_node_find_port_in(node_type, "IN[0]");
+    idx = sol_flow_node_find_port_in(*node_type, "IN[0]");
     ASSERT_INT_EQ(idx, 0);
-    idx = sol_flow_node_find_port_in(node_type, "IN[ 0 ]");
+    idx = sol_flow_node_find_port_in(*node_type, "IN[ 0 ]");
     ASSERT_INT_EQ(idx, 0);
-    idx = sol_flow_node_find_port_in(node_type, "IN[ 0");
+    idx = sol_flow_node_find_port_in(*node_type, "IN[ 0");
     ASSERT_INT_EQ(idx, UINT16_MAX);
-    idx = sol_flow_node_find_port_in(node_type, "IN[");
+    idx = sol_flow_node_find_port_in(*node_type, "IN[");
     ASSERT_INT_EQ(idx, UINT16_MAX);
-    idx = sol_flow_node_find_port_in(node_type, "IN[]");
+    idx = sol_flow_node_find_port_in(*node_type, "IN[]");
     ASSERT_INT_EQ(idx, UINT16_MAX);
-    idx = sol_flow_node_find_port_in(node_type, "IN[X");
+    idx = sol_flow_node_find_port_in(*node_type, "IN[X");
     ASSERT_INT_EQ(idx, UINT16_MAX);
-    idx = sol_flow_node_find_port_in(node_type, "IN[-123]");
+    idx = sol_flow_node_find_port_in(*node_type, "IN[-123]");
     ASSERT_INT_EQ(idx, UINT16_MAX);
-    idx = sol_flow_node_find_port_in(node_type, "IN[1234567]");
+    idx = sol_flow_node_find_port_in(*node_type, "IN[1234567]");
     ASSERT_INT_EQ(idx, UINT16_MAX);
 
-    idx = sol_flow_node_find_port_in(node_type, "IN[1]");
+    idx = sol_flow_node_find_port_in(*node_type, "IN[1]");
     ASSERT_INT_EQ(idx, 1);
 
-    idx = sol_flow_node_find_port_in(node_type, "IN[2]");
+    idx = sol_flow_node_find_port_in(*node_type, "IN[2]");
     ASSERT_INT_EQ(idx, 2);
 
-    idx = sol_flow_node_find_port_in(node_type, "NON-EXISTENT");
+    idx = sol_flow_node_find_port_in(*node_type, "NON-EXISTENT");
     ASSERT_INT_EQ(idx, UINT16_MAX);
 }
 


### PR DESCRIPTION
All nodes with internal nodes were broken on generator: a typical
construction of such nodes to 'bootstrap' them is, on their `init_type`
functions replace current type definition with a new one, so they
typically had code like `*current = type;` to replace type definitions.
However, this construction was useless when generating code (instead of
running via sol-fbp-runner): generated code end up using previous
definition instead of new one created on `init_type`. Fixed by adding
one more level of indirection on `sol_flow_get_node_type`.
While fixing current code, also noticed that current nodes that use
internal nodes were failing to initialise internal node types - fixed
it. Worth mentioning that this wasn't necessary when using
`sol-fbp-runner` as it took care of initialising types - even internals
- that it found via json definitions.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>