### PR TITLE
Enable building the JS meta-type (and flows using it) on small OSes

### DIFF
--- a/src/modules/flow-metatype/js/Kconfig
+++ b/src/modules/flow-metatype/js/Kconfig
@@ -1,6 +1,6 @@
 config FLOW_METATYPE_JAVASCRIPT
 	tristate "JavaScript flow metatype"
-	depends on FLOW_SUPPORT && PLATFORM_LINUX && HAVE_DUKTAPE_SRC
+	depends on FLOW_SUPPORT && HAVE_DUKTAPE_SRC
 	default m if MODULES=y
 	help
 	    Allow creating node types using JavaScript

--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -98,7 +98,7 @@ parse-common-module = \
 		$(eval $(4)-srcs       := $($(dest-obj)-src)) \
 		$(eval $(4)-objs       += $(dest-obj)) \
 		$(eval $(dest-obj)-module := $(if $($(dest-obj)-module),$($(dest-obj)-module),$(4))) \
-		$(eval all-objs        += $(dest-obj)) \
+		$(eval all-objs        += $(filter-out $(all-objs),$(dest-obj))) \
 	)\
 	$(eval $(4)-deps    := $(subst .mod,,$(obj-$(1)-$(3)-deps)))
 


### PR DESCRIPTION
Building a flow with JS will still require that the duktape.h and duk_config.h
files are copied to the application's source.