### PR TITLE
http-client: set error value on function return

### DIFF
--- a/src/modules/flow/http-client/http-client.c
+++ b/src/modules/flow/http-client/http-client.c
@@ -442,6 +442,7 @@ common_get_process(struct sol_flow_node *node, void *data, uint16_t port,
             SOL_WRN("Could not append the param - %.*s:%.*s",
                 SOL_STR_SLICE_PRINT(param->value.key_value.key),
                 SOL_STR_SLICE_PRINT(param->value.key_value.value));
+            r = -EINVAL;
             goto err;
         }
     }


### PR DESCRIPTION
Actually there could be two reasons to return at
this point, no memory to add to a vector or
invalid version.

It should be just a matter of returning the value
returned by add_param() function, but it's returning
a bool instead of an error value. It'll be fixed
soon as these API review changes are done anyway.