### PR TITLE
form/converter: make Python-like formatting code optional.

### DIFF
--- a/src/modules/flow/converter/Kconfig
+++ b/src/modules/flow/converter/Kconfig
@@ -1,3 +1,31 @@
 config FLOW_NODE_TYPE_CONVERTER
 	tristate "Node type: converter"
 	default y
+	help
+		The converter family of nodes will convert Soletta packets
+		from one type to another (e.g. boolean to byte). Some of them
+		will do more fancy things, like splitting a byte into (boolean)
+		individual bits. Others will compose a final packet from
+		others, like assembling four bytes into a final integer. You'll
+		also find a node that splits an error packet in other two—its
+		integer code and its string message. There are also the nodes
+		dealing with JSON data (e.g. one that gets a string packet
+		and outputs a JSON array packet, if the string is valid).
+		Finally, some of the nodes converting packets to string,
+		namely float-to-string and int-to-string, have Python-like
+		string formatting capabilities, as in
+		https://docs.python.org/3/library/stdtypes.html#str.format.
+		This code can be disabled, if not meant to be used, and
+		feeding data to those node instances, in this case, will
+		always make them output error packets.
+
+config PYTHON_FORMATTING
+	bool "Build Python-like string formatting (float-to-string/int-to-string) nodes"
+	depends on FLOW_NODE_TYPE_CONVERTER
+	default y
+	help
+		Consider changing this if this functionality won't be used
+		and the final Soletta binary is meant for constrained
+		systems. If disabled, the format of those nodes
+		will be the pristine printf ones and only the value (not the
+		range) of the inputs will be formatted.

--- a/src/modules/flow/converter/converter.c
+++ b/src/modules/flow/converter/converter.c
@@ -822,9 +822,18 @@ drange_to_string_convert(struct sol_flow_node *node, void *data, uint16_t port, 
     r = sol_flow_packet_get_drange(packet, &in_value);
     SOL_INT_CHECK(r, < 0, r);
 
+#ifdef PYTHON_FORMATTING
     r = do_float_markup(node, mdata->format, in_value, &out);
     SOL_INT_CHECK_GOTO(r, < 0, end);
+#else
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    r = sol_buffer_append_printf(&out, mdata->format, in_value.val);
+    SOL_INT_CHECK_GOTO(r, < 0, end);
+#pragma GCC diagnostic pop
+
+#endif
     r = sol_flow_send_string_slice_packet(node,
         SOL_FLOW_NODE_TYPE_CONVERTER_FLOAT_TO_STRING__OUT__OUT,
         sol_buffer_get_slice(&out));
@@ -879,8 +888,18 @@ irange_to_string_convert(struct sol_flow_node *node,
     r = sol_flow_packet_get_irange(packet, &in_value);
     SOL_INT_CHECK(r, < 0, r);
 
+#ifdef PYTHON_FORMATTING
     r = do_integer_markup(node, mdata->format, in_value, &out);
     SOL_INT_CHECK_GOTO(r, < 0, end);
+#else
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    r = sol_buffer_append_printf(&out, mdata->format, in_value.val);
+    SOL_INT_CHECK_GOTO(r, < 0, end);
+#pragma GCC diagnostic pop
+
+#endif
 
     r = sol_flow_send_string_slice_packet(node,
         SOL_FLOW_NODE_TYPE_CONVERTER_INT_TO_STRING__OUT__OUT,

--- a/src/modules/flow/form/Kconfig
+++ b/src/modules/flow/form/Kconfig
@@ -11,3 +11,14 @@ config FLOW_NODE_TYPE_FORM
 		used by other node types doing visual output, such as
 		LCD display (grove/lcd-string), in conjuntion with others
 		providing input.
+
+config PYTHON_FORMATTING
+	bool "Build Python-like string formatting (string-formatted) nodes"
+	depends on FLOW_NODE_TYPE_CONVERTER
+	default y
+	help
+		Consider changing this if this functionality won't be used
+		and the final Soletta binary is meant for constrained
+		systems. Note that the string-formatted node is made useless
+		if this is not set (any interaction with these nodes will
+		lead to error packets).

--- a/src/modules/flow/form/form.c
+++ b/src/modules/flow/form/form.c
@@ -2601,6 +2601,7 @@ struct string_formatted_chunk {
     } state;
 };
 
+#ifdef PYTHON_FORMATTING
 static int
 string_formatted_format_do(struct sol_flow_node *node)
 {
@@ -2760,7 +2761,9 @@ err:
 
     return r;
 }
+#endif
 
+#ifdef PYTHON_FORMATTING
 static bool
 string_formatted_timeout(void *data)
 {
@@ -2801,6 +2804,7 @@ string_formatted_format(struct sol_flow_node *node)
 
     return 0;
 }
+#endif
 
 static void
 string_formatted_close(struct sol_flow_node *node, void *data)
@@ -2831,6 +2835,7 @@ strtod_no_locale(const char *nptr, char **endptr)
     return sol_util_strtodn(nptr, endptr, -1, false);
 }
 
+#ifdef PYTHON_FORMATTING
 static double
 midpoint(double min, double max)
 {
@@ -2939,12 +2944,16 @@ error:
         mdata->value, value, sol_util_strerrora(-r));
     return r;
 }
+#endif
 
 static int
 string_formatted_open(struct sol_flow_node *node,
     void *data,
     const struct sol_flow_node_options *options)
 {
+#ifndef PYTHON_FORMATTING
+    return 0;
+#else
     int r;
     const char *ptr;
     bool numeric_field_present = false;
@@ -3241,6 +3250,7 @@ numeric_loop:
 value_err:
     string_formatted_close(node, mdata);
     return r;
+#endif
 }
 
 static int
@@ -3250,6 +3260,7 @@ string_formatted_up_set(struct sol_flow_node *node,
     uint16_t conn_id,
     const struct sol_flow_packet *packet)
 {
+#ifdef PYTHON_FORMATTING
     struct string_formatted_data *mdata = data;
     struct string_formatted_chunk *chunk;
 
@@ -3305,6 +3316,12 @@ string_formatted_up_set(struct sol_flow_node *node,
 
     string_formatted_force_imediate_format(mdata, true);
     return string_formatted_format(node);
+#else
+    sol_flow_send_error_packet(node, ENOTSUP, "The string-formatted node"
+        " won't work on this Soletta build -- Python-like formatting "
+        "capability was disabled");
+    return -EINVAL;
+#endif
 }
 
 static int
@@ -3314,6 +3331,7 @@ string_formatted_down_set(struct sol_flow_node *node,
     uint16_t conn_id,
     const struct sol_flow_packet *packet)
 {
+#ifdef PYTHON_FORMATTING
     struct string_formatted_data *mdata = data;
     struct string_formatted_chunk *chunk;
 
@@ -3369,6 +3387,12 @@ string_formatted_down_set(struct sol_flow_node *node,
 
     string_formatted_force_imediate_format(mdata, true);
     return string_formatted_format(node);
+#else
+    sol_flow_send_error_packet(node, ENOTSUP, "The string-formatted node"
+        " won't work on this Soletta build -- Python-like formatting "
+        "capability was disabled");
+    return -EINVAL;
+#endif
 }
 
 static int
@@ -3378,6 +3402,7 @@ string_formatted_next_set(struct sol_flow_node *node,
     uint16_t conn_id,
     const struct sol_flow_packet *packet)
 {
+#ifdef PYTHON_FORMATTING
     struct string_formatted_data *mdata = data;
     size_t cursor_pos = mdata->cursor, l = mdata->chunks.len;
     bool found = false;
@@ -3405,6 +3430,12 @@ string_formatted_next_set(struct sol_flow_node *node,
 
     string_formatted_force_imediate_format(mdata, true);
     return string_formatted_format(node);
+#else
+    sol_flow_send_error_packet(node, ENOTSUP, "The string-formatted node"
+        " won't work on this Soletta build -- Python-like formatting "
+        "capability was disabled");
+    return -EINVAL;
+#endif
 }
 
 static int
@@ -3414,6 +3445,7 @@ string_formatted_previous_set(struct sol_flow_node *node,
     uint16_t conn_id,
     const struct sol_flow_packet *packet)
 {
+#ifdef PYTHON_FORMATTING
     struct string_formatted_data *mdata = data;
     size_t cursor_pos = mdata->cursor;
     bool found = false;
@@ -3444,6 +3476,12 @@ string_formatted_previous_set(struct sol_flow_node *node,
 
     string_formatted_force_imediate_format(mdata, true);
     return string_formatted_format(node);
+#else
+    sol_flow_send_error_packet(node, ENOTSUP, "The string-formatted node"
+        " won't work on this Soletta build -- Python-like formatting "
+        "capability was disabled");
+    return -EINVAL;
+#endif
 }
 
 static int
@@ -3453,6 +3491,7 @@ string_formatted_select_set(struct sol_flow_node *node,
     uint16_t conn_id,
     const struct sol_flow_packet *packet)
 {
+#ifdef PYTHON_FORMATTING
     struct string_formatted_data *mdata = data;
     int r;
 
@@ -3471,6 +3510,12 @@ string_formatted_select_set(struct sol_flow_node *node,
     return sol_flow_send_string_slice_packet(node,
         SOL_FLOW_NODE_TYPE_FORM_INT__OUT__SELECTED,
         sol_buffer_get_slice(&mdata->formatted_value));
+#else
+    sol_flow_send_error_packet(node, ENOTSUP, "The string-formatted node"
+        " won't work on this Soletta build -- Python-like formatting "
+        "capability was disabled");
+    return -EINVAL;
+#endif
 }
 
 static int
@@ -3480,6 +3525,7 @@ string_formatted_selected_set(struct sol_flow_node *node,
     uint16_t conn_id,
     const struct sol_flow_packet *packet)
 {
+#ifdef PYTHON_FORMATTING
     struct string_formatted_data *mdata = data;
     const char *value;
     int r;
@@ -3498,6 +3544,12 @@ string_formatted_selected_set(struct sol_flow_node *node,
     mdata->blink_on = true;
 
     return string_formatted_format(node);
+#else
+    sol_flow_send_error_packet(node, ENOTSUP, "The string-formatted node"
+        " won't work on this Soletta build -- Python-like formatting "
+        "capability was disabled");
+    return -EINVAL;
+#endif
 }
 
 static int
@@ -3507,6 +3559,7 @@ string_formatted_enabled_set(struct sol_flow_node *node,
     uint16_t conn_id,
     const struct sol_flow_packet *packet)
 {
+#ifdef PYTHON_FORMATTING
     struct string_formatted_data *mdata = data;
     bool value;
     int r;
@@ -3517,6 +3570,12 @@ string_formatted_enabled_set(struct sol_flow_node *node,
     mdata->enabled = value;
 
     return 0;
+#else
+    sol_flow_send_error_packet(node, ENOTSUP, "The string-formatted node"
+        " won't work on this Soletta build -- Python-like formatting "
+        "capability was disabled");
+    return -EINVAL;
+#endif
 }
 
 #include "form-gen.c"

--- a/src/modules/flow/string/Kconfig
+++ b/src/modules/flow/string/Kconfig
@@ -30,14 +30,14 @@ config FLOW_NODE_TYPE_STRING
 		build Soletta with ICU, so that the full UTF-8 set of
 		characters is properly handled by the string nodes.
 
-# This is the solely user of ICU. If gets wider use, move up in the
+# This is the sole user of ICU. If it gets wider use, move it up in the
 # hierarchy.
 config USE_ICU
 	bool "Use ICU library"
 	depends on HAVE_ICU && FLOW_NODE_TYPE_STRING
 	default y
 
-# This is the solely user of LIBPCRE. If gets wider use, move up in
+# This is the sole user of LIBPCRE. If it gets wider use, move it up in
 # the hierarchy.
 config USE_LIBPCRE
 	bool "Use LIBPCRE library"


### PR DESCRIPTION
The user is warned of the consequences on both affected nodes. We could
accept printf-like only formatting strings on the form too, but not
now (maybe later).

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>