### PR TITLE
Add SSE support for Soletta's HTTP nodes v2

### DIFF
--- a/src/lib/common/include/sol-types.h
+++ b/src/lib/common/include/sol-types.h
@@ -116,6 +116,16 @@ struct sol_direction_vector {
 };
 
 /**
+ * @brief Checks the ranges of @c var0 and @c var1 for equality.
+ *
+ * @param var0 The first direction vector
+ * @param var1 The second direction vector
+ *
+ * @return @c true if both are equal, @c false otherwise.
+ */
+bool sol_direction_vector_equal(struct sol_direction_vector *var0, struct sol_direction_vector *var1);
+
+/**
  * @brief Data type to describe a location.
  */
 struct sol_location {
@@ -135,6 +145,16 @@ struct sol_rgb {
     uint32_t green_max; /**< @brief Green component maximum value */
     uint32_t blue_max; /**< @brief Blue component maximum value */
 };
+
+/**
+ * @brief Checks the ranges of @c var0 and @c var1 for equality.
+ *
+ * @param var0 The first RGB
+ * @param var1 The second RGB
+ *
+ * @return @c true if both are equal, @c false otherwise.
+ */
+bool sol_rgb_equal(struct sol_rgb *var0, struct sol_rgb *var1);
 
 /**
  * @brief Set a maximum value for all components of a RGB color

--- a/src/lib/common/sol-types.c
+++ b/src/lib/common/sol-types.c
@@ -23,6 +23,7 @@
 #include <errno.h>
 #include <float.h>
 #include <math.h>
+#include <string.h>
 
 
 /********** SOL_DRANGE **********/
@@ -402,6 +403,39 @@ sol_rgb_set_max(struct sol_rgb *color, uint32_t max_value)
     color->blue_max = max_value;
 
     return 0;
+}
+
+SOL_API bool
+sol_rgb_equal(struct sol_rgb *var0, struct sol_rgb *var1)
+{
+    SOL_NULL_CHECK(var0, false);
+    SOL_NULL_CHECK(var1, false);
+
+    if (var0->red != var1->red ||
+        var0->blue != var1->blue ||
+        var0->green != var1->green ||
+        var0->red_max != var1->red_max ||
+        var0->blue_max != var1->blue_max ||
+        var0->green_max != var1->green_max)
+        return false;
+    return true;
+
+}
+
+SOL_API bool
+sol_direction_vector_equal(struct sol_direction_vector *var0,
+    struct sol_direction_vector *var1)
+{
+    SOL_NULL_CHECK(var0, false);
+    SOL_NULL_CHECK(var1, false);
+
+    if (sol_util_double_equal(var0->x, var1->x) &&
+        sol_util_double_equal(var0->y, var1->y) &&
+        sol_util_double_equal(var0->z, var1->z) &&
+        sol_util_double_equal(var0->min, var1->min) &&
+        sol_util_double_equal(var0->max, var1->max))
+        return true;
+    return false;
 }
 
 #undef SOL_IRANGE_ADD_OVERFLOW

--- a/src/lib/comms/include/sol-http.h
+++ b/src/lib/comms/include/sol-http.h
@@ -115,6 +115,22 @@ struct sol_http_params {
 };
 
 /**
+ * @brief Used to rank content type priorities.
+ *
+ * @see sol_http_parse_content_type_priorities()
+ * @see sol_http_content_type_priorities_array_clear()
+ */
+struct sol_http_content_type_priority {
+    struct sol_str_slice content_type; /**< The content type itself. Example: @c "text/html" */
+    struct sol_str_slice type; /**< The type. Example @c "text" */
+    struct sol_str_slice sub_type; /**< The sub type. Example @c "html"*/
+    struct sol_vector tokens; /**< An array of @ref sol_str_slice. For the following contet type @c "text/html;level=1;level2",
+                                 this array would contains @c "level=1" and @c "level=2" */
+    double qvalue; /**< The qvalue for the content type */
+    uint16_t index; /**< The original index as found in the content type/accept HTTP header */
+};
+
+/**
  * @brief Used to define a HTTP parameter
  *
  * A parameter is defined by it's type
@@ -645,6 +661,26 @@ int sol_http_split_query(const char *query, struct sol_http_params *params);
  * @return 0 on success, negative number on error.
  */
 int sol_http_split_post_field(const char *query, struct sol_http_params *params);
+
+/**
+ * @brief Sort the content type slice based on its priorities
+ *
+ * For more infomation about how the content type is sorted check: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1
+ *
+ * @param content_type A content type slice. Example: @c "text/html, application/json;q=0.5"
+ * @param priorities An array to store the content type prioriries - It will be initialized by this function.
+ * @see sol_http_content_type_priorities_array_clear()
+ * @see @ref sol_http_content_type_priority
+ */
+int sol_http_parse_content_type_priorities(const struct sol_str_slice content_type, struct sol_vector *priorities);
+
+/**
+ * @brief Clears the priorities array
+ *
+ * @param priorities An array of @ref sol_http_content_type_priority.
+ * @see sol_http_parse_content_type_priorities()
+ */
+void sol_http_content_type_priorities_array_clear(struct sol_vector *priorities);
 
 /**
  * @}

--- a/src/lib/comms/sol-http-common.c
+++ b/src/lib/comms/sol-http-common.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <inttypes.h>
+#include <stdlib.h>
 
 #include "sol-http.h"
 #include "sol-log.h"
@@ -881,4 +882,239 @@ SOL_API int
 sol_http_split_post_field(const char *query, struct sol_http_params *params)
 {
     return sol_http_split_str_key_value(query, SOL_HTTP_PARAM_POST_FIELD, params);
+}
+
+static int
+sort_priority(const void *v1, const void *v2)
+{
+    const struct sol_http_content_type_priority *pri1, *pri2;
+    bool any_type1, any_type2;
+
+    pri1 = (const struct sol_http_content_type_priority *)v1;
+    pri2 = (const struct sol_http_content_type_priority *)v2;
+
+    any_type1 = sol_str_slice_str_eq(pri1->type, "*");
+    any_type2 = sol_str_slice_str_eq(pri2->type, "*");
+
+    //text/html have precedence over */* for example.
+    if (!any_type1 && any_type2)
+        return -1;
+    if (any_type1 && !any_type2)
+        return 1;
+
+    //Higher qvalue first
+    if (pri1->qvalue > pri2->qvalue)
+        return -1;
+    if (pri1->qvalue < pri2->qvalue)
+        return 1;
+
+    //Specialized first
+    if (pri1->tokens.len > pri2->tokens.len)
+        return -1;
+    if (pri1->tokens.len < pri2->tokens.len)
+        return 1;
+
+    //Specialized first
+    if (sol_str_slice_eq(pri1->type, pri2->type)) {
+        //text/html have precedence over text/* for example.
+        any_type1 = sol_str_slice_str_eq(pri1->sub_type, "*");
+        any_type2 = sol_str_slice_str_eq(pri2->sub_type, "*");
+
+        if (!any_type1 && any_type2)
+            return -1;
+        if (any_type1 && !any_type2)
+            return 1;
+    }
+
+    //Precedence must prevail
+    if (pri1->index > pri2->index)
+        return 1;
+    if (pri1->index < pri2->index)
+        return -1;
+
+    return 0;
+}
+
+static char *
+is_qvalue_param(const struct sol_str_slice param)
+{
+#define STATE_NEEDS_Q_CHAR (0)
+#define STATE_NEEDS_EQUAL_CHAR (1)
+
+    size_t i;
+    int state = STATE_NEEDS_Q_CHAR;
+
+    for (i = 0; i < param.len; i++) {
+        if (isspace((int)param.data[i]))
+            continue;
+
+        switch (state) {
+        case STATE_NEEDS_Q_CHAR:
+            if (param.data[i] != 'q')
+                return NULL;
+            state = STATE_NEEDS_EQUAL_CHAR;
+            break;
+        default:
+            if (param.data[i] != '=')
+                return NULL;
+            return (char *)param.data + i;
+        }
+    }
+
+    return NULL;
+
+#undef STATE_NEEDS_EQUAL_CHAR
+#undef STATE_NEEDS_Q_CHAR
+}
+
+static int
+set_type_and_sub_type(const struct sol_str_slice content_type,
+    struct sol_str_slice *type, struct sol_str_slice *sub_type)
+{
+    char *sep;
+
+    sep = memchr(content_type.data, '/', content_type.len);
+    SOL_NULL_CHECK(sep, -EINVAL);
+
+    type->data = content_type.data;
+    type->len = sep - content_type.data;
+
+    sub_type->data = sep + 1;
+    sub_type->len = content_type.len - type->len - 1;
+
+    return 0;
+}
+
+SOL_API int
+sol_http_parse_content_type_priorities(const struct sol_str_slice content_type,
+    struct sol_vector *priorities)
+{
+    struct sol_vector tokens;
+    struct sol_str_slice *token;
+    struct sol_http_content_type_priority *pri;
+    uint16_t i;
+
+    SOL_NULL_CHECK(priorities, -EINVAL);
+
+    SOL_DBG("Parsing content priorities for: %.*s",
+        SOL_STR_SLICE_PRINT(content_type));
+    tokens = sol_str_slice_split(content_type, ",", 0);
+    sol_vector_init(priorities, sizeof(struct sol_http_content_type_priority));
+
+    SOL_VECTOR_FOREACH_IDX (&tokens, token, i) {
+        char *sep;
+        int r;
+
+        pri = sol_vector_append(priorities);
+        SOL_NULL_CHECK_GOTO(pri, err_append);
+        pri->index = i;
+        pri->qvalue = 1.0;
+        sol_vector_init(&pri->tokens, sizeof(struct sol_str_slice));
+
+        sep = memchr(token->data, ';', token->len);
+
+        if (!sep) {
+            pri->content_type = sol_str_slice_trim(*token);
+            SOL_DBG("Token '%.*s' does not have qvalue, using default (1.0)",
+                SOL_STR_SLICE_PRINT(pri->content_type));
+            r = set_type_and_sub_type(pri->content_type,
+                &pri->type, &pri->sub_type);
+            SOL_INT_CHECK_GOTO(r, < 0, err_set_type);
+            continue;
+        }
+
+        pri->content_type.data = token->data;
+        pri->content_type.len = sep - token->data;
+
+        token->data = sep + 1;
+        token->len -= pri->content_type.len + 1;
+
+        pri->content_type = sol_str_slice_trim(pri->content_type);
+
+        r = set_type_and_sub_type(pri->content_type,
+            &pri->type, &pri->sub_type);
+        SOL_INT_CHECK_GOTO(r, < 0, err_set_type);
+
+        do {
+            struct sol_str_slice param;
+            char *next_sep, *qvalue_start;
+            size_t offset = 0;
+
+            next_sep = memchr(token->data, ';', token->len);
+            param.data = token->data;
+            if (!next_sep)
+                param.len = token->len;
+            else {
+                offset++;
+                param.len = next_sep - token->data;
+            }
+
+            qvalue_start = is_qvalue_param(param);
+            token->data = param.data + param.len + offset;
+            token->len -= param.len + offset;
+            if (!qvalue_start) {
+                struct sol_str_slice *p;
+
+                p = sol_vector_append(&pri->tokens);
+                SOL_NULL_CHECK_GOTO(p, err_append);
+                *p = sol_str_slice_trim(param);
+                SOL_DBG("Adding token: %.*s for %.*s",
+                    SOL_STR_SLICE_PRINT(*p),
+                    SOL_STR_SLICE_PRINT(pri->content_type));
+            } else {
+                struct sol_str_slice qvalue_slice;
+                double qvalue;
+                char *endptr = NULL;
+
+                qvalue_slice.data = qvalue_start + 1;
+                qvalue_slice.len = param.len - (qvalue_start - param.data) - 1;
+                qvalue_slice = sol_str_slice_trim(qvalue_slice);
+
+                qvalue = sol_util_strtodn(qvalue_slice.data, &endptr,
+                    qvalue_slice.len, false);
+                if (errno < 0 || endptr == qvalue_slice.data) {
+                    SOL_WRN("Could not convert the value from the content type: %.*s",
+                        SOL_STR_SLICE_PRINT(*token));
+                    goto err_convert;
+                }
+
+                if (qvalue > 1.0) {
+                    SOL_INF("The qvalue '%g' for %.*s is bigger than 1.0. Using 1.0",
+                        pri->qvalue, SOL_STR_SLICE_PRINT(pri->content_type));
+                } else
+                    pri->qvalue = qvalue;
+                SOL_DBG("Type:%.*s with qvalue: %g",
+                    SOL_STR_SLICE_PRINT(pri->content_type), pri->qvalue);
+            }
+        } while (token->len);
+    }
+
+    qsort(priorities->data, priorities->len,
+        sizeof(struct sol_http_content_type_priority), sort_priority);
+
+    sol_vector_clear(&tokens);
+    return 0;
+
+err_set_type:
+err_convert:
+    sol_http_content_type_priorities_array_clear(priorities);
+    sol_vector_clear(&tokens);
+    return -EINVAL;
+err_append:
+    sol_http_content_type_priorities_array_clear(priorities);
+    sol_vector_clear(&tokens);
+    return -ENOMEM;
+}
+
+SOL_API void
+sol_http_content_type_priorities_array_clear(struct sol_vector *priorities)
+{
+    uint16_t i;
+    struct sol_http_content_type_priority *pri;
+
+    SOL_NULL_CHECK(priorities);
+
+    SOL_VECTOR_FOREACH_IDX (priorities, pri, i)
+        sol_vector_clear(&pri->tokens);
+    sol_vector_clear(priorities);
 }

--- a/src/lib/datatypes/include/sol-str-slice.h
+++ b/src/lib/datatypes/include/sol-str-slice.h
@@ -162,9 +162,9 @@ sol_str_slice_caseeq(const struct sol_str_slice a, const struct sol_str_slice b)
  * @param haystack Slice that will be searched
  * @param needle Slice to search for in @c haystack
  *
- * @return @c true if @c needle is contained in @c haystack
+ * @return A pointer to the beginning of substring or @c NULL if not
  */
-bool sol_str_slice_contains(const struct sol_str_slice haystack, const struct sol_str_slice needle);
+char *sol_str_slice_contains(const struct sol_str_slice haystack, const struct sol_str_slice needle);
 
 /**
  * @brief Checks if @c haystack contains @c needle.
@@ -172,9 +172,9 @@ bool sol_str_slice_contains(const struct sol_str_slice haystack, const struct so
  * @param haystack Slice that will be searched
  * @param needle String to search for in @c haystack
  *
- * @return @c true if @c needle is contained in @c haystack
+ * @return A pointer to the beginning of substring or @c NULL if not
  */
-bool sol_str_slice_str_contains(const struct sol_str_slice haystack, const char *needle);
+char *sol_str_slice_str_contains(const struct sol_str_slice haystack, const char *needle);
 
 /**
  * @brief Copies the content of slice @c src into string @c dst.

--- a/src/lib/datatypes/sol-str-slice.c
+++ b/src/lib/datatypes/sol-str-slice.c
@@ -48,16 +48,18 @@ sol_str_slice_to_int(const struct sol_str_slice s, int *value)
     return 0;
 }
 
-SOL_API bool
+SOL_API char *
 sol_str_slice_contains(const struct sol_str_slice haystack, const struct sol_str_slice needle)
 {
-    return memmem(haystack.data, haystack.len, needle.data, needle.len) != NULL;
+    return memmem(haystack.data, haystack.len, needle.data, needle.len);
 }
 
-SOL_API bool
+SOL_API char *
 sol_str_slice_str_contains(const struct sol_str_slice haystack, const char *needle)
 {
-    return memmem(haystack.data, haystack.len, needle, strlen(needle)) != NULL;
+    SOL_NULL_CHECK(needle, NULL);
+
+    return memmem(haystack.data, haystack.len, needle, strlen(needle));
 }
 
 SOL_API struct sol_vector

--- a/src/modules/flow/http-client/http-client.c
+++ b/src/modules/flow/http-client/http-client.c
@@ -74,8 +74,7 @@ struct create_url_data {
 struct http_client_node_type {
     struct sol_flow_node_type base;
     int (*process_json)(struct sol_flow_node *node, const struct sol_str_slice slice);
-    int (*process_data)(struct sol_flow_node *node,
-        struct sol_http_response *response);
+    int (*process_data)(struct sol_flow_node *node, struct sol_buffer *buf);
     void (*close_node)(struct sol_flow_node *node, void *data);
     int (*setup_params)(struct http_data *mdata, struct sol_http_params *params);
     void (*http_response)(void *data,
@@ -267,7 +266,7 @@ remove_connection(struct http_data *mdata,
 static int
 check_response(struct http_data *mdata, struct sol_flow_node *node,
     const struct sol_http_client_connection *connection,
-    struct sol_http_response *response)
+    struct sol_http_response *response, bool check_content)
 {
 
     remove_connection(mdata, connection);
@@ -288,7 +287,7 @@ check_response(struct http_data *mdata, struct sol_flow_node *node,
         return -EINVAL;
     }
 
-    if (!response->content.used) {
+    if (check_content && !response->content.used) {
         sol_flow_send_error_packet(node, EINVAL,
             "Empty response from %s", mdata->url);
         return -EINVAL;
@@ -331,7 +330,7 @@ common_request_finished(void *data,
     struct http_data *mdata = sol_flow_node_get_private_data(node);
     const struct http_client_node_type *type;
 
-    ret = check_response(mdata, node, connection, response);
+    ret = check_response(mdata, node, connection, response, true);
     if (ret < 0) {
         SOL_WRN("Invalid HTTP response - Url: %s", mdata->url);
         return;
@@ -360,7 +359,7 @@ common_request_finished(void *data,
         if (ret < 0)
             goto err;
     } else {
-        ret = type->process_data(node, response);
+        ret = type->process_data(node, &response->content);
         if (ret < 0)
             goto err;
     }
@@ -372,17 +371,102 @@ err:
         "%s Could not parse url contents ", mdata->url);
 }
 
+
+static ssize_t
+sse_received_data_cb(void *data, const struct sol_http_client_connection *conn,
+    struct sol_buffer *buf)
+{
+    struct sol_flow_node *node = data;
+    const struct http_client_node_type *type;
+    const struct sol_str_slice prefix = SOL_STR_SLICE_LITERAL("data: ");
+    const struct sol_str_slice suffix = SOL_STR_SLICE_LITERAL("\n\n");
+    struct sol_str_slice slice;
+    size_t consumed = 0;
+
+    SOL_DBG("Received SSE Data - *%.*s*",
+        SOL_STR_SLICE_PRINT(sol_buffer_get_slice(buf)));
+
+    slice = sol_buffer_get_slice(buf);
+    if (!sol_str_slice_contains(slice, suffix))
+        return 0;
+
+    type = (const struct http_client_node_type *)sol_flow_node_get_type(node);
+
+    while (slice.len) {
+        char *start, *end, *content;
+        struct sol_buffer content_buf;
+        size_t content_len, total_len;
+        int r;
+
+        start = sol_str_slice_contains(slice, prefix);
+        SOL_NULL_CHECK(start, -EINVAL);
+
+        end = sol_str_slice_contains(slice, suffix);
+        if (!end) //Wait for more data
+            goto exit;
+
+        content = start + prefix.len;
+        content_len = end - content;
+
+        sol_buffer_init_flags(&content_buf, content, content_len,
+            SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED);
+        content_buf.used = content_len;
+        total_len = content_len + prefix.len + suffix.len;
+        consumed += total_len;
+
+        SOL_DBG("Parsed SSE data:*%.*s*",
+            SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&content_buf)));
+
+        if (type->process_json)
+            r = type->process_json(node, sol_buffer_get_slice(&content_buf));
+        else
+            r = type->process_data(node, &content_buf);
+        sol_buffer_fini(&content_buf);
+        SOL_INT_CHECK(r, < 0, r);
+        slice.len -= total_len;
+        slice.data += total_len;
+    }
+
+exit:
+    SOL_DBG("Buf len: %zu - Consumed: %zu", buf->used, consumed);
+    return consumed;
+}
+
+static void
+sse_response_end_cb(void *data,
+    const struct sol_http_client_connection *conn,
+    struct sol_http_response *response)
+{
+    struct sol_flow_node *node = data;
+    struct http_data *mdata = sol_flow_node_get_private_data(node);
+    int r;
+
+    SOL_DBG("SSE finished - url: %s", response->url);
+
+    remove_connection(mdata, conn);
+
+    r = check_response(mdata, node, conn, response, false);
+    SOL_INT_CHECK(r, < 0);
+}
+
 static int
 common_get_process(struct sol_flow_node *node, void *data, uint16_t port,
     uint16_t conn_id, const struct sol_flow_packet *packet)
 {
     int r;
+    bool is_sse_request = false;
     struct sol_http_params params;
     struct http_data *mdata = data;
     struct sol_http_client_connection *connection;
     uint16_t i;
     const struct http_client_node_type *type;
     struct sol_http_param_value *param;
+    static const struct sol_http_request_interface req_iface = {
+        SOL_SET_API_VERSION(.api_version = SOL_HTTP_REQUEST_INTERFACE_API_VERSION, )
+        .recv_cb = sse_received_data_cb,
+        .response_cb = sse_response_end_cb,
+    };
+
 
     type = (const struct http_client_node_type *)sol_flow_node_get_type(node);
 
@@ -392,12 +476,28 @@ common_get_process(struct sol_flow_node *node, void *data, uint16_t port,
     }
 
     sol_http_params_init(&params);
-    if (mdata->accept && !sol_http_param_add(&params,
-        SOL_HTTP_REQUEST_PARAM_HEADER("Accept", mdata->accept))) {
-        SOL_WRN("Failed to set query params");
-        r = -ENOMEM;
-        goto err;
+
+    if (mdata->accept) {
+        struct sol_vector priorities;
+        struct sol_http_content_type_priority *pri;
+
+        if (!sol_http_param_add(&params,
+            SOL_HTTP_REQUEST_PARAM_HEADER("Accept", mdata->accept))) {
+            SOL_WRN("Failed to set the 'Accept' header with value: %s",
+                mdata->accept);
+            r = -ENOMEM;
+            goto err;
+        }
+
+        r = sol_http_parse_content_type_priorities(sol_str_slice_from_str(mdata->accept), &priorities);
+        SOL_INT_CHECK_GOTO(r, < 0, err);
+        if (priorities.len) {
+            pri = sol_vector_get_nocheck(&priorities, 0);
+            is_sse_request = sol_str_slice_str_caseeq(pri->content_type, "text/stream");
+        }
+        sol_http_content_type_priorities_array_clear(&priorities);
     }
+
 
     if (mdata->last_modified && !sol_http_param_add(&params,
         SOL_HTTP_REQUEST_PARAM_HEADER("If-Since-Modified",
@@ -427,8 +527,13 @@ common_get_process(struct sol_flow_node *node, void *data, uint16_t port,
         SOL_INT_CHECK_GOTO(r, < 0, err);
     }
 
-    connection = sol_http_client_request(SOL_HTTP_METHOD_GET, mdata->url,
-        &params, type->http_response ? : common_request_finished, node);
+    if (!is_sse_request) {
+        connection = sol_http_client_request(SOL_HTTP_METHOD_GET, mdata->url,
+            &params, type->http_response ? : common_request_finished, node);
+    } else {
+        connection = sol_http_client_request_with_interface(SOL_HTTP_METHOD_GET,
+            mdata->url, &params, &req_iface, node);
+    }
 
     sol_http_params_clear(&params);
 
@@ -455,13 +560,16 @@ common_post_process(struct sol_flow_node *node, void *data,
     int r;
     va_list ap;
     char *key, *value;
-    const char *type;
+    const char *type = "application/json";
     struct sol_http_params params;
     struct http_data *mdata = data;
     struct sol_http_client_connection *connection;
 
-    type = mdata->accept ? : "application/json";
+    if (mdata->accept && strcmp(mdata->accept, "text/stream"))
+        type = mdata->accept;
+
     sol_http_params_init(&params);
+
     if (!(sol_http_param_add(&params,
         SOL_HTTP_REQUEST_PARAM_HEADER("Accept", type)))) {
         SOL_WRN("Could not add the header '%s:%s' into request to %s",
@@ -550,16 +658,13 @@ boolean_process_json(struct sol_flow_node *node, const struct sol_str_slice slic
 }
 
 static int
-boolean_process_data(struct sol_flow_node *node,
-    struct sol_http_response *response)
+boolean_process_data(struct sol_flow_node *node, struct sol_buffer *buf)
 {
     bool result;
 
-    SOL_HTTP_RESPONSE_CHECK_API(response, -EINVAL);
-
-    if (!strncasecmp("true", response->content.data, response->content.used))
+    if (!strncasecmp("true", buf->data, buf->used))
         result = true;
-    else if (!strncasecmp("false", response->content.data, response->content.used))
+    else if (!strncasecmp("false", buf->data, buf->used))
         result = false;
     else
         return -EINVAL;
@@ -618,14 +723,11 @@ string_process_json(struct sol_flow_node *node, const struct sol_str_slice slice
 }
 
 static int
-string_process_data(struct sol_flow_node *node,
-    struct sol_http_response *response)
+string_process_data(struct sol_flow_node *node, struct sol_buffer *buf)
 {
     char *result;
 
-    SOL_HTTP_RESPONSE_CHECK_API(response, -EINVAL);
-
-    result = strndup(response->content.data, response->content.used);
+    result = strndup(buf->data, buf->used);
 
     if (result) {
         return sol_flow_send_string_take_packet(node,
@@ -681,15 +783,12 @@ int_process_json(struct sol_flow_node *node, const struct sol_str_slice slice)
 }
 
 static int
-int_process_data(struct sol_flow_node *node,
-    struct sol_http_response *response)
+int_process_data(struct sol_flow_node *node, struct sol_buffer *buf)
 {
     int value;
 
-    SOL_HTTP_RESPONSE_CHECK_API(response, -EINVAL);
-
     errno = 0;
-    value = strtol(response->content.data, NULL, 0);
+    value = sol_util_strtol(buf->data, NULL, buf->used, 0);
     if (errno)
         return -EINVAL;
 
@@ -760,15 +859,12 @@ float_process_json(struct sol_flow_node *node, const struct sol_str_slice slice)
 }
 
 static int
-float_process_data(struct sol_flow_node *node,
-    struct sol_http_response *response)
+float_process_data(struct sol_flow_node *node, struct sol_buffer *buf)
 {
     double value;
 
-    SOL_HTTP_RESPONSE_CHECK_API(response, EINVAL);
-
     errno = 0;
-    value = sol_util_strtodn(response->content.data, NULL, -1, false);
+    value = sol_util_strtodn(buf->data, NULL, buf->used, false);
     if (errno)
         return -errno;
 
@@ -883,15 +979,14 @@ hex_str_to_decimal(const char *start, ssize_t len, uint32_t *value)
 }
 
 static int
-rgb_process_data(struct sol_flow_node *node,
-    struct sol_http_response *response)
+rgb_process_data(struct sol_flow_node *node, struct sol_buffer *buf)
 {
     struct sol_rgb rgb = { 0 };
     struct sol_str_slice rgb_str;
     int r;
 
-    rgb_str.data = response->content.data;
-    rgb_str.len = response->content.used;
+    rgb_str.data = buf->data;
+    rgb_str.len = buf->used;
 
     if (rgb_str.len != 7 || rgb_str.data[0] != '#') {
         SOL_WRN("Expected format #RRGGBB. Received: %.*s",
@@ -1016,15 +1111,15 @@ direction_vector_process_json(struct sol_flow_node *node, const struct sol_str_s
 
 static int
 direction_vector_process_data(struct sol_flow_node *node,
-    struct sol_http_response *response)
+    struct sol_buffer *buf)
 {
     struct sol_direction_vector dir_vector;
     struct sol_str_slice token;
     double components[3];
     size_t i = 0;
 
-    token.data = response->content.data;
-    token.len = response->content.used;
+    token.data = buf->data;
+    token.len = buf->used;
 
     if (!token.len || token.data[0] != '(' ||
         token.data[token.len - 1] != ')') {
@@ -1121,22 +1216,18 @@ generic_url_process(struct sol_flow_node *node, void *data, uint16_t port,
 }
 
 static int
-get_blob_process(struct sol_flow_node *node, struct sol_http_response *response)
+get_blob_process(struct sol_flow_node *node, struct sol_buffer *buf)
 {
     struct sol_blob *blob;
     size_t size;
     void *data;
     int r;
 
-    SOL_HTTP_RESPONSE_CHECK_API(response, -EINVAL);
-
-    SOL_DBG("Blob process - response from: %s", response->url);
-
-    data = sol_buffer_steal(&response->content, &size);
+    data = sol_buffer_steal(buf, &size);
     blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, data, size);
     if (!blob) {
         sol_flow_send_error_packet(node, ENOMEM,
-            "Could not alloc memory for the response from %s", response->url);
+            "Could not alloc memory for the response");
         return -ENOMEM;
     }
 
@@ -1189,28 +1280,22 @@ json_array_post_process(struct sol_flow_node *node, void *data, uint16_t port,
 }
 
 static int
-get_json_process(struct sol_flow_node *node, struct sol_http_response *response)
+get_json_process(struct sol_flow_node *node, struct sol_buffer *buf)
 {
     struct sol_blob *blob;
     struct sol_json_scanner object_scanner, array_scanner;
-    struct sol_str_slice trimmed_str;
+    char *start;
+    size_t len;
     int r;
 
-    SOL_DBG("Json process - response from: %s", response->url);
+    start = sol_buffer_steal_or_copy(buf, &len);
+    sol_json_scanner_init(&object_scanner, start, len);
+    sol_json_scanner_init(&array_scanner, start, len);
 
-    trimmed_str = sol_str_slice_trim(sol_buffer_get_slice(&response->content));
-    sol_json_scanner_init(&object_scanner, trimmed_str.data, trimmed_str.len);
-    sol_json_scanner_init(&array_scanner, trimmed_str.data, trimmed_str.len);
-
-    (void)sol_buffer_steal(&response->content, NULL);
-    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, trimmed_str.data,
-        trimmed_str.len);
-
+    blob = sol_blob_new(SOL_BLOB_TYPE_DEFAULT, NULL, start, len);
     if (!blob) {
         sol_flow_send_error_packet(node, ENOMEM,
-            "Could not create the json blob packet from: %s", response->url);
-        SOL_ERR("Could not create the json blob packet from: %s",
-            response->url);
+            "Could not create the json blob packet");
         return -ENOMEM;
     }
 
@@ -1222,10 +1307,8 @@ get_json_process(struct sol_flow_node *node, struct sol_http_response *response)
         r = sol_flow_send_json_array_packet(node,
             SOL_FLOW_NODE_TYPE_HTTP_CLIENT_JSON__OUT__ARRAY, blob);
     } else {
-        sol_flow_send_error_packet(node, EINVAL, "The json received from:%s"
-            " is not valid json-object or json-array", response->url);
-        SOL_ERR("The json received from:%s is not valid json-object or"
-            " json-array", response->url);
+        sol_flow_send_error_packet(node, EINVAL, "The json received"
+            " is not valid json-object or json-array");
         r = -EINVAL;
     }
 

--- a/src/modules/flow/http-client/http-client.c
+++ b/src/modules/flow/http-client/http-client.c
@@ -73,8 +73,7 @@ struct create_url_data {
 
 struct http_client_node_type {
     struct sol_flow_node_type base;
-    int (*process_token)(struct sol_flow_node *node, struct sol_json_token *key,
-        struct sol_json_token *value);
+    int (*process_json)(struct sol_flow_node *node, const struct sol_str_slice slice);
     int (*process_data)(struct sol_flow_node *node,
         struct sol_http_response *response);
     void (*close_node)(struct sol_flow_node *node, void *data);
@@ -189,22 +188,6 @@ machine_id_header_add(struct sol_http_params *params)
 }
 
 static void
-get_key(struct http_data *mdata)
-{
-    char *ptr = NULL;
-
-    if (strstartswith(mdata->url, "http://"))
-        ptr = strstr(mdata->url + strlen("http://"), "/");
-    else if (strstartswith(mdata->url, "https://"))
-        ptr = strstr(mdata->url + strlen("https://"), "/");
-
-    if (ptr)
-        mdata->key = sol_str_slice_from_str(ptr);
-    else
-        mdata->key = (struct sol_str_slice){.len = 0, .data = NULL };
-}
-
-static void
 common_close(struct sol_flow_node *node, void *data)
 {
     struct sol_http_client_connection *connection;
@@ -243,7 +226,6 @@ common_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_o
     if (opts->url && opts->url[0] != '\0') {
         r = set_basic_url_info(mdata, opts->url);
         SOL_INT_CHECK(r, < 0, r);
-        get_key(mdata);
     }
 
     if (opts->accept) {
@@ -262,13 +244,10 @@ static int
 common_url_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id,
     const struct sol_flow_packet *packet)
 {
-    struct http_data *mdata = data;
     int r;
 
     r = set_basic_url_info_from_packet(data, packet);
     SOL_INT_CHECK(r, < 0, r);
-
-    get_key(mdata);
 
     return 0;
 }
@@ -376,19 +355,10 @@ common_request_finished(void *data,
     }
 
     if (streq(response->content_type, "application/json") &&
-        type->process_token) {
-        struct sol_json_scanner scanner;
-        struct sol_json_token token, key, value;
-        enum sol_json_loop_reason reason;
-
-        sol_json_scanner_init(&scanner, response->content.data, response->content.used);
-        SOL_JSON_SCANNER_OBJECT_LOOP (&scanner, &token, &key, &value, reason) {
-            if (!sol_json_token_str_eq(&token, mdata->key.data, mdata->key.len))
-                continue;
-            ret = type->process_token(node, &key, &value);
-            if (ret < 0)
-                goto err;
-        }
+        type->process_json) {
+        ret = type->process_json(node, sol_buffer_get_slice(&response->content));
+        if (ret < 0)
+            goto err;
     } else {
         ret = type->process_data(node, response);
         if (ret < 0)
@@ -550,17 +520,30 @@ err:
 }
 
 static int
-boolean_process_token(struct sol_flow_node *node,
-    struct sol_json_token *key, struct sol_json_token *value)
+boolean_process_json(struct sol_flow_node *node, const struct sol_str_slice slice)
 {
-    bool result;
+    bool result, found;
+    enum sol_json_loop_reason reason;
+    struct sol_json_scanner sub_scanner;
+    struct sol_json_token sub_key, sub_value, token;
 
-    if (sol_json_token_get_type(value) == SOL_JSON_TYPE_TRUE)
-        result = true;
-    else if (sol_json_token_get_type(value) == SOL_JSON_TYPE_FALSE)
-        result = false;
-    else
-        return -EINVAL;
+    sol_json_scanner_init(&sub_scanner, slice.data, slice.len);
+    found = false;
+
+    SOL_JSON_SCANNER_OBJECT_LOOP (&sub_scanner, &token, &sub_key, &sub_value, reason) {
+        if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&sub_key, "value")) {
+            if (sol_json_token_get_type(&sub_value) == SOL_JSON_TYPE_TRUE)
+                result = true;
+            else if (sol_json_token_get_type(&sub_value) == SOL_JSON_TYPE_FALSE)
+                result = false;
+            else
+                return -EINVAL;
+            found = true;
+            break;
+        }
+    }
+
+    SOL_EXP_CHECK(!found, -ENOENT);
 
     return sol_flow_send_boolean_packet(node,
         SOL_FLOW_NODE_TYPE_HTTP_CLIENT_BOOLEAN__OUT__OUT, result);
@@ -602,19 +585,36 @@ boolean_post_process(struct sol_flow_node *node, void *data, uint16_t port, uint
 /*
  * --------------------------------- string node -----------------------------
  */
-static int
-string_process_token(struct sol_flow_node *node,
-    struct sol_json_token *key, struct sol_json_token *value)
-{
-    char *result = NULL;
 
-    result = strndup(value->start + 1, value->end - value->start - 2);
-    if (result) {
-        return sol_flow_send_string_take_packet(node,
-            SOL_FLOW_NODE_TYPE_HTTP_CLIENT_STRING__OUT__OUT, result);
+static int
+string_process_json(struct sol_flow_node *node, const struct sol_str_slice slice)
+{
+    bool found = false;
+    char *result = NULL;
+    enum sol_json_loop_reason reason;
+    struct sol_json_scanner sub_scanner;
+    struct sol_json_token sub_key, sub_value, token;
+
+    sol_json_scanner_init(&sub_scanner, slice.data, slice.len);
+    found = false;
+
+    SOL_JSON_SCANNER_OBJECT_LOOP (&sub_scanner, &token, &sub_key, &sub_value, reason) {
+        if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&sub_key, "value")) {
+            if (sol_json_token_get_type(&sub_value) == SOL_JSON_TYPE_STRING)
+                result = sol_json_token_get_unescaped_string_copy(&sub_value);
+            else
+                result = strndup(sub_value.start,
+                    sub_value.end - sub_value.start);
+            SOL_NULL_CHECK(result, -ENOMEM);
+            found = true;
+            break;
+        }
     }
 
-    return -ENOMEM;
+    SOL_EXP_CHECK(!found, -ENOENT);
+
+    return sol_flow_send_string_take_packet(node,
+        SOL_FLOW_NODE_TYPE_HTTP_CLIENT_STRING__OUT__OUT, result);
 }
 
 static int
@@ -652,15 +652,14 @@ string_post_process(struct sol_flow_node *node, void *data, uint16_t port, uint1
  * --------------------------------- irange node -----------------------------
  */
 static int
-int_process_token(struct sol_flow_node *node,
-    struct sol_json_token *key, struct sol_json_token *value)
+int_process_json(struct sol_flow_node *node, const struct sol_str_slice slice)
 {
     struct sol_irange irange = SOL_IRANGE_INIT();
     enum sol_json_loop_reason reason;
     struct sol_json_scanner sub_scanner;
     struct sol_json_token sub_key, sub_value, token;
 
-    sol_json_scanner_init(&sub_scanner, value->start, value->end - value->start);
+    sol_json_scanner_init(&sub_scanner, slice.data, slice.len);
     SOL_JSON_SCANNER_OBJECT_LOOP (&sub_scanner, &token, &sub_key, &sub_value, reason) {
         if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&sub_key, "value")) {
             if (sol_json_token_get_int32(&sub_value, &irange.val) < 0)
@@ -731,15 +730,14 @@ int_post_process(struct sol_flow_node *node, void *data, uint16_t port, uint16_t
  * --------------------------------- drange node -----------------------------
  */
 static int
-float_process_token(struct sol_flow_node *node,
-    struct sol_json_token *key, struct sol_json_token *value)
+float_process_json(struct sol_flow_node *node, const struct sol_str_slice slice)
 {
     struct sol_drange drange = SOL_DRANGE_INIT();
     enum sol_json_loop_reason reason;
     struct sol_json_scanner sub_scanner;
     struct sol_json_token token, sub_key, sub_value;
 
-    sol_json_scanner_init(&sub_scanner, value->start, value->end - value->start);
+    sol_json_scanner_init(&sub_scanner, slice.data, slice.len);
     SOL_JSON_SCANNER_OBJECT_LOOP (&sub_scanner, &token, &sub_key, &sub_value, reason) {
         int r;
         if (SOL_JSON_TOKEN_STR_LITERAL_EQ(&sub_key, "value")) {
@@ -814,17 +812,14 @@ float_post_process(struct sol_flow_node *node, void *data, uint16_t port, uint16
  */
 
 static int
-rgb_process_token(struct sol_flow_node *node, struct sol_json_token *key,
-    struct sol_json_token *value)
+rgb_process_json(struct sol_flow_node *node, const struct sol_str_slice slice)
 {
     struct sol_rgb rgb = { 0 };
     enum sol_json_loop_reason reason;
     struct sol_json_scanner sub_scanner;
     struct sol_json_token sub_key, sub_value, token;
 
-    sol_json_scanner_init(&sub_scanner, value->start,
-        value->end - value->start);
-
+    sol_json_scanner_init(&sub_scanner, slice.data, slice.len);
     rgb.red_max = rgb.green_max = rgb.blue_max = 255;
 
     SOL_JSON_SCANNER_OBJECT_LOOP (&sub_scanner, &token, &sub_key,
@@ -965,16 +960,14 @@ rgb_post_process(struct sol_flow_node *node, void *data, uint16_t port,
  * --------------------------------- direction vector node  -----------------------------
  */
 static int
-direction_vector_process_token(struct sol_flow_node *node,
-    struct sol_json_token *key, struct sol_json_token *value)
+direction_vector_process_json(struct sol_flow_node *node, const struct sol_str_slice slice)
 {
     struct sol_direction_vector dir_vector = { 0 };
     enum sol_json_loop_reason reason;
     struct sol_json_scanner sub_scanner;
     struct sol_json_token sub_key, sub_value, token;
 
-    sol_json_scanner_init(&sub_scanner, value->start,
-        value->end - value->start);
+    sol_json_scanner_init(&sub_scanner, slice.data, slice.len);
 
     dir_vector.max = DBL_MAX;
     dir_vector.min = -DBL_MAX;

--- a/src/modules/flow/http-client/http-client.json
+++ b/src/modules/flow/http-client/http-client.json
@@ -47,7 +47,7 @@
           },
           {
             "data_type": "string",
-            "default": "application/json",
+            "default": "text/stream, application/json, text/plain",
             "description": "The desired content type of the response",
             "name": "accept"
           }
@@ -130,7 +130,7 @@
           },
           {
             "data_type": "string",
-            "default": "text/plain",
+            "default": "text/stream, application/json, text/plain",
             "description": "The desired content type of the response",
             "name": "accept"
           }
@@ -212,7 +212,7 @@
           },
           {
             "data_type": "string",
-            "default": "application/json",
+            "default": "text/stream, application/json, text/plain",
             "description": "The desired content type of the response",
             "name": "accept"
           }
@@ -294,7 +294,7 @@
           },
           {
             "data_type": "string",
-            "default": "application/json",
+            "default": "text/stream, application/json, text/plain",
             "description": "The desired content type of the response",
             "name": "accept"
           }
@@ -377,7 +377,7 @@
           },
           {
             "data_type": "string",
-            "default": "application/json",
+            "default": "text/stream, application/json, text/plain",
             "description": "The desired content type of the response",
             "name": "accept"
           }
@@ -460,7 +460,7 @@
           },
           {
             "data_type": "string",
-            "default": "application/json",
+            "default": "text/stream, application/json, text/plain",
             "description": "The desired content type of the response",
             "name": "accept"
           }
@@ -628,7 +628,7 @@
           },
           {
             "data_type": "string",
-            "default": "application/json",
+            "default": "text/stream, application/json, text/plain",
             "description": "The desired content type of the response",
             "name": "accept"
           }

--- a/src/modules/flow/http-client/http-client.json
+++ b/src/modules/flow/http-client/http-client.json
@@ -21,7 +21,7 @@
         ],
         "data_type": "struct http_client_node_type",
         "extra_methods": {
-          "process_token": "boolean_process_token",
+          "process_json": "boolean_process_json",
           "process_data": "boolean_process_data"
         }
       },
@@ -104,7 +104,7 @@
         ],
         "data_type": "struct http_client_node_type",
         "extra_methods": {
-          "process_token": "string_process_token",
+          "process_json": "string_process_json",
           "process_data": "string_process_data"
         }
       },
@@ -187,7 +187,7 @@
         ],
         "data_type": "struct http_client_node_type",
         "extra_methods": {
-          "process_token": "rgb_process_token",
+          "process_json": "rgb_process_json",
           "process_data": "rgb_process_data"
         }
       },
@@ -269,7 +269,7 @@
         ],
         "data_type": "struct http_client_node_type",
         "extra_methods": {
-          "process_token": "direction_vector_process_token",
+          "process_json": "direction_vector_process_json",
           "process_data": "direction_vector_process_data"
         }
       },
@@ -351,7 +351,7 @@
         ],
         "data_type": "struct http_client_node_type",
         "extra_methods": {
-          "process_token": "int_process_token",
+          "process_json": "int_process_json",
           "process_data": "int_process_data"
         }
       },
@@ -434,7 +434,7 @@
         ],
         "data_type": "struct http_client_node_type",
         "extra_methods": {
-          "process_token": "float_process_token",
+          "process_json": "float_process_json",
           "process_data": "float_process_data"
         }
       },

--- a/src/modules/flow/http-server/http-server.c
+++ b/src/modules/flow/http-server/http-server.c
@@ -250,19 +250,8 @@ common_handle_response_cb(struct sol_flow_node *node,
         }
     }
 
-    if (send_json) {
-        r = sol_buffer_append_printf(&response->content,
-            "{\"%s\":", mdata->path);
-        SOL_INT_CHECK_GOTO(r, < 0, err_exit);
-    }
-
     r = type->response_cb(mdata, &response->content, send_json);
     SOL_INT_CHECK_GOTO(r, < 0, err_exit);
-
-    if (send_json) {
-        r = sol_buffer_append_char(&response->content, '}');
-        SOL_INT_CHECK_GOTO(r, < 0, err_exit);
-    }
 
     err_r = sol_http_param_add(&response->param, SOL_HTTP_REQUEST_PARAM_HEADER(
         HTTP_HEADER_CONTENT_TYPE, (send_json) ? HTTP_HEADER_CONTENT_TYPE_JSON :
@@ -694,12 +683,14 @@ boolean_post_cb(struct http_data *mdata, struct sol_flow_node *node,
 static int
 boolean_response_cb(struct http_data *mdata, struct sol_buffer *content, bool json)
 {
-    int r;
+    const char *str;
 
-    r = sol_buffer_append_printf(content, "%s", mdata->value.b == true ? "true" : "false");
-    SOL_INT_CHECK(r, < 0, r);
+    str = mdata->value.b ? "true" : "false";
 
-    return 0;
+    if (json)
+        return sol_buffer_append_printf(content, "{\"value\":%s}", str);
+    else
+        return sol_buffer_append_slice(content, sol_str_slice_from_str(str));
 }
 
 static void
@@ -731,10 +722,15 @@ boolean_process_cb(struct http_data *mdata, const struct sol_flow_packet *packet
 static int
 string_response_cb(struct http_data *mdata, struct sol_buffer *content, bool json)
 {
-    int r = 0;
+    int r;
 
     if (json) {
+        r = sol_buffer_append_slice(content,
+            sol_str_slice_from_str("{\"value\":"));
+        SOL_INT_CHECK(r, < 0, r);
         r = sol_json_serialize_string(content, mdata->value.s);
+        SOL_INT_CHECK(r, < 0, r);
+        r = sol_buffer_append_char(content, '}');
     } else {
         r = sol_buffer_append_slice(content, sol_str_slice_from_str(mdata->value.s));
     }

--- a/src/modules/flow/http-server/http-server.json
+++ b/src/modules/flow/http-server/http-server.json
@@ -580,6 +580,7 @@
         ],
         "data_type": "struct http_server_node_type",
         "extra_methods": {
+          "response_cb": "json_response_cb",
           "process_cb": "blob_process_cb",
           "send_packet_cb": "json_send_packet_cb",
           "handle_response_cb": "blob_handle_response_cb"

--- a/src/test-fbp/http-allowed-methods.fbp
+++ b/src/test-fbp/http-allowed-methods.fbp
@@ -32,6 +32,8 @@ _(http-server/int:port=8080, path="/int_post_get", value=200, allowed_methods="P
 
 _(constant/empty) OUT -> GET int_client(http-client/int:url="http://localhost:8080/int_post_get")
 
-int_client OUT -> IN _(test/int-validator:sequence="200") OUT -> RESULT _(test/result)
+int_client OUT -> IN[0] switcher(switcher/int) OUT[0] -> IN _(test/int-validator:sequence="200") OUT -> RESULT _(test/result)
 
-int_client OUT -> IN _(converter/empty-to-int:output_value=256) OUT -> POST int_client
+switcher OUT[0] -> IN _(converter/empty-to-int:output_value=256) OUT -> POST int_client
+
+switcher OUT[0] -> IN _(converter/empty-to-int:output_value=2) OUT -> OUT_PORT switcher

--- a/src/test-fbp/http-blob.fbp
+++ b/src/test-fbp/http-blob.fbp
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 get-validator(test/string-validator:sequence="Hi!")
-post-validator(test/string-validator:sequence="Bye!")
+post-validator(test/string-validator:sequence="Hi!|Bye!")
 
 _(constant/string:value="Hi!") OUT -> IN _(converter/string-to-blob) OUT -> IN server(http-server/blob:path="/test", port=8080)
 

--- a/src/test-fbp/http-boolean.fbp
+++ b/src/test-fbp/http-boolean.fbp
@@ -18,7 +18,7 @@ constant-server(constant/boolean:value=true)
 response-count(int/accumulator:setup_value=0|2)
 constant-client(converter/empty-to-boolean:output_value=false)
 string(constant/string:value="true")
-json-str(constant/string:value="{\"/test\":true}")
+json-str(constant/string:value="{\"value\":true}")
 
 json-blob(converter/json-object-to-blob)
 blob-str(converter/blob-to-string)

--- a/src/test-fbp/http-drange.fbp
+++ b/src/test-fbp/http-drange.fbp
@@ -18,7 +18,7 @@ constant-server(constant/float:value=1.5,value_spec=min:0|max:100|step:2.1415)
 response-count(int/accumulator:setup_value=0|2)
 constant-client(converter/empty-to-float:output_value=5.4)
 string(constant/string:value="1.5")
-json-str(constant/string:value="{\"/test\":{\"value\":1.5,\"min\":0,\"max\":100,\"step\":2.1415}}")
+json-str(constant/string:value="{\"value\":1.5,\"min\":0,\"max\":100,\"step\":2.1415}")
 
 json-blob(converter/json-object-to-blob)
 blob-str(converter/blob-to-string)

--- a/src/test-fbp/http-irange.fbp
+++ b/src/test-fbp/http-irange.fbp
@@ -18,7 +18,7 @@ constant-server(constant/int:value=1,value_spec=min:0|max:100|step:1)
 response-count(int/accumulator:setup_value=0|2)
 constant-client(converter/empty-to-int:output_value=5)
 string(constant/string:value="1")
-json-str(constant/string:value="{\"/test\":{\"value\":1,\"min\":0,\"max\":100,\"step\":1}}")
+json-str(constant/string:value="{\"value\":1,\"min\":0,\"max\":100,\"step\":1}")
 
 json-blob(converter/json-object-to-blob)
 blob-str(converter/blob-to-string)

--- a/src/test-fbp/http-sse.fbp
+++ b/src/test-fbp/http-sse.fbp
@@ -1,0 +1,25 @@
+# This file is part of the Soletta Project
+#
+# Copyright (C) 2015 Intel Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+seq(test/int-validator:sequence="10 11 12 13 14 15 16 17 18 19 20")
+
+timer(timer:interval=10) OUT -> INC accumulator(int/accumulator:initial_value=10) OUT -> IN _(http-server/int:port=8080)
+
+_(constant/int:value=20) OUT -> IN[0] stop(int/equal) OUT -> IN _(boolean/not) OUT -> ENABLED timer
+
+accumulator OUT -> IN[1] stop
+
+_(constant/empty) OUT -> GET _(http-client/int:url="http://localhost:8080/int") OUT -> IN seq OUT -> RESULT _(test/result)

--- a/src/test-fbp/http-string.fbp
+++ b/src/test-fbp/http-string.fbp
@@ -17,7 +17,7 @@
 constant-server(constant/string:value="hello")
 response-count(int/accumulator:setup_value=0|2)
 constant-client(converter/empty-to-string:output_value="world")
-json-str(constant/string:value="{\"/test\":\"hello\"}")
+json-str(constant/string:value="{\"value\":\"hello\"}")
 
 json-blob(converter/json-object-to-blob)
 blob-str(converter/blob-to-string)

--- a/src/test/test-http.c
+++ b/src/test/test-http.c
@@ -20,6 +20,93 @@
 #include "sol-util-internal.h"
 #include "sol-http.h"
 #include "sol-vector.h"
+#include "sol-util.h"
+
+DEFINE_TEST(go);
+
+static void
+go(void)
+{
+    size_t i;
+    int r;
+
+    static const struct {
+        const struct sol_str_slice content_type;
+        double qvalue;
+        size_t tokens_size;
+        const char *tokens[10];
+    } map [][100] = {
+        { { SOL_STR_SLICE_LITERAL("text/html"), 1.0, 0, { 0 } } },
+        {
+            { SOL_STR_SLICE_LITERAL("audio/basic"), 1.0, 0, { 0 } },
+            { SOL_STR_SLICE_LITERAL("audio/*"), 0.2, 0, { 0 } }
+        },
+        {
+            { SOL_STR_SLICE_LITERAL("text/html"), 1.0, 0, { 0 } },
+            { SOL_STR_SLICE_LITERAL("text/x-c"), 1.0, 0, { 0 } },
+            { SOL_STR_SLICE_LITERAL("text/x-dvi"), 0.8, 0, { 0 } },
+            { SOL_STR_SLICE_LITERAL("text/plain"), 0.5, 0, { 0 } },
+        },
+        {
+            { SOL_STR_SLICE_LITERAL("text/html"), 1.0, 1, { "level=1" } },
+            { SOL_STR_SLICE_LITERAL("text/html"), 1.0, 0, { 0 } },
+            { SOL_STR_SLICE_LITERAL("text/*"), 1.0, 0, { 0 } },
+            { SOL_STR_SLICE_LITERAL("*/*"), 1.0, 0, { 0 } },
+        },
+        {
+            { SOL_STR_SLICE_LITERAL("text/html"), 1.0, 1, { "level=1" } },
+            { SOL_STR_SLICE_LITERAL("text/html"), 0.7, 0, { 0 } },
+            { SOL_STR_SLICE_LITERAL("text/html"), 0.4, 2, { "level=2", "level=3" } },
+            { SOL_STR_SLICE_LITERAL("text/*"), 0.3, 0, { 0 } },
+            { SOL_STR_SLICE_LITERAL("*/*"), 0.5, 0, { 0 } },
+        },
+        {
+            { SOL_STR_SLICE_LITERAL("text/html"), 1.0, 0, { 0 } },
+            { SOL_STR_SLICE_LITERAL("text/*"), 0.8, 0, { 0 } },
+            { SOL_STR_SLICE_LITERAL("image/gif"), 0.6, 0, { 0 } },
+            { SOL_STR_SLICE_LITERAL("image/jpeg"), 0.6, 0, { 0 } },
+            { SOL_STR_SLICE_LITERAL("image/*"), 0.5, 0, { 0 } },
+            { SOL_STR_SLICE_LITERAL("*/*"), 0.1, 0, { 0 } },
+        },
+    };
+
+    static const struct {
+        int r;
+        size_t priorities_len;
+        struct sol_str_slice accept;
+    } test[] = {
+        { 0, 1, SOL_STR_SLICE_LITERAL("text/html;  q  =  2") },
+        { 0, 2, SOL_STR_SLICE_LITERAL("audio/*;q=0.2,      audio/basic   ") },
+        { 0, 4, SOL_STR_SLICE_LITERAL("text/plain; q=0.5, text/html,text/x-dvi; q=0.8, text/x-c") },
+        { 0, 4, SOL_STR_SLICE_LITERAL("text/*, text/html, text/html;level=1, */*") },
+        { 0, 5, SOL_STR_SLICE_LITERAL("text/*;q=0.3, text/html;q=0.7, text/html;level=1,text/html;level=2;level=3;q=0.4, */*;q=0.5") },
+        { 0, 6, SOL_STR_SLICE_LITERAL("text/html; q=1.0, text/*; q=0.8, image/gif; q=0.6, image/jpeg; q=0.6, image/*; q=0.5, */*; q=0.1") }
+    };
+
+    for (i = 0; i < SOL_UTIL_ARRAY_SIZE(test); i++) {
+        size_t j;
+        struct sol_vector array;
+
+        r = sol_http_parse_content_type_priorities(test[i].accept, &array);
+        ASSERT_INT_EQ(r, test[i].r);
+        ASSERT_INT_EQ(test[i].priorities_len, array.len);
+
+        for (j = 0; j < test[i].priorities_len; j++) {
+            size_t k;
+            struct sol_http_content_type_priority *pri = sol_vector_get_nocheck(&array, j);
+            ASSERT(sol_str_slice_eq(pri->content_type, map[i][j].content_type));
+            ASSERT(sol_util_double_equal(pri->qvalue, map[i][j].qvalue));
+            ASSERT_INT_EQ(map[i][j].tokens_size, pri->tokens.len);
+            for (k = 0; k < map[i][j].tokens_size; k++) {
+                struct sol_str_slice *token = sol_vector_get_nocheck(&pri->tokens, k);
+                ASSERT(sol_str_slice_str_eq(*token, map[i][j].tokens[k]));
+            }
+        }
+
+        sol_http_content_type_priorities_array_clear(&array);
+    }
+}
+
 
 DEFINE_TEST(test_split_urls);
 


### PR DESCRIPTION
Changes since v1:

* Added commits c3a27a1 and 4fcd1c1
* Added functions `sol_direction_vector_equal()` and `sol_rgb_equal()`
* Upon get request, the function `send_sse_data()` at http-server.c will not broadcast any more.
* In htt-server.c now copies the sse_clients array in order to close the sse connection.
* In http-client node - added more types to the accept option.
* Other minor fixes.