### PR TITLE
Flow uniform string to packet

### DIFF
--- a/src/lib/datatypes/include/sol-str-slice.h
+++ b/src/lib/datatypes/include/sol-str-slice.h
@@ -206,7 +206,7 @@ sol_str_slice_copy(char *dst, const struct sol_str_slice src)
 static inline bool
 sol_str_slice_starts_with(const struct sol_str_slice slice, const struct sol_str_slice prefix)
 {
-    return slice.len >= prefix.len && strncmp(slice.data, prefix.data, prefix.len);
+    return slice.len >= prefix.len && strncmp(slice.data, prefix.data, prefix.len) == 0;
 }
 
 /**

--- a/src/lib/flow/include/sol-flow-packet.h
+++ b/src/lib/flow/include/sol-flow-packet.h
@@ -740,6 +740,22 @@ int sol_flow_packet_get_http_response(const struct sol_flow_packet *packet, int 
 const char *sol_flow_packet_get_packet_type_as_string(const struct sol_str_slice type);
 
 /**
+ * @brief Returns the packet type from string.
+ *
+ * This function will return the sol_flow_packet_type based on its
+ * string name. If the @a type starts with "composed:", then it will
+ * search for composed packets with that signature and if none exists,
+ * then it will try to create one.
+ *
+ * @param type The Soletta type name (int, blob, error, string,
+ *        composed:int,boolean...)
+ *
+ * @return The Soletta packet type reference or @c NULL if the type
+ * was not found.
+ */
+const struct sol_flow_packet_type *sol_flow_packet_type_from_string(const struct sol_str_slice type);
+
+/**
  * @}
  */
 

--- a/src/lib/flow/sol-flow-composed.c
+++ b/src/lib/flow/sol-flow-composed.c
@@ -832,8 +832,8 @@ composed_metatype_generate_type_code(struct sol_buffer *out,
     bool is_splitter)
 {
     const char *data_size, *composed_port_name, *close_func,
-    *composed_port_type, *simple_port_type, *simple_port_process,
-    *composed_port_process;
+        *composed_port_type, *simple_port_type, *simple_port_process,
+        *composed_port_process;
     char *packet_signature;
     uint16_t ports_in, ports_out, i;
     struct sol_vector ports;

--- a/src/lib/flow/sol-flow-composed.c
+++ b/src/lib/flow/sol-flow-composed.c
@@ -124,40 +124,6 @@ composed_node_type_dispose(struct sol_flow_node_type *type)
     free(self);
 }
 
-static const struct sol_flow_packet_type *
-get_packet_type(const struct sol_str_slice type)
-{
-    if (sol_str_slice_str_eq(type, "int"))
-        return SOL_FLOW_PACKET_TYPE_IRANGE;
-    if (sol_str_slice_str_eq(type, "float"))
-        return SOL_FLOW_PACKET_TYPE_DRANGE;
-    if (sol_str_slice_str_eq(type, "string"))
-        return SOL_FLOW_PACKET_TYPE_STRING;
-    if (sol_str_slice_str_eq(type, "boolean"))
-        return SOL_FLOW_PACKET_TYPE_BOOLEAN;
-    if (sol_str_slice_str_eq(type, "byte"))
-        return SOL_FLOW_PACKET_TYPE_BYTE;
-    if (sol_str_slice_str_eq(type, "blob"))
-        return SOL_FLOW_PACKET_TYPE_BLOB;
-    if (sol_str_slice_str_eq(type, "rgb"))
-        return SOL_FLOW_PACKET_TYPE_RGB;
-    if (sol_str_slice_str_eq(type, "location"))
-        return SOL_FLOW_PACKET_TYPE_LOCATION;
-    if (sol_str_slice_str_eq(type, "timestamp"))
-        return SOL_FLOW_PACKET_TYPE_TIMESTAMP;
-    if (sol_str_slice_str_eq(type, "direction-vector"))
-        return SOL_FLOW_PACKET_TYPE_DIRECTION_VECTOR;
-    if (sol_str_slice_str_eq(type, "error"))
-        return SOL_FLOW_PACKET_TYPE_ERROR;
-    if (sol_str_slice_str_eq(type, "json-object"))
-        return SOL_FLOW_PACKET_TYPE_JSON_OBJECT;
-    if (sol_str_slice_str_eq(type, "json-array"))
-        return SOL_FLOW_PACKET_TYPE_JSON_ARRAY;
-    if (sol_str_slice_str_eq(type, "http-response"))
-        return SOL_FLOW_PACKET_TYPE_HTTP_RESPONSE;
-    return NULL;
-}
-
 static int
 simple_port_process(struct sol_flow_node *node, void *data, uint16_t port,
     uint16_t conn_id, const struct sol_flow_packet *packet)
@@ -291,7 +257,7 @@ setup_simple_ports(struct sol_vector *in_ports, const struct sol_str_slice conte
             goto err_exit;
         }
 
-        packet_type = get_packet_type(type_slice);
+        packet_type = sol_flow_packet_type_from_string(type_slice);
 
         if (!packet_type) {
             r = -EINVAL;
@@ -991,7 +957,7 @@ get_ports_description(const struct sol_str_slice contents,
         sizeof(struct sol_flow_packate_type *));
 
     SOL_VECTOR_FOREACH_IDX (simple_ports, port, i)
-        types[i] = get_packet_type(sol_str_slice_from_str(port->type));
+        types[i] = sol_flow_packet_type_from_string(sol_str_slice_from_str(port->type));
 
     types[i] = NULL;
     composed_type = sol_flow_packet_type_composed_new(types);

--- a/src/lib/flow/sol-flow-packet.c
+++ b/src/lib/flow/sol-flow-packet.c
@@ -54,6 +54,7 @@ struct sol_flow_packet_composed_type {
 };
 
 static struct sol_ptr_vector composed_types_cache = SOL_PTR_VECTOR_INIT;
+static const struct sol_str_slice composed_prefix = SOL_STR_SLICE_LITERAL("composed:");
 
 static inline void *
 sol_flow_packet_get_memory(const struct sol_flow_packet *packet)
@@ -1030,7 +1031,7 @@ sol_flow_packet_type_composed_new(const struct sol_flow_packet_type **types)
 
     sol_buffer_init(&buf);
 
-    r = sol_buffer_append_slice(&buf, sol_str_slice_from_str("composed:"));
+    r = sol_buffer_append_slice(&buf, composed_prefix);
     SOL_INT_CHECK_GOTO(r, < 0, err_buf);
     for (i = 0; i < types_len; i++) {
         type_name = types[i]->name;
@@ -1148,6 +1149,85 @@ sol_flow_packet_get_packet_type_as_string(const struct sol_str_slice type)
         SOL_STR_TABLE_PTR_ITEM("http-response", "SOL_FLOW_PACKET_TYPE_HTTP_RESPONSE"),
         { }
     };
+
+    return sol_str_table_ptr_lookup_fallback(map, type, NULL);
+}
+
+static const struct sol_flow_packet_type *
+composed_type_from_string(struct sol_str_slice type)
+{
+    const struct sol_flow_packet_composed_type *ctype;
+    struct sol_ptr_vector types = SOL_PTR_VECTOR_INIT;
+    struct sol_str_slice sub;
+    const struct sol_flow_packet_type *packet_type = NULL;
+    const char *itr = NULL;
+    uint16_t i;
+    int r;
+
+    type.len -= composed_prefix.len;
+    type.data += composed_prefix.len;
+    if (type.len == 0)
+        return NULL;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&composed_types_cache, ctype, i) {
+        if (sol_str_slice_str_eq(type, ctype->self.name + composed_prefix.len)) {
+            return &ctype->self;
+        }
+    }
+
+    while (sol_str_slice_str_split_iterate(type, &sub, &itr, ",")) {
+        const struct sol_flow_packet_type *pt;
+
+        sub = sol_str_slice_trim(sub);
+        pt = sol_flow_packet_type_from_string(sub);
+        if (!pt) {
+            SOL_DBG("no packet type %.*s", SOL_STR_SLICE_PRINT(sub));
+            goto error;
+        }
+
+        r = sol_ptr_vector_append(&types, pt);
+        SOL_INT_CHECK_GOTO(r, < 0, error);
+    }
+
+    if (sol_ptr_vector_get_len(&types) < 2)
+        goto error;
+
+    r = sol_ptr_vector_append(&types, NULL);
+    SOL_INT_CHECK_GOTO(r, < 0, error);
+
+    packet_type = sol_flow_packet_type_composed_new(types.base.data);
+
+error:
+    sol_ptr_vector_clear(&types);
+    return packet_type;
+}
+
+SOL_API const struct sol_flow_packet_type *
+sol_flow_packet_type_from_string(const struct sol_str_slice type)
+{
+    static const struct sol_str_table_ptr map[] = {
+        SOL_STR_TABLE_PTR_ITEM("any", &_SOL_FLOW_PACKET_TYPE_ANY),
+        SOL_STR_TABLE_PTR_ITEM("empty", &_SOL_FLOW_PACKET_TYPE_EMPTY),
+        SOL_STR_TABLE_PTR_ITEM("int", &_SOL_FLOW_PACKET_TYPE_IRANGE),
+        SOL_STR_TABLE_PTR_ITEM("float", &_SOL_FLOW_PACKET_TYPE_DRANGE),
+        SOL_STR_TABLE_PTR_ITEM("string", &_SOL_FLOW_PACKET_TYPE_STRING),
+        SOL_STR_TABLE_PTR_ITEM("boolean", &_SOL_FLOW_PACKET_TYPE_BOOLEAN),
+        SOL_STR_TABLE_PTR_ITEM("byte", &_SOL_FLOW_PACKET_TYPE_BYTE),
+        SOL_STR_TABLE_PTR_ITEM("blob", &_SOL_FLOW_PACKET_TYPE_BLOB),
+        SOL_STR_TABLE_PTR_ITEM("rgb", &_SOL_FLOW_PACKET_TYPE_RGB),
+        SOL_STR_TABLE_PTR_ITEM("location", &_SOL_FLOW_PACKET_TYPE_LOCATION),
+        SOL_STR_TABLE_PTR_ITEM("timestamp", &_SOL_FLOW_PACKET_TYPE_TIMESTAMP),
+        SOL_STR_TABLE_PTR_ITEM("direction-vector",
+            &_SOL_FLOW_PACKET_TYPE_DIRECTION_VECTOR),
+        SOL_STR_TABLE_PTR_ITEM("error", &_SOL_FLOW_PACKET_TYPE_ERROR),
+        SOL_STR_TABLE_PTR_ITEM("json-object", &_SOL_FLOW_PACKET_TYPE_JSON_OBJECT),
+        SOL_STR_TABLE_PTR_ITEM("json-array", &_SOL_FLOW_PACKET_TYPE_JSON_ARRAY),
+        SOL_STR_TABLE_PTR_ITEM("http-response", &_SOL_FLOW_PACKET_TYPE_HTTP_RESPONSE),
+        { }
+    };
+
+    if (sol_str_slice_starts_with(type, composed_prefix))
+        return composed_type_from_string(type);
 
     return sol_str_table_ptr_lookup_fallback(map, type, NULL);
 }

--- a/src/modules/flow-metatype/http-composed-client/http-composed-client.c
+++ b/src/modules/flow-metatype/http-composed-client/http-composed-client.c
@@ -536,22 +536,21 @@ static const struct sol_flow_node_type_description sol_flow_node_type_http_clien
     .license = "Apache-2.0",
     .version = "1",
     .options = &((const struct sol_flow_node_options_description){
-            .data_size = sizeof(struct http_composed_client_options),
-            SOL_SET_API_VERSION(.sub_api = SOL_FLOW_NODE_TYPE_HTTP_COMPOSED_CLIENT_OPTIONS_API_VERSION, )
-            .required = true,
-            .members = (const struct sol_flow_node_options_member_description[]){
-                {
-                    .name = "url",
-                    .description = "The URL used on requests",
-                    .data_type = "string",
-                    .required = false,
-                    .offset = offsetof(struct http_composed_client_options, url),
-                    .size = sizeof(const char *),
-                },
-                {},
-
+        .data_size = sizeof(struct http_composed_client_options),
+        SOL_SET_API_VERSION(.sub_api = SOL_FLOW_NODE_TYPE_HTTP_COMPOSED_CLIENT_OPTIONS_API_VERSION, )
+        .required = true,
+        .members = (const struct sol_flow_node_options_member_description[]){
+            {
+                .name = "url",
+                .description = "The URL used on requests",
+                .data_type = "string",
+                .required = false,
+                .offset = offsetof(struct http_composed_client_options, url),
+                .size = sizeof(const char *),
             },
-        }),
+            {},
+        },
+    }),
 };
 
 static int

--- a/src/modules/flow-metatype/http-composed-client/http-composed-client.c
+++ b/src/modules/flow-metatype/http-composed-client/http-composed-client.c
@@ -661,22 +661,6 @@ http_composed_client_type_fini(struct http_composed_client_type *type)
     sol_vector_clear(&type->ports_out);
 }
 
-static const struct sol_flow_packet_type *
-get_packet_type(const struct sol_str_slice type)
-{
-    if (sol_str_slice_str_eq(type, "int"))
-        return SOL_FLOW_PACKET_TYPE_IRANGE;
-    if (sol_str_slice_str_eq(type, "float"))
-        return SOL_FLOW_PACKET_TYPE_DRANGE;
-    if (sol_str_slice_str_eq(type, "string"))
-        return SOL_FLOW_PACKET_TYPE_STRING;
-    if (sol_str_slice_str_eq(type, "boolean"))
-        return SOL_FLOW_PACKET_TYPE_BOOLEAN;
-    if (sol_str_slice_str_eq(type, "byte"))
-        return SOL_FLOW_PACKET_TYPE_BYTE;
-    return NULL;
-}
-
 static int
 get_name_and_type_from_token(const struct sol_str_slice *token, char **name,
     struct sol_str_slice *type)
@@ -804,7 +788,7 @@ setup_ports(struct sol_vector *in_ports, struct sol_vector *ports_out,
             goto err_exit;
         }
 
-        packet_type = get_packet_type(type_slice);
+        packet_type = sol_flow_packet_type_from_string(type_slice);
         if (!packet_type) {
             r = -EINVAL;
             SOL_ERR("It's not possible to use %.*s as a port type.",

--- a/src/modules/flow-metatype/http-composed-server/http-composed-server.c
+++ b/src/modules/flow-metatype/http-composed-server/http-composed-server.c
@@ -671,22 +671,6 @@ get_context_tokens(const struct sol_str_slice *contents,
     return 0;
 }
 
-static const struct sol_flow_packet_type *
-get_packet_type(const struct sol_str_slice type)
-{
-    if (sol_str_slice_str_eq(type, "int"))
-        return SOL_FLOW_PACKET_TYPE_IRANGE;
-    if (sol_str_slice_str_eq(type, "float"))
-        return SOL_FLOW_PACKET_TYPE_DRANGE;
-    if (sol_str_slice_str_eq(type, "string"))
-        return SOL_FLOW_PACKET_TYPE_STRING;
-    if (sol_str_slice_str_eq(type, "boolean"))
-        return SOL_FLOW_PACKET_TYPE_BOOLEAN;
-    if (sol_str_slice_str_eq(type, "byte"))
-        return SOL_FLOW_PACKET_TYPE_BYTE;
-    return NULL;
-}
-
 static int
 get_name_and_type_from_token(const struct sol_str_slice *token, char **name,
     struct sol_str_slice *type)
@@ -814,7 +798,7 @@ setup_ports(struct sol_vector *in_ports, struct sol_vector *ports_out,
             goto err_exit;
         }
 
-        packet_type = get_packet_type(type_slice);
+        packet_type = sol_flow_packet_type_from_string(type_slice);
         if (!packet_type) {
             r = -EINVAL;
             SOL_ERR("It's not possible to use %.*s as a port type.",


### PR DESCRIPTION
I'm starting a huge rework of the sol-flow internals in order to help with memory consumption. Since the patchset is likely to be big and I can't work on all of it in one go, I'll submit intermediate stages as I do it.

This is the first step and makes the string to packet type conversion unified in `sol-flow-packet.h`, this one will cover the simple types and also composed, creating if required, so we don't spread that parsing all over the place.

There is a drawback: if this new function is used, then all packet types will be held. I've noticed that most of the users of the packet type don't actually need them if we offer introspection to serialize/parse based on memory description, like JS or HTTP nodes. Then with the future cleanups this may be minimized.

