### PR TITLE
Node.js bindings: Add JS bindings for SPI

### DIFF
--- a/bindings/nodejs/configure-bindings.js
+++ b/bindings/nodejs/configure-bindings.js
@@ -106,6 +106,15 @@ for ( oneVariable in process.env ) {
 				"sol-pwm.h"
 			] );
 			break;
+		case "USE_SPI":
+			sources = sources.concat( [
+				"../src/functions/spi.cc",
+				"../src/structures/sol-js-spi.cc"
+			] );
+			headers = headers.concat( [
+				"sol-spi.h"
+			] );
+			break;
 		default:
 			break;
 	}

--- a/bindings/nodejs/lib/spi.js
+++ b/bindings/nodejs/lib/spi.js
@@ -1,0 +1,75 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var soletta = require( 'bindings' )( 'soletta' ),
+    _ = require( 'lodash' );
+
+exports.open = function( init ) {
+    return new Promise( function( fulfill, reject ) {
+        var config = null;
+        var spiMode =  init.mode ? init.mode : "mode0";
+        var chipSelect =  init.chipSelect ? init.chipSelect : 0;
+        var bitsPerWord =  init.bitsPerWord ? init.bitsPerWord : 8;
+
+        config = {
+            chip_select: chipSelect,
+            mode: soletta.sol_spi_mode_from_str( spiMode ),
+            frequency: init.frequency,
+            bits_per_word: bitsPerWord,
+        }
+        fulfill( SPIBus( soletta.sol_spi_open( init.bus, config ) ) );
+    });
+}
+
+var SPIBus = function( bus ) {
+    if ( !this._isSPIBus )
+        return new SPIBus( bus );
+    this._bus = bus;
+}
+
+_.extend( SPIBus.prototype, {
+    _isSPIBus: true,
+
+    transfer: function(value) {
+       return new Promise( _.bind( function( fulfill, reject ) {
+           var txBuffer;
+           if ( Buffer.isBuffer( value ) )
+               txBuffer = value;
+           else
+               txBuffer = new Buffer(value);
+
+           var returnStatus = soletta.sol_spi_transfer( this._bus, txBuffer,
+               function( txData, rxData, count ) {
+                   var rxBffer = new Buffer( rxData );
+                   fulfill( rxBffer );
+           });
+
+           if ( ( typeof returnStatus === 'undefined' ) || !returnStatus ) {
+               reject( new Error( "SPI transmission failed" ) );
+           }
+       }, this ) );
+    },
+
+    close: function() {
+        return new Promise( _.bind( function( fulfill, reject ) {
+            fulfill( soletta.sol_spi_close( this._bus ) );
+        }, this ) );
+    },
+});
+
+exports.SPIBus = SPIBus;

--- a/bindings/nodejs/src/functions/spi.cc
+++ b/bindings/nodejs/src/functions/spi.cc
@@ -1,0 +1,166 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <node.h>
+#include <nan.h>
+#include <sol-spi.h>
+
+#include "../common.h"
+#include "../data.h"
+#include "../hijack.h"
+#include "../structures/js-handle.h"
+#include "../structures/sol-js-spi.h"
+
+using namespace v8;
+
+class SolSpi : public JSHandle<SolSpi> {
+public:
+    static const char *jsClassName() { return "SolSpi"; }
+};
+
+NAN_METHOD(bind_sol_spi_open) {
+    VALIDATE_ARGUMENT_COUNT(info, 2);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsUint32);
+    VALIDATE_ARGUMENT_TYPE(info, 1, IsObject);
+
+    sol_spi_config config;
+    sol_spi *spi = NULL;
+
+    if (!c_sol_spi_config(info[1]->ToObject(), &config)) {
+        return;
+    }
+
+    spi = sol_spi_open(info[0]->Uint32Value(), &config);
+    if (spi) {
+        info.GetReturnValue().Set(SolSpi::New(spi));
+    }
+}
+
+NAN_METHOD(bind_sol_spi_close) {
+    VALIDATE_ARGUMENT_COUNT(info, 1);
+    VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 0, IsObject);
+    Local<Object> jsSpi = Nan::To<Object>(info[0]).ToLocalChecked();
+    sol_spi *spi= (sol_spi *)SolSpi::Resolve(jsSpi);
+    if (!spi)
+        return;
+
+    sol_spi_close(spi);
+    Nan::SetInternalFieldPointer(jsSpi, 0, 0);
+}
+
+static void sol_spi_transfer_cb(void *cb_data, struct sol_spi *spi,
+    const uint8_t *tx, uint8_t *rx, ssize_t status) {
+    Nan::HandleScope scope;
+    Nan::Callback *callback = (Nan::Callback *)cb_data;
+    Local<Value> txBuffer;
+    Local<Value> rxBuffer;
+
+    if (status >= 0) {
+        txBuffer = Nan::NewBuffer((char *)tx, status).ToLocalChecked();
+        rxBuffer = Nan::NewBuffer((char *)rx, status).ToLocalChecked();
+    } else {
+        txBuffer = Nan::Null();
+        rxBuffer = Nan::Null();
+    }
+
+    Local<Value> arguments[3] = {
+        txBuffer,
+        rxBuffer,
+        Nan::New((int)status)
+    };
+
+    callback->Call(3, arguments);
+    delete callback;
+    hijack_unref();
+}
+
+NAN_METHOD(bind_sol_spi_transfer) {
+    VALIDATE_ARGUMENT_COUNT(info, 3);
+    VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 0, IsObject);
+    VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 1, IsObject);
+    VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 2, IsFunction);
+    Local<Object> jsSpi = Nan::To<Object>(info[0]).ToLocalChecked();
+    sol_spi *spi= (sol_spi *)SolSpi::Resolve(jsSpi);
+    if (!spi)
+        return;
+
+    if (!node::Buffer::HasInstance(info[1])) {
+        Nan::ThrowTypeError("Argument 1 must be a node Buffer");
+        return;
+    }
+
+    size_t length = node::Buffer::Length(info[1]);
+    uint8_t *txBuffer = (uint8_t *) malloc(length * sizeof(uint8_t));
+    if (!txBuffer) {
+        Nan::ThrowError("Failed to allocate memory for output buffer");
+        return;
+    }
+    memcpy(txBuffer, node::Buffer::Data(info[1]), length);
+
+    uint8_t *rxBuffer = (uint8_t *) malloc(length * sizeof(uint8_t));
+    if (!rxBuffer) {
+        free(txBuffer);
+        Nan::ThrowError("Failed to allocate memory for input buffer");
+        return;
+    }
+    memset(rxBuffer, 0, length * sizeof(uint8_t));
+
+    if (!hijack_ref()) {
+        free(txBuffer);
+        free(rxBuffer);
+        return;
+    }
+
+    Nan::Callback *callback =
+        new Nan::Callback(Local<Function>::Cast(info[2]));
+    bool returnValue =
+        sol_spi_transfer(spi, txBuffer, rxBuffer, length,
+            sol_spi_transfer_cb, callback);
+
+    if (!returnValue) {
+        free(txBuffer);
+        free(rxBuffer);
+        delete callback;
+        hijack_unref();
+    }
+
+    info.GetReturnValue().Set(Nan::New(returnValue));
+}
+
+NAN_METHOD(bind_sol_spi_mode_from_str) {
+    VALIDATE_ARGUMENT_COUNT(info, 1);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsString);
+
+    sol_spi_mode mode = sol_spi_mode_from_str(
+        (const char *)*String::Utf8Value(info[0]));
+    info.GetReturnValue().Set(Nan::New(mode));
+}
+
+NAN_METHOD(bind_sol_spi_mode_to_str) {
+    VALIDATE_ARGUMENT_COUNT(info, 1);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsInt32);
+
+    const char *idString = sol_spi_mode_to_str(
+        (sol_spi_mode)info[0]->Int32Value());
+
+    if (idString) {
+        info.GetReturnValue().Set(Nan::New(idString).ToLocalChecked());
+    } else {
+        info.GetReturnValue().Set(Nan::Null());
+    }
+}

--- a/bindings/nodejs/src/structures/sol-js-spi.cc
+++ b/bindings/nodejs/src/structures/sol-js-spi.cc
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <nan.h>
+#include "../common.h"
+#include "sol-js-spi.h"
+
+using namespace v8;
+
+bool c_sol_spi_config(v8::Local<v8::Object> jsSPIConfig,
+    sol_spi_config *config) {
+    SOL_SET_API_VERSION(config->api_version = SOL_SPI_CONFIG_API_VERSION;)
+
+    VALIDATE_AND_ASSIGN((*config), chip_select, unsigned int, IsUint32,
+        "(Chip select)", false, jsSPIConfig, Uint32Value);
+
+    VALIDATE_AND_ASSIGN((*config), mode, sol_spi_mode, IsInt32,
+        "(SPI transfer mode)", false, jsSPIConfig, Int32Value);
+
+    VALIDATE_AND_ASSIGN((*config), frequency, uint32_t, IsUint32,
+        "(Frequency in Hz)", false, jsSPIConfig, Uint32Value);
+
+    VALIDATE_AND_ASSIGN((*config), bits_per_word, uint8_t, IsUint32,
+        "(Bits per word)", false, jsSPIConfig, Uint32Value);
+
+    return true;
+}

--- a/bindings/nodejs/src/structures/sol-js-spi.h
+++ b/bindings/nodejs/src/structures/sol-js-spi.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __SOLETTA_JS_SPI_H__
+#define __SOLETTA_JS_SPI_H__
+
+#include <v8.h>
+#include <sol-spi.h>
+
+bool c_sol_spi_config(v8::Local<v8::Object> jsSPIConfig,
+    sol_spi_config *config);
+
+#endif /* __SOLETTA_JS_SPI_H__ */

--- a/src/lib/io/Makefile
+++ b/src/lib/io/Makefile
@@ -60,11 +60,13 @@ obj-io-i2c-$(PLATFORM_LINUX) += \
 obj-io-i2c-$(PLATFORM_ZEPHYR) += \
     sol-i2c-impl-zephyr.o
 
-obj-io-spi-$(PLATFORM_RIOTOS) := \
+obj-io-spi-$(USE_SPI) := \
+    sol-spi-common.o
+obj-io-spi-$(PLATFORM_RIOTOS) += \
     sol-spi-impl-riot.o
-obj-io-spi-$(PLATFORM_LINUX) := \
+obj-io-spi-$(PLATFORM_LINUX) += \
     sol-spi-impl-linux.o
-obj-io-spi-$(PLATFORM_ZEPHYR) := \
+obj-io-spi-$(PLATFORM_ZEPHYR) += \
     sol-spi-impl-zephyr.o
 
 obj-io-uart-$(USE_UART) := \

--- a/src/lib/io/include/sol-spi.h
+++ b/src/lib/io/include/sol-spi.h
@@ -20,8 +20,10 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <sys/types.h>
 
 #include <sol-common-buildopts.h>
+#include <sol-macros.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -80,6 +82,32 @@ struct sol_spi_config {
     uint32_t frequency; /** Clock frequency in Hz */
     uint8_t bits_per_word;
 };
+
+/**
+ * @brief Converts a string SPI mode name to sol_spi_mode
+ *
+ * This function converts a string SPI mode name to enumeration sol_spi_mode.
+ *
+ * @see sol_spi_mode_to_str().
+ *
+ * @param spi_mode Valid values are mode0", "mode1", "mode2", "mode3".
+ *
+ * @return enumeration sol_spi_mode
+ */
+enum sol_spi_mode sol_spi_mode_from_str(const char *spi_mode) SOL_ATTR_WARN_UNUSED_RESULT;
+
+/**
+ * @brief Converts sol_spi_mode to a string name.
+ *
+ * This function converts sol_spi_mode enumeration to a string SPI mode name.
+ *
+ * @see sol_spi_mode_from_str().
+ *
+ * @param spi_mode sol_spi_mode
+ *
+ * @return String representation of the sol_spi_mode
+ */
+const char *sol_spi_mode_to_str(enum sol_spi_mode spi_mode) SOL_ATTR_WARN_UNUSED_RESULT;
 
 /**
  * @brief Perform a SPI asynchronous transfer.

--- a/src/lib/io/sol-spi-common.c
+++ b/src/lib/io/sol-spi-common.c
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "sol-log-internal.h"
+#include "sol-str-table.h"
+#include "sol-spi.h"
+#include "sol-util.h"
+
+SOL_API enum sol_spi_mode
+sol_spi_mode_from_str(const char *spi_mode)
+{
+    static const struct sol_str_table table[] = {
+        SOL_STR_TABLE_ITEM("mode0", SOL_SPI_MODE_0),
+        SOL_STR_TABLE_ITEM("mode1", SOL_SPI_MODE_1),
+        SOL_STR_TABLE_ITEM("mode2", SOL_SPI_MODE_2),
+        SOL_STR_TABLE_ITEM("mode3", SOL_SPI_MODE_3),
+        { }
+    };
+
+    SOL_NULL_CHECK(spi_mode, SOL_SPI_MODE_0);
+
+    return sol_str_table_lookup_fallback(table,
+        sol_str_slice_from_str(spi_mode), SOL_SPI_MODE_0);
+}
+
+SOL_API const char *
+sol_spi_mode_to_str(enum sol_spi_mode spi_mode)
+{
+    static const char *spi_mode_names[] = {
+        [SOL_SPI_MODE_0] = "mode0",
+        [SOL_SPI_MODE_1] = "mode1",
+        [SOL_SPI_MODE_2] = "mode2",
+        [SOL_SPI_MODE_3] = "mode3"
+    };
+
+    if (spi_mode < SOL_UTIL_ARRAY_SIZE(spi_mode_names))
+        return spi_mode_names[spi_mode];
+
+    return NULL;
+}

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -208,6 +208,7 @@ bindings-nodejs: $(SOL_LIB_OUTPUT)
 		SOL_CONFIG_USE_AIO=$(USE_AIO) \
 		SOL_CONFIG_USE_UART=$(USE_UART) \
 		SOL_CONFIG_USE_PWM=$(USE_PWM) \
+		SOL_CONFIG_USE_SPI=$(USE_SPI) \
 		SOL_CONFIG_NETWORK=$(NETWORK) \
 			$(NODEJS) bindings/nodejs/configure-bindings.js
 


### PR DESCRIPTION
This patch contains the native and highlevel JavaScript bindings for SPI.

This replaces #1849 