### PR TITLE
log: make it possible to skip getting file/function names on output.

### DIFF
--- a/src/lib/common/Kconfig
+++ b/src/lib/common/Kconfig
@@ -367,6 +367,24 @@ choice
           information will be hidden and sol-fbp-runner users may also
           have a bad experience.
 
+          On Linux, one is able to control some logging parameters by
+          means of environment variables (on others, one can change
+          those by API calls, at least):
+          - SOL_LOG_SHOW_COLORS: boolean telling whether to log with
+            (ANSI terminal) colors (false by default)
+          - SOL_LOG_SHOW_FILE: boolean telling whether to prefix log
+            entries with the originating file name (true by default)
+          - SOL_LOG_SHOW_FUNCTION": boolean telling whether to prefix
+            log entries with the originating function name (true by
+            default)
+          - SOL_LOG_SHOW_LINE: boolean telling whether to prefix log
+            entries with the originating file line (true by default)
+
+          On every system, even if logging is enabled, it's possible
+          to suppress some of those logging strings that go the final
+          binary (file/function names), to save space. Refer to the
+          LOG_FUNCTIONS and LOG_FILES configuration options.
+
 
 config MAXIMUM_LOG_LEVEL_CRITICAL
 	bool "critical"
@@ -386,6 +404,26 @@ config MAXIMUM_LOG_LEVEL_DEBUG
 config MAXIMUM_LOG_LEVEL_UNLIMITED
 	bool "unlimited"
 endchoice
+
+config LOG_FILES
+	depends on LOG
+	bool "Add file name entries to the logging calls"
+	default y
+	help
+          Add file name entries to the logging calls throughout
+          Soletta. Those file name strings will end up in your final
+          binary/image, if log is enabled. For constrained systems,
+          you might want to suppress that. If unsure, say Y.
+
+config LOG_FUNCTIONS
+	depends on LOG
+	bool "Add function name entries to the logging calls"
+	default y
+	help
+          Add function name entries to the logging calls throughout
+          Soletta. Those function name strings will end up in your final
+          binary/image, if log is enabled. For constrained systems,
+          you might want to suppress that. If unsure, say Y.
 
 menu "Hardware Options"
 source "src/lib/io/Kconfig"

--- a/src/lib/common/include/sol-log.h
+++ b/src/lib/common/include/sol-log.h
@@ -458,6 +458,24 @@ sol_log_domain_init_level(struct sol_log_domain *domain)
 #define SOL_LOG_LEVEL_POSSIBLE(level) (0)
 #endif
 
+#ifdef SOL_LOG_FILES
+#ifdef SOL_LOG_FUNCTIONS
+#define SOL_LOG_FILE __FILE__
+#define SOL_LOG_FUNCTION __PRETTY_FUNCTION__
+#else
+#define SOL_LOG_FILE __FILE__
+#define SOL_LOG_FUNCTION NULL
+#endif
+#else
+#ifdef SOL_LOG_FUNCTIONS
+#define SOL_LOG_FILE NULL
+#define SOL_LOG_FUNCTION __PRETTY_FUNCTION__
+#else
+#define SOL_LOG_FILE NULL
+#define SOL_LOG_FUNCTION NULL
+#endif
+#endif
+
 /**
  * @def SOL_LOG(level, fmt, ...)
  *
@@ -472,7 +490,7 @@ sol_log_domain_init_level(struct sol_log_domain *domain)
     do { \
         if (SOL_LOG_LEVEL_POSSIBLE(level)) { \
             sol_log_print(SOL_LOG_DOMAIN, level, \
-                __FILE__, __PRETTY_FUNCTION__, __LINE__, \
+                SOL_LOG_FILE, SOL_LOG_FUNCTION,  __LINE__, \
                 fmt, ## __VA_ARGS__); \
         } \
     } while (0)

--- a/src/lib/common/sol-common-buildopts.h.in
+++ b/src/lib/common/sol-common-buildopts.h.in
@@ -27,6 +27,8 @@ st.on_value("PLATFORM_ZEPHYR", "y", "#define SOL_PLATFORM_ZEPHYR 1", "")
 
 {{
 st.on_value("LOG", "y", "#define SOL_LOG_ENABLED 1", "")
+st.on_value("LOG_FILES", "y", "#define SOL_LOG_FILES 1", "")
+st.on_value("LOG_FUNCTIONS", "y", "#define SOL_LOG_FUNCTIONS 1", "")
 st.on_value("NO_API_VERSION_NEEDED", "y", "#define SOL_NO_API_VERSION 1", "")
 }}
 

--- a/src/lib/common/sol-log.c
+++ b/src/lib/common/sol-log.c
@@ -58,11 +58,12 @@ static bool _inited = false;
         if (SOL_UNLIKELY(!_inited)) { \
             fprintf(stderr, "CRITICAL:%s:%d:%s() " \
                 "SOL_LOG used before initialization. "fmt "\n", \
-                __FILE__, __LINE__, __PRETTY_FUNCTION__, ## __VA_ARGS__); \
+                SOL_LOG_FILE ? : "", \
+                SOL_LOG_FUNCTION ? : "", \
+                ## __VA_ARGS__); \
             abort(); \
         } \
     } while (0)
-
 
 SOL_API struct sol_log_domain *sol_log_global_domain = &_global_domain;
 


### PR DESCRIPTION
Besides logging those entries or not (which was already a run-time
paramemeter), we now have the option of never including those strings to
the final binay (so even if the user asks to log those, it gets empty
strings for them). This helps save space on restricted system, while
still having log enabled, *a lot*. Without this, lots of applications
would have to be debugged with custom printfs (and Soletta general
logging turned off), what is a total PITA.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>