### PR TITLE
GPIO: Add missing enum-string mapping functions in sol-gpio.

### DIFF
--- a/src/lib/io/include/sol-gpio.h
+++ b/src/lib/io/include/sol-gpio.h
@@ -227,6 +227,32 @@ struct sol_gpio_config {
 };
 
 /**
+ * @brief Converts a string GPIO direction to sol_gpio_direction.
+ *
+ * This function converts a string GPIO direction to enumeration sol_gpio_direction.
+ *
+ * @see sol_gpio_direction_to_str().
+ *
+ * @param direction Valid values are "in", "out".
+ *
+ * @return enumeration sol_gpio_direction.
+ */
+enum sol_gpio_direction sol_gpio_direction_from_str(const char *direction) SOL_ATTR_WARN_UNUSED_RESULT;
+
+/**
+ * @brief Converts sol_gpio_direction to a string name.
+ *
+ * This function converts sol_gpio_direction enumeration to a string GPIO direction name.
+ *
+ * @see sol_gpio_direction_from_str().
+ *
+ * @param direction sol_gpio_direction.
+ *
+ * @return String representation of the sol_gpio_direction.
+ */
+const char *sol_gpio_direction_to_str(enum sol_gpio_direction direction) SOL_ATTR_WARN_UNUSED_RESULT;
+
+/**
  * @brief Converts a string GPIO edge to sol_gpio_edge
  *
  * This function converts a string GPIO edge to enumeration sol_gpio_edge
@@ -251,6 +277,32 @@ enum sol_gpio_edge sol_gpio_edge_from_str(const char *edge) SOL_ATTR_WARN_UNUSED
  * @return String representation of the sol_gpio_edge
  */
 const char *sol_gpio_edge_to_str(enum sol_gpio_edge edge) SOL_ATTR_WARN_UNUSED_RESULT;
+
+/**
+ * @brief Converts a string GPIO drive to sol_gpio_drive.
+ *
+ * This function converts a string GPIO drive to enumeration sol_gpio_drive.
+ *
+ * @see sol_gpio_drive_to_str().
+ *
+ * @param drive Valid values are "none", "up", "down".
+ *
+ * @return enumeration sol_gpio_drive.
+ */
+enum sol_gpio_drive sol_gpio_drive_from_str(const char *drive) SOL_ATTR_WARN_UNUSED_RESULT;
+
+/**
+ * @brief Converts sol_gpio_drive to a string name.
+ *
+ * This function converts sol_gpio_drive enumeration to a string GPIO drive name.
+ *
+ * @see sol_gpio_drive_from_str().
+ *
+ * @param drive sol_gpio_drive.
+ *
+ * @return String representation of the sol_gpio_drive.
+ */
+const char *sol_gpio_drive_to_str(enum sol_gpio_drive drive) SOL_ATTR_WARN_UNUSED_RESULT;
 
 /**
  * @brief Opens a given pin by its board label as general purpose input or output.

--- a/src/lib/io/sol-gpio-common.c
+++ b/src/lib/io/sol-gpio-common.c
@@ -78,6 +78,35 @@ sol_gpio_open(uint32_t pin, const struct sol_gpio_config *config)
     return gpio;
 }
 
+SOL_API enum sol_gpio_direction
+sol_gpio_direction_from_str(const char *direction)
+{
+    static const struct sol_str_table table[] = {
+        SOL_STR_TABLE_ITEM("out", SOL_GPIO_DIR_OUT),
+        SOL_STR_TABLE_ITEM("in", SOL_GPIO_DIR_IN),
+        { }
+    };
+
+    SOL_NULL_CHECK(direction, SOL_GPIO_DIR_OUT);
+
+    return sol_str_table_lookup_fallback(table,
+        sol_str_slice_from_str(direction), SOL_GPIO_DIR_OUT);
+}
+
+SOL_API const char *
+sol_gpio_direction_to_str(enum sol_gpio_direction direction)
+{
+    static const char *direction_names[] = {
+        [SOL_GPIO_DIR_OUT] = "out",
+        [SOL_GPIO_DIR_IN] = "in"
+    };
+
+    if (direction < SOL_UTIL_ARRAY_SIZE(direction_names))
+        return direction_names[direction];
+
+    return NULL;
+}
+
 SOL_API enum sol_gpio_edge
 sol_gpio_edge_from_str(const char *edge)
 {
@@ -107,6 +136,37 @@ sol_gpio_edge_to_str(enum sol_gpio_edge edge)
 
     if (edge < SOL_UTIL_ARRAY_SIZE(edge_names))
         return edge_names[edge];
+
+    return NULL;
+}
+
+SOL_API enum sol_gpio_drive
+sol_gpio_drive_from_str(const char *drive)
+{
+    static const struct sol_str_table table[] = {
+        SOL_STR_TABLE_ITEM("none", SOL_GPIO_DRIVE_NONE),
+        SOL_STR_TABLE_ITEM("up", SOL_GPIO_DRIVE_PULL_UP),
+        SOL_STR_TABLE_ITEM("down", SOL_GPIO_DRIVE_PULL_DOWN),
+        { }
+    };
+
+    SOL_NULL_CHECK(drive, SOL_GPIO_DRIVE_NONE);
+
+    return sol_str_table_lookup_fallback(table,
+        sol_str_slice_from_str(drive), SOL_GPIO_DRIVE_NONE);
+}
+
+SOL_API const char *
+sol_gpio_drive_to_str(enum sol_gpio_drive drive)
+{
+    static const char *drive_names[] = {
+        [SOL_GPIO_DRIVE_NONE] = "none",
+        [SOL_GPIO_DRIVE_PULL_UP] = "up",
+        [SOL_GPIO_DRIVE_PULL_DOWN] = "down"
+    };
+
+    if (drive < SOL_UTIL_ARRAY_SIZE(drive_names))
+        return drive_names[drive];
 
     return NULL;
 }


### PR DESCRIPTION
This patch adds missing enum-string mapping functions for gpio_drive and gpio_direction, so that these common functions can be used in the bindings for the conversion from string to enum and vice versa.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>