### PR TITLE
sol-log: Fix checking for NULL file and function macros

### DIFF
--- a/src/lib/common/include/sol-log.h
+++ b/src/lib/common/include/sol-log.h
@@ -472,7 +472,7 @@ sol_log_domain_init_level(struct sol_log_domain *domain)
 #ifdef SOL_LOG_FILES
 #define SOL_LOG_FILE __FILE__
 #else
-#define SOL_LOG_FILE NULL
+#define SOL_LOG_FILE ""
 #endif
 
 /**
@@ -489,7 +489,7 @@ sol_log_domain_init_level(struct sol_log_domain *domain)
 #ifdef SOL_LOG_FUNCTIONS
 #define SOL_LOG_FUNCTION __PRETTY_FUNCTION__
 #else
-#define SOL_LOG_FUNCTION NULL
+#define SOL_LOG_FUNCTION ""
 #endif
 
 /**

--- a/src/lib/common/sol-log.c
+++ b/src/lib/common/sol-log.c
@@ -58,9 +58,9 @@ static bool _inited = false;
         if (SOL_UNLIKELY(!_inited)) { \
             fprintf(stderr, "CRITICAL:%s:%d:%s() " \
                 "SOL_LOG used before initialization. "fmt "\n", \
-                SOL_LOG_FILE ? : "", \
+                SOL_LOG_FILE, \
                 __LINE__, \
-                SOL_LOG_FUNCTION ? : "", \
+                SOL_LOG_FUNCTION, \
                 ## __VA_ARGS__); \
             abort(); \
         } \


### PR DESCRIPTION
We can simplify the logic a little when printing the file and function
in sol-log by imposing them to be an empty string (instead of NULL).

This also solves this warning using gcc 5.3:

      CC   build/stage/lib/common/sol-worker-thread.o
      CC   build/stage/lib/common/sol-worker-thread-impl-posix.o
./src/lib/common/sol-log.c: In function 'sol_log_domain_init_level':
./src/lib/common/sol-log.c:63:34: warning: the address of '__PRETTY_FUNCTION__' will always evaluate as  true' [-Waddress]
                 SOL_LOG_FUNCTION ? : "", \
                                  ^
./src/lib/common/sol-log.c:271:5: note: in expansion of macro 'SOL_LOG_INIT_CHECK'
     SOL_LOG_INIT_CHECK("domain=%p", domain);
     ^
./src/lib/common/sol-log.c: In function 'sol_log_vprint':
./src/lib/common/sol-log.c:63:34: warning: the address of '__PRETTY_FUNCTION__' will always evaluate as  true' [-Waddress]
                 SOL_LOG_FUNCTION ? : "", \
                                  ^
./src/lib/common/sol-log.c:301:5: note: in expansion of macro 'SOL_LOG_INIT_CHECK'
     SOL_LOG_INIT_CHECK("domain=%p, file=%s, function=%s, line=%d, fomart=%s",
     ^
./src/lib/common/sol-log.c: In function 'sol_log_set_print_function':
./src/lib/common/sol-log.c:63:34: warning: the address of '__PRETTY_FUNCTION__' will always evaluate as  true' [-Waddress]
                 SOL_LOG_FUNCTION ? : "", \
                                  ^
./src/lib/common/sol-log.c:341:5: note: in expansion of macro 'SOL_LOG_INIT_CHECK'
     SOL_LOG_INIT_CHECK("cb=%p, data=%p", cb, data);
     ^
./src/lib/common/sol-log.c: In function 'sol_log_level_to_str':
./src/lib/common/sol-log.c:63:34: warning: the address of '__PRETTY_FUNCTION__' will always evaluate as  true' [-Waddress]
                 SOL_LOG_FUNCTION ? : "", \
                                  ^
./src/lib/common/sol-log.c:369:5: note: in expansion of macro 'SOL_LOG_INIT_CHECK'
     SOL_LOG_INIT_CHECK("level=%hhu, buf=%p, buflen=%zd", level, buf, buflen);
     ^
./src/lib/common/sol-log.c: In function 'sol_log_get_level_color':
./src/lib/common/sol-log.c:63:34: warning: the address of '__PRETTY_FUNCTION__' will always evaluate as  true' [-Waddress]
                 SOL_LOG_FUNCTION ? : "", \
                                  ^

Signed-off-by: Vinicius Costa Gomes <vinicius.gomes@intel.com>