### PR TITLE
Node.js bindings: Copy high-level APIs to repo root

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -38,6 +38,21 @@
 					} ]
 				},
 				{
+					"target_name": "copyapis",
+					"type": "none",
+					"actions": [ {
+						"action_name": "copyapis",
+						"message": "Copying JS APIs",
+						"inputs": [ "./bindings/nodejs/lib" ],
+						"outputs": [ "" ],
+						"action": [
+							"sh",
+							"-c",
+							"cp -a ./bindings/nodejs/lib/* ."
+						]
+					} ]
+				},
+				{
 					"target_name": "soletta",
 					"includes": [
 						"bindings/nodejs/generated/nodejs-bindings-sources.gyp"
@@ -50,7 +65,7 @@
 						"OTHER_CFLAGS": [ '<!@(echo "${SOLETTA_CFLAGS}")' ]
 					},
 					"libraries": [ '<!@(echo "${SOLETTA_LIBS}")' ],
-					"dependencies": [ "collectbindings" ]
+					"dependencies": [ "collectbindings", "copyapis" ]
 				}
 			]
 		} ]

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
   "homepage": "https://github.com/solettaproject/soletta#readme",
   "dependencies": {
     "bindings": "^1.2.1",
+    "lodash": "^4.3.0",
     "nan": "^2.1.0"
   },
   "devDependencies": {
     "async": "^1.5.2",
     "glob": "^6.0.4",
-    "lodash": "^4.3.0",
     "qunitjs": "^1.21.0",
     "uuid": "^2.0.1",
     "yargs": "^4.2.0"

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -200,7 +200,7 @@ bins-out += bindings-nodejs
 NODE_GYP ?= $(NODE_GYP_PATH)/node-gyp
 
 bindings-nodejs: $(SOL_LIB_OUTPUT)
-	$(Q) $(NODEJS_NPM) install --ignore-scripts
+	$(Q) $(NODEJS_NPM) install --ignore-scripts --production
 
 	$(Q) \
 		SOL_CONFIG_OIC=$(OIC) \
@@ -215,6 +215,14 @@ bindings-nodejs: $(SOL_LIB_OUTPUT)
 		export SOLETTA_CFLAGS="$(addprefix -I,$(abspath $(HEADERDIRS)))"; \
 		export SOLETTA_LIBS="$(FIND_LIBRARY_LDFLAGS)"; \
 			$(NODE_GYP) configure && $(NODE_GYP) build )
+
+	$(Q) mkdir -p $(build_nodejs_bindingsdir)
+	$(Q) cp -a *js package.json $(build_nodejs_bindingsdir)
+	$(Q) mkdir -p $(build_nodejs_bindingsdir)/build
+	$(Q) cp $$(find build -type f -name soletta.node | head -n 1) \
+		$(build_nodejs_bindingsdir)/build
+	$(Q) mkdir -p $(build_nodejs_bindingsdir)/node_modules
+	$(Q) cp -a ./node_modules/* $(build_nodejs_bindingsdir)/node_modules
 
 PHONY += bindings-nodejs
 

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -144,6 +144,7 @@ build_datadir := $(build_sysroot)$(SOL_DATADIR)
 build_flowdatadir := $(build_sysroot)$(SOL_FLOW_DATADIR)
 build_gdbautoload := $(build_sysroot)$(DATADIR)gdb/auto-load/
 build_docdir := $(build_stagedir)doc/
+build_nodejs_bindingsdir := $(build_libdir)/node_modules/soletta/
 
 PACKAGE_DOCNAME := soletta-$(VERSION)-doc
 build_doxygendir := $(build_docdir)doxygen/


### PR DESCRIPTION
This only happens when building an npm package