### PR TITLE
LWM2M: Add SOL_LWM2M_RESOURCE_INT_INIT() macro.

### DIFF
--- a/src/lib/comms/include/sol-lwm2m.h
+++ b/src/lib/comms/include/sol-lwm2m.h
@@ -27,6 +27,7 @@
 #include "sol-str-slice.h"
 #include "sol-vector.h"
 #include "sol-buffer.h"
+#include "sol-types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -361,6 +362,36 @@ struct sol_lwm2m_resource {
     do { \
         SOL_SET_API_VERSION((resource_)->api_version = SOL_LWM2M_RESOURCE_API_VERSION; ) \
         (ret_value_) = sol_lwm2m_resource_init((resource_), (id_), (resource_len_), (data_type_), __VA_ARGS__); \
+    } while (0)
+
+/**
+ * @brief A helper macro to init int resources.
+ *
+ * This macro will automatically cast the int value to an @c int64_t, thus avoiding
+ * some problems that may happen depending on the platform.
+ * The most common case to use this macro is when one wants to set a resource using
+ * a literal number.
+ * Example:
+ * @code
+ * //Some code...
+ * SOL_LWM2M_RESOUCE_INT_INIT(ret_value, &my_resource, resource_id, 10);
+ * return ret_value;
+ * //More code...
+ * @endcode
+ *
+ * @param ret_value_ The return value of sol_lwm2m_resource_init()
+ * @param resource_ The resource to be initialized.
+ * @param id_ The resource id.
+ * @param value_ The int value
+ * @see SOL_LWM2M_RESOURCE_INIT()
+ * @see sol_lwm2m_resource_init()
+ * @see SOL_TYPE_CHECK()
+ * @note This can be safely used for @ref SOL_LWM2M_RESOURCE_DATA_TYPE_TIME
+ */
+#define SOL_LWM2M_RESOURCE_INT_INIT(ret_value_, resource_, id_, value_) \
+    do { \
+        SOL_SET_API_VERSION((resource_)->api_version = SOL_LWM2M_RESOURCE_API_VERSION; ) \
+        (ret_value_) = sol_lwm2m_resource_init((resource_), (id_), 1, SOL_LWM2M_RESOURCE_DATA_TYPE_INT, SOL_TYPE_CHECK(int64_t, (value_))); \
     } while (0)
 
 /** @brief A LWM2M object implementation.

--- a/src/samples/coap/lwm2m-client.c
+++ b/src/samples/coap/lwm2m-client.c
@@ -270,8 +270,7 @@ read_security_server_obj(void *instance_data, void *user_data,
             SOL_LWM2M_RESOURCE_DATA_TYPE_BOOLEAN, false);
         break;
     case SECURITY_SERVER_SERVER_ID_RES_ID:
-        SOL_LWM2M_RESOURCE_INIT(r, res, 10, 1,
-            SOL_LWM2M_RESOURCE_DATA_TYPE_INT, 101);
+        SOL_LWM2M_RESOURCE_INT_INIT(r, res, 10, 101);
         break;
     default:
         if (res_id >= 2 && res_id <= 11)
@@ -293,12 +292,10 @@ read_server_obj(void *instance_data, void *user_data,
     //It implements only the necassary info to connect to a LWM2M server Without encryption.
     switch (res_id) {
     case SERVER_OBJ_SHORT_RES_ID:
-        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
-            SOL_LWM2M_RESOURCE_DATA_TYPE_INT, 101);
+        SOL_LWM2M_RESOURCE_INT_INIT(r, res, res_id, 101);
         break;
     case SERVER_OBJ_LIFETIME_RES_ID:
-        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
-            SOL_LWM2M_RESOURCE_DATA_TYPE_INT, LIFETIME);
+        SOL_LWM2M_RESOURCE_INT_INIT(r, res, res_id, LIFETIME);
         break;
     case SERVER_OBJ_BINDING_RES_ID:
         SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,

--- a/src/test/test-lwm2m.c
+++ b/src/test/test-lwm2m.c
@@ -95,8 +95,7 @@ security_object_read(void *instance_data, void *user_data,
             SOL_LWM2M_RESOURCE_DATA_TYPE_BOOLEAN, false);
         break;
     case SECURITY_SERVER_ID:
-        SOL_LWM2M_RESOURCE_INIT(r, res, 10, 1,
-            SOL_LWM2M_RESOURCE_DATA_TYPE_INT, 101);
+        SOL_LWM2M_RESOURCE_INT_INIT(r, res, 10, 101);
         break;
     default:
         r = -EINVAL;
@@ -114,12 +113,10 @@ server_object_read(void *instance_data, void *user_data,
 
     switch (res_id) {
     case SERVER_OBJECT_SERVER_ID:
-        SOL_LWM2M_RESOURCE_INIT(r, res, 0, 1,
-            SOL_LWM2M_RESOURCE_DATA_TYPE_INT, 101);
+        SOL_LWM2M_RESOURCE_INT_INIT(r, res, 0, 101);
         break;
     case SERVER_OBJECT_LIFETIME:
-        SOL_LWM2M_RESOURCE_INIT(r, res, 1, 1,
-            SOL_LWM2M_RESOURCE_DATA_TYPE_INT, LIFETIME);
+        SOL_LWM2M_RESOURCE_INT_INIT(r, res, 1, LIFETIME);
         break;
     case SERVER_OBJECT_BINDING:
         SOL_LWM2M_RESOURCE_INIT(r, res, 7, 1,
@@ -298,8 +295,7 @@ read_dummy_resource(void *instance_data, void *user_data,
             sol_str_slice_from_str(ctx->opaque));
         break;
     case DUMMY_OBJECT_INT_ID:
-        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
-            SOL_LWM2M_RESOURCE_DATA_TYPE_INT, ctx->i);
+        SOL_LWM2M_RESOURCE_INT_INIT(r, res, res_id, ctx->i);
         break;
     case DUMMY_OBJECT_BOOLEAN_FALSE_ID:
         SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
@@ -427,9 +423,7 @@ read_cb(void *data,
 
     check_tlv_and_save(&tlvs, NULL);
 
-    SOL_LWM2M_RESOURCE_INIT(r, &res, DUMMY_OBJECT_INT_ID, 1,
-        SOL_LWM2M_RESOURCE_DATA_TYPE_INT,
-        (int64_t)INT_REPLACE_VALUE);
+    SOL_LWM2M_RESOURCE_INT_INIT(r, &res, DUMMY_OBJECT_INT_ID, INT_REPLACE_VALUE);
     ASSERT(r == 0);
     r = sol_lwm2m_server_write(server, client, "/999/0/2",
         &res, 1, write_cb, NULL);
@@ -509,8 +503,7 @@ create_obj(struct sol_lwm2m_server *server, struct sol_lwm2m_client_info *cinfo)
         SOL_LWM2M_RESOURCE_DATA_TYPE_OPAQUE,
         sol_str_slice_from_str(OPAQUE_STR));
     ASSERT(r == 0);
-    SOL_LWM2M_RESOURCE_INIT(r, &res[2], DUMMY_OBJECT_INT_ID, 1,
-        SOL_LWM2M_RESOURCE_DATA_TYPE_INT, (int64_t)INT_VALUE);
+    SOL_LWM2M_RESOURCE_INT_INIT(r, &res[2], DUMMY_OBJECT_INT_ID, INT_VALUE);
     ASSERT(r == 0);
     SOL_LWM2M_RESOURCE_INIT(r, &res[3], DUMMY_OBJECT_BOOLEAN_FALSE_ID, 1,
         SOL_LWM2M_RESOURCE_DATA_TYPE_BOOLEAN, false);


### PR DESCRIPTION
This macro will prevent some problems that might occur when
reading the int value with va_args in some platform.
The macro will automatically cast the value to int64_t.

Signed-off-by: Guilherme Iscaro <guilherme.iscaro@intel.com>