### PR TITLE
Iio create sync v2

### DIFF
--- a/src/lib/io/include/sol-iio.h
+++ b/src/lib/io/include/sol-iio.h
@@ -151,7 +151,7 @@ bool sol_iio_device_start_buffer(struct sol_iio_device *device);
  * This function provides a way of addressing an IIO device to get its IIO
  * id from a series of space separated @a commands. Commands are processed
  * from left to right and processing stops on first command that worked.
- * A provided callback will be called with IIO device id or -1 if no command
+ * IIO device id will be returned, or a negative number if no command
  * resolved to an IIO device.
  *
  * There are essentially five commands. It can be an absolute path
@@ -171,19 +171,14 @@ bool sol_iio_device_start_buffer(struct sol_iio_device *device);
  * @arg @a devnumber is device number on bus, like 0xA4
  * @arg @a devname is device name, the one recognized by its driver
  *
- * If device already exists, will just return its IIO id on @a cb.
+ * If device already exists, will just return its IIO id.
  *
  * @param commands space separated commands on format specified above. e.g. <tt>
  * l3g4200d create,i2c,platform/80860F41:05,0x69,l3g4200d </tt>
- * @param cb callback to be called after device resolution. It contains IIO
- * device id, or -1 if unsuccessful
- * @param data user data to be passed to callback
  *
- * @return @a true if attempt to resolve device was successful, @a false
- * othewise. Note that to really know if device was resolved, besides return,
- * one needs to check callback device_id.
+ * @return IIO device id on success. A negative number means failure.
  */
-bool sol_iio_address_device(const char *commands, void (*cb)(void *data, int device_id), const void *data);
+int sol_iio_address_device(const char *commands);
 
 /**
  * @brief Returns raw buffer with channel sample.

--- a/src/lib/io/sol-iio.c
+++ b/src/lib/io/sol-iio.c
@@ -82,18 +82,8 @@ struct resolve_name_path_data {
     int id;
 };
 
-struct create_and_resolve_path_data {
-    struct sol_str_slice slice;
-    struct sol_vector commands;
-    struct sol_buffer path;
-    char *addresses;
-    void (*cb)(void *data, int device_id);
-    const void *data;
-    int command_index;
-};
-
 struct resolve_absolute_path_data {
-    char *path;
+    const char *path;
     int id;
 };
 
@@ -132,8 +122,6 @@ struct resolve_absolute_path_data {
 #define REL_PATH_IDX 2
 #define DEV_NUMBER_IDX 3
 #define DEV_NAME_IDX 4
-
-static bool create_or_resolve_device_address_dispatch(void *data);
 
 SOL_ATTR_PRINTF(3, 4)
 static bool
@@ -349,14 +337,14 @@ set_buffer_size(struct sol_iio_device *device, int buffer_size)
     char path[PATH_MAX];
     int r;
 
-    if (craft_filename_path(path, sizeof(path), BUFFER_LENGHT_DEVICE_PATH, device->device_id)) {
+    if (!craft_filename_path(path, sizeof(path), BUFFER_LENGHT_DEVICE_PATH, device->device_id)) {
         SOL_WRN("Could not set IIO device buffer size");
         return;
     }
 
     if ((r = sol_util_write_file(path, "%d", buffer_size)) < 0) {
         SOL_WRN("Could not set IIO device buffer size to %d at '%s': %s",
-            buffer_size, path, sol_util_strerrora(r));
+            buffer_size, path, sol_util_strerrora(-r));
     }
 
     return;
@@ -1216,10 +1204,22 @@ resolve_absolute_path(const char *address)
 {
     char real_path[PATH_MAX];
     struct resolve_absolute_path_data result = { .id = -1 };
+    struct timespec start = sol_util_timespec_get_current();
 
-    if (realpath(address, real_path)) {
-        result.path = real_path;
-        sol_util_iterate_dir(SYSFS_DEVICES_PATH, resolve_absolute_path_cb, &result);
+    /* Wait up to one second for the file to exist. Useful if we created
+     * via i2c */
+    while (result.id == -1) {
+        struct timespec elapsed, now;
+
+        if (realpath(address, real_path)) {
+            result.path = address;
+            sol_util_iterate_dir(SYSFS_DEVICES_PATH, resolve_absolute_path_cb, &result);
+        }
+
+        now = sol_util_timespec_get_current();
+        sol_util_timespec_sub(&now, &start, &elapsed);
+        if (elapsed.tv_sec > 0)
+            break;
     }
 
     return result.id;
@@ -1286,41 +1286,12 @@ resolve_device_address(const char *address)
     return resolve_name_path(address);
 }
 
-static void
-create_and_resolver_data_del(struct create_and_resolve_path_data *data)
+static char *
+create_device_address(struct sol_str_slice *command)
 {
-    sol_vector_clear(&data->commands);
-    sol_buffer_fini(&data->path);
-    free(data->addresses);
-    free(data);
-}
-
-/* This ifdef is here to avoid warnings by not having I2C support.
- * It'll probably be extended for other supported hardware */
-#ifdef USE_I2C
-static bool
-create_and_resolve_path_timeout_cb(void *data)
-{
-    struct create_and_resolve_path_data *dispatcher_data = data;
-    int r;
-
-    r = resolve_absolute_path((char *)dispatcher_data->path.data);
-    if (r > -1) {
-        dispatcher_data->cb((void *)dispatcher_data->data, r);
-        create_and_resolver_data_del(dispatcher_data);
-    } else
-        create_or_resolve_device_address_dispatch(dispatcher_data);
-
-    return false;
-}
-#endif
-
-static bool
-create_device_address(struct sol_str_slice *command, struct create_and_resolve_path_data *dispatcher_data)
-{
-    char *rel_path = NULL, *dev_number_s = NULL, *dev_name = NULL;
-    bool ret = false;
+    char *rel_path = NULL, *dev_number_s = NULL, *dev_name = NULL, *result = NULL;
     struct sol_vector instructions = SOL_VECTOR_INIT(struct sol_str_slice);
+    struct sol_buffer path = SOL_BUFFER_INIT_EMPTY;
 
     if (strstartswith(command->data, "create,i2c,")) {
 #ifndef USE_I2C
@@ -1356,17 +1327,10 @@ create_device_address(struct sol_str_slice *command, struct create_and_resolve_p
             *(const struct sol_str_slice *)sol_vector_get(&instructions, DEV_NAME_IDX));
         SOL_NULL_CHECK_GOTO(dev_name, end);
 
-        r = sol_i2c_create_device(rel_path, dev_name, dev_number,
-            &dispatcher_data->path);
+        r = sol_i2c_create_device(rel_path, dev_name, dev_number, &path);
 
-        if (r >= 0 || r == -EEXIST) {
-            /* Giving some time to sysfs update. Maybe listen for udev events? */
-            if (sol_timeout_add(1000, create_and_resolve_path_timeout_cb, dispatcher_data)) {
-                ret = true;
-            }
-        } else {
-            goto end;
-        }
+        if (r >= 0 || r == -EEXIST)
+            result = sol_buffer_steal(&path, NULL);
 #endif
     }
 
@@ -1375,73 +1339,50 @@ end:
     free(dev_number_s);
     free(dev_name);
     sol_vector_clear(&instructions);
+    sol_buffer_fini(&path);
 
-    return ret;
+    return result;
 }
 
-static bool
-create_or_resolve_device_address_dispatch(void *data)
+SOL_API int
+sol_iio_address_device(const char *commands)
 {
-    struct create_and_resolve_path_data *dispatcher_data = data;
+    struct sol_vector commands_vector;
     struct sol_str_slice *command;
-    int r = -1;
+    char *command_s;
+    int r = -1, command_index = 0;
+
+    SOL_NULL_CHECK(commands, -EINVAL);
+
+    commands_vector = sol_str_slice_split(sol_str_slice_from_str(commands), " ", 0);
 
     do {
-        command = sol_vector_get(&dispatcher_data->commands, dispatcher_data->command_index++);
+        command = sol_vector_get(&commands_vector, command_index++);
         if (!command) {
             SOL_WRN("Could not create or resolve device address using any of commands");
-            dispatcher_data->cb((void *)dispatcher_data->data, -1);
-            create_and_resolver_data_del(dispatcher_data);
 
-            return false;
+            r = -EINVAL;
+            goto end;
         }
 
         SOL_DBG("IIO device creation/resolving dispatching command: %.*s",
             SOL_STR_SLICE_PRINT(*command));
 
-        if (strstartswith(command->data, "create,")) {
-            if (create_device_address(command, dispatcher_data)) {
-                /* As this is an async call, lets wait it's answer */
-                return false;
-            }
-        } else {
-            char *command_s = sol_str_slice_to_string(*command);
-            if (command_s) {
-                r = resolve_device_address(command_s);
-                if (r > -1) {
-                    dispatcher_data->cb((void *)dispatcher_data->data, r);
-                    create_and_resolver_data_del(dispatcher_data);
-                }
-                free(command_s);
-            }
+        if (strstartswith(command->data, "create,"))
+            command_s = create_device_address(command);
+        else
+            command_s = sol_str_slice_to_string(*command);
+
+        if (command_s) {
+            r = resolve_device_address(command_s);
+            free(command_s);
         }
     } while (r < 0);
 
-    return false;
-}
+end:
+    sol_vector_clear(&commands_vector);
 
-SOL_API bool
-sol_iio_address_device(const char *commands, void (*cb)(void *data, int device_id), const void *data)
-{
-    struct create_and_resolve_path_data *dispatcher_data;
-
-    SOL_NULL_CHECK(commands, false);
-    SOL_NULL_CHECK(cb, false);
-
-    dispatcher_data = calloc(1, sizeof(struct create_and_resolve_path_data));
-    SOL_NULL_CHECK(dispatcher_data, false);
-
-    sol_buffer_init(&dispatcher_data->path);
-    dispatcher_data->cb = cb;
-    dispatcher_data->data = data;
-
-    dispatcher_data->addresses = strdup(commands);
-    dispatcher_data->slice = sol_str_slice_from_str(dispatcher_data->addresses);
-    dispatcher_data->commands = sol_str_slice_split(dispatcher_data->slice, " ", 0);
-
-    sol_idle_add(create_or_resolve_device_address_dispatch, dispatcher_data);
-
-    return true;
+    return r;
 }
 
 SOL_API struct sol_str_slice

--- a/src/lib/io/sol-memmap-storage.c
+++ b/src/lib/io/sol-memmap-storage.c
@@ -607,6 +607,7 @@ resolve_i2c_path(const char *path, char **resolved_path)
         /* Let's wait up to one second */
         if (!sol_util_busy_wait_file(*resolved_path, SOL_NSEC_PER_SEC)) {
             ret = -ENODEV;
+            free(*resolved_path);
             goto end;
         }
     }
@@ -687,6 +688,7 @@ sol_memmap_remove_map(const struct sol_memmap_map *map)
                 sol_timeout_del(map_internal->timeout);
                 perform_pending_writes(map_internal);
             }
+            free(map_internal->resolved_path);
             return sol_vector_del(&memory_maps, i);
         }
     }

--- a/src/modules/flow/iio/nodes.c
+++ b/src/modules/flow/iio/nodes.c
@@ -70,14 +70,13 @@ error:
     SOL_WRN("%s", errmsg);
 }
 
-static void
-create_device_cb(void *data, int device_id)
+static bool
+create_device_channels(struct gyroscope_data *mdata, int device_id)
 {
-    struct gyroscope_data *mdata = data;
     struct sol_iio_channel_config channel_config = SOL_IIO_CHANNEL_CONFIG_INIT;
 
     mdata->device = sol_iio_open(device_id, &mdata->config);
-    SOL_NULL_CHECK(mdata->device);
+    SOL_NULL_CHECK(mdata->device, false);
 
 #define ADD_CHANNEL(_axis) \
     if (!mdata->use_device_default_scale) \
@@ -95,12 +94,13 @@ create_device_cb(void *data, int device_id)
 
     sol_iio_device_start_buffer(mdata->device);
 
-    return;
+    return true;
 
 error:
     SOL_WRN("Could not create iio/gyroscope node. Failed to open IIO device %d",
         device_id);
     sol_iio_close(mdata->device);
+    return false;
 }
 
 static int
@@ -108,6 +108,7 @@ gyroscope_open(struct sol_flow_node *node, void *data, const struct sol_flow_nod
 {
     struct gyroscope_data *mdata = data;
     const struct sol_flow_node_type_iio_gyroscope_options *opts;
+    int device_id;
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_IIO_GYROSCOPE_OPTIONS_API_VERSION,
         -EINVAL);
@@ -135,11 +136,15 @@ gyroscope_open(struct sol_flow_node *node, void *data, const struct sol_flow_nod
     mdata->offset = opts->offset;
     mdata->out_range = opts->out_range;
 
-    if (!sol_iio_address_device(opts->iio_device, create_device_cb, mdata)) {
+    device_id = sol_iio_address_device(opts->iio_device);
+    if (device_id < 0) {
         SOL_WRN("Could not create iio/gyroscope node. Failed to open IIO device %s",
             opts->iio_device);
         goto err;
     }
+
+    if (!create_device_channels(mdata, device_id))
+        goto err;
 
     return 0;
 
@@ -225,14 +230,13 @@ error:
     SOL_WRN("%s", errmsg);
 }
 
-static void
-magnet_create_device_cb(void *data, int device_id)
+static bool
+magnet_create_channels(struct magnet_data *mdata, int device_id)
 {
-    struct magnet_data *mdata = data;
     struct sol_iio_channel_config channel_config = SOL_IIO_CHANNEL_CONFIG_INIT;
 
     mdata->device = sol_iio_open(device_id, &mdata->config);
-    SOL_NULL_CHECK(mdata->device);
+    SOL_NULL_CHECK(mdata->device, false);
 
 #define ADD_CHANNEL(_axis) \
     if (!mdata->use_device_default_scale) \
@@ -250,12 +254,13 @@ magnet_create_device_cb(void *data, int device_id)
 
     sol_iio_device_start_buffer(mdata->device);
 
-    return;
+    return true;
 
 error:
     SOL_WRN("Could not create iio/magnet node. Failed to open IIO device %d",
         device_id);
     sol_iio_close(mdata->device);
+    return false;
 }
 
 static int
@@ -263,6 +268,7 @@ magnet_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_o
 {
     struct magnet_data *mdata = data;
     const struct sol_flow_node_type_iio_magnet_options *opts;
+    int device_id;
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_IIO_MAGNET_OPTIONS_API_VERSION,
         -EINVAL);
@@ -289,11 +295,15 @@ magnet_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_o
     mdata->offset = opts->offset;
     mdata->out_range = opts->out_range;
 
-    if (!sol_iio_address_device(opts->iio_device, magnet_create_device_cb, mdata)) {
+    device_id = sol_iio_address_device(opts->iio_device);
+    if (device_id < 0) {
         SOL_WRN("Could not create iio/magnet node. Failed to open IIO device %s",
             opts->iio_device);
         goto err;
     }
+
+    if (!magnet_create_channels(mdata, device_id))
+        goto err;
 
     return 0;
 
@@ -372,14 +382,13 @@ error:
     SOL_WRN("%s", errmsg);
 }
 
-static void
-temp_create_device_cb(void *data, int device_id)
+static bool
+temp_create_channels(struct temperature_data *mdata, int device_id)
 {
-    struct temperature_data *mdata = data;
     struct sol_iio_channel_config channel_config = SOL_IIO_CHANNEL_CONFIG_INIT;
 
     mdata->device = sol_iio_open(device_id, &mdata->config);
-    SOL_NULL_CHECK(mdata->device);
+    SOL_NULL_CHECK(mdata->device, false);
 
 #define ADD_CHANNEL(_val) \
     if (!mdata->use_device_default_scale) \
@@ -395,13 +404,14 @@ temp_create_device_cb(void *data, int device_id)
 
     sol_iio_device_start_buffer(mdata->device);
 
-    return;
+    return true;
 
 error:
     SOL_WRN("Could not create iio/temperature node. Failed to open IIO device %d",
         device_id);
 
     sol_iio_close(mdata->device);
+    return false;
 }
 
 static int
@@ -409,6 +419,7 @@ temperature_open(struct sol_flow_node *node, void *data, const struct sol_flow_n
 {
     struct temperature_data *mdata = data;
     const struct sol_flow_node_type_iio_temperature_options *opts;
+    int device_id;
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_IIO_TEMPERATURE_OPTIONS_API_VERSION,
         -EINVAL);
@@ -435,11 +446,15 @@ temperature_open(struct sol_flow_node *node, void *data, const struct sol_flow_n
     mdata->offset = opts->offset;
     mdata->out_range = opts->out_range;
 
-    if (!sol_iio_address_device(opts->iio_device, temp_create_device_cb, mdata)) {
+    device_id = sol_iio_address_device(opts->iio_device);
+    if (device_id < 0) {
         SOL_WRN("Could not create iio/temperature node. Failed to open IIO device %s",
             opts->iio_device);
         goto err;
     }
+
+    if (!temp_create_channels(mdata, device_id))
+        goto err;
 
     return 0;
 
@@ -519,14 +534,13 @@ error:
     SOL_WRN("%s", errmsg);
 }
 
-static void
-pressure_create_device_cb(void *data, int device_id)
+static bool
+pressure_create_channels(struct pressure_data *mdata, int device_id)
 {
-    struct pressure_data *mdata = data;
     struct sol_iio_channel_config channel_config = SOL_IIO_CHANNEL_CONFIG_INIT;
 
     mdata->device = sol_iio_open(device_id, &mdata->config);
-    SOL_NULL_CHECK(mdata->device);
+    SOL_NULL_CHECK(mdata->device, false);
 
 #define ADD_CHANNEL(_val) \
     if (!mdata->use_device_default_scale) \
@@ -542,13 +556,14 @@ pressure_create_device_cb(void *data, int device_id)
 
     sol_iio_device_start_buffer(mdata->device);
 
-    return;
+    return true;
 
 error:
     SOL_WRN("Could not create iio/pressure node. Failed to open IIO device %d",
         device_id);
 
     sol_iio_close(mdata->device);
+    return false;
 }
 
 static int
@@ -556,6 +571,7 @@ pressure_open(struct sol_flow_node *node, void *data, const struct sol_flow_node
 {
     struct pressure_data *mdata = data;
     const struct sol_flow_node_type_iio_pressure_options *opts;
+    int device_id;
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_IIO_PRESSURE_OPTIONS_API_VERSION,
         -EINVAL);
@@ -582,11 +598,15 @@ pressure_open(struct sol_flow_node *node, void *data, const struct sol_flow_node
     mdata->offset = opts->offset;
     mdata->out_range = opts->out_range;
 
-    if (!sol_iio_address_device(opts->iio_device, pressure_create_device_cb, mdata)) {
+    device_id = sol_iio_address_device(opts->iio_device);
+    if (device_id < 0) {
         SOL_WRN("Could not create iio/pressure node. Failed to open IIO device %s",
             opts->iio_device);
         goto err;
     }
+
+    if (!pressure_create_channels(mdata, device_id))
+        goto err;
 
     return 0;
 
@@ -678,14 +698,13 @@ error:
     SOL_WRN("%s", errmsg);
 }
 
-static void
-color_create_device_cb(void *data, int device_id)
+static bool
+color_create_channels(struct color_data *mdata, int device_id)
 {
-    struct color_data *mdata = data;
     struct sol_iio_channel_config channel_config = SOL_IIO_CHANNEL_CONFIG_INIT;
 
     mdata->device = sol_iio_open(device_id, &mdata->config);
-    SOL_NULL_CHECK(mdata->device);
+    SOL_NULL_CHECK(mdata->device, false);
 
 #define ADD_CHANNEL(_axis) \
     if (!mdata->use_device_default_scale) \
@@ -703,12 +722,13 @@ color_create_device_cb(void *data, int device_id)
 
     sol_iio_device_start_buffer(mdata->device);
 
-    return;
+    return true;
 
 error:
     SOL_WRN("Could not create iio/color node. Failed to open IIO device %d",
         device_id);
     sol_iio_close(mdata->device);
+    return false;
 }
 
 static int
@@ -716,6 +736,7 @@ color_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_op
 {
     struct color_data *mdata = data;
     const struct sol_flow_node_type_iio_color_options *opts;
+    int device_id;
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_IIO_COLOR_OPTIONS_API_VERSION,
         -EINVAL);
@@ -742,11 +763,15 @@ color_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_op
     mdata->offset = opts->offset;
     mdata->out_range = opts->out_range;
 
-    if (!sol_iio_address_device(opts->iio_device, color_create_device_cb, mdata)) {
+    device_id = sol_iio_address_device(opts->iio_device);
+    if (device_id < 0) {
         SOL_WRN("Could not create iio/color node. Failed to open IIO device %s",
             opts->iio_device);
         goto err;
     }
+
+    if (!color_create_channels(mdata, device_id))
+        goto err;
 
     return 0;
 
@@ -832,14 +857,13 @@ error:
     SOL_WRN("%s", errmsg);
 }
 
-static void
-accelerate_create_device_cb(void *data, int device_id)
+static bool
+accelerate_create_channels(struct accelerate_data *mdata, int device_id)
 {
-    struct accelerate_data *mdata = data;
     struct sol_iio_channel_config channel_config = SOL_IIO_CHANNEL_CONFIG_INIT;
 
     mdata->device = sol_iio_open(device_id, &mdata->config);
-    SOL_NULL_CHECK(mdata->device);
+    SOL_NULL_CHECK(mdata->device, false);
 
 #define ADD_CHANNEL(_axis) \
     if (!mdata->use_device_default_scale) \
@@ -857,12 +881,13 @@ accelerate_create_device_cb(void *data, int device_id)
 
     sol_iio_device_start_buffer(mdata->device);
 
-    return;
+    return true;
 
 error:
     SOL_WRN("Could not create iio/accelerate node. Failed to open IIO device %d",
         device_id);
     sol_iio_close(mdata->device);
+    return false;
 }
 
 static int
@@ -870,6 +895,7 @@ accelerate_open(struct sol_flow_node *node, void *data, const struct sol_flow_no
 {
     struct accelerate_data *mdata = data;
     const struct sol_flow_node_type_iio_accelerate_options *opts;
+    int device_id;
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_IIO_ACCELERATE_OPTIONS_API_VERSION,
         -EINVAL);
@@ -896,11 +922,15 @@ accelerate_open(struct sol_flow_node *node, void *data, const struct sol_flow_no
     mdata->offset = opts->offset;
     mdata->out_range = opts->out_range;
 
-    if (!sol_iio_address_device(opts->iio_device, accelerate_create_device_cb, mdata)) {
+    device_id = sol_iio_address_device(opts->iio_device);
+    if (device_id < 0) {
         SOL_WRN("Could not create iio/accelerate node. Failed to open IIO device %s",
             opts->iio_device);
         goto err;
     }
+
+    if (!accelerate_create_channels(mdata, device_id))
+        goto err;
 
     return 0;
 
@@ -979,14 +1009,13 @@ error:
     SOL_WRN("%s", errmsg);
 }
 
-static void
-humidity_create_device_cb(void *data, int device_id)
+static bool
+humidity_create_channels(struct humidity_data *mdata, int device_id)
 {
-    struct humidity_data *mdata = data;
     struct sol_iio_channel_config channel_config = SOL_IIO_CHANNEL_CONFIG_INIT;
 
     mdata->device = sol_iio_open(device_id, &mdata->config);
-    SOL_NULL_CHECK(mdata->device);
+    SOL_NULL_CHECK(mdata->device, false);
 
 #define ADD_CHANNEL(_val) \
     if (!mdata->use_device_default_scale) \
@@ -1002,13 +1031,14 @@ humidity_create_device_cb(void *data, int device_id)
 
     sol_iio_device_start_buffer(mdata->device);
 
-    return;
+    return true;
 
 error:
     SOL_WRN("Could not create iio/humidity node. Failed to open IIO device %d",
         device_id);
 
     sol_iio_close(mdata->device);
+    return false;
 }
 
 static int
@@ -1016,6 +1046,7 @@ humidity_open(struct sol_flow_node *node, void *data, const struct sol_flow_node
 {
     struct humidity_data *mdata = data;
     const struct sol_flow_node_type_iio_humidity_options *opts;
+    int device_id;
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_IIO_HUMIDITY_OPTIONS_API_VERSION,
         -EINVAL);
@@ -1042,11 +1073,15 @@ humidity_open(struct sol_flow_node *node, void *data, const struct sol_flow_node
     mdata->offset = opts->offset;
     mdata->out_range = opts->out_range;
 
-    if (!sol_iio_address_device(opts->iio_device, humidity_create_device_cb, mdata)) {
+    device_id = sol_iio_address_device(opts->iio_device);
+    if (device_id < 0) {
         SOL_WRN("Could not create iio/humidity node. Failed to open IIO device %s",
             opts->iio_device);
         goto err;
     }
+
+    if (!humidity_create_channels(mdata, device_id))
+        goto err;
 
     return 0;
 
@@ -1126,14 +1161,13 @@ error:
     SOL_WRN("%s", errmsg);
 }
 
-static void
-adc_create_device_cb(void *data, int device_id)
+static bool
+adc_create_channels(struct adc_data *mdata, int device_id)
 {
-    struct adc_data *mdata = data;
     struct sol_iio_channel_config channel_config = SOL_IIO_CHANNEL_CONFIG_INIT;
 
     mdata->device = sol_iio_open(device_id, &mdata->config);
-    SOL_NULL_CHECK(mdata->device);
+    SOL_NULL_CHECK(mdata->device, false);
 
 #define ADD_CHANNEL(_val) \
     if (!mdata->use_device_default_scale) \
@@ -1149,13 +1183,14 @@ adc_create_device_cb(void *data, int device_id)
 
     sol_iio_device_start_buffer(mdata->device);
 
-    return;
+    return true;
 
 error:
     SOL_WRN("Could not create iio/adc node. Failed to open IIO device %d",
         device_id);
 
     sol_iio_close(mdata->device);
+    return false;
 }
 
 static int
@@ -1163,6 +1198,7 @@ adc_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_opti
 {
     struct adc_data *mdata = data;
     const struct sol_flow_node_type_iio_adc_options *opts;
+    int device_id;
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_IIO_ADC_OPTIONS_API_VERSION,
         -EINVAL);
@@ -1189,11 +1225,15 @@ adc_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_opti
     mdata->offset = opts->offset;
     mdata->out_range = opts->out_range;
 
-    if (!sol_iio_address_device(opts->iio_device, adc_create_device_cb, mdata)) {
+    device_id = sol_iio_address_device(opts->iio_device);
+    if (device_id < 0) {
         SOL_WRN("Could not create iio/adc node. Failed to open IIO device %s",
             opts->iio_device);
         goto err;
     }
+
+    if (!adc_create_channels(mdata, device_id))
+        goto err;
 
     return 0;
 
@@ -1273,14 +1313,13 @@ error:
     SOL_WRN("%s", errmsg);
 }
 
-static void
-light_create_device_cb(void *data, int device_id)
+static bool
+light_create_channels(struct light_data *mdata, int device_id)
 {
-    struct light_data *mdata = data;
     struct sol_iio_channel_config channel_config = SOL_IIO_CHANNEL_CONFIG_INIT;
 
     mdata->device = sol_iio_open(device_id, &mdata->config);
-    SOL_NULL_CHECK(mdata->device);
+    SOL_NULL_CHECK(mdata->device, false);
 
 #define ADD_CHANNEL(_val) \
     if (!mdata->use_device_default_scale) \
@@ -1298,13 +1337,14 @@ light_create_device_cb(void *data, int device_id)
 
     sol_iio_device_start_buffer(mdata->device);
 
-    return;
+    return true;
 
 error:
     SOL_WRN("Could not create iio/light node. Failed to open IIO device %d",
         device_id);
 
     sol_iio_close(mdata->device);
+    return false;
 }
 
 static int
@@ -1312,6 +1352,7 @@ light_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_op
 {
     struct light_data *mdata = data;
     const struct sol_flow_node_type_iio_light_options *opts;
+    int device_id;
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_IIO_LIGHT_OPTIONS_API_VERSION,
         -EINVAL);
@@ -1338,11 +1379,15 @@ light_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_op
     mdata->offset = opts->offset;
     mdata->out_range = opts->out_range;
 
-    if (!sol_iio_address_device(opts->iio_device, light_create_device_cb, mdata)) {
+    device_id = sol_iio_address_device(opts->iio_device);
+    if (device_id < 0) {
         SOL_WRN("Could not create iio/light node. Failed to open IIO device %s",
             opts->iio_device);
         goto err;
     }
+
+    if (!light_create_channels(mdata, device_id))
+        goto err;
 
     return 0;
 

--- a/src/shared/include/sol-util-file.h
+++ b/src/shared/include/sol-util-file.h
@@ -283,6 +283,24 @@ bool sol_util_iterate_dir(const char *path, bool (*iterate_dir_cb)(void *data, c
 int sol_util_move_file(const char *old_path, const char *new_path, mode_t mode);
 
 /**
+ * @brief Wait for some file to become available.
+ *
+ * When dealing with sysfs, it's really common to perform an action that
+ * will create new files on sysfs. This function helps those who need
+ * to wait for some of these files.
+ *
+ * @param path where to look for the file
+ * @param nanoseconds how much time to wait
+ *
+ * @return @c true if file come to existence before @a nanoseconds.
+ * @c false if wait ended after timeout
+ *
+ * @note This function blocks current thread on a busy wait. Use with
+ * caution.
+ */
+bool sol_util_busy_wait_file(const char *path, uint64_t nanoseconds);
+
+/**
  * @}
  */
 

--- a/src/shared/sol-util-file.c
+++ b/src/shared/sol-util-file.c
@@ -565,3 +565,21 @@ err_rename:
 
     return r;
 }
+
+SOL_API bool
+sol_util_busy_wait_file(const char *path, uint64_t nanoseconds)
+{
+    struct stat st;
+    struct timespec start = sol_util_timespec_get_current();
+
+    while (stat(path, &st)) {
+        struct timespec elapsed, now = sol_util_timespec_get_current();
+
+        sol_util_timespec_sub(&now, &start, &elapsed);
+        if ((uint64_t)elapsed.tv_sec >= (nanoseconds / SOL_NSEC_PER_SEC) &&
+            (uint64_t)elapsed.tv_nsec > (nanoseconds % SOL_NSEC_PER_SEC))
+            return false;
+    }
+
+    return true;
+}


### PR DESCRIPTION
v2:
v1 was flawed: it was busy waiting on a directory where a file was supposed to appear - and not on file itself. As we have no way to know what will be file name, we now keep scanning directory till file appears - up to one second. I was fooled into thinking it was working thanks to slowness caused by running Soletta with DBG log level =/
Thanks to this change, first patch - sol-util-file one - may be unnecessary. I'll leave it if no complains appears, as it's a cool patch.