### PR TITLE
SPI: Add enum-string mapping functions for sol_spi_mode

### DIFF
--- a/src/lib/io/Makefile
+++ b/src/lib/io/Makefile
@@ -60,11 +60,13 @@ obj-io-i2c-$(PLATFORM_LINUX) += \
 obj-io-i2c-$(PLATFORM_ZEPHYR) += \
     sol-i2c-impl-zephyr.o
 
-obj-io-spi-$(PLATFORM_RIOTOS) := \
+obj-io-spi-$(USE_SPI) := \
+    sol-spi-common.o
+obj-io-spi-$(PLATFORM_RIOTOS) += \
     sol-spi-impl-riot.o
-obj-io-spi-$(PLATFORM_LINUX) := \
+obj-io-spi-$(PLATFORM_LINUX) += \
     sol-spi-impl-linux.o
-obj-io-spi-$(PLATFORM_ZEPHYR) := \
+obj-io-spi-$(PLATFORM_ZEPHYR) += \
     sol-spi-impl-zephyr.o
 
 obj-io-uart-$(USE_UART) := \

--- a/src/lib/io/include/sol-spi.h
+++ b/src/lib/io/include/sol-spi.h
@@ -22,6 +22,7 @@
 #include <stdbool.h>
 
 #include <sol-common-buildopts.h>
+#include <sol-macros.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -80,6 +81,32 @@ struct sol_spi_config {
     uint32_t frequency; /** Clock frequency in Hz */
     uint8_t bits_per_word;
 };
+
+/**
+ * @brief Converts a string SPI mode name to sol_spi_mode
+ *
+ * This function converts a string SPI mode name to enumeration sol_spi_mode.
+ *
+ * @see sol_spi_mode_to_str().
+ *
+ * @param spi_mode Valid values are mode0", "mode1", "mode2", "mode3".
+ *
+ * @return enumeration sol_spi_mode
+ */
+enum sol_spi_mode sol_spi_mode_from_str(const char *spi_mode) SOL_ATTR_WARN_UNUSED_RESULT;
+
+/**
+ * @brief Converts sol_spi_mode to a string name.
+ *
+ * This function converts sol_spi_mode enumeration to a string SPI mode name.
+ *
+ * @see sol_spi_mode_from_str().
+ *
+ * @param spi_mode sol_spi_mode
+ *
+ * @return String representation of the sol_spi_mode
+ */
+const char *sol_spi_mode_to_str(enum sol_spi_mode spi_mode) SOL_ATTR_WARN_UNUSED_RESULT;
 
 /**
  * @brief Perform a SPI asynchronous transfer.

--- a/src/lib/io/sol-spi-common.c
+++ b/src/lib/io/sol-spi-common.c
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "sol-log-internal.h"
+#include "sol-str-table.h"
+#include "sol-spi.h"
+#include "sol-util.h"
+
+SOL_API enum sol_spi_mode
+sol_spi_mode_from_str(const char *spi_mode)
+{
+    static const struct sol_str_table table[] = {
+        SOL_STR_TABLE_ITEM("mode0", SOL_SPI_MODE_0),
+        SOL_STR_TABLE_ITEM("mode1", SOL_SPI_MODE_1),
+        SOL_STR_TABLE_ITEM("mode2", SOL_SPI_MODE_2),
+        SOL_STR_TABLE_ITEM("mode3", SOL_SPI_MODE_3),
+        { }
+    };
+
+    SOL_NULL_CHECK(spi_mode, SOL_SPI_MODE_0);
+
+    return sol_str_table_lookup_fallback(table,
+        sol_str_slice_from_str(spi_mode), SOL_SPI_MODE_0);
+}
+
+SOL_API const char *
+sol_spi_mode_to_str(enum sol_spi_mode spi_mode)
+{
+    static const char *spi_mode_names[] = {
+        [SOL_SPI_MODE_0] = "mode0",
+        [SOL_SPI_MODE_1] = "mode1",
+        [SOL_SPI_MODE_2] = "mode2",
+        [SOL_SPI_MODE_3] = "mode3"
+    };
+
+    if (spi_mode < SOL_UTIL_ARRAY_SIZE(spi_mode_names))
+        return spi_mode_names[spi_mode];
+
+    return NULL;
+}


### PR DESCRIPTION
This patch adds enum-string mapping functions for sol_spi_mode, so that these common functions can be used in the bindings for the conversion from string to enum and vice versa.

This replaces #1853

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>