### PR TITLE
lib/sol-iio: release buffer on sol_iio_close()

### DIFF
--- a/src/lib/io/sol-iio.c
+++ b/src/lib/io/sol-iio.c
@@ -873,6 +873,9 @@ sol_iio_close(struct sol_iio_device *device)
     }
     sol_ptr_vector_clear(&device->channels);
 
+    if ((device->buffer_enabled) && (!set_buffer_enabled(device, false)))
+        SOL_WRN("Could not disable buffer for device%d", device->device_id);
+
     if (device->fd_handler) sol_fd_del(device->fd_handler);
     if (device->fd > -1) close(device->fd);
     if (device->name_fd > -1) close(device->name_fd);


### PR DESCRIPTION
Otherwise after using a Soletta application the following
issue should happen when trying to access it:

root@edison:/sys/bus/iio/devices/iio:device1# cat *raw
cat: in_voltage0_raw: Device or resource busy
cat: in_voltage1_raw: Device or resource busy
cat: in_voltage2_raw: Device or resource busy

@edersondisouza could you please confirm that?
I didn't try to reproduce this issue (or fix), but
doing some code browsing the reason to stay busy
is thanks to buffer keep set as enabled.

Thanks