### PR TITLE
composed:http:client: Fix wrong check

### DIFF
--- a/src/modules/flow-metatype/http-composed-client/http-composed-client-code.h
+++ b/src/modules/flow-metatype/http-composed-client/http-composed-client-code.h
@@ -147,11 +147,6 @@
     "        return;\n" \
     "    }\n" \
     "    SOL_HTTP_RESPONSE_CHECK_API(response);\n" \
-    "    if (!response->content.used) {\n" \
-    "        sol_flow_send_error_packet(node, EINVAL,\n" \
-    "            \"Empty response from %s\", cdata->url);\n" \
-    "        return;\n" \
-    "    }\n" \
     "    if (response->response_code != SOL_HTTP_STATUS_OK) {\n" \
     "        sol_flow_send_error_packet(node, EINVAL,\n" \
     "            \"%s returned an unhandled response code: %d\",\n" \


### PR DESCRIPTION
The generated code was checking if the response content was empty.
This check is not valid because the case of a POST the response has no content.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>