### PR TITLE
Node.js bindings: Add bindings for GPIO enum-string translation functions

### DIFF
--- a/bindings/nodejs/lib/gpio.js
+++ b/bindings/nodejs/lib/gpio.js
@@ -27,25 +27,17 @@ exports.open = function( init ) {
         var config = null;
         var gpiopin;
         var callback_data = [];
-        var edge = "any";
+        var direction = init.direction ? init.direction : "out";
+        var edge = init.edge ? init.edge : "any";
+        var pull = init.pull ? init.pull : "none";
 
-        if ( init.pullup )
-            drive_mode = soletta.sol_gpio_drive.SOL_GPIO_DRIVE_PULL_UP;
-        else if ( init.pullup === false )
-            drive_mode = soletta.sol_gpio_drive.SOL_GPIO_DRIVE_PULL_DOWN;
-        else
-            drive_mode = soletta.sol_gpio_drive.SOL_GPIO_DRIVE_NONE;
-
-        if ( init.edge )
-            edge = init.edge;
-
-        if ( init.direction == "in" ) {
+        if ( direction == "in" ) {
             config = {
-                dir: soletta.sol_gpio_direction.SOL_GPIO_DIR_IN,
+                dir: soletta.sol_gpio_direction_from_str( direction ),
                 active_low: init.activeLow,
                 poll_timeout: init.poll,
-                drive_mode: drive_mode,
-                trigger_mode: edge,
+                drive_mode: soletta.sol_gpio_drive_from_str( pull ),
+                trigger_mode: soletta.sol_gpio_edge_from_str( edge ),
                 callback: function( value ) {
                     callback_data[0].dispatchEvent( "change", {
                         type: "change",
@@ -56,9 +48,9 @@ exports.open = function( init ) {
 
         } else {
             config = {
-                dir: soletta.sol_gpio_direction.SOL_GPIO_DIR_OUT,
+                dir: soletta.sol_gpio_direction_from_str( direction ),
                 active_low: init.activeLow,
-                drive_mode: drive_mode,
+                drive_mode: soletta.sol_gpio_drive_from_str( pull ),
             }
         }
 

--- a/bindings/nodejs/src/functions/gpio.cc
+++ b/bindings/nodejs/src/functions/gpio.cc
@@ -142,3 +142,72 @@ NAN_METHOD(bind_sol_gpio_read) {
     gpio = gpio_data->gpio;
     info.GetReturnValue().Set(Nan::New(sol_gpio_read(gpio)));
 }
+
+NAN_METHOD(bind_sol_gpio_direction_from_str) {
+    VALIDATE_ARGUMENT_COUNT(info, 1);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsString);
+
+    sol_gpio_direction direction = sol_gpio_direction_from_str(
+        (const char *)*String::Utf8Value(info[0]));
+    info.GetReturnValue().Set(Nan::New(direction));
+}
+
+NAN_METHOD(bind_sol_gpio_direction_to_str) {
+    VALIDATE_ARGUMENT_COUNT(info, 1);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsInt32);
+
+    const char *idString = sol_gpio_direction_to_str(
+        (sol_gpio_direction)info[0]->Int32Value());
+
+    if (idString) {
+        info.GetReturnValue().Set(Nan::New(idString).ToLocalChecked());
+    } else {
+        info.GetReturnValue().Set(Nan::Null());
+    }
+}
+
+NAN_METHOD(bind_sol_gpio_edge_from_str) {
+    VALIDATE_ARGUMENT_COUNT(info, 1);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsString);
+
+    sol_gpio_edge edge = sol_gpio_edge_from_str(
+        (const char *)*String::Utf8Value(info[0]));
+    info.GetReturnValue().Set(Nan::New(edge));
+}
+
+NAN_METHOD(bind_sol_gpio_edge_to_str) {
+    VALIDATE_ARGUMENT_COUNT(info, 1);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsInt32);
+
+    const char *idString = sol_gpio_edge_to_str(
+        (sol_gpio_edge)info[0]->Int32Value());
+
+    if (idString) {
+        info.GetReturnValue().Set(Nan::New(idString).ToLocalChecked());
+    } else {
+        info.GetReturnValue().Set(Nan::Null());
+    }
+}
+
+NAN_METHOD(bind_sol_gpio_drive_from_str) {
+    VALIDATE_ARGUMENT_COUNT(info, 1);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsString);
+
+    sol_gpio_drive drive = sol_gpio_drive_from_str(
+        (const char *)*String::Utf8Value(info[0]));
+    info.GetReturnValue().Set(Nan::New(drive));
+}
+
+NAN_METHOD(bind_sol_gpio_drive_to_str) {
+    VALIDATE_ARGUMENT_COUNT(info, 1);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsInt32);
+
+    const char *idString = sol_gpio_drive_to_str(
+        (sol_gpio_drive)info[0]->Int32Value());
+
+    if (idString) {
+        info.GetReturnValue().Set(Nan::New(idString).ToLocalChecked());
+    } else {
+        info.GetReturnValue().Set(Nan::Null());
+    }
+}

--- a/bindings/nodejs/src/structures/sol-js-gpio.cc
+++ b/bindings/nodejs/src/structures/sol-js-gpio.cc
@@ -26,17 +26,17 @@ bool c_sol_gpio_config(v8::Local<v8::Object> jsGPIOConfig,
     sol_gpio_data *gpio_data, sol_gpio_config *config) {
     SOL_SET_API_VERSION(config->api_version = SOL_GPIO_CONFIG_API_VERSION; )
 
-    VALIDATE_AND_ASSIGN((*config), dir, sol_gpio_direction, IsUint32,
-                        "(GPIO direction)", false, jsGPIOConfig,
-                        Uint32Value);
+    VALIDATE_AND_ASSIGN((*config), dir, sol_gpio_direction, IsInt32,
+        "(GPIO direction)", false, jsGPIOConfig,
+        Int32Value);
 
-    VALIDATE_AND_ASSIGN((*config), drive_mode, sol_gpio_drive, IsUint32,
-                        "(GPIO pull-up/pull-down resistor)", false, jsGPIOConfig,
-                        Uint32Value);
+    VALIDATE_AND_ASSIGN((*config), drive_mode, sol_gpio_drive, IsInt32,
+        "(GPIO pull-up/pull-down resistor)", false, jsGPIOConfig,
+        Int32Value);
 
     VALIDATE_AND_ASSIGN((*config), active_low, bool, IsBoolean,
-                        "(GPIO active_low state)", false, jsGPIOConfig,
-                        BooleanValue);
+        "(GPIO active_low state)", false, jsGPIOConfig,
+        BooleanValue);
 
     if (config->dir == SOL_GPIO_DIR_IN) {
         Local<Value> poll_timeout =
@@ -49,10 +49,9 @@ bool c_sol_gpio_config(v8::Local<v8::Object> jsGPIOConfig,
         Local<Value> trigger_mode =
             Nan::Get(jsGPIOConfig, Nan::New("trigger_mode").ToLocalChecked())
                 .ToLocalChecked();
-        VALIDATE_VALUE_TYPE(trigger_mode, IsString, "GPIO in trigger_mode",
+        VALIDATE_VALUE_TYPE(trigger_mode, IsInt32, "GPIO in trigger_mode",
             false);
-        config->in.trigger_mode = (sol_gpio_edge)sol_gpio_edge_from_str(
-            (const char *)*(String::Utf8Value(trigger_mode)));
+        config->in.trigger_mode = (sol_gpio_edge) trigger_mode->Int32Value();
 
         Local<Value> read_cb = Nan::Get(jsGPIOConfig,
             Nan::New("callback").ToLocalChecked()).ToLocalChecked();


### PR DESCRIPTION
This adds bindings for GPIO enum-string translation functions and use them in the highlevel JS bindings.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>