### PR TITLE
coap: fix coverity-pointed error

### DIFF
--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -775,7 +775,7 @@ on_can_write(void *data, struct sol_socket *s)
         sol_ptr_vector_get_len(&server->pending),
         outgoing->pkt->buf.used, outgoing->pkt->buf.capacity);
     sol_coap_packet_debug(outgoing->pkt);
-    if (err < 0) {
+    if (ret < 0) {
         uint16_t id;
         SOL_BUFFER_DECLARE_STATIC(addr, SOL_INET_ADDR_STRLEN);
 


### PR DESCRIPTION
CID 143930.

Since sol_socket_sendmsg()'s return type changed to ssize_t and it's
we're now storing its return value on ret var, fix the error check below
it.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>