### PR TITLE
grove-samples: Make it possible to use LED_PWM in gtk mode

### DIFF
--- a/src/samples/flow/grove-kit/sol-flow.json
+++ b/src/samples/flow/grove-kit/sol-flow.json
@@ -25,6 +25,16 @@
     "range": "0|400"
    },
    "type": "gtk/slider"
+  },
+  {
+   "name": "LED_PWM",
+   "options": {
+    "duty_cycle": 0,
+    "enabled": true,
+    "period": 2040816,
+    "pin": "6"
+   },
+   "type": "gtk/pwm-viewer"
   }
  ]
 }


### PR DESCRIPTION
Running fine samples grove-led-accumulator.fbp and
grove-led-wave-generator.fbp

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>