### PR TITLE
socket: Set errno error stating that method is not implemented

### DIFF
--- a/src/lib/comms/sol-socket.c
+++ b/src/lib/comms/sol-socket.c
@@ -51,6 +51,7 @@ sol_socket_ip_new(const struct sol_socket_options *options)
 #ifdef DTLS
         s = sol_socket_default_dtls_new(options);
 #else
+        errno = ENOSYS;
         SOL_WRN("DTLS is not enabled, secure socket is not possible");
         return NULL;
 #endif


### PR DESCRIPTION
In Oic server and client we need to know if secure server creation has
failed because it is not enabled or if an error occurred. If we have a
real error we need to abort server creation. If it is not supported, we
need to start an insecure server.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>