### PR TITLE
Memdesc

### DIFF
--- a/src/lib/common/sol-common-buildopts.h.in
+++ b/src/lib/common/sol-common-buildopts.h.in
@@ -33,6 +33,10 @@ st.on_value("NO_API_VERSION_NEEDED", "y", "#define SOL_NO_API_VERSION 1", "")
 }}
 
 {{
+st.on_value("MEMDESC_DESCRIPTION", "y", "#define SOL_MEMDESC_DESCRIPTION 1", "")
+}}
+
+{{
 st.on_value("MODULES", "y", "#define SOL_DYNAMIC_MODULES 1", "")
 }}
 

--- a/src/lib/common/sol-missing.h
+++ b/src/lib/common/sol-missing.h
@@ -155,6 +155,10 @@ err:
 #define SSIZE_MAX LONG_MAX
 #endif
 
+#ifndef SSIZE_MIN
+#define SSIZE_MIN LONG_MIN
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/datatypes/Kconfig
+++ b/src/lib/datatypes/Kconfig
@@ -1,0 +1,17 @@
+
+menu "Data Type Options"
+
+config MEMDESC_DESCRIPTION
+    bool "Include description text in sol_memdesc"
+    default n if RIOT || CONTIKI || ZEPHYR
+    default y
+    help
+            Enable description text in sol_memdesc.
+
+            The textual description is used to provide nicer
+            introspection when using memory descriptions, however it
+            will increase binary size due larger read-only text
+            strings, sometimes it's not desired on smaller systems
+            where disk footprint matters.
+
+endmenu

--- a/src/lib/datatypes/Makefile
+++ b/src/lib/datatypes/Makefile
@@ -3,6 +3,7 @@ obj-y += datatypes.mod
 obj-datatypes-y := \
     sol-arena.o \
     sol-buffer.o \
+    sol-memdesc.o \
     sol-str-slice.o \
     sol-str-table.o\
     sol-vector.o
@@ -13,4 +14,5 @@ headers-y := \
     include/sol-str-table.h \
     include/sol-buffer.h \
     include/sol-str-slice.h \
+    include/sol-memdesc.h \
     include/sol-vector.h

--- a/src/lib/datatypes/include/sol-memdesc.h
+++ b/src/lib/datatypes/include/sol-memdesc.h
@@ -25,6 +25,7 @@
 #include <sol-common-buildopts.h>
 #include <sol-str-slice.h>
 #include <sol-macros.h>
+#include <sol-buffer.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -1000,6 +1001,491 @@ sol_memdesc_new_with_defaults(const struct sol_memdesc *desc)
     errno = 0;
     return mem;
 }
+
+/**
+ * @brief Helper to fetch the memory as the largest supported unsigned integer.
+ *
+ * @param desc the memory description.
+ * @param container the memory of the container.
+ *
+ * @return the number as uint64_t. On errors, errno is set to non-zero.
+ */
+static inline uint64_t
+sol_memdesc_get_as_uint64(const struct sol_memdesc *desc, const void *container)
+{
+    const void *mem;
+    int64_t i64;
+
+    mem = sol_memdesc_get_memory(desc, container);
+    if (!mem)
+        return 0;
+
+    errno = 0;
+    switch (desc->type) {
+    case SOL_MEMDESC_TYPE_UINT8:
+        return *(const uint8_t *)mem;
+    case SOL_MEMDESC_TYPE_UINT16:
+        return *(const uint16_t *)mem;
+    case SOL_MEMDESC_TYPE_UINT32:
+        return *(const uint32_t *)mem;
+    case SOL_MEMDESC_TYPE_UINT64:
+        return *(const uint64_t *)mem;
+    case SOL_MEMDESC_TYPE_ULONG:
+        return *(const unsigned long *)mem;
+    case SOL_MEMDESC_TYPE_SIZE:
+        return *(const size_t *)mem;
+    case SOL_MEMDESC_TYPE_INT8:
+        i64 = *(const int8_t *)mem;
+        goto check_signed;
+    case SOL_MEMDESC_TYPE_INT16:
+        i64 = *(const int16_t *)mem;
+        goto check_signed;
+    case SOL_MEMDESC_TYPE_INT32:
+        i64 = *(const int32_t *)mem;
+        goto check_signed;
+    case SOL_MEMDESC_TYPE_INT64:
+        i64 = *(const int64_t *)mem;
+        goto check_signed;
+    case SOL_MEMDESC_TYPE_LONG:
+        i64 = *(const long *)mem;
+        goto check_signed;
+    case SOL_MEMDESC_TYPE_SSIZE:
+        i64 = *(const ssize_t *)mem;
+        goto check_signed;
+    case SOL_MEMDESC_TYPE_BOOLEAN:
+        return *(const bool *)mem;
+    case SOL_MEMDESC_TYPE_DOUBLE:
+        i64 = *(const double *)mem;
+        goto check_signed;
+    case SOL_MEMDESC_TYPE_STRING:
+    case SOL_MEMDESC_TYPE_CONST_STRING:
+    case SOL_MEMDESC_TYPE_PTR:
+    case SOL_MEMDESC_TYPE_STRUCTURE:
+    case SOL_MEMDESC_TYPE_ARRAY:
+    default:
+        errno = EINVAL;
+        return 0;
+    }
+
+check_signed:
+    if (i64 < 0) {
+        errno = ERANGE;
+        return 0;
+    }
+    return i64;
+}
+
+/**
+ * @brief Helper to fetch the memory as the largest supported signed integer.
+ *
+ * @param desc the memory description.
+ * @param container the memory of the container.
+ *
+ * @return the number as int64_t. On errors, errno is set to non-zero.
+ */
+static inline int64_t
+sol_memdesc_get_as_int64(const struct sol_memdesc *desc, const void *container)
+{
+    const void *mem;
+    uint64_t u64;
+
+    mem = sol_memdesc_get_memory(desc, container);
+    if (!mem)
+        return 0;
+
+    errno = 0;
+    switch (desc->type) {
+    case SOL_MEMDESC_TYPE_UINT8:
+        return *(const uint8_t *)mem;
+    case SOL_MEMDESC_TYPE_UINT16:
+        return *(const uint16_t *)mem;
+    case SOL_MEMDESC_TYPE_UINT32:
+        return *(const uint32_t *)mem;
+    case SOL_MEMDESC_TYPE_UINT64:
+        u64 = *(const uint64_t *)mem;
+        goto check_overflow;
+    case SOL_MEMDESC_TYPE_ULONG:
+        u64 = *(const unsigned long *)mem;
+        goto check_overflow;
+    case SOL_MEMDESC_TYPE_SIZE:
+        u64 = *(const size_t *)mem;
+        goto check_overflow;
+    case SOL_MEMDESC_TYPE_INT8:
+        return *(const int8_t *)mem;
+    case SOL_MEMDESC_TYPE_INT16:
+        return *(const int16_t *)mem;
+    case SOL_MEMDESC_TYPE_INT32:
+        return *(const int32_t *)mem;
+    case SOL_MEMDESC_TYPE_INT64:
+        return *(const int64_t *)mem;
+    case SOL_MEMDESC_TYPE_LONG:
+        return *(const long *)mem;
+    case SOL_MEMDESC_TYPE_SSIZE:
+        return *(const ssize_t *)mem;
+    case SOL_MEMDESC_TYPE_BOOLEAN:
+        return *(const bool *)mem;
+    case SOL_MEMDESC_TYPE_DOUBLE:
+        return *(const double *)mem;
+    case SOL_MEMDESC_TYPE_STRING:
+    case SOL_MEMDESC_TYPE_CONST_STRING:
+    case SOL_MEMDESC_TYPE_PTR:
+    case SOL_MEMDESC_TYPE_STRUCTURE:
+    case SOL_MEMDESC_TYPE_ARRAY:
+    default:
+        errno = EINVAL;
+        return 0;
+    }
+
+check_overflow:
+    if (u64 > INT64_MAX) {
+        errno = ERANGE;
+        return 0;
+    }
+    return u64;
+}
+
+/**
+ * @brief Helper to check if type is unsigned integer-compatible.
+ *
+ * @param desc the memory description.
+ *
+ * @return true if it is unsigned integer (uint8_t, uint16_t, uint32_t, uint64_t,
+ *         unsigned long or size_t).
+ */
+static inline bool
+sol_memdesc_is_unsigned(const struct sol_memdesc *desc)
+{
+    errno = EINVAL;
+    if (!desc)
+        return false;
+
+#ifndef SOL_NO_API_VERSION
+    if (desc->api_version != SOL_MEMDESC_API_VERSION_COMPILED)
+        return false;
+#endif
+
+    errno = 0;
+    switch (desc->type) {
+    case SOL_MEMDESC_TYPE_UINT8:
+    case SOL_MEMDESC_TYPE_UINT16:
+    case SOL_MEMDESC_TYPE_UINT32:
+    case SOL_MEMDESC_TYPE_UINT64:
+    case SOL_MEMDESC_TYPE_ULONG:
+    case SOL_MEMDESC_TYPE_SIZE:
+        return true;
+    case SOL_MEMDESC_TYPE_INT8:
+    case SOL_MEMDESC_TYPE_INT16:
+    case SOL_MEMDESC_TYPE_INT32:
+    case SOL_MEMDESC_TYPE_INT64:
+    case SOL_MEMDESC_TYPE_LONG:
+    case SOL_MEMDESC_TYPE_SSIZE:
+    case SOL_MEMDESC_TYPE_BOOLEAN:
+    case SOL_MEMDESC_TYPE_DOUBLE:
+    case SOL_MEMDESC_TYPE_STRING:
+    case SOL_MEMDESC_TYPE_CONST_STRING:
+    case SOL_MEMDESC_TYPE_PTR:
+    case SOL_MEMDESC_TYPE_STRUCTURE:
+    case SOL_MEMDESC_TYPE_ARRAY:
+    default:
+        return false;
+    }
+}
+
+/**
+ * @brief Helper to check if type is signed integer-compatible.
+ *
+ * @param desc the memory description.
+ *
+ * @return true if it is signed integer (int8_t, int16_t, int32_t, int64_t,
+ *         long or ssize_t).
+ */
+static inline bool
+sol_memdesc_is_signed(const struct sol_memdesc *desc)
+{
+    errno = EINVAL;
+    if (!desc)
+        return false;
+
+#ifndef SOL_NO_API_VERSION
+    if (desc->api_version != SOL_MEMDESC_API_VERSION_COMPILED)
+        return false;
+#endif
+
+    errno = 0;
+    switch (desc->type) {
+    case SOL_MEMDESC_TYPE_UINT8:
+    case SOL_MEMDESC_TYPE_UINT16:
+    case SOL_MEMDESC_TYPE_UINT32:
+    case SOL_MEMDESC_TYPE_UINT64:
+    case SOL_MEMDESC_TYPE_ULONG:
+    case SOL_MEMDESC_TYPE_SIZE:
+        return false;
+    case SOL_MEMDESC_TYPE_INT8:
+    case SOL_MEMDESC_TYPE_INT16:
+    case SOL_MEMDESC_TYPE_INT32:
+    case SOL_MEMDESC_TYPE_INT64:
+    case SOL_MEMDESC_TYPE_LONG:
+    case SOL_MEMDESC_TYPE_SSIZE:
+        return true;
+    case SOL_MEMDESC_TYPE_BOOLEAN:
+    case SOL_MEMDESC_TYPE_DOUBLE:
+    case SOL_MEMDESC_TYPE_STRING:
+    case SOL_MEMDESC_TYPE_CONST_STRING:
+    case SOL_MEMDESC_TYPE_PTR:
+    case SOL_MEMDESC_TYPE_STRUCTURE:
+    case SOL_MEMDESC_TYPE_ARRAY:
+    default:
+        return false;
+    }
+}
+
+/**
+ * @brief Options on how to serialize a memory given its description.
+ */
+struct sol_memdesc_serialize_options {
+#ifndef SOL_NO_API_VERSION
+#define SOL_MEMDESC_SERIALIZE_OPTIONS_API_VERSION (1) /**< @brief API version to use in struct sol_memdesc_serialize_options::api_version */
+    uint16_t api_version; /**< @brief API version, must match SOL_MEMDESC_SERIALIZE_OPTIONS_API_VERSION at runtime */
+#endif
+    /**
+     * @brief function used to format a signed integer.
+     *
+     * If not provided printf() will be used using the current locale.
+     *
+     * Should return 0 on success, negative errno on failure.
+     */
+    int (*serialize_int64)(const struct sol_memdesc *desc, int64_t value, struct sol_buffer *buffer);
+    /**
+     * @brief function used to format an unsigned integer.
+     *
+     * If not provided printf() will be used using the current locale.
+     *
+     * Should return 0 on success, negative errno on failure.
+     */
+    int (*serialize_uint64)(const struct sol_memdesc *desc, uint64_t value, struct sol_buffer *buffer);
+    /**
+     * @brief function used to format a double precision floating point number.
+     *
+     * If not provided printf() with @c "%g" will be used using the current locale.
+     *
+     * Should return 0 on success, negative errno on failure.
+     */
+    int (*serialize_double)(const struct sol_memdesc *desc, double value, struct sol_buffer *buffer);
+    /**
+     * @brief function used to format a boolean.
+     *
+     * If not provided "true"  or "false" will be used.
+     *
+     * Should return 0 on success, negative errno on failure.
+     */
+    int (*serialize_boolean)(const struct sol_memdesc *desc, bool value, struct sol_buffer *buffer);
+    /**
+     * @brief function used to format a pointer.
+     *
+     * If not provided printf() with @c "%p" will be used using the
+     * current locale.
+     *
+     * Often this is used for NULL or when the desc->children is
+     * empty, otherwise the code will handle SOL_MEMDESC_TYPE_PTR as a
+     * structure, accessing the pointed memory.
+     *
+     * Should return 0 on success, negative errno on failure.
+     */
+    int (*serialize_pointer)(const struct sol_memdesc *desc, const void *value, struct sol_buffer *buffer);
+    /**
+     * @brief function used to format a string.
+     *
+     * If not will place the string inside double-quotes and inner
+     * quotes and non-printable chars will be escaped.
+     *
+     * @note the given value may be @c NULL!
+     *
+     * Should return 0 on success, negative errno on failure.
+     */
+    int (*serialize_string)(const struct sol_memdesc *desc, const char *value, struct sol_buffer *buffer);
+    /**
+     * @brief function used to format a struct member.
+     *
+     * If not provided the function will print use the
+     * struct sol_str_slice under
+     * struct sol_memdesc_serialize_options::structure. If
+     * struct sol_memdesc_serialize_options::structure::show_key, then
+     * struct sol_memdesc_serialize_options::structure::key::start and
+     * struct sol_memdesc_serialize_options::structure::key::end are used around the
+     * struct sol_memdesc::name that is dumped as-is.
+     *
+     * If multiple members exist, they will be separated with
+     * struct sol_memdesc_serialize_options::structure::separator.
+     *
+     * Should return 0 on success, negative errno on failure.
+     */
+    int (*serialize_structure_member)(const struct sol_memdesc *structure, const struct sol_memdesc *member, const void *container, struct sol_buffer *buffer, const struct sol_memdesc_serialize_options *opts, struct sol_buffer *prefix, bool is_first);
+    /**
+     * @brief function used to format an array item.
+     *
+     * If not provided the function will print use the
+     * struct sol_str_slice under
+     * struct sol_memdesc_serialize_options::array. If
+     * struct sol_memdesc_serialize_options::array::show_index, then
+     * struct sol_memdesc_serialize_options::array::index::start and
+     * struct sol_memdesc_serialize_options::array::index::end are used around the
+     * @c idx.
+     *
+     * If multiple items exist, they will be separated with
+     * struct sol_memdesc_serialize_options::array::separator.
+     *
+     * Should return 0 on success, negative errno on failure.
+     */
+    int (*serialize_array_item)(const struct sol_memdesc *desc, size_t idx, const void *memory, struct sol_buffer *buffer, const struct sol_memdesc_serialize_options *opts, struct sol_buffer *prefix);
+    /**
+     * @brief options used by serialize_structure_member.
+     *
+     * These options control the behavior of
+     * struct sol_memdesc_serialize_options::serialize_structure_member.
+     */
+    struct {
+        struct {
+            /**
+             * Used when starting a new structure.
+             */
+            const struct sol_str_slice start;
+            /**
+             * Used when finishing a structure.
+             */
+            const struct sol_str_slice end;
+            /**
+             * Used to indent a new container.
+             */
+            const struct sol_str_slice indent;
+        } container;
+        struct {
+            /**
+             * Used when starting a new structure member.
+             *
+             * This is only to be used if
+             * struct sol_memdesc_serialize_options::structure::show_key.
+             */
+            const struct sol_str_slice start;
+            /**
+             * Used when finishing a structure member.
+             *
+             * This is only to be used if
+             * struct sol_memdesc_serialize_options::structure::show_key.
+             */
+            const struct sol_str_slice end;
+            /**
+             * Used to indent a new key.
+             */
+            const struct sol_str_slice indent;
+        } key;
+        struct {
+            /**
+             * Used when starting a new structure value.
+             */
+            const struct sol_str_slice start;
+            /**
+             * Used when finishing structure value.
+             */
+            const struct sol_str_slice end;
+            /**
+             * Used to indent a new value.
+             */
+            const struct sol_str_slice indent;
+        } value;
+        /**
+         * Used if multiple members exist.
+         */
+        struct sol_str_slice separator;
+        /**
+         * Controls whenever the key is to be serialized.
+         */
+        bool show_key;
+    } structure;
+    /**
+     * @brief options used by serialize_array_item
+     *
+     * These options control the behavior of
+     * struct sol_memdesc_serialize_options::serialize_array_item.
+     */
+    struct {
+        struct {
+            /**
+             * Used when starting a new array.
+             */
+            const struct sol_str_slice start;
+            /**
+             * Used when finishing a array.
+             */
+            const struct sol_str_slice end;
+            /**
+             * Used to indent a new array.
+             */
+            const struct sol_str_slice indent;
+        } container;
+        struct {
+            /**
+             * Used when starting a new array item.
+             *
+             * This is only to be used if
+             * struct sol_memdesc_serialize_options::array::show_index.
+             */
+            const struct sol_str_slice start;
+            /**
+             * Used when finishing a array item.
+             *
+             * This is only to be used if
+             * struct sol_memdesc_serialize_options::array::show_index.
+             */
+            const struct sol_str_slice end;
+            /**
+             * Used to indent a new index.
+             */
+            const struct sol_str_slice indent;
+        } index;
+        struct {
+            /**
+             * Used when starting a new array item value.
+             */
+            const struct sol_str_slice start;
+            /**
+             * Used when finishing array item value.
+             */
+            const struct sol_str_slice end;
+            /**
+             * Used to indent a new value.
+             */
+            const struct sol_str_slice indent;
+        } value;
+        /**
+         * Used if multiple items exist.
+         */
+        struct sol_str_slice separator;
+        /**
+         * Controls whenever the index is to be serialized.
+         */
+        bool show_index;
+    } array;
+    bool detailed;
+};
+
+/**
+ * @brief Serialize a memory to a buffer using a description.
+ *
+ * If no options are provided, then it will serialize in a C-like
+ * pattern, however if struct member names are not valid C symbols, it
+ * will not be a valid C.
+ *
+ * @param desc the memory description.
+ * @param container the memory container to serialize.
+ * @param buffer where to serialize the memory. Must be pre-initialized,
+ *        contents will be appended.
+ * @param opts if provided will modify how to serialize the memory.
+ * @param prefix some prefix to be added to lines, it will be modified during iteration to
+ *        contain new indent strings.
+ *
+ * @return 0 on success, negative errno otherwise.
+ */
+int sol_memdesc_serialize(const struct sol_memdesc *desc, const void *container, struct sol_buffer *buffer, const struct sol_memdesc_serialize_options *opts, struct sol_buffer *prefix);
 
 /**
  * @}

--- a/src/lib/datatypes/include/sol-memdesc.h
+++ b/src/lib/datatypes/include/sol-memdesc.h
@@ -1,0 +1,1010 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2016 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <sol-common-buildopts.h>
+#include <sol-str-slice.h>
+#include <sol-macros.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file
+ * @brief These are routines that Soletta provides for its memory description (memdesc) implementation.
+ */
+
+/**
+ * @defgroup MemDesc Memory Description
+ * @ingroup Datatypes
+ *
+ * @brief A memory description (memdesc) allows code to know how to
+ * handle it in runtime, such as decode/parse from some other
+ * representation (text/json), or serialize/encode. It will, as well,
+ * offer special handling such as memory being duplicated and freed
+ * for strings, or defined per-description with
+ * struct sol_memdesc::ops.
+ *
+ * @{
+ */
+
+/**
+ * @brief Designates the type of the memory description
+ */
+enum sol_memdesc_type {
+    SOL_MEMDESC_TYPE_UNKNOWN = 0, /**< @brief not to be used. */
+    /**
+     * @brief uint8_t equivalent (one unsigned byte).
+     *
+     * Initial content is specified in
+     * struct sol_memdesc::defcontent::u8 and struct sol_memdesc::children
+     * is not used.
+     */
+    SOL_MEMDESC_TYPE_UINT8,
+    /**
+     * @brief uint16_t equivalent (two unsigned bytes).
+     *
+     * Initial content is specified in
+     * struct sol_memdesc::defcontent::u16 and struct sol_memdesc::children
+     * is not used.
+     */
+    SOL_MEMDESC_TYPE_UINT16,
+    /**
+     * @brief uint32_t equivalent (four unsigned bytes).
+     *
+     * Initial content is specified in
+     * struct sol_memdesc::defcontent::u32 and struct sol_memdesc::children
+     * is not used.
+     */
+    SOL_MEMDESC_TYPE_UINT32,
+    /**
+     * @brief uint64_t equivalent (four unsigned bytes).
+     *
+     * Initial content is specified in
+     * struct sol_memdesc::defcontent::u64 and struct sol_memdesc::children
+     * is not used.
+     */
+    SOL_MEMDESC_TYPE_UINT64,
+    /**
+     * @brief unsigned long equivalent.
+     *
+     * Initial content is specified in
+     * struct sol_memdesc::defcontent::ul and struct sol_memdesc::children
+     * is not used.
+     */
+    SOL_MEMDESC_TYPE_ULONG,
+    /**
+     * @brief size_t equivalent (four or eight unsigned bytes, depends on platform).
+     *
+     * Initial content is specified in
+     * struct sol_memdesc::defcontent::sz and struct sol_memdesc::children
+     * is not used.
+     */
+    SOL_MEMDESC_TYPE_SIZE,
+    /**
+     * @brief int8_t equivalent (one signed byte).
+     *
+     * Initial content is specified in
+     * struct sol_memdesc::defcontent::i8 and struct sol_memdesc::children
+     * is not used.
+     */
+    SOL_MEMDESC_TYPE_INT8,
+    /**
+     * @brief int16_t equivalent (two signed bytes).
+     *
+     * Initial content is specified in
+     * struct sol_memdesc::defcontent::i16 and struct sol_memdesc::children
+     * is not used.
+     */
+    SOL_MEMDESC_TYPE_INT16,
+    /**
+     * @brief int32_t equivalent (four signed bytes).
+     *
+     * Initial content is specified in
+     * struct sol_memdesc::defcontent::i32 and struct sol_memdesc::children
+     * is not used.
+     */
+    SOL_MEMDESC_TYPE_INT32,
+    /**
+     * @brief int64_t equivalent (eight signed bytes).
+     *
+     * Initial content is specified in
+     * struct sol_memdesc::defcontent::i64 and struct sol_memdesc::children
+     * is not used.
+     */
+    SOL_MEMDESC_TYPE_INT64,
+    /**
+     * @brief signed long equivalent.
+     *
+     * Initial content is specified in
+     * struct sol_memdesc::defcontent::l and struct sol_memdesc::children
+     * is not used.
+     */
+    SOL_MEMDESC_TYPE_LONG,
+    /**
+     * @brief ssize_t equivalent (four or eight signed bytes, depends on platform).
+     *
+     * Initial content is specified in
+     * struct sol_memdesc::defcontent::ssz and struct sol_memdesc::children
+     * is not used.
+     */
+    SOL_MEMDESC_TYPE_SSIZE,
+    /**
+     * @brief boolean equivalent.
+     *
+     * Initial content is specified in
+     * struct sol_memdesc::defcontent::b and struct sol_memdesc::children
+     * is not used.
+     */
+    SOL_MEMDESC_TYPE_BOOLEAN,
+    /**
+     * @brief double precision floating point equivalent.
+     *
+     * Initial content is specified in
+     * struct sol_memdesc::defcontent::d and struct sol_memdesc::children
+     * is not used.
+     */
+    SOL_MEMDESC_TYPE_DOUBLE,
+    /**
+     * @brief null-terminated C-string (@c char*).
+     *
+     * Initial content is specified in
+     * struct sol_memdesc::defcontent::s and struct sol_memdesc::children
+     * is not used. It may be null.
+     *
+     * By default, strings are duplicated and freed as required.
+     * @see SOL_MEMDESC_TYPE_CONST_STRING
+     */
+    SOL_MEMDESC_TYPE_STRING,
+    /**
+     * @brief null-terminated C-string (@c const char*).
+     *
+     * Initial content is specified in
+     * struct sol_memdesc::defcontent::s and struct sol_memdesc::children
+     * is not used. It may be null.
+     *
+     * By default, strings are NOT duplicated neither freed.
+     * @see SOL_MEMDESC_TYPE_STRING
+     */
+    SOL_MEMDESC_TYPE_CONST_STRING,
+    /**
+     * @brief generic pointer (void *).
+     *
+     * If struct sol_memdesc::children is non-NULL, it will be managed
+     * as such (malloc/free). Note that the initial value is still
+     * defined as a pointer to the actual contents in struct
+     * sol_memdesc::defcontent::p. If that is non-NULL, then the
+     * pointer is allocated and that one will use defaults specified
+     * in struct sol_memdesc::children::defcontent, then values from
+     * struct sol_memdesc::defcontent::p is applied on top.
+     *
+     * By default the value is based on
+     * struct sol_memdesc::defcontent::p.
+     *
+     * @see SOL_MEMDESC_TYPE_STRUCTURE
+     */
+    SOL_MEMDESC_TYPE_PTR,
+    /**
+     * @brief structure with internal members.
+     *
+     * This is a recursive type with children described in
+     * struct sol_memdesc::children, an array that is null-terminated
+     * (all element members are zeroed).
+     *
+     * During initialization, each member will be considered according
+     * to its initial value. Then, if
+     * struct sol_memdesc::defcontent::p is non-NULL, it will be
+     * applied on top.
+     */
+    SOL_MEMDESC_TYPE_STRUCTURE,
+    /**
+     * @brief an array with internal members.
+     *
+     * This is a pointer to an array of items that are defined in
+     * struct sol_memdesc::children. It will not be touched, you
+     * should manage it yourself with struct sol_memdesc::ops.
+     *
+     * To map a struct sol_vector, use
+     * @c .size=sizeof(struct sol_vector),
+     * And provide a @c .children with the description on what is to
+     * be in the element, like a structure or a pointer to one, this
+     * way sol_memdesc_init_defaults() will set
+     * struct sol_vector::elem_size to size of children. Then you must
+     * provide the following struct sol_memdesc::ops:
+     *
+     *  @li @c init_defaults: set @c elem_size from
+     *      @c sol_memdesc_get_size(desc->children).
+     *  @li @c array.get_length: return @c len.
+     *  @li @c array.get_element: proxy return of sol_vector_get().
+     *  @li @c array.resize: if shrinking, remember to call
+     *      @c sol_memdesc_free_content(desc->children, it) for
+     *      every item that will be removed, then call
+     *      sol_vector_del_range(). If growing, call
+     *      sol_vector_append_n() and initialze children with
+     *      @c sol_memdesc_init_defaults(desc->children, it).
+     *
+     * @see SOL_MEMDESC_OPS_VECTOR and SOL_MEMDESC_OPS_PTR_VECTOR.
+     */
+    SOL_MEMDESC_TYPE_ARRAY
+};
+
+/**
+ * @brief Converts a Memdesc Type from string to sol_memdesc_type.
+ *
+ * @param str the string representing a valid type.
+ * @return the type or SOL_MEMDESC_TYPE_UNKNOWN if invalid.
+ */
+enum sol_memdesc_type sol_memdesc_type_from_str(const char *str) SOL_ATTR_WARN_UNUSED_RESULT SOL_ATTR_NONNULL(1);
+
+/**
+ * @brief Converts a sol_memdesc_type to a string.
+ *
+ * @param type the type to be converted.
+ * @return the string or NULL, if the type is invalid.
+ */
+const char *sol_memdesc_type_to_str(enum sol_memdesc_type type) SOL_ATTR_WARN_UNUSED_RESULT;
+
+/**
+ * @def SOL_MEMDESC_DESCRIPTION
+ *
+ * This is selected at compile time to allow reducing binary size if
+ * this cpp symbol is undefined.
+ */
+#ifndef SOL_MEMDESC_DESCRIPTION
+/* keep doxygen happy */
+#define SOL_MEMDESC_DESCRIPTION
+#undef SOL_MEMDESC_DESCRIPTION
+#endif
+
+/**
+ * @def SOL_MEMDESC_SET_DESCRIPTION(text)
+ *
+ * Helper to set the description member of struct sol_memdesc if that
+ * is available (conditional to #SOL_MEMDESC_SET_DESCRIPTION).
+ */
+#ifdef SOL_MEMDESC_DESCRIPTION
+#define SOL_MEMDESC_SET_DESCRIPTION(text) .description = (text)
+#else
+#define SOL_MEMDESC_SET_DESCRIPTION(text)
+#endif
+
+#ifndef SOL_NO_API_VERSION
+/**
+ * @brief the SOL_MEMDESC_API_VERSION this soletta build used.
+ *
+ * This symbol is defined by soletta to match SOL_MEMDESC_API_VERSION,
+ * but unlike that macro this symbol will be relative to soletta build
+ * and is used in our macros and static-inline functions that must
+ * check for valid handles.
+ */
+extern const uint16_t SOL_MEMDESC_API_VERSION_COMPILED;
+#endif
+
+/**
+ * @brief Data type to describe a memory region.
+ */
+struct sol_memdesc {
+#ifndef SOL_NO_API_VERSION
+#define SOL_MEMDESC_API_VERSION (1) /**< @brief API version to use in struct sol_memdesc::api_version */
+    uint16_t api_version; /**< @brief API version, must match SOL_MEMDESC_API_VERSION at runtime */
+#endif
+    /**
+     * @brief offset in bytes relative to containing memory.
+     *
+     * If this is a member of a structure, then it's the
+     * @c offsetof(struct, member). It is used to access the actual
+     * memory.
+     */
+    uint16_t offset;
+    /**
+     * @brief size in bytes of the member memory.
+     *
+     * Usually this is @c sizeof(type), if a structure it will account
+     * for all members plus paddings.
+     *
+     * For strings, this will be the size of the pointer, not the
+     * actual string length. Likewise, for arrays this is the size of
+     * the pointer, not the length of the array.
+     */
+    uint16_t size;
+    /**
+     * @brief basic type of the member memory.
+     *
+     * All handling of the memory depends on how it is to be
+     * accessed. Like integers will have sign or not and a number of
+     * bits. Strings will be duplicated with @c strdup() and then
+     * released with @c free().
+     */
+    enum sol_memdesc_type type;
+    /**
+     * @brief whenever memory is mandatory in serialization and parsing.
+     *
+     * If false, must exist when serializing/parsing. if true, then
+     * defcontent could be used if missing from input.
+     */
+    bool optional : 1;
+    /**
+     * @brief whenever memory is extended detail.
+     *
+     * If true, should only be included in serialization if detail is
+     * wanted.
+     */
+    bool detail : 1;
+    /**
+     * @brief memory name, such as the member name in a structure.
+     *
+     * This may be used in serialization and parsing to provide a
+     * descriptive identifier.
+     */
+    const char *name;
+#ifdef SOL_MEMDESC_DESCRIPTION
+    /**
+     * @brief long description of the memory
+     *
+     * This may be used while presenting information to the user on
+     * what's the purpose of the memory.
+     *
+     * It only exist if #SOL_MEMDESC_DESCRIPTION is defined, allowing
+     * for footprint savings in constrained systems.
+     */
+    const char *description;
+#endif
+    /**
+     * @brief default contents to be used if @c required == false.
+     *
+     * If struct sol_memdesc::required is false, then this content
+     * can be used to provide defaults.
+     *
+     * Note that complex types SOL_MEMDESC_TYPE_STRUCTURE and
+     * SOL_MEMDESC_TYPE_ARRAY have their own handling with struct
+     * sol_memdesc::children.
+     */
+    union {
+        uint8_t u8; /**< @brief use when SOL_MEMDESC_TYPE_UINT8 */
+        uint16_t u16; /**< @brief use when SOL_MEMDESC_TYPE_UINT16 */
+        uint32_t u32; /**< @brief use when SOL_MEMDESC_TYPE_UINT32 */
+        uint64_t u64; /**< @brief use when SOL_MEMDESC_TYPE_UINT64 */
+        unsigned long ul; /**< @brief use when SOL_MEMDESC_TYPE_ULONG */
+        size_t sz; /**< @brief use when SOL_MEMDESC_TYPE_SIZE */
+        int8_t i8; /**< @brief use when SOL_MEMDESC_TYPE_INT8 */
+        int16_t i16; /**< @brief use when SOL_MEMDESC_TYPE_INT16 */
+        int32_t i32; /**< @brief use when SOL_MEMDESC_TYPE_INT32 */
+        int64_t i64; /**< @brief use when SOL_MEMDESC_TYPE_INT64 */
+        long l; /**< @brief use when SOL_MEMDESC_TYPE_LONG */
+        ssize_t ssz; /**< @brief use when SOL_MEMDESC_TYPE_SSIZE */
+        bool b; /**< @brief use when SOL_MEMDESC_TYPE_BOOLEAN */
+        double d; /**< @brief use when SOL_MEMDESC_TYPE_DOUBLE */
+        const char *s; /**< @brief use when SOL_MEMDESC_TYPE_STRING or SOL_MEMDESC_TYPE_CONST_STRING */
+        const void *p; /**< @brief use when SOL_MEMDESC_TYPE_PTR, SOL_MEMDESC_TYPE_STRUCTURE or SOL_MEMDESC_TYPE_ARRAY */
+    } defcontent;
+    /**
+     * @brief how to access complex types (structures and arrays).
+     *
+     * If the memory is complex, use a recursive description
+     * specified here.
+     */
+    const struct sol_memdesc *children;
+
+    /**
+     * @brief override operations to be used in this memory description.
+     *
+     * By default the operations will be done in a fixed way unless
+     * overriden by an @c ops structure, this may be used to correlate
+     * members in a structure, such as struct sol_vector where length
+     * is a member and the contents is another, with element_size
+     * being specified in yet-another. Then things like "copy" will
+     * not be a simple copy of each member.
+     *
+     * To map struct sol_vector, use SOL_MEMDESC_OPS_VECTOR. to map
+     * struct sol_ptr_vector use SOL_MEMDESC_OPS_PTR_VECTOR.
+     */
+    const struct sol_memdesc_ops {
+#ifndef SOL_NO_API_VERSION
+#define SOL_MEMDESC_OPS_API_VERSION (1) /**< API version to use in struct sol_memdesc_ops::api_version */
+        uint16_t api_version; /**< @brief API version, must match SOL_MEMDESC_OPS_API_VERSION at runtime */
+#endif
+        /**
+         * @brief initialize the defaults of memory.
+         *
+         * If provided, will be used to initialize the memory instead of
+         * the traditional use of struct sol_memdesc::defcontent.
+         *
+         * Should return 0 on success, negative errno on errors.
+         */
+        int (*init_defaults)(const struct sol_memdesc *desc, void *container);
+        /**
+         * @brief sets the content of a memory.
+         *
+         * If provided, will be used to set the memory instead of the
+         * traditional code that will, for example, strdup() and free()
+         * strings.
+         *
+         * The parameter @c ptr_content is a pointer to the actual content,
+         * depends on the actual type. If a SOL_MEMDESC_TYPE_BOOLEAN, for
+         * example, it must be a @c bool*.
+         *
+         * Should return 0 on success, negative errno on errors.
+         */
+        int (*set_content)(const struct sol_memdesc *desc, void *container, const void *ptr_content);
+        /**
+         * @brief copy the content from another memory.
+         *
+         * If provided, will be used to set the memory instead of the
+         * traditional code that will, for example, strdup() and free()
+         * strings.
+         *
+         * Should return 0 on success, negative errno on errors.
+         */
+        int (*copy)(const struct sol_memdesc *desc, const void *src_container, void *dst_container);
+        /**
+         * @brief compare the content of two memories.
+         *
+         * If provided, will be used to compare the memory contents
+         * instead of the traditional code that will, for example,
+         * call strcmp() on strings.
+         *
+         * Should return 0 for equal, <0 if a_container is smaller, >0 if b_container is smaller.
+         * On error, return 0 and set errno.
+         */
+        int (*compare)(const struct sol_memdesc *desc, const void *a_container, const void *b_container);
+        /**
+         * @brief free the contents (internal memory) of a memory.
+         *
+         * If provided, will be used to free the contents of a memory
+         * instead of the traditional code that will, for example, free()
+         * strings.
+         *
+         * Should return 0 on success, negative errno on errors.
+         */
+        int (*free_content)(const struct sol_memdesc *desc, void *container);
+        struct {
+            /**
+             * @brief calculate array length.
+             *
+             * Will be used to calculate the array
+             * length. Return should be number of items, each defined in
+             * struct sol_memdesc::children.
+             *
+             * @note must be provided if type is SOL_MEMDESC_TYPE_ARRAY.
+             *
+             * @note the given memory is already inside the container, do
+             *       not use @c offset or sol_memdesc_get_memory().
+             *
+             * On error, negative errno is returned.
+             */
+            ssize_t (*get_length)(const struct sol_memdesc *desc, const void *memory);
+            /**
+             * @brief get memory of the given array item.
+             *
+             * Will be used to get the array element by its index.
+             * Return should be the memory pointer or NULL on error (then set errno accordingly).
+             *
+             * @note the given memory is already inside the container, do
+             *       not use @c offset or sol_memdesc_get_memory().
+             *
+             * @note must be provided if type is SOL_MEMDESC_TYPE_ARRAY.
+             */
+            void *(*get_element)(const struct sol_memdesc *desc, const void *memory, size_t idx);
+            /**
+             * @brief resize array length.
+             *
+             * Will be used to resize the array
+             * length. The given size should be number of items, each defined in
+             * struct sol_memdesc::children.
+             *
+             * When implementing, always remember to free the items that
+             * are not needed anymore when the new length is smaller than
+             * the old. Failing to do so will lead to memory leaks.
+             *
+             * @note must be provided if type is SOL_MEMDESC_TYPE_ARRAY.
+             *
+             * @note the given memory is already inside the container, do
+             *       not use @c offset or sol_memdesc_get_memory().
+             *
+             * On error, negative errno is returned.
+             */
+            int (*resize)(const struct sol_memdesc *desc, void *memory, size_t length);
+        } array;
+    } *ops;
+};
+
+/**
+ * @brief operations to handle struct sol_vector.
+ *
+ * If one wants to use SOL_MEMDESC_TYPE_ARRAY with a
+ * struct sol_vector, then use this operations to
+ * initialize, get length, get element and resize the array.
+ */
+extern const struct sol_memdesc_ops SOL_MEMDESC_OPS_VECTOR;
+/**
+ * @brief operations to handle struct sol_ptr_vector.
+ *
+ * If one wants to use SOL_MEMDESC_TYPE_ARRAY with a
+ * struct sol_ptr_vector, then use this operations to
+ * initialize, get length, get element and resize the array.
+ */
+extern const struct sol_memdesc_ops SOL_MEMDESC_OPS_PTR_VECTOR;
+
+/**
+ * @brief get the pointer to the memory description inside the given container.
+ *
+ * This will use the struct sol_memdesc::offset to find the offset
+ * inside the container.
+ *
+ * @param desc the memory description.
+ * @param container the memory of the container.
+ *
+ * @return @c NULL on errors or the pointer inside @a container on success.
+ */
+static inline void *
+sol_memdesc_get_memory(const struct sol_memdesc *desc, const void *container)
+{
+    errno = EINVAL;
+    if (!desc || !container)
+        return NULL;
+
+#ifndef SOL_NO_API_VERSION
+    if (desc->api_version != SOL_MEMDESC_API_VERSION_COMPILED)
+        return NULL;
+#endif
+
+    errno = 0;
+    return ((uint8_t *)container) + desc->offset;
+}
+
+/**
+ * @brief get the size in bytes of the memory description.
+ *
+ * This will use the struct sol_memdesc::size or will assume a value
+ * per type.
+ *
+ * @param desc the memory description.
+ *
+ * @return @c 0 on errors (and errno is set to EINVAL) or the size in bytes.
+ */
+static inline uint16_t
+sol_memdesc_get_size(const struct sol_memdesc *desc)
+{
+    errno = EINVAL;
+    if (!desc)
+        return 0;
+
+#ifndef SOL_NO_API_VERSION
+    if (desc->api_version != SOL_MEMDESC_API_VERSION_COMPILED)
+        return 0;
+#endif
+
+    errno = 0;
+    if (desc->size)
+        return desc->size;
+
+    switch (desc->type) {
+    case SOL_MEMDESC_TYPE_UINT8:
+        return sizeof(uint8_t);
+    case SOL_MEMDESC_TYPE_UINT16:
+        return sizeof(uint16_t);
+    case SOL_MEMDESC_TYPE_UINT32:
+        return sizeof(uint32_t);
+    case SOL_MEMDESC_TYPE_UINT64:
+        return sizeof(uint64_t);
+    case SOL_MEMDESC_TYPE_ULONG:
+        return sizeof(unsigned long);
+    case SOL_MEMDESC_TYPE_SIZE:
+        return sizeof(size_t);
+    case SOL_MEMDESC_TYPE_INT8:
+        return sizeof(int8_t);
+    case SOL_MEMDESC_TYPE_INT16:
+        return sizeof(int16_t);
+    case SOL_MEMDESC_TYPE_INT32:
+        return sizeof(int32_t);
+    case SOL_MEMDESC_TYPE_INT64:
+        return sizeof(int64_t);
+    case SOL_MEMDESC_TYPE_LONG:
+        return sizeof(long);
+    case SOL_MEMDESC_TYPE_SSIZE:
+        return sizeof(ssize_t);
+    case SOL_MEMDESC_TYPE_BOOLEAN:
+        return sizeof(bool);
+    case SOL_MEMDESC_TYPE_DOUBLE:
+        return sizeof(double);
+    case SOL_MEMDESC_TYPE_STRING:
+        return sizeof(char *);
+    case SOL_MEMDESC_TYPE_CONST_STRING:
+        return sizeof(const char *);
+    case SOL_MEMDESC_TYPE_PTR:
+        return sizeof(void *);
+    case SOL_MEMDESC_TYPE_STRUCTURE:
+    case SOL_MEMDESC_TYPE_ARRAY:
+    /* must provide size */
+    default:
+        errno = EINVAL;
+        return 0;
+    }
+}
+
+/**
+ * @brief initialize the memory inside the container.
+ *
+ * This will use the default content specified in struct
+ * sol_memdesc::defcontent according to the type spefified in
+ * struct sol_memdesc::type.
+ *
+ * @param desc the memory description.
+ * @param container the memory of the container.
+ *
+ * @return 0 on success, negative errno on failure.
+ *
+ * @see sol_memdesc_new_with_defaults()
+ */
+int sol_memdesc_init_defaults(const struct sol_memdesc *desc, void *container);
+
+/**
+ * @brief copy the memory using the given description.
+ *
+ * This function will copy @a src_container to @a dst_container using
+ * the given description, with that members that need special
+ * treatment will have it, like strings will be duplicated.
+ *
+ * @param desc the memory description.
+ * @param src_container the memory of the source/origin container.
+ * @param dst_container the memory of the destination/target container.
+ *
+ * @return 0 on success, negative errno on failure.
+ *
+ * @see sol_memdesc_set_content()
+ */
+int sol_memdesc_copy(const struct sol_memdesc *desc, const void *src_container, void *dst_container);
+
+/**
+ * @brief set the content of this memory.
+ *
+ * This function take care to set the content, disposing of the previous
+ * content if any and duplicating the new one as required, like for
+ * strings.
+ *
+ * @param desc the memory description.
+ * @param container the memory of the container.
+ * @param ptr_content a pointer to the given content, dependent on the
+ *        type. If a SOL_MEMDESC_TYPE_BOOLEAN, then it must be a
+ *        pointer to a bool.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int sol_memdesc_set_content(const struct sol_memdesc *desc, void *container, const void *ptr_content);
+
+/**
+ * @brief compare two memories using the given description.
+ *
+ * This function will compare @a a_container to @a b_container using
+ * the given description, with that members that need special
+ * treatment will have it, like strings will be strcmp(). Operations
+ * may be overriden per-memdesc as defined in
+ * struct sol_memdesc::ops.
+ *
+ * @param desc the memory description.
+ * @param a_container the first memory to compare.
+ * @param b_container the second memory to compare.
+ *
+ * @return On error, 0 and errno is set to non-zero. On success (errno
+ * == 0), 0 means equal, <0 means a_container is smaller, >0 means
+ * b_container is smaller.
+ */
+int sol_memdesc_compare(const struct sol_memdesc *desc, const void *a_container, const void *b_container);
+
+/**
+ * @brief Get the length of an array.
+ *
+ * This function must be applied to SOL_MEMDESC_TYPE_ARRAY and will
+ * call struct sol_memdesc::ops::array::get_length.
+ *
+ * The returned value is about the number of items according to
+ * struct sol_memdesc::children.
+ *
+ * @param desc the memory description.
+ * @param memory the memory holding the array. Use sol_memdesc_get_memory()
+ *        if it's inside a container.
+ *
+ * @return On error, negative errno is returned. Zero or more for success.
+ */
+ssize_t sol_memdesc_get_array_length(const struct sol_memdesc *desc, const void *memory);
+
+/**
+ * @brief Get the array element.
+ *
+ * This function must be applied to SOL_MEMDESC_TYPE_ARRAY and will
+ * call struct sol_memdesc::ops::array::get_element.
+ *
+ * @note for speed purposes, this function will not guarantee
+ * out-of-bounds checking, please ensure the index is less than
+ * sol_memdesc_get_array_length() before calling it.
+ *
+ * @param desc the memory description.
+ * @param memory the memory holding the array. Use sol_memdesc_get_memory()
+ *        if it's inside a container.
+ * @param idx the index of the element inside the array.
+ *
+ * @return On error NULL is returned and errno is set. On success the
+ * memory of the item is returned.
+ *
+ * @see sol_memdesc_get_array_length()
+ */
+void *sol_memdesc_get_array_element(const struct sol_memdesc *desc, const void *memory, size_t idx);
+
+/**
+ * @brief Resize the length of an array.
+ *
+ * This function must be applied to SOL_MEMDESC_TYPE_ARRAY and will
+ * call struct sol_memdesc::ops::array::resize.
+ *
+ * The returned value is about the number of items according to
+ * struct sol_memdesc::children.
+ *
+ * @param desc the memory description.
+ * @param memory the memory holding the array. Use sol_memdesc_get_memory()
+ *        if it's inside a container.
+ * @param length the new length.
+ *
+ * @return On error, negative errno is returned. 0 on success.
+ */
+int sol_memdesc_resize_array(const struct sol_memdesc *desc, void *memory, size_t length);
+
+/**
+ * @brief Append the array element.
+ *
+ * This function must be applied to SOL_MEMDESC_TYPE_ARRAY and will
+ * call struct sol_memdesc::ops::array::get_element,
+ * struct sol_memdesc::ops::array::get_length and
+ * struct sol_memdesc::ops::array::resize to resize the array
+ * and add one item at the end. Then sol_memdesc_set_content() is
+ * called at the new element.
+ *
+ * @param desc the memory description.
+ * @param memory the memory holding the array. Use sol_memdesc_get_memory()
+ *        if it's inside a container.
+ * @param ptr_content a pointer to the given content, dependent on the
+ *        type of children. If a SOL_MEMDESC_TYPE_BOOLEAN, then it must
+ *        be a pointer to a bool.
+ *
+ * @return On error, negative errno is returned. 0 on success
+ *
+ * @see sol_memdesc_get_array_length()
+ * @see sol_memdesc_get_array_element()
+ * @see sol_memdesc_resize_array()
+ * @see sol_memdesc_set_content()
+ */
+static inline int
+sol_memdesc_append_array_element(const struct sol_memdesc *desc, void *memory, const void *ptr_content)
+{
+    void *element;
+    ssize_t len;
+    int r;
+
+    len = sol_memdesc_get_array_length(desc, memory);
+    if (len < 0)
+        return len;
+
+    if (!desc->children)
+        return -EINVAL;
+
+    r = sol_memdesc_resize_array(desc, memory, len + 1);
+    if (r < 0)
+        return r;
+
+    element = sol_memdesc_get_array_element(desc, memory, len);
+    if (!element)
+        return -errno;
+
+    r = sol_memdesc_set_content(desc->children, element, ptr_content);
+    if (r < 0)
+        sol_memdesc_resize_array(desc, memory, len);
+
+    return r;
+}
+
+/**
+ * @brief Macro to loop of array elements in a given range.
+ *
+ * @param desc the memory description of type SOL_MEMDESC_TYPE_ARRAY.
+ * @param memory the memory holding the array. Use sol_memdesc_get_memory()
+ *        if it's inside a container.
+ * @param start_idx the starting index (inclusive).
+ * @param end_idx the ending index (non-inclusive, up to it).
+ * @param itr_idx where to store the current iteration index.
+ * @param element where to store the element or NULL on last iteration.
+ */
+#define SOL_MEMDESC_FOREACH_ARRAY_ELEMENT_IN_RANGE(desc, memory, start_idx, end_idx, itr_idx, element) \
+    for (itr_idx = start_idx, \
+        element = (itr_idx < end_idx) ? sol_memdesc_get_array_element((desc), (memory), itr_idx) : NULL; \
+        itr_idx < end_idx && element; \
+        itr_idx++, \
+        element = (itr_idx < end_idx) ? sol_memdesc_get_array_element((desc), (memory), itr_idx) : NULL)
+
+/**
+ * @def _SOL_MEMDESC_CHECK_API_VERSION(desc)
+ *
+ * Helper to check api-version if needed.
+ * @internal
+ */
+#ifdef SOL_NO_API_VERSION
+#define _SOL_MEMDESC_CHECK_API_VERSION(desc) 1
+#else
+#define _SOL_MEMDESC_CHECK_API_VERSION(desc) ((desc)->api_version == SOL_MEMDESC_API_VERSION_COMPILED)
+#endif
+
+/**
+ * @def _SOL_MEMDESC_CHECK(desc)
+ *
+ * Helper to check for a valid struct sol_memdesc.
+ *
+ * @internal
+ */
+#define _SOL_MEMDESC_CHECK(desc) \
+    ((desc) &&  _SOL_MEMDESC_CHECK_API_VERSION(desc) && (desc)->name)
+
+/**
+ * @def _SOL_MEMDESC_CHECK_STRUCTURE(desc)
+ *
+ * Helper to check for a valid struct sol_memdesc of type SOL_MEMDESC_TYPE_STRUCTURE
+ *
+ * @internal
+ */
+#define _SOL_MEMDESC_CHECK_STRUCTURE(desc) \
+    (_SOL_MEMDESC_CHECK(desc) && (desc)->children && _SOL_MEMDESC_CHECK((desc)->children))
+
+/**
+ * @def _SOL_MEMDESC_CHECK_STRUCTURE_MEMBER(desc, member)
+ *
+ * Helper to check for a valid struct sol_memdesc of type
+ * SOL_MEMDESC_TYPE_STRUCTURE and if member is within structure
+ * boundaries.
+ *
+ * @internal
+ */
+#define _SOL_MEMDESC_CHECK_STRUCTURE_MEMBER(desc, member) \
+    (_SOL_MEMDESC_CHECK(member) && \
+    ((member)->offset + sol_memdesc_get_size((member)) <= sol_memdesc_get_size((desc))))
+
+/**
+ * @brief Macro to loop over all structure members.
+ *
+ * @param desc the memory description of type SOL_MEMDESC_TYPE_STRUCTURE
+ * @param element where to store the member (child) memdesc. NULL when iteration ends.
+ */
+#define SOL_MEMDESC_FOREACH_STRUCTURE_MEMBER(desc, element) \
+    for (element = (_SOL_MEMDESC_CHECK_STRUCTURE(desc) && _SOL_MEMDESC_CHECK_STRUCTURE_MEMBER(desc, desc->children)) ? desc->children : NULL; \
+        _SOL_MEMDESC_CHECK_STRUCTURE_MEMBER(desc, element); \
+        element = _SOL_MEMDESC_CHECK_STRUCTURE_MEMBER(desc, element + 1) ? element + 1 : NULL)
+
+/**
+ * @brief Find structure member (child) given its name.
+ *
+ * The name is taken as a slice since sometimes it's not available as
+ * a null-terminated strings (such as loading from other protocols
+ * such as JSON).
+ *
+ * @param desc a description of type SOL_MEMDESC_TYPE_STRUCTURE.
+ * @param name the name to look for.
+ *
+ * @return pointer on success or NULL on errors (with errno set).
+ *
+ * @see sol_str_slice_from_str()
+ * @see SOL_STR_SLICE_STR()
+ * @see SOL_STR_SLICE_LITERAL()
+ */
+static inline const struct sol_memdesc *
+sol_memdesc_find_structure_member(const struct sol_memdesc *desc, struct sol_str_slice name)
+{
+    const struct sol_memdesc *itr;
+
+    errno = EINVAL;
+    if (!desc || !name.len)
+        return NULL;
+
+    SOL_MEMDESC_FOREACH_STRUCTURE_MEMBER(desc, itr) {
+        if (sol_str_slice_str_eq(name, itr->name)) {
+            errno = 0;
+            return itr;
+        }
+    }
+
+    errno = ENOENT;
+    return NULL;
+}
+
+/**
+ * @brief free the contents (internal memory) of a member.
+ *
+ * This function will take care of special handling needed for each
+ * member, like strings that must be freed.
+ *
+ * @param desc the memory description.
+ * @param container the memory of the container to free the internal memory.
+ *
+ * @return 0 on success, negative errno on failure.
+ *
+ * @see sol_memdesc_free()
+ */
+int sol_memdesc_free_content(const struct sol_memdesc *desc, void *container);
+
+/**
+ * @brief Free the contents and the memory.
+ *
+ * @param desc the memory description.
+ * @param container the memory of the container to free the  memory.
+ *
+ * @see sol_memdesc_free_content()
+ */
+static inline void
+sol_memdesc_free(const struct sol_memdesc *desc, void *container)
+{
+    sol_memdesc_free_content(desc, container);
+    free(container);
+}
+
+/**
+ * @brief Allocate the memory required by this description and initialize it.
+ *
+ * This will allocate offset + size bytes, then fill these bytes with
+ * the content defined in struct sol_memdesc::defcontent.
+ *
+ * @param desc the memory description.
+ *
+ * @return NULL on error, newly allocated memory on success. Free
+ * using sol_memdesc_free().
+ *
+ * @see sol_memdesc_free()
+ */
+static inline void *
+sol_memdesc_new_with_defaults(const struct sol_memdesc *desc)
+{
+    void *mem;
+    uint16_t size;
+    int r;
+
+    size = sol_memdesc_get_size(desc);
+    if (!size)
+        return NULL;
+
+    mem = malloc(desc->offset + size);
+    if (!mem)
+        return NULL;
+
+    r = sol_memdesc_init_defaults(desc, mem);
+    if (r < 0) {
+        sol_memdesc_free(desc, mem);
+        errno = -r;
+        return NULL;
+    }
+
+    errno = 0;
+    return mem;
+}
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/lib/datatypes/include/sol-vector.h
+++ b/src/lib/datatypes/include/sol-vector.h
@@ -198,6 +198,20 @@ sol_vector_del_last(struct sol_vector *v)
 }
 
 /**
+ * @brief Remove an range of element from the vector.
+ *
+ * Removes the range starting at index @a start from the vector and
+ * goes until @a start + @a len.
+ *
+ * @param v Vector pointer
+ * @param start Index of the first element to remove
+ * @param len the number of elements to remover
+ *
+ * @return @c 0 on success, error code (always negative) otherwise
+ */
+int sol_vector_del_range(struct sol_vector *v, uint16_t start, uint16_t len);
+
+/**
  * @brief Delete all elements from the vector.
  *
  * And frees the memory allocated for them. The vector returns to the initial state (empty).

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -142,6 +142,8 @@ sol_buffer_append_bytes(struct sol_buffer *buf, const uint8_t *bytes, size_t siz
     int err;
 
     SOL_NULL_CHECK(buf, -EINVAL);
+    if (size == 0)
+        return 0;
 
     err = sol_buffer_expand(buf, size);
     if (err < 0)
@@ -177,6 +179,9 @@ sol_buffer_set_slice_at(struct sol_buffer *buf, size_t pos, const struct sol_str
     size_t nul_size;
 
     SOL_NULL_CHECK(buf, -EINVAL);
+    if (slice.len == 0)
+        return 0;
+
     if (buf->used < pos) {
         return -EINVAL;
     }
@@ -244,6 +249,9 @@ sol_buffer_insert_bytes(struct sol_buffer *buf, size_t pos, const uint8_t *bytes
 
     SOL_NULL_CHECK(buf, -EINVAL);
     SOL_INT_CHECK(pos, > buf->used, -EINVAL);
+
+    if (size == 0)
+        return 0;
 
     if (pos == buf->used)
         return sol_buffer_append_bytes(buf, bytes, size);

--- a/src/lib/datatypes/sol-memdesc.c
+++ b/src/lib/datatypes/sol-memdesc.c
@@ -1,0 +1,806 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2016 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <errno.h>
+
+#include "sol-log-internal.h"
+#include "sol-macros.h"
+#include "sol-util-internal.h"
+#include "sol-str-table.h"
+#include "sol-memdesc.h"
+
+#ifndef SOL_NO_API_VERSION
+#define _CHECK_API(name, h, b, on_failure) \
+    do { \
+        if ((h)->api_version != (b)) { \
+            SOL_WRN("%s%s%s" # h "(%p)->api_version(%" PRIu16 ") != " # b "(%" PRIu16 ")", \
+                (name) ? "name='" : "", (name) ? (name) : "", (name) ? "' " : "", \
+                (h), (h)->api_version, b); \
+            on_failure; \
+        } \
+    } while (0)
+
+#else
+#define _CHECK_API(name, h, b, on_failure)
+#endif
+
+#define CHECK_API(name, h, b, ...) _CHECK_API(name, h, b, return __VA_ARGS__)
+#define CHECK_API_GOTO(name, h, b, label) _CHECK_API(name, h, b, goto label)
+
+#define VALIDATE_MEMDESC(memdesc, on_failure) \
+    do { \
+        _CHECK_API(NULL, memdesc, SOL_MEMDESC_API_VERSION, on_failure); \
+        if (memdesc->ops) { \
+            _CHECK_API(memdesc->name, memdesc->ops, SOL_MEMDESC_OPS_API_VERSION, on_failure); \
+        } \
+        if (memdesc->type == SOL_MEMDESC_TYPE_ARRAY || memdesc->type == SOL_MEMDESC_TYPE_STRUCTURE) { \
+            if (!memdesc->size) { \
+                SOL_WRN("name='%s' " # memdesc "(%p)->size cannot be zero for array or structure.", \
+                    memdesc->name, memdesc); \
+                on_failure; \
+            } \
+            if (memdesc->children) { \
+                _CHECK_API(memdesc->name, memdesc->children, SOL_MEMDESC_API_VERSION, on_failure); \
+            } \
+        } \
+    } while (0)
+
+#define CHECK_MEMDESC(memdesc, ...) \
+    do { \
+        SOL_NULL_CHECK(memdesc, __VA_ARGS__); \
+        VALIDATE_MEMDESC(memdesc, return __VA_ARGS__); \
+    } while (0)
+
+#define CHECK_MEMDESC_GOTO(memdesc, label) \
+    do { \
+        SOL_NULL_CHECK_GOTO(memdesc, label); \
+        VALIDATE_MEMDESC(memdesc, goto label); \
+    } while (0)
+
+#ifndef SOL_NO_API_VERSION
+SOL_API const uint16_t SOL_MEMDESC_API_VERSION_COMPILED = SOL_MEMDESC_API_VERSION;
+#endif
+
+SOL_API enum sol_memdesc_type
+sol_memdesc_type_from_str(const char *str)
+{
+    static const struct sol_str_table table[] = {
+        SOL_STR_TABLE_ITEM("uint8_t", SOL_MEMDESC_TYPE_UINT8),
+        SOL_STR_TABLE_ITEM("uint16_t", SOL_MEMDESC_TYPE_UINT16),
+        SOL_STR_TABLE_ITEM("uint32_t", SOL_MEMDESC_TYPE_UINT32),
+        SOL_STR_TABLE_ITEM("uint64_t", SOL_MEMDESC_TYPE_UINT64),
+        SOL_STR_TABLE_ITEM("unsigned long", SOL_MEMDESC_TYPE_ULONG),
+        SOL_STR_TABLE_ITEM("size_t", SOL_MEMDESC_TYPE_SIZE),
+        SOL_STR_TABLE_ITEM("int8_t", SOL_MEMDESC_TYPE_INT8),
+        SOL_STR_TABLE_ITEM("int16_t", SOL_MEMDESC_TYPE_INT16),
+        SOL_STR_TABLE_ITEM("int32_t", SOL_MEMDESC_TYPE_INT32),
+        SOL_STR_TABLE_ITEM("int64_t", SOL_MEMDESC_TYPE_INT64),
+        SOL_STR_TABLE_ITEM("long", SOL_MEMDESC_TYPE_LONG),
+        SOL_STR_TABLE_ITEM("ssize_t", SOL_MEMDESC_TYPE_SSIZE),
+        SOL_STR_TABLE_ITEM("boolean", SOL_MEMDESC_TYPE_BOOLEAN),
+        SOL_STR_TABLE_ITEM("double", SOL_MEMDESC_TYPE_DOUBLE),
+        SOL_STR_TABLE_ITEM("string", SOL_MEMDESC_TYPE_STRING),
+        SOL_STR_TABLE_ITEM("const string", SOL_MEMDESC_TYPE_CONST_STRING),
+        SOL_STR_TABLE_ITEM("pointer", SOL_MEMDESC_TYPE_PTR),
+        SOL_STR_TABLE_ITEM("structure", SOL_MEMDESC_TYPE_STRUCTURE),
+        SOL_STR_TABLE_ITEM("array", SOL_MEMDESC_TYPE_ARRAY),
+        { }
+    };
+
+    SOL_NULL_CHECK(str, SOL_MEMDESC_TYPE_UNKNOWN);
+
+    return sol_str_table_lookup_fallback(table,
+        sol_str_slice_from_str(str), SOL_MEMDESC_TYPE_UNKNOWN);
+}
+
+SOL_API const char *
+sol_memdesc_type_to_str(enum sol_memdesc_type type)
+{
+    static const char *strs[] = {
+        [SOL_MEMDESC_TYPE_UINT8] = "uint8_t",
+        [SOL_MEMDESC_TYPE_UINT16] = "uint16_t",
+        [SOL_MEMDESC_TYPE_UINT32] = "uint32_t",
+        [SOL_MEMDESC_TYPE_UINT64] = "uint64_t",
+        [SOL_MEMDESC_TYPE_ULONG] = "unsigned long",
+        [SOL_MEMDESC_TYPE_SIZE] = "size_t",
+        [SOL_MEMDESC_TYPE_INT8] = "int8_t",
+        [SOL_MEMDESC_TYPE_INT16] = "int16_t",
+        [SOL_MEMDESC_TYPE_INT32] = "int32_t",
+        [SOL_MEMDESC_TYPE_INT64] = "int64_t",
+        [SOL_MEMDESC_TYPE_LONG] = "long",
+        [SOL_MEMDESC_TYPE_SSIZE] = "ssize_t",
+        [SOL_MEMDESC_TYPE_BOOLEAN] = "boolean",
+        [SOL_MEMDESC_TYPE_DOUBLE] = "double",
+        [SOL_MEMDESC_TYPE_STRING] = "string",
+        [SOL_MEMDESC_TYPE_CONST_STRING] = "const string",
+        [SOL_MEMDESC_TYPE_PTR] = "pointer",
+        [SOL_MEMDESC_TYPE_STRUCTURE] = "structure",
+        [SOL_MEMDESC_TYPE_ARRAY] = "array",
+    };
+
+    if (type < SOL_UTIL_ARRAY_SIZE(strs))
+        return strs[type];
+
+    return NULL;
+}
+
+static int copy_structure(const struct sol_memdesc *desc, void *container, const void *ptr_content);
+static int copy_array(const struct sol_memdesc *desc, void *dst_memory, const void *src_memory);
+
+static inline const void *
+get_defcontent(const struct sol_memdesc *desc)
+{
+    switch (desc->type) {
+    case SOL_MEMDESC_TYPE_UINT8:
+        return &desc->defcontent.u8;
+    case SOL_MEMDESC_TYPE_UINT16:
+        return &desc->defcontent.u16;
+    case SOL_MEMDESC_TYPE_UINT32:
+        return &desc->defcontent.u32;
+    case SOL_MEMDESC_TYPE_UINT64:
+        return &desc->defcontent.u64;
+    case SOL_MEMDESC_TYPE_ULONG:
+        return &desc->defcontent.ul;
+    case SOL_MEMDESC_TYPE_SIZE:
+        return &desc->defcontent.sz;
+    case SOL_MEMDESC_TYPE_INT8:
+        return &desc->defcontent.i8;
+    case SOL_MEMDESC_TYPE_INT16:
+        return &desc->defcontent.i16;
+    case SOL_MEMDESC_TYPE_INT32:
+        return &desc->defcontent.i32;
+    case SOL_MEMDESC_TYPE_INT64:
+        return &desc->defcontent.i64;
+    case SOL_MEMDESC_TYPE_LONG:
+        return &desc->defcontent.l;
+    case SOL_MEMDESC_TYPE_SSIZE:
+        return &desc->defcontent.ssz;
+    case SOL_MEMDESC_TYPE_BOOLEAN:
+        return &desc->defcontent.b;
+    case SOL_MEMDESC_TYPE_DOUBLE:
+        return &desc->defcontent.d;
+    case SOL_MEMDESC_TYPE_STRING:
+    case SOL_MEMDESC_TYPE_CONST_STRING:
+        return &desc->defcontent.s;
+    case SOL_MEMDESC_TYPE_PTR:
+        return &desc->defcontent.p;
+    case SOL_MEMDESC_TYPE_STRUCTURE:
+    case SOL_MEMDESC_TYPE_ARRAY:
+        return desc->defcontent.p;
+
+    default:
+        return NULL;
+    }
+}
+
+static inline int
+set_content(const struct sol_memdesc *desc, void *container, const void *ptr_content)
+{
+    void *mem;
+
+    if (desc->ops && desc->ops->set_content)
+        return desc->ops->set_content(desc, container, ptr_content);
+
+    mem = sol_memdesc_get_memory(desc, container);
+
+    if (desc->type == SOL_MEMDESC_TYPE_STRING) {
+        const char *const *pv = ptr_content;
+        int r = sol_util_replace_str_if_changed(mem, *pv);
+        if (r >= 0)
+            return 0;
+        return r;
+    } else if (desc->type == SOL_MEMDESC_TYPE_PTR && desc->children) {
+        const void *const *pv = ptr_content;
+        void **m = mem;
+
+        if (!*m && *pv) {
+            *m = sol_memdesc_new_with_defaults(desc->children);
+            if (!*m)
+                return -errno;
+        } else if (*m && !*pv) {
+            sol_memdesc_free(desc->children, *m);
+            *m = NULL;
+            return 0;
+        } else if (!*pv)
+            return 0;
+
+        return set_content(desc->children, *m, *pv);
+
+    } else if (desc->type == SOL_MEMDESC_TYPE_STRUCTURE) {
+        if (!desc->children) {
+            SOL_WRN("desc=%p (%s) is SOL_MEMDESC_TYPE_STRUCTURE but does not provide children", desc, desc->name);
+            return -EINVAL;
+        }
+
+        return copy_structure(desc, mem, ptr_content);
+    } else if (desc->type == SOL_MEMDESC_TYPE_ARRAY) {
+        if (!desc->children) {
+            SOL_WRN("desc=%p (%s) is SOL_MEMDESC_TYPE_ARRAY but does not provide children", desc, desc->name);
+            return -EINVAL;
+        }
+
+        return copy_array(desc, mem, ptr_content);
+    }
+
+    memcpy(mem, ptr_content, sol_memdesc_get_size(desc));
+    return 0;
+}
+
+static int
+copy_content(const struct sol_memdesc *desc, const void *src_container, void *dst_container)
+{
+    const void *src_mem;
+
+    if (desc->ops && desc->ops->copy)
+        return desc->ops->copy(desc, src_container, dst_container);
+
+    src_mem = sol_memdesc_get_memory(desc, src_container);
+    return set_content(desc, dst_container, src_mem);
+}
+
+static int
+copy_structure(const struct sol_memdesc *desc, void *container, const void *ptr_content)
+{
+    const struct sol_memdesc *itr;
+
+    SOL_MEMDESC_FOREACH_STRUCTURE_MEMBER(desc, itr) {
+        int r;
+
+        r = copy_content(itr, ptr_content, container);
+        if (r < 0)
+            return r;
+    }
+
+    return 0;
+}
+
+static int compare_content(const struct sol_memdesc *desc, const void *a_container, const void *b_container);
+
+static int
+compare_structure(const struct sol_memdesc *desc, const void *a_container, const void *b_container)
+{
+    const struct sol_memdesc *itr;
+
+    errno = 0;
+    SOL_MEMDESC_FOREACH_STRUCTURE_MEMBER(desc, itr) {
+        int r;
+
+        r = compare_content(itr, a_container, b_container);
+        if (r != 0 || errno)
+            return r;
+    }
+
+    return 0;
+}
+
+static int
+compare_array(const struct sol_memdesc *desc, const void *a_memory, const void *b_memory)
+{
+    const void *a_item, *b_item;
+    ssize_t idx, len, a_len, b_len;
+
+    a_len = sol_memdesc_get_array_length(desc, a_memory);
+    if (a_len < 0) {
+        errno = -a_len;
+        return 0;
+    }
+    b_len = sol_memdesc_get_array_length(desc, b_memory);
+    if (b_len < 0) {
+        errno = -b_len;
+        return 0;
+    }
+
+    len = sol_util_min(a_len, b_len);
+    SOL_MEMDESC_FOREACH_ARRAY_ELEMENT_IN_RANGE(desc, a_memory, 0, len, idx, a_item) {
+        int r;
+
+        b_item = sol_memdesc_get_array_element(desc, b_memory, idx);
+        if (!b_item)
+            return 0;
+
+        r = compare_content(desc->children, a_item, b_item);
+        if (r != 0 || errno)
+            return r;
+    }
+
+    if (idx < len) /* loop failed */
+        return 0;
+
+    if (a_len < b_len)
+        return -1;
+    if (a_len > b_len)
+        return 1;
+
+    return 0;
+}
+
+static int
+copy_array(const struct sol_memdesc *desc, void *dst_memory, const void *src_memory)
+{
+    const void *src_item;
+    ssize_t idx, len;
+    int r;
+
+    len = sol_memdesc_get_array_length(desc, src_memory);
+    if (len < 0) {
+        errno = -len;
+        return 0;
+    }
+
+    r = sol_memdesc_resize_array(desc, dst_memory, len);
+    if (r < 0)
+        return r;
+
+    SOL_MEMDESC_FOREACH_ARRAY_ELEMENT_IN_RANGE(desc, src_memory, 0, len, idx, src_item) {
+        void *dst_item = sol_memdesc_get_array_element(desc, dst_memory, idx);
+
+        if (!dst_item) {
+            r = -errno;
+            goto failure;
+        }
+
+        r = set_content(desc->children, dst_item, src_item);
+        if (r < 0)
+            goto failure;
+    }
+
+    if (idx < len) {
+        r = errno ? -errno : -EINVAL;
+        goto failure;
+    }
+
+    return 0;
+
+failure:
+    sol_memdesc_resize_array(desc, dst_memory, idx);
+    return r;
+}
+
+static int
+compare_content(const struct sol_memdesc *desc, const void *a_container, const void *b_container)
+{
+    const void *a_mem, *b_mem;
+
+    if (desc->ops && desc->ops->compare)
+        return desc->ops->compare(desc, a_container, b_container);
+
+    a_mem = sol_memdesc_get_memory(desc, a_container);
+    b_mem = sol_memdesc_get_memory(desc, b_container);
+
+#define RET_CMP_INT(type) \
+    do { \
+        const type *a = a_mem; \
+        const type *b = b_mem; \
+        if (*a < *b) \
+            return -1; \
+        else if (*a > *b) \
+            return 1; \
+        else \
+            return 0; \
+    } while (0)
+
+    switch (desc->type) {
+    case SOL_MEMDESC_TYPE_UINT8:
+        RET_CMP_INT(uint8_t);
+    case SOL_MEMDESC_TYPE_UINT16:
+        RET_CMP_INT(uint16_t);
+    case SOL_MEMDESC_TYPE_UINT32:
+        RET_CMP_INT(uint32_t);
+    case SOL_MEMDESC_TYPE_UINT64:
+        RET_CMP_INT(uint64_t);
+    case SOL_MEMDESC_TYPE_ULONG:
+        RET_CMP_INT(unsigned long);
+    case SOL_MEMDESC_TYPE_SIZE:
+        RET_CMP_INT(size_t);
+    case SOL_MEMDESC_TYPE_INT8:
+        RET_CMP_INT(int8_t);
+    case SOL_MEMDESC_TYPE_INT16:
+        RET_CMP_INT(int16_t);
+    case SOL_MEMDESC_TYPE_INT32:
+        RET_CMP_INT(int32_t);
+    case SOL_MEMDESC_TYPE_INT64:
+        RET_CMP_INT(int64_t);
+    case SOL_MEMDESC_TYPE_LONG:
+        RET_CMP_INT(long);
+    case SOL_MEMDESC_TYPE_SSIZE:
+        RET_CMP_INT(ssize_t);
+    case SOL_MEMDESC_TYPE_BOOLEAN: {
+        const bool *a = a_mem;
+        const bool *b = b_mem;
+
+        if (!*a && *b)
+            return -1;
+        else if (*a && !*b)
+            return 1;
+        else
+            return 0;
+    }
+    case SOL_MEMDESC_TYPE_DOUBLE: {
+        const double *a = a_mem;
+        const double *b = b_mem;
+
+        if (sol_util_double_equal(*a, *b))
+            return 0;
+        else if (*a < *b)
+            return -1;
+        else
+            return 1;
+    }
+    case SOL_MEMDESC_TYPE_CONST_STRING:
+    case SOL_MEMDESC_TYPE_STRING: {
+        const char *const *a = a_mem;
+        const char *const *b = b_mem;
+
+        if (!*a && *b)
+            return -1;
+        else if (*a && !*b)
+            return 1;
+        else if (*a == *b)
+            return 0;
+        else
+            return strcmp(*a, *b);
+    }
+    case SOL_MEMDESC_TYPE_PTR: {
+        const void *const *a = a_mem;
+        const void *const *b = b_mem;
+
+        if (!desc->children || !*a || !*b) {
+            if (*a < *b)
+                return -1;
+            else if (*a > *b)
+                return 1;
+            else
+                return 0;
+        }
+
+        return compare_content(desc->children, *a, *b);
+    }
+    case SOL_MEMDESC_TYPE_STRUCTURE: {
+        if (!desc->children) {
+            SOL_WRN("desc=%p (%s) is SOL_MEMDESC_TYPE_STRUCTURE but does not provide children", desc, desc->name);
+            errno = EINVAL;
+            return 0;
+        }
+        return compare_structure(desc, a_mem, b_mem);
+    }
+    case SOL_MEMDESC_TYPE_ARRAY: {
+        if (!desc->children) {
+            SOL_WRN("desc=%p (%s) is SOL_MEMDESC_TYPE_ARRAY but does not provide children", desc, desc->name);
+            errno = EINVAL;
+            return 0;
+        }
+        return compare_array(desc, a_mem, b_mem);
+    }
+    default:
+        errno = EINVAL;
+        return 0;
+    }
+
+#undef RET_CMP_INT
+}
+
+SOL_API int
+sol_memdesc_init_defaults(const struct sol_memdesc *desc, void *container)
+{
+    const void *defcontent;
+    void *mem;
+
+    CHECK_MEMDESC(desc, -EINVAL);
+    SOL_NULL_CHECK(container, -EINVAL);
+
+    mem = sol_memdesc_get_memory(desc, container);
+    memset(mem, 0, sol_memdesc_get_size(desc));
+
+    if (desc->ops && desc->ops->init_defaults)
+        return desc->ops->init_defaults(desc, container);
+
+    if (desc->type == SOL_MEMDESC_TYPE_STRUCTURE) {
+        const struct sol_memdesc *itr;
+
+        if (!desc->children) {
+            SOL_WRN("desc=%p (%s) is SOL_MEMDESC_TYPE_STRUCTURE but does not provide children", desc, desc->name);
+            return -EINVAL;
+        }
+
+        SOL_MEMDESC_FOREACH_STRUCTURE_MEMBER(desc, itr) {
+            int r;
+
+            r = sol_memdesc_init_defaults(itr, mem);
+            if (r < 0)
+                return r;
+        }
+
+        if (desc->defcontent.p)
+            return set_content(desc, container, desc->defcontent.p);
+
+        return 0;
+    } else if (desc->type == SOL_MEMDESC_TYPE_ARRAY) {
+        if (desc->defcontent.p)
+            return set_content(desc, container, desc->defcontent.p);
+
+        return 0;
+    }
+
+    defcontent = get_defcontent(desc);
+    return set_content(desc, container, defcontent);
+}
+
+SOL_API int
+sol_memdesc_copy(const struct sol_memdesc *desc, const void *src_container, void *dst_container)
+{
+    CHECK_MEMDESC(desc, -EINVAL);
+    SOL_NULL_CHECK(src_container, -EINVAL);
+    SOL_NULL_CHECK(dst_container, -EINVAL);
+
+    return copy_content(desc, src_container, dst_container);
+}
+
+SOL_API int
+sol_memdesc_set_content(const struct sol_memdesc *desc, void *container, const void *ptr_content)
+{
+    CHECK_MEMDESC(desc, -EINVAL);
+    SOL_NULL_CHECK(container, -EINVAL);
+    SOL_NULL_CHECK(ptr_content, -EINVAL);
+
+    return set_content(desc, container, ptr_content);
+}
+
+SOL_API int
+sol_memdesc_compare(const struct sol_memdesc *desc, const void *a_container, const void *b_container)
+{
+    errno = EINVAL;
+    CHECK_MEMDESC(desc, 0);
+    SOL_NULL_CHECK(a_container, 0);
+    SOL_NULL_CHECK(b_container, 0);
+
+    errno = 0;
+    return compare_content(desc, a_container, b_container);
+}
+
+SOL_API int
+sol_memdesc_free_content(const struct sol_memdesc *desc, void *container)
+{
+    void *mem;
+
+    CHECK_MEMDESC(desc, -EINVAL);
+    SOL_NULL_CHECK(container, -EINVAL);
+
+    if (desc->ops && desc->ops->free_content)
+        return desc->ops->free_content(desc, container);
+
+    mem = sol_memdesc_get_memory(desc, container);
+
+    if (desc->type == SOL_MEMDESC_TYPE_STRING) {
+        char **m = mem;
+        free(*m);
+        *m = NULL;
+        return 0;
+    } else if (desc->type == SOL_MEMDESC_TYPE_PTR && desc->children) {
+        void **m = mem;
+
+        if (*m) {
+            sol_memdesc_free(desc->children, *m);
+            *m = NULL;
+        }
+        return 0;
+    } else if (desc->type == SOL_MEMDESC_TYPE_STRUCTURE) {
+        const struct sol_memdesc *itr;
+        int ret = 0;
+
+        if (!desc->children) {
+            SOL_WRN("desc=%p (%s) is SOL_MEMDESC_TYPE_STRUCTURE but does not provide children", desc, desc->name);
+            return -EINVAL;
+        }
+
+        SOL_MEMDESC_FOREACH_STRUCTURE_MEMBER(desc, itr) {
+            int r;
+
+            r = sol_memdesc_free_content(itr, mem);
+            if (r < 0 && ret == 0)
+                ret = r;
+        }
+        return ret;
+    } else if (desc->type == SOL_MEMDESC_TYPE_ARRAY)
+        return sol_memdesc_resize_array(desc, mem, 0);
+
+    memset(mem, 0, sol_memdesc_get_size(desc));
+    return 0;
+}
+
+SOL_API ssize_t
+sol_memdesc_get_array_length(const struct sol_memdesc *desc, const void *memory)
+{
+    CHECK_MEMDESC(desc, -EINVAL);
+    SOL_NULL_CHECK(memory, -EINVAL);
+
+    if (desc->type != SOL_MEMDESC_TYPE_ARRAY) {
+        SOL_WRN("desc=%p (%s) is not SOL_MEMDESC_TYPE_ARRAY", desc, desc->name);
+        return -EINVAL;
+    } else if (!desc->ops || !desc->ops->array.get_length) {
+        SOL_WRN("desc=%p (%s) is SOL_MEMDESC_TYPE_ARRAY but does not provide ops->array.get_length", desc, desc->name);
+        return -EINVAL;
+    }
+
+    return desc->ops->array.get_length(desc, memory);
+}
+
+SOL_API void *
+sol_memdesc_get_array_element(const struct sol_memdesc *desc, const void *memory, size_t idx)
+{
+    errno = EINVAL;
+    CHECK_MEMDESC(desc, NULL);
+    SOL_NULL_CHECK(memory, NULL);
+
+    if (desc->type != SOL_MEMDESC_TYPE_ARRAY) {
+        SOL_WRN("desc=%p (%s) is not SOL_MEMDESC_TYPE_ARRAY", desc, desc->name);
+        return NULL;
+    } else if (!desc->ops || !desc->ops->array.get_element) {
+        SOL_WRN("desc=%p (%s) is SOL_MEMDESC_TYPE_ARRAY but does not provide ops->array.get_element", desc, desc->name);
+        return NULL;
+    }
+
+    errno = 0;
+    return desc->ops->array.get_element(desc, memory, idx);
+}
+
+SOL_API int
+sol_memdesc_resize_array(const struct sol_memdesc *desc, void *memory, size_t length)
+{
+    CHECK_MEMDESC(desc, -EINVAL);
+    SOL_NULL_CHECK(memory, -EINVAL);
+
+    if (desc->type != SOL_MEMDESC_TYPE_ARRAY) {
+        SOL_WRN("desc=%p (%s) is not SOL_MEMDESC_TYPE_ARRAY", desc, desc->name);
+        return -EINVAL;
+    } else if (!desc->ops || !desc->ops->array.resize) {
+        SOL_WRN("desc=%p (%s) is SOL_MEMDESC_TYPE_ARRAY but does not provide ops->array.resize", desc, desc->name);
+        return -EINVAL;
+    }
+
+    return desc->ops->array.resize(desc, memory, length);
+}
+
+static int
+vector_ops_init_defaults(const struct sol_memdesc *desc, void *container)
+{
+    struct sol_vector *v = sol_memdesc_get_memory(desc, container);
+    uint16_t child_size = sol_memdesc_get_size(desc->children);
+
+    SOL_INT_CHECK(child_size, == 0, -EINVAL);
+    SOL_INT_CHECK(desc->children->offset, != 0, -EINVAL);
+    SOL_INT_CHECK(desc->size, != sizeof(struct sol_vector), -EINVAL);
+
+    sol_vector_init(v, child_size);
+
+    if (desc->defcontent.p)
+        return sol_memdesc_set_content(desc, container, desc->defcontent.p);
+
+    return 0;
+}
+
+static ssize_t
+vector_ops_get_array_length(const struct sol_memdesc *desc, const void *memory)
+{
+    const struct sol_vector *v = memory;
+
+    return v->len;
+}
+
+static void *
+vector_ops_get_array_element(const struct sol_memdesc *desc, const void *memory, size_t idx)
+{
+    const struct sol_vector *v = memory;
+
+    errno = ERANGE;
+    SOL_INT_CHECK(idx, > UINT16_MAX, NULL);
+    errno = 0;
+
+    return sol_vector_get(v, idx);
+}
+
+static int
+vector_ops_resize_array(const struct sol_memdesc *desc, void *memory, size_t len)
+{
+    struct sol_vector *v = memory;
+    uint16_t oldlen;
+
+    SOL_INT_CHECK(len, > UINT16_MAX, -ERANGE);
+
+    oldlen = v->len;
+    if (oldlen == len)
+        return 0;
+
+    if (oldlen < len) {
+        void *m = sol_vector_append_n(v, len - oldlen);
+
+        if (!m)
+            return errno ? -errno : -ENOMEM;
+
+        if (sol_memdesc_get_size(desc->children)) {
+            uint16_t idx;
+
+            for (idx = oldlen; idx < len; idx++) {
+                void *itmem;
+                int r;
+
+                itmem = sol_vector_get_nocheck(v, idx);
+                r = sol_memdesc_init_defaults(desc->children, itmem);
+                if (r < 0) {
+                    sol_vector_del_range(v, idx, len - idx);
+                    return r;
+                }
+            }
+        }
+
+        return 0;
+    } else {
+        if (sol_memdesc_get_size(desc->children)) {
+            uint16_t idx;
+
+            for (idx = len; idx < oldlen; idx++) {
+                void *itmem;
+
+                itmem = sol_vector_get_nocheck(v, idx);
+                sol_memdesc_free_content(desc->children, itmem);
+            }
+        }
+
+        return sol_vector_del_range(v, len, oldlen - len);
+    }
+}
+
+SOL_API const struct sol_memdesc_ops SOL_MEMDESC_OPS_VECTOR = {
+    SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_OPS_API_VERSION, )
+    .init_defaults = vector_ops_init_defaults,
+    .array = {
+        .get_length = vector_ops_get_array_length,
+        .get_element = vector_ops_get_array_element,
+        .resize = vector_ops_resize_array,
+    },
+};
+
+
+static int
+ptr_vector_ops_init_defaults(const struct sol_memdesc *desc, void *container)
+{
+    struct sol_ptr_vector *v = sol_memdesc_get_memory(desc, container);
+
+    if (desc->size != sizeof(struct sol_ptr_vector))
+        return -EINVAL;
+
+    if (desc->children && sol_memdesc_get_size(desc->children) != sizeof(void *))
+        return -EINVAL;
+
+    sol_ptr_vector_init(v);
+
+    if (desc->defcontent.p)
+        return sol_memdesc_set_content(desc, container, desc->defcontent.p);
+
+    return 0;
+}
+
+SOL_API const struct sol_memdesc_ops SOL_MEMDESC_OPS_PTR_VECTOR = {
+    SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_OPS_API_VERSION, )
+    .init_defaults = ptr_vector_ops_init_defaults,
+    .array = {
+        .get_length = vector_ops_get_array_length,
+        .get_element = vector_ops_get_array_element,
+        .resize = vector_ops_resize_array,
+    },
+};

--- a/src/lib/datatypes/sol-memdesc.c
+++ b/src/lib/datatypes/sol-memdesc.c
@@ -804,3 +804,541 @@ SOL_API const struct sol_memdesc_ops SOL_MEMDESC_OPS_PTR_VECTOR = {
         .resize = vector_ops_resize_array,
     },
 };
+
+static int
+serialize_indent(struct sol_buffer *buf, struct sol_buffer *prefix, const struct sol_str_slice str)
+{
+    int r;
+
+    if (!str.len)
+        return 0;
+
+    r = sol_buffer_append_slice(prefix, str);
+    if (r < 0)
+        return r;
+
+    return sol_buffer_append_buffer(buf, prefix);
+}
+
+static int
+serialize_deindent(struct sol_buffer *buf, struct sol_buffer *prefix, const struct sol_str_slice str, bool output)
+{
+    int r;
+
+    if (!str.len)
+        return 0;
+
+    SOL_INT_CHECK(prefix->used, < str.len, -EINVAL);
+
+    r = sol_buffer_remove_data(prefix, prefix->used - str.len, str.len);
+    if (r < 0)
+        return r;
+
+    if (output)
+        return sol_buffer_append_buffer(buf, prefix);
+    return 0;
+}
+
+static int
+default_serialize_int64(const struct sol_memdesc *desc, int64_t value, struct sol_buffer *buffer)
+{
+    return sol_buffer_append_printf(buffer, "%" PRIi64, value);
+}
+
+static int
+default_serialize_uint64(const struct sol_memdesc *desc, uint64_t value, struct sol_buffer *buffer)
+{
+    return sol_buffer_append_printf(buffer, "%" PRIu64, value);
+}
+
+static int
+default_serialize_double(const struct sol_memdesc *desc, double value, struct sol_buffer *buffer)
+{
+    return sol_buffer_append_printf(buffer, "%g", value);
+}
+
+static int
+default_serialize_boolean(const struct sol_memdesc *desc, bool value, struct sol_buffer *buffer)
+{
+    if (value)
+        return sol_buffer_append_slice(buffer, sol_str_slice_from_str("true"));
+    else
+        return sol_buffer_append_slice(buffer, sol_str_slice_from_str("false"));
+}
+
+static int
+default_serialize_pointer(const struct sol_memdesc *desc, const void *value, struct sol_buffer *buffer)
+{
+    return sol_buffer_append_printf(buffer, "%p", value);
+}
+
+static int
+default_serialize_string(const struct sol_memdesc *desc, const char *value, struct sol_buffer *buffer)
+{
+    const char *last = value;
+    const char *itr;
+    int r;
+
+    if (!value)
+        return sol_buffer_append_slice(buffer, sol_str_slice_from_str("NULL"));
+
+    r = sol_buffer_append_char(buffer, '"');
+    if (r < 0)
+        return r;
+
+    for (itr = value; *itr != '\0'; itr++) {
+        if (!isprint(*itr) || *itr == '"') {
+            r = sol_buffer_append_bytes(buffer, (const uint8_t *)last, itr - last);
+            if (r < 0)
+                return r;
+            last = itr + 1;
+
+            if (*itr == '"')
+                r = sol_buffer_append_slice(buffer, sol_str_slice_from_str("\\\""));
+            else if (*itr == '\t')
+                r = sol_buffer_append_slice(buffer, sol_str_slice_from_str("\\t"));
+            else if (*itr == '\n')
+                r = sol_buffer_append_slice(buffer, sol_str_slice_from_str("\\n"));
+            else if (*itr == '\r')
+                r = sol_buffer_append_slice(buffer, sol_str_slice_from_str("\\r"));
+            else if (*itr == '\f')
+                r = sol_buffer_append_slice(buffer, sol_str_slice_from_str("\\f"));
+            else if (*itr == '\v')
+                r = sol_buffer_append_slice(buffer, sol_str_slice_from_str("\\v"));
+            else
+                r = sol_buffer_append_printf(buffer, "\\x%x", *itr);
+            if (r < 0)
+                return r;
+        }
+    }
+
+    if (last < itr) {
+        r = sol_buffer_append_bytes(buffer, (const uint8_t *)last, itr - last);
+        if (r < 0)
+            return r;
+    }
+
+    return sol_buffer_append_char(buffer, '"');
+}
+
+static int
+default_serialize_structure_member_key(const struct sol_memdesc *member, struct sol_buffer *buf, const struct sol_memdesc_serialize_options *opts, struct sol_buffer *prefix)
+{
+    int r;
+
+    r = serialize_indent(buf, prefix, opts->structure.key.indent);
+    if (r < 0)
+        return r;
+
+    if (opts->structure.key.start.len) {
+        r = sol_buffer_append_slice(buf, opts->structure.key.start);
+        if (r < 0)
+            return r;
+    }
+
+    r = sol_buffer_append_slice(buf, sol_str_slice_from_str(member->name));
+    if (r < 0)
+        return r;
+
+    if (opts->structure.key.end.len) {
+        r = sol_buffer_append_slice(buf, opts->structure.key.end);
+        if (r < 0)
+            return r;
+    }
+
+    return 0;
+}
+
+static int
+default_serialize_structure_member(const struct sol_memdesc *structure, const struct sol_memdesc *member, const void *container, struct sol_buffer *buf, const struct sol_memdesc_serialize_options *opts, struct sol_buffer *prefix, bool is_first)
+{
+    int r;
+
+    if (!is_first) {
+        if (opts->structure.separator.len) {
+            r = sol_buffer_append_slice(buf, opts->structure.separator);
+            if (r < 0)
+                return r;
+        }
+    }
+
+    if (opts->structure.show_key) {
+        r = default_serialize_structure_member_key(member, buf, opts, prefix);
+        if (r < 0)
+            return r;
+    }
+
+    r = serialize_indent(buf, prefix, opts->structure.value.indent);
+    if (r < 0)
+        return r;
+
+    if (opts->structure.value.start.len) {
+        r = sol_buffer_append_slice(buf, opts->structure.value.start);
+        if (r < 0)
+            return r;
+    }
+
+    r = sol_memdesc_serialize(member, container, buf, opts, prefix);
+    if (r < 0)
+        return r;
+
+    if (opts->structure.value.end.len) {
+        r = sol_buffer_append_slice(buf, opts->structure.value.end);
+        if (r < 0)
+            return r;
+    }
+
+    r = serialize_deindent(buf, prefix, opts->structure.value.indent, false);
+    if (r < 0)
+        return r;
+
+    if (opts->structure.show_key)
+        return serialize_deindent(buf, prefix, opts->structure.key.indent, false);
+    return 0;
+}
+
+static int
+default_serialize_array_item_index(size_t idx, struct sol_buffer *buf, const struct sol_memdesc_serialize_options *opts, struct sol_buffer *prefix)
+{
+    int r;
+
+    r = serialize_indent(buf, prefix, opts->array.index.indent);
+    if (r < 0)
+        return r;
+
+    if (opts->array.index.start.len) {
+        r = sol_buffer_append_slice(buf, opts->array.index.start);
+        if (r < 0)
+            return r;
+    }
+
+    r = sol_buffer_append_printf(buf, "%zu", idx);
+    if (r < 0)
+        return r;
+
+    if (opts->array.index.end.len) {
+        r = sol_buffer_append_slice(buf, opts->array.index.end);
+        if (r < 0)
+            return r;
+    }
+
+    return 0;
+}
+
+static int
+default_serialize_array_item(const struct sol_memdesc *desc, size_t idx, const void *memory, struct sol_buffer *buf, const struct sol_memdesc_serialize_options *opts, struct sol_buffer *prefix)
+{
+    int r;
+
+    if (idx > 0) {
+        if (opts->array.separator.len) {
+            r = sol_buffer_append_slice(buf, opts->array.separator);
+            if (r < 0)
+                return r;
+        }
+    }
+
+    if (opts->array.show_index) {
+        r = default_serialize_array_item_index(idx, buf, opts, prefix);
+        if (r < 0)
+            return r;
+    }
+
+    r = serialize_indent(buf, prefix, opts->array.value.indent);
+    if (r < 0)
+        return r;
+
+    if (opts->array.value.start.len) {
+        r = sol_buffer_append_slice(buf, opts->array.value.start);
+        if (r < 0)
+            return r;
+    }
+
+    r = sol_memdesc_serialize(desc->children, memory, buf, opts, prefix);
+    if (r < 0)
+        return r;
+
+    if (opts->array.value.end.len) {
+        r = sol_buffer_append_slice(buf, opts->array.value.end);
+        if (r < 0)
+            return r;
+    }
+
+    r = serialize_deindent(buf, prefix, opts->array.value.indent, false);
+    if (r < 0)
+        return r;
+
+    if (opts->array.show_index)
+        return serialize_deindent(buf, prefix, opts->array.index.indent, false);
+    return 0;
+}
+
+static const struct sol_memdesc_serialize_options default_serialize_options = {
+    SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_SERIALIZE_OPTIONS_API_VERSION, )
+    .serialize_int64 = default_serialize_int64,
+    .serialize_uint64 = default_serialize_uint64,
+    .serialize_double = default_serialize_double,
+    .serialize_boolean = default_serialize_boolean,
+    .serialize_pointer = default_serialize_pointer,
+    .serialize_string = default_serialize_string,
+    .serialize_structure_member = default_serialize_structure_member,
+    .serialize_array_item = default_serialize_array_item,
+    .structure = {
+        .container = {
+            .start = SOL_STR_SLICE_LITERAL("{\n"),
+            .end = SOL_STR_SLICE_LITERAL("}"),
+        },
+        .key = {
+            .start = SOL_STR_SLICE_LITERAL("."),
+            .end = SOL_STR_SLICE_LITERAL(" = "),
+            .indent = SOL_STR_SLICE_LITERAL("    "),
+        },
+        .separator = SOL_STR_SLICE_LITERAL(",\n"),
+        .show_key = true,
+    },
+    .array = {
+        .container = {
+            .start = SOL_STR_SLICE_LITERAL("{\n"),
+            .end = SOL_STR_SLICE_LITERAL("}"),
+        },
+        .index = {
+            .start = SOL_STR_SLICE_LITERAL("["),
+            .end = SOL_STR_SLICE_LITERAL("] = "),
+            .indent = SOL_STR_SLICE_LITERAL("    "),
+        },
+        .separator = SOL_STR_SLICE_LITERAL(",\n"),
+        .show_index = true,
+    },
+    .detailed = true,
+};
+
+static int
+serialize_boolean(const struct sol_memdesc *desc, const void *container, struct sol_buffer *buf, const struct sol_memdesc_serialize_options *opts)
+{
+    const bool *m = sol_memdesc_get_memory(desc, container);
+
+    if (opts->serialize_boolean)
+        return opts->serialize_boolean(desc, *m, buf);
+    else
+        return default_serialize_boolean(desc, *m, buf);
+}
+
+static int
+serialize_double(const struct sol_memdesc *desc, const void *container, struct sol_buffer *buf, const struct sol_memdesc_serialize_options *opts)
+{
+    const double *m = sol_memdesc_get_memory(desc, container);
+
+    if (opts->serialize_double)
+        return opts->serialize_double(desc, *m, buf);
+    else
+        return default_serialize_double(desc, *m, buf);
+}
+
+static int
+serialize_int64(const struct sol_memdesc *desc, const void *container, struct sol_buffer *buf, const struct sol_memdesc_serialize_options *opts)
+{
+    int64_t m = sol_memdesc_get_as_int64(desc, container);
+
+    if (opts->serialize_int64)
+        return opts->serialize_int64(desc, m, buf);
+    else
+        return default_serialize_int64(desc, m, buf);
+}
+
+static int
+serialize_uint64(const struct sol_memdesc *desc, const void *container, struct sol_buffer *buf, const struct sol_memdesc_serialize_options *opts)
+{
+    uint64_t m = sol_memdesc_get_as_uint64(desc, container);
+
+    if (opts->serialize_uint64)
+        return opts->serialize_uint64(desc, m, buf);
+    else
+        return default_serialize_uint64(desc, m, buf);
+}
+
+static int
+serialize_string(const struct sol_memdesc *desc, const void *container, struct sol_buffer *buf, const struct sol_memdesc_serialize_options *opts)
+{
+    const char *const *m = sol_memdesc_get_memory(desc, container);
+
+    if (opts->serialize_string)
+        return opts->serialize_string(desc, *m, buf);
+    else
+        return default_serialize_string(desc, *m, buf);
+}
+
+static int serialize(const struct sol_memdesc *desc, const void *container, struct sol_buffer *buf, const struct sol_memdesc_serialize_options *opts, struct sol_buffer *prefix);
+
+static int
+serialize_pointer(const struct sol_memdesc *desc, const void *container, struct sol_buffer *buf, const struct sol_memdesc_serialize_options *opts, struct sol_buffer *prefix)
+{
+    const void *const *m = sol_memdesc_get_memory(desc, container);
+
+    if (!*m || !desc->children) {
+        if (opts->serialize_pointer)
+            return opts->serialize_pointer(desc, *m, buf);
+        else
+            return default_serialize_pointer(desc, *m, buf);
+    }
+
+    CHECK_MEMDESC(desc->children, -EINVAL);
+    return serialize(desc->children, *m, buf, opts, prefix);
+}
+
+static int
+serialize_structure_member(const struct sol_memdesc *structure, const struct sol_memdesc *member, const void *container, struct sol_buffer *buffer, const struct sol_memdesc_serialize_options *opts, struct sol_buffer *prefix, bool is_first)
+{
+    if (opts->serialize_structure_member)
+        return opts->serialize_structure_member(structure, member, container, buffer, opts, prefix, is_first);
+    else
+        return default_serialize_structure_member(structure, member, container, buffer, opts, prefix, is_first);
+}
+
+static int
+serialize_structure(const struct sol_memdesc *desc, const void *container, struct sol_buffer *buf, const struct sol_memdesc_serialize_options *opts, struct sol_buffer *prefix)
+{
+    const struct sol_memdesc *itr;
+    bool is_first = true;
+    int r;
+
+    r = serialize_indent(buf, prefix, opts->structure.container.indent);
+    if (r < 0)
+        return r;
+
+    if (opts->structure.container.start.len) {
+        r = sol_buffer_append_slice(buf, opts->structure.container.start);
+        if (r < 0)
+            return r;
+    }
+
+    SOL_MEMDESC_FOREACH_STRUCTURE_MEMBER(desc, itr) {
+        if (!opts->detailed && itr->detail)
+            continue;
+        r = serialize_structure_member(desc, itr, container, buf, opts, prefix, is_first);
+        if (r < 0)
+            return r;
+        if (is_first)
+            is_first = false;
+    }
+
+    r = serialize_deindent(buf, prefix, opts->structure.container.indent, true);
+    if (r < 0)
+        return r;
+
+    if (opts->structure.container.end.len) {
+        r = sol_buffer_append_slice(buf, opts->structure.container.end);
+        if (r < 0)
+            return r;
+    }
+
+    return 0;
+}
+
+static int
+serialize_array_item(const struct sol_memdesc *desc, size_t idx, const void *memory, struct sol_buffer *buffer, const struct sol_memdesc_serialize_options *opts, struct sol_buffer *prefix)
+{
+    if (opts->serialize_array_item)
+        return opts->serialize_array_item(desc, idx, memory, buffer, opts, prefix);
+    else
+        return default_serialize_array_item(desc, idx, memory, buffer, opts, prefix);
+}
+
+static int
+serialize_array(const struct sol_memdesc *desc, const void *container, struct sol_buffer *buf, const struct sol_memdesc_serialize_options *opts, struct sol_buffer *prefix)
+{
+    const void *mem = sol_memdesc_get_memory(desc, container);
+    const void *item;
+    ssize_t idx, len;
+    int r;
+
+    SOL_NULL_CHECK(mem, -EINVAL);
+
+    len = sol_memdesc_get_array_length(desc, mem);
+    if (len < 0)
+        return len;
+
+    r = serialize_indent(buf, prefix, opts->array.container.indent);
+    if (r < 0)
+        return r;
+
+    if (opts->array.container.start.len) {
+        r = sol_buffer_append_slice(buf, opts->array.container.start);
+        if (r < 0)
+            return r;
+    }
+
+    SOL_MEMDESC_FOREACH_ARRAY_ELEMENT_IN_RANGE(desc, mem, 0, len, idx, item) {
+        r = serialize_array_item(desc, idx, item, buf, opts, prefix);
+        if (r < 0)
+            return r;
+    }
+
+    r = serialize_deindent(buf, prefix, opts->array.container.indent, true);
+    if (r < 0)
+        return r;
+
+    if (opts->array.container.end.len) {
+        r = sol_buffer_append_slice(buf, opts->array.container.end);
+        if (r < 0)
+            return r;
+    }
+
+    return 0;
+}
+
+static int
+serialize(const struct sol_memdesc *desc, const void *container, struct sol_buffer *buf, const struct sol_memdesc_serialize_options *opts, struct sol_buffer *prefix)
+{
+    if (desc->type == SOL_MEMDESC_TYPE_BOOLEAN)
+        return serialize_boolean(desc, container, buf, opts);
+    else if (desc->type == SOL_MEMDESC_TYPE_DOUBLE)
+        return serialize_double(desc, container, buf, opts);
+    else if (desc->type == SOL_MEMDESC_TYPE_STRING ||
+        desc->type == SOL_MEMDESC_TYPE_CONST_STRING)
+        return serialize_string(desc, container, buf, opts);
+    else if (sol_memdesc_is_unsigned(desc))
+        return serialize_uint64(desc, container, buf, opts);
+    else if (sol_memdesc_is_signed(desc))
+        return serialize_int64(desc, container, buf, opts);
+    else if (desc->type == SOL_MEMDESC_TYPE_PTR)
+        return serialize_pointer(desc, container, buf, opts, prefix);
+    else if (desc->type == SOL_MEMDESC_TYPE_STRUCTURE)
+        return serialize_structure(desc, container, buf, opts, prefix);
+    else if (desc->type == SOL_MEMDESC_TYPE_ARRAY)
+        return serialize_array(desc, container, buf, opts, prefix);
+    else {
+        SOL_WRN("unhandled type %d for desc=%p (%s)", desc->type, desc, desc->name);
+        return -EINVAL;
+    }
+}
+
+SOL_API int
+sol_memdesc_serialize(const struct sol_memdesc *desc, const void *container, struct sol_buffer *buffer, const struct sol_memdesc_serialize_options *opts, struct sol_buffer *prefix)
+{
+    struct sol_buffer local_prefix = SOL_BUFFER_INIT_EMPTY;
+    int r;
+
+    CHECK_MEMDESC(desc, -EINVAL);
+    SOL_NULL_CHECK(container, -EINVAL);
+    SOL_NULL_CHECK(buffer, -EINVAL);
+
+    if (!opts)
+        opts = &default_serialize_options;
+#ifndef SOL_NO_API_VERSION
+    else {
+        if (opts->api_version != SOL_MEMDESC_SERIALIZE_OPTIONS_API_VERSION) {
+            SOL_WRN("opts(%p)->api_version(%" PRIu16 ") != SOL_MEMDESC_SERIALIZE_OPTIONS_API_VERSION(%" PRIu16 ")",
+                opts, opts->api_version, SOL_MEMDESC_SERIALIZE_OPTIONS_API_VERSION);
+            return -EINVAL;
+        }
+    }
+#endif
+
+    if (!prefix)
+        prefix = &local_prefix;
+
+    r = serialize(desc, container, buffer, opts, prefix);
+    sol_buffer_fini(&local_prefix);
+
+    return r;
+}

--- a/src/lib/datatypes/sol-vector.c
+++ b/src/lib/datatypes/sol-vector.c
@@ -139,6 +139,34 @@ sol_vector_del(struct sol_vector *v, uint16_t i)
     return 0;
 }
 
+SOL_API int
+sol_vector_del_range(struct sol_vector *v, uint16_t start, uint16_t len)
+{
+    size_t tail_len;
+
+    if (start >= v->len)
+        return -EINVAL;
+
+    if ((uint32_t)start + len >= (uint32_t)v->len)
+        len = v->len - start;
+
+    v->len -= len;
+    tail_len = v->len - start;
+
+    if (tail_len) {
+        unsigned char *data, *dst, *src;
+
+        data = v->data;
+        dst = &data[v->elem_size * start];
+        src = dst + len * v->elem_size;
+        memmove(dst, src, v->elem_size * tail_len);
+    }
+
+    sol_vector_shrink(v);
+    return 0;
+}
+
+
 SOL_API void
 sol_vector_clear(struct sol_vector *v)
 {

--- a/src/lib/parsers/include/sol-json.h
+++ b/src/lib/parsers/include/sol-json.h
@@ -29,6 +29,7 @@
 #include <sol-macros.h>
 #include <sol-str-slice.h>
 #include <sol-buffer.h>
+#include <sol-memdesc.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -817,6 +818,45 @@ sol_json_serialize_null(struct sol_buffer *buffer)
 
     return sol_buffer_append_slice(buffer, null);
 }
+
+/**
+ * @brief Appends the serialization of the given memory based on its description.
+ *
+ * If the SOL_MEMDESC_TYPE_STRUCTURE or SOL_MEMDESC_TYPE_PTR with
+ * children, then it will be serialized as an object with keys being
+ * the description name.
+ *
+ * @param buffer Buffer containing the new JSON document.
+ * @param desc the memory description to use when serializing.
+ * @param container the container memory described by @a desc.
+ * @param detailed if false, all members of struct, pointer and arrays
+ *        marked as detailed will be omitted. If the given @a desc is
+ *        explicitly given and it's a detailed member, it will be
+ *        always serialized. That is, the option is only valid for
+ *        sub-members in children array.
+ *
+ * @return @c 0 on success, error code (always negative) otherwise.
+ *
+ * @see sol_json_load_memdesc()
+ */
+int sol_json_serialize_memdesc(struct sol_buffer *buffer, const struct sol_memdesc *desc, const void *container, bool detailed) SOL_ATTR_NONNULL(1, 2, 3);
+
+/**
+ * @brief Loads the members of a memory from JSON according to its description.
+ *
+ * If the SOL_MEMDESC_TYPE_STRUCTURE or SOL_MEMDESC_TYPE_PTR with
+ * children, then it will be loaded from an object with keys being
+ * the description name.
+ *
+ * @param token the token to convert to memory using description.
+ * @param desc the memory description to use when loading.
+ * @param container the container memory described by @a desc.
+ *
+ * @return @c 0 on success, error code (always negative) otherwise.
+ *
+ * @see sol_json_serialize_memdesc()
+ */
+int sol_json_load_memdesc(const struct sol_json_token *token, const struct sol_memdesc *desc, void *container) SOL_ATTR_NONNULL(1, 2, 3);
 
 /**
  *  @brief Copy to a @ref sol_buffer the string pointed by @c token.

--- a/src/test/Kconfig
+++ b/src/test/Kconfig
@@ -2,6 +2,10 @@ config TEST_ARENA
 	bool "arena"
 	default y
 
+config TEST_MEMDESC
+	bool "memdesc"
+	default y
+
 config TEST_BUFFER
 	bool "buffer"
 	default y

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -1,6 +1,9 @@
 test-$(TEST_ARENA) += test-arena
 test-test-arena-$(TEST_ARENA) := test.c test-arena.c
 
+test-$(TEST_MEMDESC) += test-memdesc
+test-test-memdesc-$(TEST_MEMDESC) := test.c test-memdesc.c
+
 test-internal-$(TEST_COAP) += test-coap
 test-internal-test-coap-$(TEST_COAP) := test.c test-coap.c
 test-internal-test-coap-$(TEST_COAP)-deps := lib/comms/coap.o

--- a/src/test/test-json.c
+++ b/src/test/test-json.c
@@ -567,4 +567,936 @@ test_json_token_get_double(void)
     }
 }
 
+DEFINE_TEST(test_json_serialize_memdesc);
+static void
+test_json_serialize_memdesc(void)
+{
+    const struct myst {
+        int64_t i64;
+        char *s;
+        uint8_t u8;
+        void *ptr;
+    } myst_defcontent = {
+        .i64 = 0x7234567890123456,
+        .s = (char *)"some string \"quotes\" and \t tab",
+        .u8 = 0xf2,
+        .ptr = NULL
+    };
+    struct sol_vector int_vector = SOL_VECTOR_INIT(int32_t);
+    struct sol_vector kv_vector = SOL_VECTOR_INIT(struct sol_key_value);
+    const struct test {
+        struct sol_memdesc desc;
+        const char *expected_detailed;
+        const char *expected_essential;
+    } *itr, tests[] = {
+        {
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_BOOLEAN,
+                .name = "SOL_MEMDESC_TYPE_BOOLEAN",
+                .defcontent.b = true,
+            },
+            .expected_essential = "true",
+        },
+        {
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_BOOLEAN,
+                .name = "SOL_MEMDESC_TYPE_BOOLEAN",
+                .defcontent.b = false,
+            },
+            .expected_essential = "false",
+        },
+        {
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_INT64,
+                .name = "SOL_MEMDESC_TYPE_INT64",
+                .defcontent.i64 = 0x7234567890123456,
+            },
+            .expected_essential = "8229297494925915222",
+        },
+        {
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_UINT64,
+                .name = "SOL_MEMDESC_TYPE_UINT64",
+                .defcontent.i64 = 0xf234567890123456,
+            },
+            .expected_essential = "17452669531780691030",
+        },
+        {
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_STRING,
+                .name = "SOL_MEMDESC_TYPE_STRING",
+                .defcontent.s = "some string \"quotes\" and \t tab",
+            },
+            .expected_essential = "\"some string \\\"quotes\\\" and \\t tab\"",
+        },
+        {
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .size = sizeof(struct myst),
+                .type = SOL_MEMDESC_TYPE_STRUCTURE,
+                .name = "SOL_MEMDESC_TYPE_STRUCTURE",
+                .defcontent.p = &myst_defcontent,
+                .children = (const struct sol_memdesc[]){
+                    {
+                        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                        .offset = offsetof(struct myst, i64),
+                        .type = SOL_MEMDESC_TYPE_INT64,
+                        .name = "i64",
+                        .detail = true,
+                    },
+                    {
+                        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                        .offset = offsetof(struct myst, s),
+                        .type = SOL_MEMDESC_TYPE_STRING,
+                        .name = "s",
+                    },
+                    {
+                        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                        .offset = offsetof(struct myst, u8),
+                        .type = SOL_MEMDESC_TYPE_UINT8,
+                        .name = "u8",
+                    },
+                    {
+                        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                        .offset = offsetof(struct myst, ptr),
+                        .type = SOL_MEMDESC_TYPE_PTR,
+                        .name = "ptr",
+                        .detail = true,
+                    },
+                    {}
+                },
+            },
+            .expected_detailed = "{\"i64\":8229297494925915222,\"s\":\"some string \\\"quotes\\\" and \\t tab\",\"u8\":242,\"ptr\":null}",
+            .expected_essential = "{\"s\":\"some string \\\"quotes\\\" and \\t tab\",\"u8\":242}",
+        },
+        {
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_PTR,
+                .name = "SOL_MEMDESC_TYPE_PTR",
+                .defcontent.p = &myst_defcontent,
+                .children = &(const struct sol_memdesc){
+                    SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                    .size = sizeof(struct myst),
+                    .type = SOL_MEMDESC_TYPE_STRUCTURE,
+                    .name = "SOL_MEMDESC_TYPE_STRUCTURE",
+                    .children = (const struct sol_memdesc[]){
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, i64),
+                            .type = SOL_MEMDESC_TYPE_INT64,
+                            .name = "i64",
+                            .detail = true,
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, s),
+                            .type = SOL_MEMDESC_TYPE_STRING,
+                            .name = "s",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, u8),
+                            .type = SOL_MEMDESC_TYPE_UINT8,
+                            .name = "u8",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, ptr),
+                            .type = SOL_MEMDESC_TYPE_PTR,
+                            .name = "ptr",
+                            .detail = true,
+                        },
+                        {}
+                    },
+                },
+            },
+            .expected_detailed = "{\"i64\":8229297494925915222,\"s\":\"some string \\\"quotes\\\" and \\t tab\",\"u8\":242,\"ptr\":null}",
+            .expected_essential = "{\"s\":\"some string \\\"quotes\\\" and \\t tab\",\"u8\":242}",
+        },
+        {
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_PTR,
+                .name = "SOL_MEMDESC_TYPE_PTR",
+                .children = &(const struct sol_memdesc){
+                    SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                    .size = sizeof(struct myst),
+                    .type = SOL_MEMDESC_TYPE_STRUCTURE,
+                    .name = "SOL_MEMDESC_TYPE_STRUCTURE",
+                    .children = (const struct sol_memdesc[]){
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, i64),
+                            .type = SOL_MEMDESC_TYPE_INT64,
+                            .name = "i64",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, s),
+                            .type = SOL_MEMDESC_TYPE_STRING,
+                            .name = "s",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, u8),
+                            .type = SOL_MEMDESC_TYPE_UINT8,
+                            .name = "u8",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, ptr),
+                            .type = SOL_MEMDESC_TYPE_PTR,
+                            .name = "ptr",
+                        },
+                        {}
+                    },
+                },
+            },
+            .expected_essential = "null",
+        },
+        {
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .size = sizeof(struct sol_vector),
+                .type = SOL_MEMDESC_TYPE_ARRAY,
+                .name = "SOL_MEMDESC_TYPE_ARRAY",
+                .defcontent.p = &int_vector,
+                .ops = &SOL_MEMDESC_OPS_VECTOR,
+                .children = &(const struct sol_memdesc){
+                    SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                    .type = SOL_MEMDESC_TYPE_INT32,
+                    .name = "SOL_MEMDESC_TYPE_INT32",
+                },
+            },
+            .expected_essential = "[10,20,30,40,50,60,70,80,90,100]",
+        },
+        {
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .size = sizeof(struct sol_vector),
+                .type = SOL_MEMDESC_TYPE_ARRAY,
+                .name = "SOL_MEMDESC_TYPE_ARRAY",
+                .defcontent.p = &kv_vector,
+                .ops = &SOL_MEMDESC_OPS_VECTOR,
+                .children = &(const struct sol_memdesc){
+                    SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                    .size = sizeof(struct sol_key_value),
+                    .type = SOL_MEMDESC_TYPE_STRUCTURE,
+                    .name = "SOL_MEMDESC_TYPE_STRUCTURE",
+                    .children = (const struct sol_memdesc[]){
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct sol_key_value, key),
+                            .type = SOL_MEMDESC_TYPE_STRING,
+                            .name = "key",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct sol_key_value, value),
+                            .type = SOL_MEMDESC_TYPE_STRING,
+                            .name = "value",
+                        },
+                        {}
+                    },
+                },
+            },
+            .expected_essential = "[{\"key\":\"akey\",\"value\":\"avalue\"},{\"key\":\"xkey\",\"value\":\"xvalue\"}]",
+        },
+        { }
+    };
+    size_t i;
+    int32_t *int_items;
+    struct sol_key_value *kv_items;
+
+    int_items = sol_vector_append_n(&int_vector, 10);
+    ASSERT(int_items);
+    ASSERT_INT_EQ(int_vector.len, 10);
+    for (i = 0; i < int_vector.len; i++)
+        int_items[i] = (i + 1) * 10;
+
+    kv_items = sol_vector_append_n(&kv_vector, 2);
+    ASSERT(kv_items);
+    ASSERT_INT_EQ(kv_vector.len, 2);
+    kv_items[0].key = "akey";
+    kv_items[0].value = "avalue";
+    kv_items[1].key = "xkey";
+    kv_items[1].value = "xvalue";
+
+    for (itr = tests; itr->expected_essential != NULL; itr++) {
+        void *mem = sol_memdesc_new_with_defaults(&itr->desc);
+        struct sol_buffer buf = SOL_BUFFER_INIT_EMPTY;
+        struct sol_str_slice out;
+        int r;
+
+        ASSERT(mem);
+        r = sol_json_serialize_memdesc(&buf, &itr->desc, mem, false);
+        ASSERT_INT_EQ(r, 0);
+
+        out = sol_buffer_get_slice(&buf);
+        ASSERT_STR_EQ(out.data, itr->expected_essential);
+
+        sol_buffer_fini(&buf);
+
+        if (itr->expected_detailed) {
+            r = sol_json_serialize_memdesc(&buf, &itr->desc, mem, true);
+            ASSERT_INT_EQ(r, 0);
+
+            out = sol_buffer_get_slice(&buf);
+            ASSERT_STR_EQ(out.data, itr->expected_detailed);
+
+            sol_buffer_fini(&buf);
+        }
+
+        sol_memdesc_free(&itr->desc, mem);
+    }
+
+    sol_vector_clear(&int_vector);
+    sol_vector_clear(&kv_vector);
+}
+
+DEFINE_TEST(test_json_load_memdesc);
+static void
+test_json_load_memdesc(void)
+{
+    const struct myst {
+        int64_t i64;
+        char *s;
+        uint8_t u8;
+        void *ptr;
+    } myst_defcontent = {
+        .i64 = 0x7234567890123456,
+        .s = (char *)"some string \"quotes\" and \t tab",
+        .u8 = 0xf2,
+        .ptr = NULL
+    };
+    struct sol_vector int_vector = SOL_VECTOR_INIT(int32_t);
+    struct sol_vector kv_vector = SOL_VECTOR_INIT(struct sol_key_value);
+    const struct test {
+        const char *input;
+        struct sol_memdesc desc;
+        struct sol_memdesc desc_expected;
+    } *itr, tests[] = {
+        {
+            .input = "true",
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_BOOLEAN,
+                .name = "SOL_MEMDESC_TYPE_BOOLEAN",
+                .defcontent.b = false,
+            },
+            .desc_expected = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_BOOLEAN,
+                .name = "SOL_MEMDESC_TYPE_BOOLEAN",
+                .defcontent.b = true,
+            },
+        },
+        {
+            .input = "false",
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_BOOLEAN,
+                .name = "SOL_MEMDESC_TYPE_BOOLEAN",
+                .defcontent.b = true,
+            },
+            .desc_expected = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_BOOLEAN,
+                .name = "SOL_MEMDESC_TYPE_BOOLEAN",
+                .defcontent.b = false,
+            },
+        },
+        {
+            .input = "8229297494925915222",
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_INT64,
+                .name = "SOL_MEMDESC_TYPE_INT64",
+            },
+            .desc_expected = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_INT64,
+                .name = "SOL_MEMDESC_TYPE_INT64",
+                .defcontent.i64 = 0x7234567890123456,
+            },
+        },
+        {
+            .input = "17452669531780691030",
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_UINT64,
+                .name = "SOL_MEMDESC_TYPE_UINT64",
+            },
+            .desc_expected = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_UINT64,
+                .name = "SOL_MEMDESC_TYPE_UINT64",
+                .defcontent.i64 = 0xf234567890123456,
+            },
+        },
+        {
+            .input = "\"some string \\\"quotes\\\" and \\t tab\"",
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_STRING,
+                .name = "SOL_MEMDESC_TYPE_STRING",
+            },
+            .desc_expected = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_STRING,
+                .name = "SOL_MEMDESC_TYPE_STRING",
+                .defcontent.s = "some string \"quotes\" and \t tab",
+            },
+        },
+        {
+            .input = "{\"i64\":8229297494925915222,\"s\":\"some string \\\"quotes\\\" and \\t tab\",\"u8\":242,\"ptr\":null}",
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .size = sizeof(struct myst),
+                .type = SOL_MEMDESC_TYPE_STRUCTURE,
+                .name = "SOL_MEMDESC_TYPE_STRUCTURE",
+                .children = (const struct sol_memdesc[]){
+                    {
+                        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                        .offset = offsetof(struct myst, i64),
+                        .type = SOL_MEMDESC_TYPE_INT64,
+                        .name = "i64",
+                    },
+                    {
+                        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                        .offset = offsetof(struct myst, s),
+                        .type = SOL_MEMDESC_TYPE_STRING,
+                        .name = "s",
+                    },
+                    {
+                        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                        .offset = offsetof(struct myst, u8),
+                        .type = SOL_MEMDESC_TYPE_UINT8,
+                        .name = "u8",
+                    },
+                    {
+                        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                        .offset = offsetof(struct myst, ptr),
+                        .type = SOL_MEMDESC_TYPE_PTR,
+                        .name = "ptr",
+                    },
+                    {}
+                },
+            },
+            .desc_expected = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .size = sizeof(struct myst),
+                .type = SOL_MEMDESC_TYPE_STRUCTURE,
+                .name = "SOL_MEMDESC_TYPE_STRUCTURE",
+                .defcontent.p = &myst_defcontent,
+                .children = (const struct sol_memdesc[]){
+                    {
+                        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                        .offset = offsetof(struct myst, i64),
+                        .type = SOL_MEMDESC_TYPE_INT64,
+                        .name = "i64",
+                    },
+                    {
+                        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                        .offset = offsetof(struct myst, s),
+                        .type = SOL_MEMDESC_TYPE_STRING,
+                        .name = "s",
+                    },
+                    {
+                        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                        .offset = offsetof(struct myst, u8),
+                        .type = SOL_MEMDESC_TYPE_UINT8,
+                        .name = "u8",
+                    },
+                    {
+                        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                        .offset = offsetof(struct myst, ptr),
+                        .type = SOL_MEMDESC_TYPE_PTR,
+                        .name = "ptr",
+                    },
+                    {}
+                },
+            },
+        },
+        {
+            .input = "{\"i64\":8229297494925915222,\"s\":\"some string \\\"quotes\\\" and \\t tab\",\"u8\":242,\"ptr\":null}",
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_PTR,
+                .name = "SOL_MEMDESC_TYPE_PTR",
+                .children = &(const struct sol_memdesc){
+                    SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                    .size = sizeof(struct myst),
+                    .type = SOL_MEMDESC_TYPE_STRUCTURE,
+                    .name = "SOL_MEMDESC_TYPE_STRUCTURE",
+                    .children = (const struct sol_memdesc[]){
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, i64),
+                            .type = SOL_MEMDESC_TYPE_INT64,
+                            .name = "i64",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, s),
+                            .type = SOL_MEMDESC_TYPE_STRING,
+                            .name = "s",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, u8),
+                            .type = SOL_MEMDESC_TYPE_UINT8,
+                            .name = "u8",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, ptr),
+                            .type = SOL_MEMDESC_TYPE_PTR,
+                            .name = "ptr",
+                        },
+                        {}
+                    },
+                },
+            },
+            .desc_expected = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .size = sizeof(struct myst *),
+                .type = SOL_MEMDESC_TYPE_PTR,
+                .name = "SOL_MEMDESC_TYPE_PTR",
+                .defcontent.p = &myst_defcontent,
+                .children = &(const struct sol_memdesc){
+                    SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                    .size = sizeof(struct myst),
+                    .type = SOL_MEMDESC_TYPE_STRUCTURE,
+                    .name = "SOL_MEMDESC_TYPE_STRUCTURE",
+                    .children = (const struct sol_memdesc[]){
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, i64),
+                            .type = SOL_MEMDESC_TYPE_INT64,
+                            .name = "i64",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, s),
+                            .type = SOL_MEMDESC_TYPE_STRING,
+                            .name = "s",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, u8),
+                            .type = SOL_MEMDESC_TYPE_UINT8,
+                            .name = "u8",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, ptr),
+                            .type = SOL_MEMDESC_TYPE_PTR,
+                            .name = "ptr",
+                        },
+                        {}
+                    },
+                },
+            },
+        },
+        {
+            .input = "null",
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_PTR,
+                .name = "SOL_MEMDESC_TYPE_PTR",
+                .children = &(const struct sol_memdesc){
+                    SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                    .size = sizeof(struct myst),
+                    .type = SOL_MEMDESC_TYPE_STRUCTURE,
+                    .name = "SOL_MEMDESC_TYPE_STRUCTURE",
+                    .children = (const struct sol_memdesc[]){
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, i64),
+                            .type = SOL_MEMDESC_TYPE_INT64,
+                            .name = "i64",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, s),
+                            .type = SOL_MEMDESC_TYPE_STRING,
+                            .name = "s",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, u8),
+                            .type = SOL_MEMDESC_TYPE_UINT8,
+                            .name = "u8",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, ptr),
+                            .type = SOL_MEMDESC_TYPE_PTR,
+                            .name = "ptr",
+                        },
+                        {}
+                    },
+                },
+            },
+            .desc_expected = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .type = SOL_MEMDESC_TYPE_PTR,
+                .name = "SOL_MEMDESC_TYPE_PTR",
+                .defcontent.p = NULL,
+                .children = &(const struct sol_memdesc){
+                    SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                    .size = sizeof(struct myst),
+                    .type = SOL_MEMDESC_TYPE_STRUCTURE,
+                    .name = "SOL_MEMDESC_TYPE_STRUCTURE",
+                    .children = (const struct sol_memdesc[]){
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, i64),
+                            .type = SOL_MEMDESC_TYPE_INT64,
+                            .name = "i64",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, s),
+                            .type = SOL_MEMDESC_TYPE_STRING,
+                            .name = "s",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, u8),
+                            .type = SOL_MEMDESC_TYPE_UINT8,
+                            .name = "u8",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct myst, ptr),
+                            .type = SOL_MEMDESC_TYPE_PTR,
+                            .name = "ptr",
+                        },
+                        {}
+                    },
+                },
+            },
+        },
+        {
+            .input = "[10,20,30,40,50,60,70,80,90,100]",
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .size = sizeof(struct sol_vector),
+                .type = SOL_MEMDESC_TYPE_ARRAY,
+                .name = "SOL_MEMDESC_TYPE_ARRAY",
+                .ops = &SOL_MEMDESC_OPS_VECTOR,
+                .children = &(const struct sol_memdesc){
+                    SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                    .type = SOL_MEMDESC_TYPE_INT32,
+                    .name = "SOL_MEMDESC_TYPE_INT32",
+                },
+            },
+            .desc_expected = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .size = sizeof(struct sol_vector),
+                .type = SOL_MEMDESC_TYPE_ARRAY,
+                .name = "SOL_MEMDESC_TYPE_ARRAY",
+                .defcontent.p = &int_vector,
+                .ops = &SOL_MEMDESC_OPS_VECTOR,
+                .children = &(const struct sol_memdesc){
+                    SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                    .type = SOL_MEMDESC_TYPE_INT32,
+                    .name = "SOL_MEMDESC_TYPE_INT32",
+                },
+            },
+        },
+        {
+            .input = "[{\"key\":\"akey\",\"value\":\"avalue\"},{\"key\":\"xkey\",\"value\":\"xvalue\"}]",
+            .desc = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .size = sizeof(struct sol_vector),
+                .type = SOL_MEMDESC_TYPE_ARRAY,
+                .name = "SOL_MEMDESC_TYPE_ARRAY",
+                .ops = &SOL_MEMDESC_OPS_VECTOR,
+                .children = &(const struct sol_memdesc){
+                    SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                    .size = sizeof(struct sol_key_value),
+                    .type = SOL_MEMDESC_TYPE_STRUCTURE,
+                    .name = "SOL_MEMDESC_TYPE_STRUCTURE",
+                    .children = (const struct sol_memdesc[]){
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct sol_key_value, key),
+                            .type = SOL_MEMDESC_TYPE_STRING,
+                            .name = "key",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct sol_key_value, value),
+                            .type = SOL_MEMDESC_TYPE_STRING,
+                            .name = "value",
+                        },
+                        {}
+                    },
+                },
+            },
+            .desc_expected = {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .size = sizeof(struct sol_vector),
+                .type = SOL_MEMDESC_TYPE_ARRAY,
+                .name = "SOL_MEMDESC_TYPE_ARRAY",
+                .defcontent.p = &kv_vector,
+                .ops = &SOL_MEMDESC_OPS_VECTOR,
+                .children = &(const struct sol_memdesc){
+                    SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                    .size = sizeof(struct sol_key_value),
+                    .type = SOL_MEMDESC_TYPE_STRUCTURE,
+                    .name = "SOL_MEMDESC_TYPE_STRUCTURE",
+                    .children = (const struct sol_memdesc[]){
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct sol_key_value, key),
+                            .type = SOL_MEMDESC_TYPE_STRING,
+                            .name = "key",
+                        },
+                        {
+                            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                            .offset = offsetof(struct sol_key_value, value),
+                            .type = SOL_MEMDESC_TYPE_STRING,
+                            .name = "value",
+                        },
+                        {}
+                    },
+                },
+            },
+        },
+        {}
+    };
+    size_t i;
+    int32_t *int_items;
+    struct sol_key_value *kv_items;
+
+    int_items = sol_vector_append_n(&int_vector, 10);
+    ASSERT(int_items);
+    ASSERT_INT_EQ(int_vector.len, 10);
+    for (i = 0; i < int_vector.len; i++)
+        int_items[i] = (i + 1) * 10;
+
+    kv_items = sol_vector_append_n(&kv_vector, 2);
+    ASSERT(kv_items);
+    ASSERT_INT_EQ(kv_vector.len, 2);
+    kv_items[0].key = "akey";
+    kv_items[0].value = "avalue";
+    kv_items[1].key = "xkey";
+    kv_items[1].value = "xvalue";
+
+    for (itr = tests; itr->input != NULL; itr++) {
+        void *mem = sol_memdesc_new_with_defaults(&itr->desc);
+        void *mem_expected = sol_memdesc_new_with_defaults(&itr->desc_expected);
+        struct sol_json_token token;
+        int r;
+
+        ASSERT(mem);
+        ASSERT(mem_expected);
+
+        sol_json_token_init_from_slice(&token, sol_str_slice_from_str(itr->input));
+        r = sol_json_load_memdesc(&token, &itr->desc, mem);
+        ASSERT_INT_EQ(r, 0);
+
+        r = sol_memdesc_compare(&itr->desc, mem, mem_expected);
+        ASSERT_INT_EQ(r, 0);
+
+        sol_memdesc_free(&itr->desc, mem);
+        sol_memdesc_free(&itr->desc_expected, mem_expected);
+    }
+
+    sol_vector_clear(&int_vector);
+    sol_vector_clear(&kv_vector);
+}
+
+DEFINE_TEST(test_json_memdesc_complex);
+static void
+test_json_memdesc_complex(void)
+{
+    struct myst {
+        uint64_t u64;
+        struct sol_vector v;
+        uint8_t u8;
+    };
+    struct myst defval = {
+        .u64 = 0xf234567890123456,
+        .v = SOL_VECTOR_INIT(struct sol_vector),
+        .u8 = 0x72,
+    };
+    struct sol_memdesc desc = {
+        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+        .size = sizeof(struct myst),
+        .type = SOL_MEMDESC_TYPE_STRUCTURE,
+        .name = "struct myst",
+        .defcontent.p = &defval,
+        .children = (const struct sol_memdesc[]){
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct myst, u64),
+                .type = SOL_MEMDESC_TYPE_UINT64,
+                .name = "u64",
+            },
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct myst, v),
+                .size = sizeof(struct sol_vector),
+                .type = SOL_MEMDESC_TYPE_ARRAY,
+                .name = "v",
+                .ops = &SOL_MEMDESC_OPS_VECTOR,
+                .children = &(const struct sol_memdesc){
+                    SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                    .size = sizeof(struct sol_vector),
+                    .type = SOL_MEMDESC_TYPE_ARRAY,
+                    .name = "struct sol_key_value",
+                    .ops = &SOL_MEMDESC_OPS_VECTOR,
+                    .children = &(const struct sol_memdesc){
+                        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                        .size = sizeof(struct sol_key_value),
+                        .type = SOL_MEMDESC_TYPE_STRUCTURE,
+                        .name = "SOL_MEMDESC_TYPE_STRUCTURE",
+                        .children = (const struct sol_memdesc[]){
+                            {
+                                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                                .offset = offsetof(struct sol_key_value, key),
+                                .type = SOL_MEMDESC_TYPE_STRING,
+                                .name = "key",
+                            },
+                            {
+                                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                                .offset = offsetof(struct sol_key_value, value),
+                                .type = SOL_MEMDESC_TYPE_STRING,
+                                .name = "value",
+                            },
+                            {}
+                        },
+                    },
+                },
+            },
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct myst, u8),
+                .type = SOL_MEMDESC_TYPE_UINT8,
+                .name = "u8",
+            },
+            {}
+        },
+    };
+    struct myst a;
+    struct sol_key_value *kv;
+    size_t i, j;
+    int r;
+    struct sol_buffer buf = SOL_BUFFER_INIT_EMPTY;
+    const char expected[] = "{\"u64\":17452669531780691030,\"v\":[[{\"key\":\"key0\",\"value\":\"value0\"}],[{\"key\":\"key100\",\"value\":\"value100\"},{\"key\":\"key101\",\"value\":\"value101\"}],[{\"key\":\"key200\",\"value\":\"value200\"},{\"key\":\"key201\",\"value\":\"value201\"},{\"key\":\"key202\",\"value\":\"value202\"}],[{\"key\":\"key300\",\"value\":\"value300\"},{\"key\":\"key301\",\"value\":\"value301\"},{\"key\":\"key302\",\"value\":\"value302\"},{\"key\":\"key303\",\"value\":\"value303\"}]],\"u8\":114}";
+    struct sol_json_token token;
+
+    for (j = 0; j < 4; j++) {
+        struct sol_vector *vec = sol_vector_append(&defval.v);
+
+        ASSERT(vec);
+        sol_vector_init(vec, sizeof(struct sol_key_value));
+        for (i = 0; i < (j + 1); i++) {
+            char *k, *v;
+
+            r = asprintf(&k, "key%zd", i + j * 100);
+            ASSERT(r > 0);
+
+            r = asprintf(&v, "value%zd", i + j * 100);
+            ASSERT(r > 0);
+
+            kv = sol_vector_append(vec);
+            ASSERT(kv);
+            kv->key = k;
+            kv->value = v;
+        }
+    }
+
+    r = sol_memdesc_init_defaults(&desc, &a);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(a.v.len, defval.v.len);
+
+    for (j = 0; j < defval.v.len; j++) {
+        const struct sol_vector *vec_a = sol_vector_get(&a.v, j);
+        const struct sol_vector *vec_b = sol_vector_get(&defval.v, j);
+
+        ASSERT(vec_a);
+        ASSERT(vec_b);
+        ASSERT_INT_EQ(vec_a->len, vec_b->len);
+    }
+
+    r = sol_memdesc_compare(&desc, &a, &defval);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    for (j = 0; j < defval.v.len; j++) {
+        const struct sol_vector *vec_a = sol_vector_get(&a.v, j);
+        const struct sol_vector *vec_b = sol_vector_get(&defval.v, j);
+
+        ASSERT(vec_a);
+        ASSERT(vec_b);
+
+        for (i = 0; i < vec_b->len; i++) {
+            const struct sol_key_value *ita, *itb;
+
+            ita = sol_vector_get(vec_a, i);
+            ASSERT(ita);
+
+            itb = sol_vector_get(vec_b, i);
+            ASSERT(itb);
+
+            ASSERT_STR_EQ(ita->key, itb->key);
+            ASSERT_STR_EQ(ita->value, itb->value);
+        }
+    }
+
+    r = sol_json_serialize_memdesc(&buf, &desc, &a, true);
+    ASSERT_INT_EQ(r, 0);
+
+    ASSERT_STR_EQ(buf.data, expected);
+
+    sol_buffer_fini(&buf);
+
+    sol_memdesc_free_content(&desc, &a);
+
+    /* no default means an empty array, but elem_size must be set from children size */
+    desc.defcontent.p = NULL;
+    memset(&a, 0xff, sizeof(a));
+
+    r = sol_memdesc_init_defaults(&desc, &a);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(a.v.len, 0);
+    ASSERT_INT_EQ(a.v.elem_size, sizeof(struct sol_vector));
+    ASSERT(!a.v.data);
+
+    sol_json_token_init_from_slice(&token, sol_str_slice_from_str(expected));
+    r = sol_json_load_memdesc(&token, &desc, &a);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memdesc_compare(&desc, &a, &defval);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    sol_memdesc_free_content(&desc, &a);
+
+    for (j = 0; j < defval.v.len; j++) {
+        struct sol_vector *vec = sol_vector_get(&defval.v, j);
+
+        for (i = 0; i <  vec->len; i++) {
+            kv = sol_vector_get(vec, i);
+            free((void *)kv->key);
+            free((void *)kv->value);
+        }
+
+        sol_vector_clear(vec);
+    }
+    sol_vector_clear(&defval.v);
+}
+
 TEST_MAIN();

--- a/src/test/test-memdesc.c
+++ b/src/test/test-memdesc.c
@@ -1185,4 +1185,166 @@ test_vector_SOL_MEMDESC_TYPE_ARRAY(void)
     sol_vector_clear(&defval.v);
 }
 
+DEFINE_TEST(test_serialize);
+static void
+test_serialize(void)
+{
+    struct myst {
+        uint64_t u64;
+        struct sol_vector v;
+        uint8_t u8;
+    };
+    struct myst defval = {
+        .u64 = 0xf234567890123456,
+        .v = SOL_VECTOR_INIT(struct sol_vector),
+        .u8 = 0x72,
+    };
+    struct sol_memdesc desc = {
+        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+        .size = sizeof(struct myst),
+        .type = SOL_MEMDESC_TYPE_STRUCTURE,
+        .name = "struct myst",
+        .defcontent.p = &defval,
+        .children = (const struct sol_memdesc[]){
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct myst, u64),
+                .type = SOL_MEMDESC_TYPE_UINT64,
+                .name = "u64",
+            },
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct myst, v),
+                .size = sizeof(struct sol_vector),
+                .type = SOL_MEMDESC_TYPE_ARRAY,
+                .name = "v",
+                .ops = &SOL_MEMDESC_OPS_VECTOR,
+                .children = &(const struct sol_memdesc){
+                    SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                    .size = sizeof(struct sol_vector),
+                    .type = SOL_MEMDESC_TYPE_ARRAY,
+                    .name = "struct sol_key_value",
+                    .ops = &SOL_MEMDESC_OPS_VECTOR,
+                    .children = &(const struct sol_memdesc){
+                        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                        .size = sizeof(struct sol_key_value),
+                        .type = SOL_MEMDESC_TYPE_STRUCTURE,
+                        .name = "SOL_MEMDESC_TYPE_STRUCTURE",
+                        .children = (const struct sol_memdesc[]){
+                            {
+                                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                                .offset = offsetof(struct sol_key_value, key),
+                                .type = SOL_MEMDESC_TYPE_STRING,
+                                .name = "key",
+                            },
+                            {
+                                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                                .offset = offsetof(struct sol_key_value, value),
+                                .type = SOL_MEMDESC_TYPE_STRING,
+                                .name = "value",
+                            },
+                            {}
+                        },
+                    },
+                },
+            },
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct myst, u8),
+                .type = SOL_MEMDESC_TYPE_UINT8,
+                .name = "u8",
+            },
+            {}
+        },
+    };
+    const char expected[] = ""
+        "{\n"
+        "    .u64 = 17452669531780691030,\n"
+        "    .v = {\n"
+        "        [0] = {\n"
+        "            [0] = {\n"
+        "                .key = \"key\\t0\",\n"
+        "                .value = \"value\\\"0\\\"\"}},\n"
+        "        [1] = {\n"
+        "            [0] = {\n"
+        "                .key = \"key\\t100\",\n"
+        "                .value = \"value\\\"100\\\"\"},\n"
+        "            [1] = {\n"
+        "                .key = \"key\\t101\",\n"
+        "                .value = \"value\\\"101\\\"\"}},\n"
+        "        [2] = {\n"
+        "            [0] = {\n"
+        "                .key = \"key\\t200\",\n"
+        "                .value = \"value\\\"200\\\"\"},\n"
+        "            [1] = {\n"
+        "                .key = \"key\\t201\",\n"
+        "                .value = \"value\\\"201\\\"\"},\n"
+        "            [2] = {\n"
+        "                .key = \"key\\t202\",\n"
+        "                .value = \"value\\\"202\\\"\"}},\n"
+        "        [3] = {\n"
+        "            [0] = {\n"
+        "                .key = \"key\\t300\",\n"
+        "                .value = \"value\\\"300\\\"\"},\n"
+        "            [1] = {\n"
+        "                .key = \"key\\t301\",\n"
+        "                .value = \"value\\\"301\\\"\"},\n"
+        "            [2] = {\n"
+        "                .key = \"key\\t302\",\n"
+        "                .value = \"value\\\"302\\\"\"},\n"
+        "            [3] = {\n"
+        "                .key = \"key\\t303\",\n"
+        "                .value = \"value\\\"303\\\"\"}}},\n"
+        "    .u8 = 114}"
+        "";
+    struct sol_buffer out = SOL_BUFFER_INIT_EMPTY;
+    struct myst a;
+    struct sol_key_value *kv;
+    size_t i, j;
+    int r;
+
+    for (j = 0; j < 4; j++) {
+        struct sol_vector *vec = sol_vector_append(&defval.v);
+
+        ASSERT(vec);
+        sol_vector_init(vec, sizeof(struct sol_key_value));
+        for (i = 0; i < (j + 1); i++) {
+            char *k, *v;
+
+            r = asprintf(&k, "key\t%zd", i + j * 100);
+            ASSERT(r > 0);
+
+            r = asprintf(&v, "value\"%zd\"", i + j * 100);
+            ASSERT(r > 0);
+
+            kv = sol_vector_append(vec);
+            ASSERT(kv);
+            kv->key = k;
+            kv->value = v;
+        }
+    }
+
+    r = sol_memdesc_init_defaults(&desc, &a);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(a.v.len, defval.v.len);
+
+    for (j = 0; j < defval.v.len; j++) {
+        const struct sol_vector *vec_a = sol_vector_get(&a.v, j);
+        const struct sol_vector *vec_b = sol_vector_get(&defval.v, j);
+
+        ASSERT(vec_a);
+        ASSERT(vec_b);
+        ASSERT_INT_EQ(vec_a->len, vec_b->len);
+    }
+
+    r = sol_memdesc_serialize(&desc, &a, &out, NULL, NULL);
+    ASSERT_INT_EQ(r, 0);
+
+    ASSERT_STR_EQ(out.data, expected);
+
+    sol_memdesc_free_content(&desc, &a);
+    sol_buffer_fini(&out);
+
+}
+
 TEST_MAIN();

--- a/src/test/test-memdesc.c
+++ b/src/test/test-memdesc.c
@@ -1,0 +1,1188 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2016 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <errno.h>
+
+#include "sol-memdesc.h"
+#include "sol-util-internal.h"
+
+#include "test.h"
+
+#define TEST_SIMPLE_INTEGER(ctype, mdtype, access, defval) \
+    DEFINE_TEST(test_simple_ ## mdtype); \
+    static void test_simple_ ## mdtype(void) { \
+        const struct sol_memdesc desc = { \
+            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, ) \
+            .type = mdtype, \
+            .name = "" # ctype, \
+            .defcontent.access = defval \
+        }; \
+        ctype a, b, c; \
+        int r; \
+        r = sol_memdesc_init_defaults(&desc, &a); \
+        ASSERT_INT_EQ(r, 0); \
+        ASSERT(a == desc.defcontent.access); \
+        r = sol_memdesc_init_defaults(&desc, &b); \
+        ASSERT_INT_EQ(r, 0); \
+        ASSERT(b == desc.defcontent.access); \
+        r = sol_memdesc_compare(&desc, &a, &b); \
+        ASSERT_INT_EQ(r, 0); \
+        ASSERT_INT_EQ(errno, 0); \
+        c = a + 1; \
+        r = sol_memdesc_set_content(&desc, &a, &c); \
+        ASSERT_INT_EQ(r, 0); \
+        ASSERT(a == c); \
+        r = sol_memdesc_compare(&desc, &a, &b); \
+        ASSERT(r > 0); \
+        sol_memdesc_free_content(&desc, &a); \
+        sol_memdesc_free_content(&desc, &b); \
+    }
+
+TEST_SIMPLE_INTEGER(uint8_t, SOL_MEMDESC_TYPE_UINT8, u8, 0xf2);
+TEST_SIMPLE_INTEGER(uint16_t, SOL_MEMDESC_TYPE_UINT16, u16, 0xf234);
+TEST_SIMPLE_INTEGER(uint32_t, SOL_MEMDESC_TYPE_UINT32, u32, 0xf2345678);
+TEST_SIMPLE_INTEGER(uint64_t, SOL_MEMDESC_TYPE_UINT64, u64, 0xf234567890123456);
+TEST_SIMPLE_INTEGER(unsigned long, SOL_MEMDESC_TYPE_ULONG, ul, ULONG_MAX / 10);
+TEST_SIMPLE_INTEGER(size_t, SOL_MEMDESC_TYPE_SIZE, sz, SIZE_MAX / 10);
+
+TEST_SIMPLE_INTEGER(int8_t, SOL_MEMDESC_TYPE_INT8, i8, 0x72);
+TEST_SIMPLE_INTEGER(int16_t, SOL_MEMDESC_TYPE_INT16, i16, 0x7234);
+TEST_SIMPLE_INTEGER(int32_t, SOL_MEMDESC_TYPE_INT32, i32, 0x72345678);
+TEST_SIMPLE_INTEGER(int64_t, SOL_MEMDESC_TYPE_INT64, i64, 0x7234567890123456);
+TEST_SIMPLE_INTEGER(long, SOL_MEMDESC_TYPE_LONG, l, LONG_MAX / 10);
+TEST_SIMPLE_INTEGER(ssize_t, SOL_MEMDESC_TYPE_SSIZE, ssz, SSIZE_MAX / 10);
+
+
+DEFINE_TEST(test_simple_SOL_MEMDESC_TYPE_BOOLEAN);
+static void
+test_simple_SOL_MEMDESC_TYPE_BOOLEAN(void)
+{
+    const struct sol_memdesc desc = {
+        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+        .type = SOL_MEMDESC_TYPE_BOOLEAN,
+        .name = "SOL_MEMDESC_TYPE_BOOLEAN",
+        .defcontent.b = true,
+    };
+    bool a, b, c;
+    int r;
+
+    r = sol_memdesc_init_defaults(&desc, &a);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a == desc.defcontent.b);
+
+    r = sol_memdesc_init_defaults(&desc, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(b == desc.defcontent.b);
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    c = false;
+    r = sol_memdesc_set_content(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a == c);
+
+    r = sol_memdesc_compare(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT(r < 0);
+
+    sol_memdesc_free_content(&desc, &a);
+    sol_memdesc_free_content(&desc, &b);
+}
+
+DEFINE_TEST(test_simple_SOL_MEMDESC_TYPE_DOUBLE);
+static void
+test_simple_SOL_MEMDESC_TYPE_DOUBLE(void)
+{
+    const struct sol_memdesc desc = {
+        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+        .type = SOL_MEMDESC_TYPE_DOUBLE,
+        .name = "SOL_MEMDESC_TYPE_DOUBLE",
+        .defcontent.d = 1.2345e-67,
+    };
+    double a, b, c;
+    int r;
+
+    r = sol_memdesc_init_defaults(&desc, &a);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_util_double_equal(a, desc.defcontent.d));
+
+    r = sol_memdesc_init_defaults(&desc, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_util_double_equal(b, desc.defcontent.d));
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    c = a + 1;
+    r = sol_memdesc_set_content(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(sol_util_double_equal(a, c));
+
+    r = sol_memdesc_compare(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT(r > 0);
+
+    sol_memdesc_free_content(&desc, &a);
+    sol_memdesc_free_content(&desc, &b);
+}
+
+DEFINE_TEST(test_simple_SOL_MEMDESC_TYPE_STRING);
+static void
+test_simple_SOL_MEMDESC_TYPE_STRING(void)
+{
+    const struct sol_memdesc desc = {
+        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+        .type = SOL_MEMDESC_TYPE_STRING,
+        .name = "SOL_MEMDESC_TYPE_STRING",
+        .defcontent.s = "hello world"
+    };
+    char *a, *b;
+    const char *c;
+    int r;
+
+    r = sol_memdesc_init_defaults(&desc, &a);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a != desc.defcontent.s);
+    ASSERT_STR_EQ(a, "hello world");
+
+    r = sol_memdesc_init_defaults(&desc, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(b != desc.defcontent.s);
+    ASSERT_STR_EQ(b, "hello world");
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    c = "other string";
+    r = sol_memdesc_set_content(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a != c);
+    ASSERT_STR_EQ(a, "other string");
+
+    r = sol_memdesc_compare(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT(r > 0);
+
+    sol_memdesc_free_content(&desc, &a);
+    sol_memdesc_free_content(&desc, &b);
+}
+
+DEFINE_TEST(test_simple_SOL_MEMDESC_TYPE_CONST_STRING);
+static void
+test_simple_SOL_MEMDESC_TYPE_CONST_STRING(void)
+{
+    const struct sol_memdesc desc = {
+        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+        .type = SOL_MEMDESC_TYPE_CONST_STRING,
+        .name = "SOL_MEMDESC_TYPE_CONST_STRING",
+        .defcontent.s = "hello world"
+    };
+    const char *a, *b, *c;
+    int r;
+
+    r = sol_memdesc_init_defaults(&desc, &a);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a == desc.defcontent.s);
+
+    r = sol_memdesc_init_defaults(&desc, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(b == desc.defcontent.s);
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    c = "other const string";
+    r = sol_memdesc_set_content(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a == c);
+
+    r = sol_memdesc_compare(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT(r > 0);
+
+    sol_memdesc_free_content(&desc, &a);
+    sol_memdesc_free_content(&desc, &b);
+}
+
+DEFINE_TEST(test_simple_SOL_MEMDESC_TYPE_PTR);
+static void
+test_simple_SOL_MEMDESC_TYPE_PTR(void)
+{
+    const struct sol_memdesc desc = {
+        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+        .type = SOL_MEMDESC_TYPE_PTR,
+        .name = "SOL_MEMDESC_TYPE_PTR",
+        .defcontent.p = (void *)0x1234
+    };
+    const char *a, *b, *c;
+    int r;
+
+    r = sol_memdesc_init_defaults(&desc, &a);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a == desc.defcontent.s);
+
+    r = sol_memdesc_init_defaults(&desc, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(b == desc.defcontent.s);
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    c = a + 1;
+    r = sol_memdesc_set_content(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a == c);
+
+    r = sol_memdesc_compare(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT(r > 0);
+
+    sol_memdesc_free_content(&desc, &a);
+    sol_memdesc_free_content(&desc, &b);
+}
+
+DEFINE_TEST(test_SOL_MEMDESC_TYPE_PTR_of_uint64);
+static void
+test_SOL_MEMDESC_TYPE_PTR_of_uint64(void)
+{
+    const uint64_t defval = 0xf234567890123456;
+    struct sol_memdesc desc = {
+        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+        .type = SOL_MEMDESC_TYPE_PTR,
+        .name = "SOL_MEMDESC_TYPE_PTR",
+        .defcontent.p = &defval,
+        .children = &(const struct sol_memdesc){
+            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+            .type = SOL_MEMDESC_TYPE_UINT64,
+            .name = "SOL_MEMDESC_TYPE_UINT64",
+            .defcontent.u64 = 0xdeadbeaf, /* not used due &defval */
+        },
+    };
+    uint64_t *a, *b, *c, d;
+    int r;
+
+    r = sol_memdesc_init_defaults(&desc, &a);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(*a == defval);
+
+    r = sol_memdesc_init_defaults(&desc, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(*b == defval);
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+    ASSERT(a != b);
+
+    d = *a + 1;
+    c = &d;
+    r = sol_memdesc_set_content(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(*a == d);
+
+    c = NULL;
+    r = sol_memdesc_set_content(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a == NULL);
+
+    c = &d;
+    r = sol_memdesc_set_content(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(*a == d);
+
+    r = sol_memdesc_compare(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT(r > 0);
+
+    sol_memdesc_free_content(&desc, &a);
+    sol_memdesc_free_content(&desc, &b);
+
+    desc.defcontent.p = NULL; /* no value to set, pointer is null */
+    r = sol_memdesc_init_defaults(&desc, &a);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a == NULL);
+}
+
+DEFINE_TEST(test_SOL_MEMDESC_TYPE_STRUCTURE);
+static void
+test_SOL_MEMDESC_TYPE_STRUCTURE(void)
+{
+    struct myst {
+        int64_t i64;
+        char *s;
+        uint8_t u8;
+    };
+    const struct myst defval = {
+        .i64 = 0x7234567890123456,
+        .s = (char *)"hello world",
+        .u8 = 0xf2
+    };
+    struct sol_memdesc desc = {
+        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+        .size = sizeof(struct myst),
+        .type = SOL_MEMDESC_TYPE_STRUCTURE,
+        .name = "struct myst",
+        .defcontent.p = &defval,
+        .children = (const struct sol_memdesc[]){
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct myst, i64),
+                .type = SOL_MEMDESC_TYPE_INT64,
+                .name = "i64",
+                .defcontent.i64 = 0xdeadbeaf,
+            },
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct myst, s),
+                .type = SOL_MEMDESC_TYPE_STRING,
+                .name = "s",
+                .defcontent.s = "xxx",
+            },
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct myst, u8),
+                .type = SOL_MEMDESC_TYPE_UINT8,
+                .name = "u8",
+                .defcontent.u8 = 0x12,
+            },
+            {}
+        },
+    };
+    struct myst a, b, c;
+    int r;
+
+    r = sol_memdesc_init_defaults(&desc, &a);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a.i64 == defval.i64);
+    ASSERT_STR_EQ(a.s, defval.s);
+    ASSERT(a.u8 == defval.u8);
+
+    r = sol_memdesc_compare(&desc, &a, &defval);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    r = sol_memdesc_init_defaults(&desc, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(b.i64 == defval.i64);
+    ASSERT_STR_EQ(b.s, defval.s);
+    ASSERT(b.u8 == defval.u8);
+
+    r = sol_memdesc_compare(&desc, &b, &defval);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    c.i64 = a.i64 + 1;
+    c.s = (char *)"other string";
+    c.u8 = a.u8 + 1;
+    r = sol_memdesc_set_content(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a.i64 == c.i64);
+    ASSERT_STR_EQ(a.s, c.s);
+    ASSERT(a.u8 == c.u8);
+
+    r = sol_memdesc_compare(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT(r > 0);
+
+    sol_memdesc_free_content(&desc, &a);
+    sol_memdesc_free_content(&desc, &b);
+
+    desc.defcontent.p = NULL; /* use defcontent of each member */
+
+    r = sol_memdesc_init_defaults(&desc, &a);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a.i64 == desc.children[0].defcontent.i64);
+    ASSERT_STR_EQ(a.s, desc.children[1].defcontent.s);
+    ASSERT(a.u8 == desc.children[2].defcontent.u8);
+
+    sol_memdesc_free_content(&desc, &a);
+}
+
+DEFINE_TEST(test_SOL_MEMDESC_TYPE_STRUCTURE_of_struct);
+static void
+test_SOL_MEMDESC_TYPE_STRUCTURE_of_struct(void)
+{
+    struct otherst {
+        bool b;
+        char *s;
+        long l;
+    };
+    struct myst {
+        int64_t i64;
+        char *s;
+        struct otherst st;
+        struct otherst *pst;
+        uint8_t u8;
+    };
+    const struct otherst defvalother = {
+        .b = true,
+        .s = (char *)"other st here",
+        .l = LONG_MAX / 10
+    };
+    const struct myst defval = {
+        .i64 = 0x7234567890123456,
+        .s = (char *)"hello world",
+        .st = defvalother,
+        .pst = (struct otherst *)&defvalother,
+        .u8 = 0xf2
+    };
+    const struct sol_memdesc otherdesc = {
+        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+        .size = sizeof(struct otherst),
+        .type = SOL_MEMDESC_TYPE_STRUCTURE,
+        .name = "struct otherst",
+        .children = (const struct sol_memdesc[]){
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct otherst, b),
+                .type = SOL_MEMDESC_TYPE_BOOLEAN,
+                .name = "b",
+                .defcontent.i64 = true,
+            },
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct otherst, s),
+                .type = SOL_MEMDESC_TYPE_STRING,
+                .name = "s",
+                .defcontent.s = "other st default value",
+            },
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct otherst, l),
+                .type = SOL_MEMDESC_TYPE_LONG,
+                .name = "l",
+                .defcontent.l = LONG_MAX / 20
+            },
+            { }
+        },
+
+    };
+    struct sol_memdesc desc = {
+        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+        .size = sizeof(struct myst),
+        .type = SOL_MEMDESC_TYPE_STRUCTURE,
+        .name = "struct myst",
+        .defcontent.p = &defval,
+        .children = (const struct sol_memdesc[]){
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct myst, i64),
+                .type = SOL_MEMDESC_TYPE_INT64,
+                .name = "i64",
+                .defcontent.i64 = 0xdeadbeaf,
+            },
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct myst, s),
+                .type = SOL_MEMDESC_TYPE_STRING,
+                .name = "s",
+                .defcontent.s = "xxx",
+            },
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct myst, st),
+                .size = sizeof(struct otherst),
+                .type = SOL_MEMDESC_TYPE_STRUCTURE,
+                .name = "st",
+                .children = otherdesc.children,
+            },
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct myst, pst),
+                .type = SOL_MEMDESC_TYPE_PTR,
+                .name = "pst",
+                .children = (const struct sol_memdesc []){
+                    otherdesc,
+                    {}
+                },
+            },
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct myst, u8),
+                .type = SOL_MEMDESC_TYPE_UINT8,
+                .name = "u8",
+                .defcontent.u8 = 0x12,
+            },
+            {}
+        },
+    };
+    struct myst a, b, c;
+    int r;
+
+    r = sol_memdesc_init_defaults(&desc, &a);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a.i64 == defval.i64);
+    ASSERT_STR_EQ(a.s, defval.s);
+    ASSERT(a.st.b == defval.st.b);
+    ASSERT_STR_EQ(a.st.s, defval.st.s);
+    ASSERT(a.st.l == defval.st.l);
+    ASSERT(a.pst);
+    ASSERT(a.pst->b == defval.st.b);
+    ASSERT_STR_EQ(a.pst->s, defval.st.s);
+    ASSERT(a.pst->l == defval.st.l);
+    ASSERT(a.u8 == defval.u8);
+
+    r = sol_memdesc_compare(&desc, &a, &defval);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    r = sol_memdesc_init_defaults(&desc, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(b.i64 == defval.i64);
+    ASSERT_STR_EQ(b.s, defval.s);
+    ASSERT(b.st.b == defval.st.b);
+    ASSERT_STR_EQ(b.st.s, defval.st.s);
+    ASSERT(b.st.l == defval.st.l);
+    ASSERT(b.pst);
+    ASSERT(b.pst->b == defval.st.b);
+    ASSERT_STR_EQ(b.pst->s, defval.st.s);
+    ASSERT(b.pst->l == defval.st.l);
+    ASSERT(b.u8 == defval.u8);
+
+    r = sol_memdesc_compare(&desc, &b, &defval);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    c = a;
+    c.st.l = a.st.l + 1;
+    c.st.s = (char *)"x: a is not c"; /* makes compare() return 1 */
+    c.pst = NULL;
+    r = sol_memdesc_set_content(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a.i64 == c.i64);
+    ASSERT_STR_EQ(a.s, c.s);
+    ASSERT(a.st.b == c.st.b);
+    ASSERT_STR_EQ(a.st.s, c.st.s);
+    ASSERT(a.st.l == c.st.l);
+    ASSERT(a.pst == NULL);
+    ASSERT(a.u8 == c.u8);
+
+    r = sol_memdesc_compare(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT(r > 0);
+
+
+    sol_memdesc_free_content(&desc, &a);
+    sol_memdesc_free_content(&desc, &b);
+
+    desc.defcontent.p = NULL; /* use defcontent of each member */
+
+    r = sol_memdesc_init_defaults(&desc, &a);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a.i64 == desc.children[0].defcontent.i64);
+    ASSERT_STR_EQ(a.s, desc.children[1].defcontent.s);
+    ASSERT(a.st.b == desc.children[2].children[0].defcontent.b);
+    ASSERT_STR_EQ(a.st.s, desc.children[2].children[1].defcontent.s);
+    ASSERT(a.st.l == desc.children[2].children[2].defcontent.l);
+    ASSERT(!a.pst);
+    ASSERT(a.u8 == desc.children[4].defcontent.u8);
+
+    sol_memdesc_free_content(&desc, &a);
+}
+
+/* sol_vector links elem_size and len to access data. */
+/*
+ * SOL_MEMDESC_TYPE_ARRAY with strdup()/free()/strcmp()/strlen() as
+ * operations should behave the same as SOL_MEMDESC_TYPE_STRING.
+ */
+static int
+vector_ops_set_content(const struct sol_memdesc *desc, void *container, const void *ptr_content)
+{
+    const struct sol_vector *pv = ptr_content;
+    struct sol_vector *v = sol_memdesc_get_memory(desc, container);
+    void *m;
+
+    sol_vector_clear(v);
+    v->elem_size = pv->elem_size;
+
+    m = sol_vector_append_n(v, pv->len);
+    if (!m)
+        return -ENOMEM;
+
+    memcpy(m, pv->data, pv->len * pv->elem_size);
+
+    return 0;
+}
+
+static int
+vector_ops_free_content(const struct sol_memdesc *desc, void *container)
+{
+    struct sol_vector *v = sol_memdesc_get_memory(desc, container);
+
+    sol_vector_clear(v);
+    return 0;
+}
+
+
+DEFINE_TEST(test_vector_SOL_MEMDESC_TYPE_STRUCTURE);
+static void
+test_vector_SOL_MEMDESC_TYPE_STRUCTURE(void)
+{
+    struct sol_vector defval = SOL_VECTOR_INIT(int32_t);
+    const struct sol_memdesc_ops vector_ops = {
+        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_OPS_API_VERSION, )
+        .set_content = vector_ops_set_content,
+        .free_content = vector_ops_free_content,
+    };
+    struct sol_memdesc desc = {
+        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+        .size = sizeof(struct sol_vector),
+        .type = SOL_MEMDESC_TYPE_STRUCTURE,
+        .name = "struct sol_vector",
+        .defcontent.p = &defval,
+        .children = (const struct sol_memdesc[]){
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct sol_vector, data),
+                .type = SOL_MEMDESC_TYPE_PTR,
+                .name = "data",
+            },
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct sol_vector, len),
+                .type = SOL_MEMDESC_TYPE_UINT16,
+                .name = "len",
+            },
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct sol_vector, elem_size),
+                .type = SOL_MEMDESC_TYPE_UINT16,
+                .name = "elem_size",
+            },
+            { }
+        },
+        .ops = &vector_ops,
+    };
+    uint32_t i, *pv;
+    struct sol_vector a, b, c = {};
+    int r;
+
+    pv = sol_vector_append_n(&defval, 16);
+    ASSERT(pv);
+    for (i = 0; i < defval.len; i++)
+        pv[i] = i;
+
+    r = sol_memdesc_init_defaults(&desc, &a);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(a.len, defval.len);
+    ASSERT_INT_EQ(a.elem_size, defval.elem_size);
+    ASSERT(memcmp(a.data, defval.data, defval.len * defval.elem_size) == 0);
+
+    r = sol_memdesc_init_defaults(&desc, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(b.len, defval.len);
+    ASSERT_INT_EQ(b.elem_size, defval.elem_size);
+    ASSERT(memcmp(b.data, defval.data, defval.len * defval.elem_size) == 0);
+
+    r = sol_memdesc_copy(&desc, &defval, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(c.len, defval.len);
+    ASSERT_INT_EQ(c.elem_size, defval.elem_size);
+    ASSERT(memcmp(c.data, defval.data, defval.len * defval.elem_size) == 0);
+
+    pv = sol_vector_append(&c);
+    ASSERT(pv);
+    *pv = 1234;
+
+    r = sol_memdesc_set_content(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(a.len, defval.len + 1);
+    ASSERT_INT_EQ(a.elem_size, defval.elem_size);
+    ASSERT(memcmp(a.data, defval.data, defval.len * defval.elem_size) == 0);
+    pv = sol_vector_get(&a, defval.len);
+    ASSERT(pv);
+    ASSERT_INT_EQ(*pv, 1234);
+
+    sol_memdesc_free_content(&desc, &c);
+
+    sol_memdesc_free_content(&desc, &a);
+    sol_memdesc_free_content(&desc, &b);
+    sol_vector_clear(&defval);
+}
+
+/*
+ * SOL_MEMDESC_TYPE_ARRAY with strdup()/free()/strcmp()/strlen() as
+ * operations should behave the same as SOL_MEMDESC_TYPE_STRING.
+ */
+static int
+array_char_ops_set_content(const struct sol_memdesc *desc, void *container, const void *ptr_content)
+{
+    const char *const *pv = ptr_content;
+    char **m = sol_memdesc_get_memory(desc, container);
+
+    if (*m == *pv)
+        return 0;
+
+    free(*m);
+    if (!*pv) {
+        *m = NULL;
+        return 0;
+    }
+
+    *m = strdup(*pv);
+    if (!*m)
+        return -errno;
+    return 0;
+}
+
+static int
+array_char_ops_compare(const struct sol_memdesc *desc, const void *a_container, const void *b_container)
+{
+    const char *const *a = sol_memdesc_get_memory(desc, a_container);
+    const char *const *b = sol_memdesc_get_memory(desc, b_container);
+
+    if (!*a && *b)
+        return -1;
+    else if (*a && !*b)
+        return 1;
+    else if (!*a && !*b)
+        return 0;
+    else
+        return strcmp(*a, *b);
+}
+
+static int
+array_char_ops_free_content(const struct sol_memdesc *desc, void *container)
+{
+    char **m = sol_memdesc_get_memory(desc, container);
+
+    free(*m);
+    return 0;
+}
+
+static ssize_t
+array_char_ops_get_array_length(const struct sol_memdesc *desc, const void *memory)
+{
+    const char *const *m = memory;
+
+    if (!*m)
+        return 0;
+    return strlen(*m);
+}
+
+static void *
+array_char_ops_get_array_element(const struct sol_memdesc *desc, const void *memory, size_t idx)
+{
+    const char *const *m = memory;
+
+    if (!*m)
+        return 0;
+    return (void *)(*m + idx);
+}
+
+static int
+array_char_ops_resize_array(const struct sol_memdesc *desc, void *memory, size_t len)
+{
+    char **m = memory;
+    char *tmp;
+    size_t oldlen;
+
+    if (!len) {
+        free(*m);
+        *m = NULL;
+        return 0;
+    }
+
+    if (!*m)
+        oldlen = 0;
+    else
+        oldlen = strlen(*m);
+
+    tmp = realloc(*m, len + 1);
+    if (!tmp)
+        return -errno;
+
+    *m = tmp;
+    if (oldlen < len)
+        memset(tmp + oldlen, 0, (len - oldlen));
+    tmp[len] = '\0';
+    return 0;
+}
+
+DEFINE_TEST(test_simple_SOL_MEMDESC_TYPE_ARRAY);
+static void
+test_simple_SOL_MEMDESC_TYPE_ARRAY(void)
+{
+    const char *defval = "hello world";
+    const struct sol_memdesc_ops array_char_ops = {
+        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_OPS_API_VERSION, )
+        .set_content = array_char_ops_set_content,
+        .compare = array_char_ops_compare,
+        .free_content = array_char_ops_free_content,
+        .array = {
+            .get_length = array_char_ops_get_array_length,
+            .get_element = array_char_ops_get_array_element,
+            .resize = array_char_ops_resize_array,
+        },
+    };
+    const struct sol_memdesc desc = {
+        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+        .size = sizeof(char *),
+        .type = SOL_MEMDESC_TYPE_ARRAY,
+        .name = "SOL_MEMDESC_TYPE_ARRAY",
+        .defcontent.p = &defval,
+        .ops = &array_char_ops,
+        .children = &(const struct sol_memdesc){
+            SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+            .type = SOL_MEMDESC_TYPE_INT8,
+            .name = "char",
+        },
+    };
+    char *a, *b;
+    const char *c;
+    size_t i, len;
+    int r;
+
+    r = sol_memdesc_init_defaults(&desc, &a);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a != defval);
+    ASSERT_STR_EQ(a, defval);
+
+    r = sol_memdesc_compare(&desc, &a, &defval);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    r = sol_memdesc_init_defaults(&desc, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a != defval);
+    ASSERT_STR_EQ(a, defval);
+
+    r = sol_memdesc_compare(&desc, &b, &defval);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    c = "other string";
+    r = sol_memdesc_set_content(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT(a != c);
+    ASSERT_STR_EQ(a, "other string");
+
+    r = sol_memdesc_compare(&desc, &a, &c);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT(r > 0);
+
+    len = sol_memdesc_get_array_length(&desc, &b);
+    ASSERT_INT_EQ(len, strlen(defval));
+    for (i = 0; i < len; i++) {
+        const char *elem = sol_memdesc_get_array_element(&desc, &b, i);
+
+        ASSERT(elem);
+        ASSERT_INT_EQ(*elem, defval[i]);
+    }
+
+    r = sol_memdesc_resize_array(&desc, &b, len + 1);
+    ASSERT_INT_EQ(r, 0);
+    {
+        char *elem = sol_memdesc_get_array_element(&desc, &b, len);
+
+        ASSERT(elem);
+        *elem = '!';
+        ASSERT_STR_EQ(b, "hello world!");
+    }
+
+    {
+        int8_t chr = '?';
+
+        r = sol_memdesc_append_array_element(&desc, &b, &chr);
+        ASSERT_INT_EQ(r, 0);
+        len = sol_memdesc_get_array_length(&desc, &b);
+        ASSERT_INT_EQ(len, strlen(defval) + 2);
+        ASSERT_STR_EQ(b, "hello world!?");
+    }
+
+    sol_memdesc_free_content(&desc, &a);
+    sol_memdesc_free_content(&desc, &b);
+}
+
+DEFINE_TEST(test_vector_SOL_MEMDESC_TYPE_ARRAY);
+static void
+test_vector_SOL_MEMDESC_TYPE_ARRAY(void)
+{
+    struct myst {
+        uint64_t u64;
+        struct sol_vector v;
+        uint8_t u8;
+    };
+    struct myst defval = {
+        .u64 = 0xf234567890123456,
+        .v = SOL_VECTOR_INIT(struct sol_vector),
+        .u8 = 0x72,
+    };
+    struct sol_memdesc desc = {
+        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+        .size = sizeof(struct myst),
+        .type = SOL_MEMDESC_TYPE_STRUCTURE,
+        .name = "struct myst",
+        .defcontent.p = &defval,
+        .children = (const struct sol_memdesc[]){
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct myst, u64),
+                .type = SOL_MEMDESC_TYPE_UINT64,
+                .name = "u64",
+            },
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct myst, v),
+                .size = sizeof(struct sol_vector),
+                .type = SOL_MEMDESC_TYPE_ARRAY,
+                .name = "v",
+                .ops = &SOL_MEMDESC_OPS_VECTOR,
+                .children = &(const struct sol_memdesc){
+                    SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                    .size = sizeof(struct sol_vector),
+                    .type = SOL_MEMDESC_TYPE_ARRAY,
+                    .name = "struct sol_key_value",
+                    .ops = &SOL_MEMDESC_OPS_VECTOR,
+                    .children = &(const struct sol_memdesc){
+                        SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                        .size = sizeof(struct sol_key_value),
+                        .type = SOL_MEMDESC_TYPE_STRUCTURE,
+                        .name = "SOL_MEMDESC_TYPE_STRUCTURE",
+                        .children = (const struct sol_memdesc[]){
+                            {
+                                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                                .offset = offsetof(struct sol_key_value, key),
+                                .type = SOL_MEMDESC_TYPE_STRING,
+                                .name = "key",
+                            },
+                            {
+                                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                                .offset = offsetof(struct sol_key_value, value),
+                                .type = SOL_MEMDESC_TYPE_STRING,
+                                .name = "value",
+                            },
+                            {}
+                        },
+                    },
+                },
+            },
+            {
+                SOL_SET_API_VERSION(.api_version = SOL_MEMDESC_API_VERSION, )
+                .offset = offsetof(struct myst, u8),
+                .type = SOL_MEMDESC_TYPE_UINT8,
+                .name = "u8",
+            },
+            {}
+        },
+    };
+    struct myst a, b;
+    struct sol_key_value *kv;
+    size_t i, j;
+    int r;
+
+    for (j = 0; j < 4; j++) {
+        struct sol_vector *vec = sol_vector_append(&defval.v);
+
+        ASSERT(vec);
+        sol_vector_init(vec, sizeof(struct sol_key_value));
+        for (i = 0; i < (j + 1); i++) {
+            char *k, *v;
+
+            r = asprintf(&k, "key%zd", i + j * 100);
+            ASSERT(r > 0);
+
+            r = asprintf(&v, "value%zd", i + j * 100);
+            ASSERT(r > 0);
+
+            kv = sol_vector_append(vec);
+            ASSERT(kv);
+            kv->key = k;
+            kv->value = v;
+        }
+    }
+
+    r = sol_memdesc_init_defaults(&desc, &a);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(a.v.len, defval.v.len);
+
+    for (j = 0; j < defval.v.len; j++) {
+        const struct sol_vector *vec_a = sol_vector_get(&a.v, j);
+        const struct sol_vector *vec_b = sol_vector_get(&defval.v, j);
+
+        ASSERT(vec_a);
+        ASSERT(vec_b);
+        ASSERT_INT_EQ(vec_a->len, vec_b->len);
+    }
+
+    r = sol_memdesc_init_defaults(&desc, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(b.v.len, defval.v.len);
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    r = sol_memdesc_compare(&desc, &a, &defval);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    for (j = 0; j < defval.v.len; j++) {
+        const struct sol_vector *vec_a = sol_vector_get(&a.v, j);
+        const struct sol_vector *vec_b = sol_vector_get(&defval.v, j);
+
+        ASSERT(vec_a);
+        ASSERT(vec_b);
+
+        for (i = 0; i < vec_b->len; i++) {
+            const struct sol_key_value *ita, *itb;
+
+            ita = sol_vector_get(vec_a, i);
+            ASSERT(ita);
+
+            itb = sol_vector_get(vec_b, i);
+            ASSERT(itb);
+
+            ASSERT_STR_EQ(ita->key, itb->key);
+            ASSERT_STR_EQ(ita->value, itb->value);
+        }
+    }
+
+    {
+        struct sol_vector it = SOL_VECTOR_INIT(struct sol_key_value);
+        struct sol_key_value kv_tmp = {
+            .key = "otherkey",
+            .value = "othervalue",
+        };
+        struct sol_vector *vec;
+        ssize_t len;
+
+        kv = sol_vector_append(&it);
+        ASSERT(kv);
+
+        kv->key = "somekey";
+        kv->value = "somevalue";
+
+        r = sol_memdesc_append_array_element(&desc.children[1], &a.v, &it);
+        ASSERT_INT_EQ(r, 0);
+
+        len = sol_memdesc_get_array_length(&desc.children[1], &a.v);
+        ASSERT_INT_EQ(len, defval.v.len + 1);
+        ASSERT_INT_EQ(a.v.len, defval.v.len + 1);
+
+        vec = sol_memdesc_get_array_element(&desc.children[1], &a.v, defval.v.len);
+        ASSERT(vec);
+        ASSERT_INT_EQ(vec->len, it.len);
+
+        kv = sol_memdesc_get_array_element(desc.children[1].children, vec, 0);
+        ASSERT(kv);
+
+        ASSERT_STR_EQ(kv->key, "somekey");
+        ASSERT_STR_EQ(kv->value, "somevalue");
+
+        r = sol_memdesc_append_array_element(desc.children[1].children, vec, &kv_tmp);
+        ASSERT_INT_EQ(r, 0);
+        ASSERT_INT_EQ(vec->len, it.len + 1);
+
+        kv = sol_memdesc_get_array_element(desc.children[1].children, vec, it.len);
+        ASSERT(kv);
+
+        ASSERT_STR_EQ(kv->key, kv_tmp.key);
+        ASSERT(kv->key != kv_tmp.key);
+
+        ASSERT_STR_EQ(kv->value, kv_tmp.value);
+        ASSERT(kv->value != kv_tmp.value);
+
+        sol_vector_clear(&it);
+    }
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT(r > 0);
+
+    r = sol_memdesc_resize_array(&desc.children[1], &a.v, defval.v.len);
+    ASSERT_INT_EQ(r, 0);
+
+    r = sol_memdesc_compare(&desc, &a, &b);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(errno, 0);
+
+    sol_memdesc_free_content(&desc, &a);
+    sol_memdesc_free_content(&desc, &b);
+
+    /* no default means an empty array, but elem_size must be set from children size */
+    desc.defcontent.p = NULL;
+    memset(&a, 0xff, sizeof(a));
+
+    r = sol_memdesc_init_defaults(&desc, &a);
+    ASSERT_INT_EQ(r, 0);
+    ASSERT_INT_EQ(a.v.len, 0);
+    ASSERT_INT_EQ(a.v.elem_size, sizeof(struct sol_vector));
+    ASSERT(!a.v.data);
+
+    sol_memdesc_free_content(&desc, &a);
+
+    for (j = 0; j < defval.v.len; j++) {
+        struct sol_vector *vec = sol_vector_get(&defval.v, j);
+
+        for (i = 0; i <  vec->len; i++) {
+            kv = sol_vector_get(vec, i);
+            free((void *)kv->key);
+            free((void *)kv->value);
+        }
+
+        sol_vector_clear(vec);
+    }
+    sol_vector_clear(&defval.v);
+}
+
+TEST_MAIN();

--- a/src/test/test-vector.c
+++ b/src/test/test-vector.c
@@ -381,6 +381,66 @@ vector_initializes_elements_to_zero(void)
 }
 
 
+DEFINE_TEST(test_vector_del_range);
+
+static void
+test_vector_del_range(void)
+{
+    static const unsigned int N = 16;
+    struct sol_vector v;
+    uint32_t *item;
+    uint16_t i;
+
+    sol_vector_init(&v, sizeof(uint32_t));
+
+    // Add elements.
+    for (i = 0; i < N; i++) {
+        item = sol_vector_append(&v);
+        ASSERT(item);
+        *item = i;
+    }
+    ASSERT_INT_EQ(v.len, N);
+
+    // Delete elements.
+    sol_vector_del_range(&v, 0, 2);
+    ASSERT_INT_EQ(v.len, N - 2);
+
+    // Verify elements.
+    for (i = 0; i < N - 2; i++) {
+        item = sol_vector_get(&v, i);
+        ASSERT(item);
+        ASSERT_INT_EQ(*item, i + 2);
+    }
+
+    // Delete elements.
+    sol_vector_del_range(&v, N - 4, 2);
+    ASSERT_INT_EQ(v.len, N - 4);
+
+    // Verify elements.
+    for (i = 0; i < N - 4; i++) {
+        item = sol_vector_get(&v, i);
+        ASSERT(item);
+        ASSERT_INT_EQ(*item, i + 2);
+    }
+
+    // Delete elements.
+    sol_vector_del_range(&v, N / 2, 3);
+    ASSERT_INT_EQ(v.len, N - 7);
+
+    // Verify elements.
+    for (i = 0; i < N - 7; i++) {
+        item = sol_vector_get(&v, i);
+        ASSERT(item);
+        if (i < N / 2) {
+            ASSERT_INT_EQ(*item, i + 2);
+        } else {
+            ASSERT_INT_EQ(*item, i + 2 + 3);
+        }
+    }
+
+    sol_vector_clear(&v);
+}
+
 DEFINE_TEST(test_vector_del);
 
 static void


### PR DESCRIPTION
This PR introduces infrastructure to describe memory segments. The idea is to use this as a common description for packets, options and serialization to/from CBOR in OIC.

So far nothing was converted to use it, I plan to do that in other PRs. First I plan to convert the `struct sol_flow_packet` to use that, then remove custom packet serialization from inspector, console and possibly others. Then I plan to proceed with flow options.

Someone should check converting CBOR/OIC to use that instead of custom conversions. This way `sol-oic-gen.py` would only generate the `struct sol_memdesc` for each resource, the actual conversion would be done automatically. This may expose new needs, such as enumerations, that can be added, let me know.

There is a sample serialization and load from JSON. The serialization was made into a common function that can be reused. The load I didn't think of any way to make it more general.

This is a followup to my PR #271.