### PR TITLE
sol-oic-gen.py: fix missing argument TypeError

### DIFF
--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -152,7 +152,7 @@ def generate_object_to_repr_vec_fn_common_c(state_struct_name, name, props, clie
         if 'enum' in prop_descr:
             tbl = '%s_%s_tbl' % (state_struct_name, prop_name)
             val = '%s[state->state.%s].key' % (tbl, prop_name)
-            vallen = '%s[state->state.%s].len' % val
+            vallen = '%s[state->state.%s].len' % (val, prop_name)
 
             ftype = 'SOL_OIC_REPR_TEXT_STRING'
             fargs = (val, vallen)


### PR DESCRIPTION
3fd4cfd was incomplete and the generator started spitting:

"TypeError: not enough arguments for format string"

This makes the resulting oic.c incomplete and the build
fails.

Fixes: #1897 

Reported-by @rojkov