### PR TITLE
node.js: Copy correct soletta.node file in installation

### DIFF
--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -220,7 +220,7 @@ bindings-nodejs: $(SOL_LIB_OUTPUT)
 	$(Q) mkdir -p $(build_nodejs_bindingsdir)
 	$(Q) cp -a *js package.json $(build_nodejs_bindingsdir)
 	$(Q) mkdir -p $(build_nodejs_bindingsdir)/build
-	$(Q) cp $$(find build -type f -name soletta.node | head -n 1) \
+	$(Q) cp $$(find build -type f -name soletta.node | grep obj.target | head -n 1) \
 		$(build_nodejs_bindingsdir)/build
 	$(Q) mkdir -p $(build_nodejs_bindingsdir)/node_modules
 	$(Q) cp -a ./node_modules/* $(build_nodejs_bindingsdir)/node_modules


### PR DESCRIPTION
Node.js build was failing everytime we rebuild the project. That was
happening because installing process used a find command to locate the
soletta.node file to be installed in sysroot. But after first build,
soletta.node file located in sysroot is found and we try to copy it to
itself.

Some people may not be affected by this bug because depending on locale
settings, find result order will be different

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>