### PR TITLE
NodeJS Bindings: Add JS Implementation for i2c.

### DIFF
--- a/bindings/nodejs/configure-bindings.js
+++ b/bindings/nodejs/configure-bindings.js
@@ -115,6 +115,14 @@ for ( oneVariable in process.env ) {
 				"sol-spi.h"
 			] );
 			break;
+		case "USE_I2C":
+			sources = sources.concat( [
+				"../src/functions/i2c.cc"
+			] );
+			headers = headers.concat( [
+				"sol-i2c.h"
+			] );
+			break;
 		default:
 			break;
 	}

--- a/bindings/nodejs/lib/i2c.js
+++ b/bindings/nodejs/lib/i2c.js
@@ -1,0 +1,144 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var soletta = require( 'bindings' )( 'soletta' ),
+    _ = require( 'lodash' );
+
+exports.open = function( init ) {
+    return new Promise( function( fulfill, reject ) {
+        var bus = init.bus;
+        var spd = soletta.sol_i2c_speed_from_str(init.speed);
+        var i2cbus = null;
+
+        if (init.raw) {
+            i2cbus = I2CBus( soletta.sol_i2c_open_raw( bus, spd ) );
+        } else {
+            i2cbus = I2CBus( soletta.sol_i2c_open( bus, spd ) );
+        }
+
+        //copy the properties
+        _.extend(i2cbus, init);
+
+        fulfill( i2cbus );
+    });
+
+}
+
+var I2CBus = function( i2cbus ) {
+    if ( !this._isI2CBus )
+        return new I2CBus ( i2cbus );
+    this._i2cbus = i2cbus;
+}
+
+_.extend( I2CBus.prototype, {
+    _isI2CBus: true,
+    _pending: null,
+    busy: {
+        get: function() {
+            return soletta.sol_i2c_busy( this._i2cbus );
+        }
+    },
+
+    read: function( device, size, register, repetitions ) {
+        return new Promise( _.bind( function( fulfill, reject ) {
+            if (!repetitions)
+                repetitions = 1;
+
+            soletta.sol_i2c_set_slave_address( this._i2cbus, device );
+            if (register == null) {
+                this._pending = soletta.sol_i2c_read( this._i2cbus,
+                    register, size, function( data, status ) {
+                    this._pending = null;
+                    fulfill( data );
+                });
+            } else if (repetitions > 1) {
+                this._pending = soletta.sol_i2c_read_register_multiple(
+                    this._i2cbus, register, size, repetitions,
+                    function( register, data, status ) {
+                    this._pending = null;
+                    fulfill( data );
+                });
+            } else {
+                this._pending = soletta.sol_i2c_read_register(
+                    this._i2cbus, register, size,
+                    function( register, data, status ) {
+                    this._pending = null;
+                    fulfill( data );
+                });
+            }
+            if (!this._pending)
+                reject( new Error( "I2C read failed" ) );
+        }, this ) );
+    },
+
+    write: function( device, data, register ) {
+        return new Promise( _.bind( function( fulfill, reject ) {
+            soletta.sol_i2c_set_slave_address( this._i2cbus, device );
+            var buf;
+
+            if (Buffer.isBuffer( data ))
+                buf = data;
+            else
+                buf = new Buffer(data);
+
+            if (!register) {
+                this._pending = soletta.sol_i2c_write( this._i2cbus,
+                    buf, function( data, status ) {
+                    this._pending = null;
+                    fulfill();
+                } );
+            } else {
+                this._pending = soletta.sol_i2c_write_register(
+                    this._i2cbus, register, buf,
+                    function( register, data, status ) {
+                    this._pending = null;
+                    fulfill();
+                } );
+            }
+            if (!this._pending)
+                reject( new Error( "I2C write failed" ) );
+        }, this ) );
+    },
+
+    writeBit: function( device, data ) {
+        return new Promise( _.bind( function( fulfill, reject ) {
+            soletta.sol_i2c_set_slave_address( this._i2cbus, device );
+            this._pending = soletta.sol_i2c_write_quick(
+                this._i2cbus, data, function( status ) {
+                this._pending = null;
+                fulfill();
+            } );
+            if (!this._pending)
+                reject( new Error( "I2C writeBit failed" ) );
+        }, this ) );
+    },
+
+    close: function() {
+        if (this.raw)
+            soletta.sol_i2c_close_raw( this._i2cbus);
+        else
+            soletta.sol_i2c_close( this._i2cbus);
+    },
+
+    abort: function() {
+        soletta.sol_i2c_pending_cancel( this._i2cbus, this._pending );
+        this._pending = null;
+    }
+});
+
+exports.I2CBus = I2CBus;

--- a/bindings/nodejs/src/functions/i2c.cc
+++ b/bindings/nodejs/src/functions/i2c.cc
@@ -1,0 +1,529 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <v8.h>
+#include <node.h>
+#include <nan.h>
+
+#include <sol-i2c.h>
+
+#include "../common.h"
+#include "../data.h"
+#include "../hijack.h"
+#include "../structures/js-handle.h"
+
+using namespace v8;
+
+class SolI2c : public JSHandle<SolI2c> {
+public:
+    static const char *jsClassName() { return "SolI2c"; }
+};
+
+NAN_METHOD(bind_sol_i2c_open)
+{
+    VALIDATE_ARGUMENT_COUNT(info, 2);
+    VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 0, IsUint32);
+    VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 1, IsUint32);
+
+    sol_i2c *i2c = NULL;
+    sol_i2c_speed speed = (sol_i2c_speed) info[1]->Uint32Value();
+
+    i2c = sol_i2c_open(info[0]->Uint32Value(), speed);
+
+    if (i2c) {
+        info.GetReturnValue().Set(SolI2c::New(i2c));
+    }
+}
+
+NAN_METHOD(bind_sol_i2c_open_raw)
+{
+    VALIDATE_ARGUMENT_COUNT(info, 2);
+    VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 0, IsUint32);
+    VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 1, IsUint32);
+
+    sol_i2c *i2c = NULL;
+    sol_i2c_speed speed = (sol_i2c_speed) info[1]->Uint32Value();
+    i2c = sol_i2c_open_raw(info[0]->Uint32Value(), speed);
+
+    if (i2c) {
+        info.GetReturnValue().Set(SolI2c::New(i2c));
+    }
+}
+
+NAN_METHOD(bind_sol_i2c_set_slave_address)
+{
+    VALIDATE_ARGUMENT_COUNT(info, 2);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsObject);
+    VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 1, IsUint32);
+
+    Local<Object> jsI2c = Nan::To<Object>(info[0]).ToLocalChecked();
+    sol_i2c *i2c = (sol_i2c *)SolI2c::Resolve(jsI2c);
+
+    bool returnValue = sol_i2c_set_slave_address(i2c, info[1]->Uint32Value());
+    info.GetReturnValue().Set(Nan::New(returnValue));
+}
+
+NAN_METHOD(bind_sol_i2c_close)
+{
+    VALIDATE_ARGUMENT_COUNT(info, 1);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsObject);
+
+    Local<Object> jsI2c = Nan::To<Object>(info[0]).ToLocalChecked();
+    sol_i2c *i2c = (sol_i2c *)SolI2c::Resolve(jsI2c);
+
+    sol_i2c_close(i2c);
+    Nan::SetInternalFieldPointer(jsI2c, 0, 0);
+}
+
+NAN_METHOD(bind_sol_i2c_close_raw)
+{
+    VALIDATE_ARGUMENT_COUNT(info, 1);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsObject);
+
+    Local<Object> jsI2c = Nan::To<Object>(info[0]).ToLocalChecked();
+    sol_i2c *i2c = (sol_i2c *)SolI2c::Resolve(jsI2c);
+
+    sol_i2c_close_raw(i2c);
+    Nan::SetInternalFieldPointer(jsI2c, 0, 0);
+}
+
+NAN_METHOD(bind_sol_i2c_busy)
+{
+    VALIDATE_ARGUMENT_COUNT(info, 1);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsObject);
+
+    Local<Object> jsI2c = Nan::To<Object>(info[0]).ToLocalChecked();
+    sol_i2c *i2c = (sol_i2c *)SolI2c::Resolve(jsI2c);
+    bool returnValue = sol_i2c_busy(i2c);
+
+    info.GetReturnValue().Set(Nan::New(returnValue));
+}
+
+NAN_METHOD(bind_sol_i2c_pending_cancel)
+{
+    VALIDATE_ARGUMENT_COUNT(info, 2);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsObject);
+    VALIDATE_ARGUMENT_TYPE(info, 1, IsObject);
+
+    Local<Object> jsI2c = Nan::To<Object>(info[0]).ToLocalChecked();
+    sol_i2c *i2c = (sol_i2c *)SolI2c::Resolve(jsI2c);
+
+    Local<Object> jsI2cPending = Nan::To<Object>(info[1]).ToLocalChecked();
+    sol_i2c_pending *i2c_pending = (sol_i2c_pending *)SolI2c::Resolve(jsI2cPending);
+
+    sol_i2c_pending_cancel(i2c, i2c_pending);
+    Nan::SetInternalFieldPointer(jsI2cPending, 0, 0);
+    hijack_unref();
+}
+
+static void sol_i2c_write_cb(void *cb_data, struct sol_i2c *i2c,
+                             uint8_t *data, ssize_t status)
+{
+    Nan::HandleScope scope;
+    Nan::Callback *callback = (Nan::Callback *)cb_data;
+    Local<Value> buffer;
+
+    if (status >= 0) {
+        buffer = Nan::NewBuffer((char *)data, status).ToLocalChecked();
+    } else {
+        buffer = Nan::Null();
+        free(data);
+    }
+
+    Local<Value> arguments[2] = {
+        buffer,
+        Nan::New((int)status)
+    };
+
+    callback->Call(2, arguments);
+    delete callback;
+    hijack_unref();
+}
+
+NAN_METHOD(bind_sol_i2c_write)
+{
+    VALIDATE_ARGUMENT_COUNT(info, 3);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsObject);
+    VALIDATE_ARGUMENT_TYPE(info, 1, IsObject);
+    VALIDATE_ARGUMENT_TYPE(info, 2, IsFunction);
+
+    uint8_t *inputBuffer = (uint8_t *) 0;
+    size_t count = 0;
+
+    Local<Object> jsI2c = Nan::To<Object>(info[0]).ToLocalChecked();
+    sol_i2c *i2c = (sol_i2c *)SolI2c::Resolve(jsI2c);
+
+    if (!node::Buffer::HasInstance(info[1])) {
+        Nan::ThrowTypeError("Argument 1 must be a node Buffer");
+        return;
+    }
+
+    count = node::Buffer::Length(info[1]);
+
+    inputBuffer = (uint8_t *) calloc(count, sizeof(uint8_t));
+    if (!inputBuffer)
+    {
+        Nan::ThrowError("Failed to allocate memory for input buffer");
+        return;
+    }
+
+    memcpy(inputBuffer, node::Buffer::Data(info[1]), count);
+
+    if (!hijack_ref()) {
+        free(inputBuffer);
+        return;
+    }
+
+    Nan::Callback *callback =
+            new Nan::Callback(Local<Function>::Cast(info[2]));
+    sol_i2c_pending *i2c_pending =
+            sol_i2c_write(i2c, inputBuffer, count, sol_i2c_write_cb, callback);
+
+    if (!i2c_pending) {
+        free(inputBuffer);
+        delete callback;
+        hijack_unref();
+        return;
+    }
+
+    info.GetReturnValue().Set(SolI2c::New(i2c_pending));
+}
+
+static void sol_i2c_write_reg_cb(void *cb_data, struct sol_i2c *i2c,
+                                 uint8_t reg, uint8_t *data, ssize_t status)
+{
+    Nan::HandleScope scope;
+    Nan::Callback *callback = (Nan::Callback *)cb_data;
+    Local<Value> buffer;
+
+    if (status >= 0) {
+        buffer = Nan::NewBuffer((char *)data, status).ToLocalChecked();
+    } else {
+        buffer = Nan::Null();
+        free(data);
+    }
+
+    Local<Value> arguments[3] = {
+        Nan::New(reg),
+        buffer,
+        Nan::New((int)status)
+    };
+
+    callback->Call(3, arguments);
+
+    delete callback;
+    hijack_unref();
+}
+
+NAN_METHOD(bind_sol_i2c_write_register)
+{
+    VALIDATE_ARGUMENT_COUNT(info, 4);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsObject);
+    VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 1, IsUint32);
+    VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 2, IsObject);
+    VALIDATE_ARGUMENT_TYPE(info, 3, IsFunction);
+
+    uint8_t *inputBuffer = (uint8_t *) 0;
+    size_t count;
+
+    Local<Object> jsI2c = Nan::To<Object>(info[0]).ToLocalChecked();
+    sol_i2c *i2c = (sol_i2c *)SolI2c::Resolve(jsI2c);
+
+    uint8_t reg = info[1]->Uint32Value();
+
+    if (!node::Buffer::HasInstance(info[2])) {
+        Nan::ThrowTypeError("Argument 2 must be a node Buffer");
+        return;
+    }
+
+    count = node::Buffer::Length(info[2]);
+
+    inputBuffer = (uint8_t *) calloc(count, sizeof(uint8_t));
+    if (!inputBuffer) {
+        Nan::ThrowError("Failed to allocate memory for input buffer");
+        return;
+    }
+
+    memcpy(inputBuffer, node::Buffer::Data(info[2]), count);
+
+    if (!hijack_ref()) {
+        free(inputBuffer);
+        return;
+    }
+
+    Nan::Callback *callback =
+            new Nan::Callback(Local<Function>::Cast(info[3]));
+    sol_i2c_pending *i2c_pending =
+            sol_i2c_write_register(i2c, reg, inputBuffer, count,
+                                   sol_i2c_write_reg_cb, callback);
+
+    if (!i2c_pending) {
+        free(inputBuffer);
+        delete callback;
+        hijack_unref();
+        return;
+    }
+
+    info.GetReturnValue().Set(SolI2c::New(i2c_pending));
+}
+
+static void sol_i2c_write_quick_cb(void *cb_data, struct sol_i2c *i2c,
+                                   ssize_t status)
+{
+    Nan::HandleScope scope;
+    Nan::Callback *callback = (Nan::Callback *)cb_data;
+
+    Local<Value> arguments[1] = {
+        Nan::New((int)status)
+    };
+
+    callback->Call(1, arguments);
+    delete callback;
+    hijack_unref();
+}
+
+NAN_METHOD(bind_sol_i2c_write_quick)
+{
+    VALIDATE_ARGUMENT_COUNT(info, 3);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsObject);
+    VALIDATE_ARGUMENT_TYPE(info, 1, IsBoolean);
+    VALIDATE_ARGUMENT_TYPE(info, 2, IsFunction);
+
+    Local<Object> jsI2c = Nan::To<Object>(info[0]).ToLocalChecked();
+    sol_i2c *i2c = (sol_i2c *)SolI2c::Resolve(jsI2c);
+
+    bool rw = info[1]->BooleanValue();
+
+    if (!hijack_ref())
+        return;
+
+    Nan::Callback *callback =
+            new Nan::Callback(Local<Function>::Cast(info[2]));
+
+    sol_i2c_pending *i2c_pending =
+            sol_i2c_write_quick(i2c, rw, sol_i2c_write_quick_cb, callback);
+
+    if (!i2c_pending) {
+        delete callback;
+        hijack_unref();
+        return;
+    }
+
+    info.GetReturnValue().Set(SolI2c::New(i2c_pending));
+}
+
+static void sol_i2c_read_cb(void *cb_data, struct sol_i2c *i2c, uint8_t *data,
+                            ssize_t status)
+{
+    Nan::HandleScope scope;
+    Nan::Callback *callback = (Nan::Callback *)cb_data;
+    Local<Value> buffer;
+
+    if (status >= 0) {
+        buffer = Nan::NewBuffer((char *)data, status).ToLocalChecked();
+    } else {
+        buffer = Nan::Null();
+        free(data);
+    }
+
+    Local<Value> arguments[2] = {
+        buffer,
+        Nan::New((int)status)
+    };
+
+    callback->Call(2, arguments);
+    delete callback;
+    hijack_unref();
+}
+
+NAN_METHOD(bind_sol_i2c_read)
+{
+    VALIDATE_ARGUMENT_COUNT(info, 3);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsObject);
+    VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 1, IsUint32);
+    VALIDATE_ARGUMENT_TYPE(info, 2, IsFunction);
+
+    uint8_t *outputBuffer = (uint8_t *) 0;
+    Local<Object> jsI2c = Nan::To<Object>(info[0]).ToLocalChecked();
+    sol_i2c *i2c = (sol_i2c *)SolI2c::Resolve(jsI2c);
+
+    size_t count = info[1]->Uint32Value();
+    outputBuffer = (uint8_t *) calloc(count, sizeof(uint8_t));
+
+    if (!outputBuffer) {
+        Nan::ThrowError("Failed to allocate memory for output buffer");
+        return;
+    }
+
+    if (!hijack_ref()) {
+        free(outputBuffer);
+        return;
+    }
+
+    Nan::Callback *callback =
+            new Nan::Callback(Local<Function>::Cast(info[2]));
+
+    sol_i2c_pending *i2c_pending =
+            sol_i2c_read(i2c, outputBuffer, count, sol_i2c_read_cb, callback);
+
+    if (!i2c_pending) {
+        free(outputBuffer);
+        delete callback;
+        hijack_unref();
+        return;
+    }
+
+    info.GetReturnValue().Set(SolI2c::New(i2c_pending));
+}
+
+static void sol_i2c_read_reg_cb(void *cb_data, struct sol_i2c *i2c,
+                                uint8_t reg, uint8_t *data, ssize_t status)
+{
+    Nan::HandleScope scope;
+    Nan::Callback *callback = (Nan::Callback *)cb_data;
+    Local<Value> buffer;
+
+    if (status >= 0) {
+        buffer = Nan::NewBuffer((char *)data, status).ToLocalChecked();
+    } else {
+        free(data);
+        buffer = Nan::Null();
+    }
+
+    Local<Value> arguments[3] = {
+        Nan::New(reg),
+        buffer,
+        Nan::New((int)status)
+    };
+
+    callback->Call(3, arguments);
+    delete callback;
+    hijack_unref();
+}
+
+NAN_METHOD(bind_sol_i2c_read_register)
+{
+    VALIDATE_ARGUMENT_COUNT(info, 4);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsObject);
+    VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 1, IsUint32);
+    VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 2, IsUint32);
+    VALIDATE_ARGUMENT_TYPE(info, 3, IsFunction);
+
+    uint8_t *outputBuffer = (uint8_t *) 0;
+    Local<Object> jsI2c = Nan::To<Object>(info[0]).ToLocalChecked();
+    sol_i2c *i2c = (sol_i2c *)SolI2c::Resolve(jsI2c);
+
+    uint8_t reg = info[1]->Uint32Value();
+    size_t count = info[2]->Uint32Value();
+
+    outputBuffer = (uint8_t *) calloc(count, sizeof(uint8_t));
+    if (!outputBuffer) {
+        Nan::ThrowError("Failed to allocate memory for output buffer");
+        return;
+    }
+
+    if (!hijack_ref()) {
+        free(outputBuffer);
+        return;
+    }
+
+    Nan::Callback *callback =
+            new Nan::Callback(Local<Function>::Cast(info[3]));
+
+    sol_i2c_pending *i2c_pending =
+            sol_i2c_read_register(i2c, reg, outputBuffer, count,
+                                  sol_i2c_read_reg_cb, callback);
+
+    if (!i2c_pending) {
+        free(outputBuffer);
+        delete callback;
+        hijack_unref();
+        return;
+    }
+
+    info.GetReturnValue().Set(SolI2c::New(i2c_pending));
+}
+
+NAN_METHOD(bind_sol_i2c_read_register_multiple)
+{
+    VALIDATE_ARGUMENT_COUNT(info, 5);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsObject);
+    VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 1, IsUint32);
+    VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 2, IsUint32);
+    VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 3, IsUint32);
+    VALIDATE_ARGUMENT_TYPE(info, 4, IsFunction);
+
+    uint8_t *outputBuffer = (uint8_t *) 0;
+    Local<Object> jsI2c = Nan::To<Object>(info[0]).ToLocalChecked();
+    sol_i2c *i2c = (sol_i2c *)SolI2c::Resolve(jsI2c);
+
+    uint8_t reg = info[1]->Uint32Value();
+    size_t count = info[2]->Uint32Value();
+    uint8_t times = info[3]->Uint32Value();
+
+    outputBuffer = (uint8_t *) calloc(times * count, sizeof(uint8_t));
+    if (!outputBuffer) {
+        Nan::ThrowError("Failed to allocate memory for output buffer");
+        return;
+    }
+
+    if (!hijack_ref()) {
+        free(outputBuffer);
+        return;
+    }
+
+    Nan::Callback *callback =
+            new Nan::Callback(Local<Function>::Cast(info[4]));
+
+    sol_i2c_pending *i2c_pending =
+            sol_i2c_read_register_multiple(i2c, reg, outputBuffer,
+                                           count, times,
+                                           sol_i2c_read_reg_cb, callback);
+
+    if (!i2c_pending) {
+        free(outputBuffer);
+        delete callback;
+        hijack_unref();
+        return;
+    }
+
+    info.GetReturnValue().Set(SolI2c::New(i2c_pending));
+}
+
+NAN_METHOD(bind_sol_i2c_speed_from_str) {
+    VALIDATE_ARGUMENT_COUNT(info, 1);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsString);
+
+    sol_i2c_speed speed = sol_i2c_speed_from_str(
+        (const char *)*String::Utf8Value(info[0]));
+    info.GetReturnValue().Set(Nan::New(speed));
+}
+
+NAN_METHOD(bind_sol_i2c_speed_to_str) {
+    VALIDATE_ARGUMENT_COUNT(info, 1);
+    VALIDATE_ARGUMENT_TYPE(info, 0, IsInt32);
+
+    const char *idString = sol_i2c_speed_to_str(
+        (sol_i2c_speed)info[0]->Int32Value());
+
+    if (idString) {
+        info.GetReturnValue().Set(Nan::New(idString).ToLocalChecked());
+    } else {
+        info.GetReturnValue().Set(Nan::Null());
+    }
+}

--- a/src/lib/io/include/sol-i2c.h
+++ b/src/lib/io/include/sol-i2c.h
@@ -62,6 +62,32 @@ enum sol_i2c_speed {
 };
 
 /**
+ * @brief Converts a string I2C speed to sol_i2c_speed
+ *
+ * This function converts a string I2C speed to enumeration sol_i2c_speed.
+ *
+ * @see sol_i2c_speed_to_str().
+ *
+ * @param speed Valid values are "10kbps", "100kbps", "400kbps", "1000kbps", "3400kbps".
+ *
+ * @return enumeration sol_i2c_speed.
+ */
+enum sol_i2c_speed sol_i2c_speed_from_str(const char *speed) SOL_ATTR_WARN_UNUSED_RESULT;
+
+/**
+ * @brief Converts sol_i2c_speed to a string name.
+ *
+ * This function converts sol_i2c_speed enumeration to a string I2C speed name.
+ *
+ * @see sol_i2c_speed_from_str().
+ *
+ * @param speed sol_i2c_speed.
+ *
+ * @return String representation of the sol_i2c_speed.
+ */
+const char *sol_i2c_speed_to_str(enum sol_i2c_speed speed) SOL_ATTR_WARN_UNUSED_RESULT;
+
+/**
  * @brief Open an I2C bus.
  *
  * @param bus The I2C bus number to open

--- a/src/lib/io/sol-i2c-common.c
+++ b/src/lib/io/sol-i2c-common.c
@@ -26,6 +26,8 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "i2c");
 #ifdef USE_PIN_MUX
 #include "sol-pin-mux.h"
 #endif
+#include "sol-str-table.h"
+#include "sol-util.h"
 #include "sol-vector.h"
 
 struct sol_i2c_shared {
@@ -91,4 +93,39 @@ sol_i2c_close(struct sol_i2c *i2c)
             break;
         }
     }
+}
+
+SOL_API enum sol_i2c_speed
+sol_i2c_speed_from_str(const char *speed)
+{
+    static const struct sol_str_table table[] = {
+        SOL_STR_TABLE_ITEM("10kbps", SOL_I2C_SPEED_10KBIT),
+        SOL_STR_TABLE_ITEM("100kbps", SOL_I2C_SPEED_100KBIT),
+        SOL_STR_TABLE_ITEM("400kbps", SOL_I2C_SPEED_400KBIT),
+        SOL_STR_TABLE_ITEM("1000kbps", SOL_I2C_SPEED_1MBIT),
+        SOL_STR_TABLE_ITEM("3400kbps", SOL_I2C_SPEED_3MBIT_400KBIT),
+        { }
+    };
+
+    SOL_NULL_CHECK(speed, SOL_I2C_SPEED_10KBIT);
+
+    return sol_str_table_lookup_fallback(table,
+        sol_str_slice_from_str(speed), SOL_I2C_SPEED_10KBIT);
+}
+
+SOL_API const char *
+sol_i2c_speed_to_str(enum sol_i2c_speed speed)
+{
+    static const char *speed_names[] = {
+        [SOL_I2C_SPEED_10KBIT] = "10kbps",
+        [SOL_I2C_SPEED_100KBIT] = "100kbps",
+        [SOL_I2C_SPEED_400KBIT] = "400kbps",
+        [SOL_I2C_SPEED_1MBIT] = "1000kbps",
+        [SOL_I2C_SPEED_3MBIT_400KBIT] = "3400kbps"
+    };
+
+    if (speed < SOL_UTIL_ARRAY_SIZE(speed_names))
+        return speed_names[speed];
+
+    return NULL;
 }

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -209,6 +209,7 @@ bindings-nodejs: $(SOL_LIB_OUTPUT)
 		SOL_CONFIG_USE_UART=$(USE_UART) \
 		SOL_CONFIG_USE_PWM=$(USE_PWM) \
 		SOL_CONFIG_USE_SPI=$(USE_SPI) \
+		SOL_CONFIG_USE_I2C=$(USE_I2C) \
 		SOL_CONFIG_NETWORK=$(NETWORK) \
 			$(NODEJS) bindings/nodejs/configure-bindings.js
 


### PR DESCRIPTION
This provides the implementation for i2c JavaScript bindings
based on the Soletta i2c API.

Replaces #1913

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>
Signed-off-by: Srinivasa Ragavan <srinivasa.ragavan.venkateswaran@intel.com>