### PR TITLE
Parse the test cases results log by json [v2]

### DIFF
--- a/bindings/nodejs/tests/getresult.js
+++ b/bindings/nodejs/tests/getresult.js
@@ -1,0 +1,51 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2016 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fs = require( "fs" );
+
+var jsonFilename = require( "path" ).resolve( __dirname, "results.json" );
+
+var date = new Date(),
+  data = "",
+  caseList = [],
+  setList = [],
+  allList = [],
+  test = {},
+  testInfo = {};
+
+exports.getTestResult = function( status ) {
+
+  testInfo = {
+    "message": (  status.runtime  + ": " + status.message ),
+    "result": ( status.result ? "PASS" : "FAIL" ),
+    "runtime": ( date.toLocaleTimeString() )
+  };
+
+  if ( setList.indexOf( status.name ) > -1 && ( "results" in test ) ) {
+    test.results.push( testInfo );
+    caseList.push( test );
+  } else {
+    setList.push( status.name );
+    test = { "test": status.name, "results": [ testInfo ] };
+    caseList.push( test );
+    allList.push( test );
+  }
+
+  data = JSON.stringify( { "output": allList }, null, 4 );
+  fs.writeFileSync( jsonFilename, data );
+};

--- a/bindings/nodejs/tests/setup.js
+++ b/bindings/nodejs/tests/setup.js
@@ -18,7 +18,8 @@
 
 var success = "\x1b[42;30m✓\x1b[0m",
 	failure = "\x1b[41;30m✗\x1b[0m",
-	QUnit = require( "qunitjs" );
+	QUnit = require( "qunitjs" ),
+	results = require( "./getresult" );
 
 // Right-align runtime in a field that's 10 columns wide
 function formatRuntime( runtime ) {
@@ -55,6 +56,8 @@ QUnit.config.callbacks.testStart.push( function( status ) {
 QUnit.config.callbacks.log.push( function( status ) {
 
 	// Parameters: status: { module, result(t/f), message, actual, expected, testId, runtime }
+
+	results.getTestResult( status );
 
 	console.log(
 		( status.result ? success : failure ) +


### PR DESCRIPTION
Update the code #1856

- Generate a json file to collect the test results.
- Locate easily the failed tests in result file when using the results file
- Quickly generate results to match the specified format that QA required
- JSON dose not need to take up extra workspace.

Signed-off-by: Wang Hongjuan <hongjuan.wang@intel.com>