### PR TITLE
Js sample v2

### DIFF
--- a/bindings/nodejs/lib/aio.js
+++ b/bindings/nodejs/lib/aio.js
@@ -23,16 +23,23 @@ var soletta = require( 'bindings' )( 'soletta' ),
 exports.open = function( init ) {
 	return new Promise( function( fulfill, reject ) {
 		var precision = 12;
+		var aio;
 
 		if (init.precision)
 			precision = init.precision;
 
 		if (init.name && init.name != "") {
-			fulfill( AIOPin( soletta.sol_aio_open_by_label( init.name, precision ) ) );
+			aio = soletta.sol_aio_open_by_label( init.name, precision );
 		} else if (init.raw) {
-			fulfill( AIOPin( soletta.sol_aio_open_raw( init.device, init.pin, precision ) ) );
+			aio = soletta.sol_aio_open_raw( init.device, init.pin, precision );
 		} else {
-			fulfill( AIOPin( soletta.sol_aio_open( init.device, init.pin, precision ) ) );
+			aio = soletta.sol_aio_open( init.device, init.pin, precision );
+		}
+
+		if ( aio ) {
+			fulfill( AIOPin( aio ) );
+		} else {
+			reject( new Error( "Could not open AIO device" ) );
 		}
 	});
 

--- a/bindings/nodejs/lib/gpio.js
+++ b/bindings/nodejs/lib/gpio.js
@@ -30,12 +30,14 @@ exports.open = function( init ) {
         var direction = init.direction ? init.direction : "out";
         var edge = init.edge ? init.edge : "any";
         var pull = init.pull ? init.pull : "none";
+        var active_low = init.activeLow ? init.activeLow : false;
+        var poll = init.poll ? init.poll : 0;
 
         if ( direction == "in" ) {
             config = {
                 dir: soletta.sol_gpio_direction_from_str( direction ),
-                active_low: init.activeLow,
-                poll_timeout: init.poll,
+                active_low: active_low,
+                poll_timeout: poll,
                 drive_mode: soletta.sol_gpio_drive_from_str( pull ),
                 trigger_mode: soletta.sol_gpio_edge_from_str( edge ),
                 callback: function( value ) {
@@ -49,7 +51,7 @@ exports.open = function( init ) {
         } else {
             config = {
                 dir: soletta.sol_gpio_direction_from_str( direction ),
-                active_low: init.activeLow,
+                active_low: active_low,
                 drive_mode: soletta.sol_gpio_drive_from_str( pull ),
             }
         }

--- a/bindings/nodejs/lib/gpio.js
+++ b/bindings/nodejs/lib/gpio.js
@@ -32,6 +32,7 @@ exports.open = function( init ) {
         var pull = init.pull ? init.pull : "none";
         var active_low = init.activeLow ? init.activeLow : false;
         var poll = init.poll ? init.poll : 0;
+        var gpio;
 
         if ( direction == "in" ) {
             config = {
@@ -56,9 +57,14 @@ exports.open = function( init ) {
             }
         }
 
-        gpiopin = GPIOPin( soletta.sol_gpio_open( pin, config ) );
-        callback_data.push( gpiopin );
-        fulfill( gpiopin );
+        gpio = soletta.sol_gpio_open( pin, config );
+        if ( gpio ) {
+            gpiopin = GPIOPin( gpio );
+            callback_data.push( gpiopin );
+            fulfill( gpiopin );
+        } else {
+            reject( new Error( "Could not open GPIO device" ) );
+        }
     });
 
 }

--- a/bindings/nodejs/lib/pwm.js
+++ b/bindings/nodejs/lib/pwm.js
@@ -26,6 +26,7 @@ exports.open = function( init ) {
         var enabled = ( typeof init.enabled === 'undefined' ) ? false : init.enabled;
         var alignment = init.alignment ? init.alignment : "left";
         var polarity = init.polarity ? init.polarity : "normal";
+        var pwm;
 
         config = {
             period_ns: init.period,
@@ -36,13 +37,20 @@ exports.open = function( init ) {
         }
 
         if ( typeof init.name === 'string' && init.name !== "" ) {
-            fulfill( PWMPin( soletta.sol_pwm_open_by_label( init.name, config ) ) );
+            pwm = soletta.sol_pwm_open_by_label( init.name, config );
         } else {
             if ( raw )
-                fulfill( PWMPin( soletta.sol_pwm_open_raw( init.device, init.channel, config ) ) );
+                pwm = soletta.sol_pwm_open_raw( init.device, init.channel, config );
             else
-                fulfill( PWMPin( soletta.sol_pwm_open( init.device, init.channel, config ) ) );
+                pwm = soletta.sol_pwm_open( init.device, init.channel, config );
         }
+
+        if ( pwm ) {
+            fulfill( PWMPin( pwm ) );
+        } else {
+            reject( new Error( "Could not open PWM device" ) );
+        }
+
     });
 }
 

--- a/bindings/nodejs/lib/spi.js
+++ b/bindings/nodejs/lib/spi.js
@@ -25,6 +25,7 @@ exports.open = function( init ) {
         var spiMode =  init.mode ? init.mode : "mode0";
         var chipSelect =  init.chipSelect ? init.chipSelect : 0;
         var bitsPerWord =  init.bitsPerWord ? init.bitsPerWord : 8;
+        var spi;
 
         config = {
             chip_select: chipSelect,
@@ -32,7 +33,13 @@ exports.open = function( init ) {
             frequency: init.frequency,
             bits_per_word: bitsPerWord,
         }
-        fulfill( SPIBus( soletta.sol_spi_open( init.bus, config ) ) );
+
+        spi = soletta.sol_spi_open( init.bus, config );
+        if ( spi ) {
+            fulfill( SPIBus( spi ) );
+        } else {
+            reject( new Error( "Could not open SPI device" ) );
+        }
     });
 }
 

--- a/bindings/nodejs/lib/uart.js
+++ b/bindings/nodejs/lib/uart.js
@@ -45,8 +45,10 @@ exports.open = function( init ) {
         }
 
         var uart = soletta.sol_uart_open( init.port, config );
-        if ( !uart )
+        if ( !uart ) {
+            reject( new Error( "Could not open SPI device" ) );
             return;
+        }
         connection = UARTConnection( uart );
         callback_data.push( connection );
         fulfill( connection );

--- a/src/samples/nodejs/calamari.js
+++ b/src/samples/nodejs/calamari.js
@@ -1,0 +1,109 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* A simple sample of nodejs Soletta API. On a Calamari Lure - on top of a
+ * MinnowBoard MAX - pressing buttons should toggle each colour of RGB led.
+ * Moving Calamari lever shall also change intensit of lure PWM LED1.
+ */
+
+gp = require('soletta/gpio')
+spi = require('soletta/spi')
+pwm = require('soletta/pwm')
+
+var pwmLed;
+var gpios = [];
+var lever;
+
+gpio_map = [{pin: 338}, {pin: 339}, {pin: 464},
+            {pin: 472, direction: "in", edge: "rising"},
+            {pin: 483, direction: "in", edge: "rising"},
+            {pin: 482, direction: "in", edge: "rising"}]
+            .map(function(pin_config) {
+                return new Promise(function(fullfill) {
+                    gp.open(pin_config)
+                        .then((gpio) => {
+                            gpios.push(gpio);
+                            fullfill(gpio)
+                        })
+                        .catch(function(fail) {
+                            console.log("Could not open gpio: ", fail);
+                            fullfill();
+                        });
+                });
+            });
+
+/* Hack in place: I really don't care about fullfilled values, only about
+ * `gpios` array itself, as it is the one that contains valid gpios.
+ * If we don't have six of them, then application failed. At least, we can
+ * close all gpio that were opened at exit handler */
+Promise.all(gpio_map).then(_ => {
+    if (gpios.length == 6) {
+        btnLedControllers = [
+            {led: gpios[0], btn: gpios[3]},
+            {led: gpios[1], btn: gpios[4]},
+            {led: gpios[2], btn: gpios[5]},
+        ];
+        btnLedControllers.map(function(controller) {
+            var status = {status: true};
+            controller.btn.onchange = function(status, event) {
+                status.status = !status.status;
+                controller.led.write(status.status);
+            }.bind(this, status);
+        });
+    } else {
+        process.exit();
+    }
+});
+
+spi.open({bus: 0, frequency: 100 * 1000})
+    .then(function(_lever) {
+        lever = _lever;
+        setInterval(function() {
+            lever.transfer([0x01, 0x80, 0x00])
+                .then(function(read) {
+                    var val = (read[1] << 8 | read[2]) & 0x3ff;
+                    if (pwmLed) {
+                        pwmLed.setDutyCycle(Math.floor(val * 10000 / 1023));
+                    }
+                })
+        }, 100)
+    })
+    .catch(function(fail){
+        console.log("Could not open SPI: ", fail);
+        process.exit();
+    });
+
+pwm.open({device: 0, channel: 0, period: 10000, dutyCycle: 0, enabled: true})
+    .then(function(led){
+        pwmLed = led;
+    })
+    .catch(function(fail){
+        console.log("Could not open PWM: ", fail);
+        process.exit();
+    });
+
+process.on("exit", (code) => {
+    for (var i = 0; i < gpios.length; i++) {
+        gpios[i].close();
+    }
+
+    if (lever)
+        lever.close();
+    if (pwmLed)
+        pwmLed.close();
+});


### PR DESCRIPTION
v2:
 Fix PWM code;
 Using default poll of 0;
 Using `onchange` instead of adding 'change' listener;

Small JS API sample for Calamari Lure. While writing this sample, I've found some bugs, whose fixes are on this PR as well.
@gabrielschulhof @nagineni @sragavan Could you please review this PR? See if sample uses correctly JS bindings - please, share what can be improved, as I'm not expert on JavaScript, I may have chosen not so optimal solutions =D
Please notice my 'hack' comment on sample: I'm not sure if that is the best approach. I wanted to open all GPIO pins and if any of them failed, close all that were opened.
Another thing that I'd like to know is if there's something like conffile for js: what if I want to run it on a different setup than Calamari? How do I change pin numbers and so on?