### PR TITLE
memdesc: Fix warning when comparing signed and unsigned expressions

### DIFF
--- a/src/lib/datatypes/include/sol-memdesc.h
+++ b/src/lib/datatypes/include/sol-memdesc.h
@@ -1531,12 +1531,12 @@ sol_memdesc_set_as_int64(const struct sol_memdesc *desc, void *memory, int64_t v
         *(uint64_t *)memory = value;
         return 0;
     case SOL_MEMDESC_TYPE_ULONG:
-        if (value < 0 || value > ULONG_MAX)
+        if (value < 0 || (uint64_t)value > ULONG_MAX)
             return -EOVERFLOW;
         *(unsigned long *)memory = value;
         return 0;
     case SOL_MEMDESC_TYPE_SIZE:
-        if (value < 0 || value > SIZE_MAX)
+        if (value < 0 || (uint64_t)value > SIZE_MAX)
             return -EOVERFLOW;
         *(size_t *)memory = value;
         return 0;


### PR DESCRIPTION
Cast value to unsigned before comparing with signed constants. As we are
checking if value is lower than 0 before comparing, we won't cast
negative numbers.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>