### PR TITLE
oic: Make oic server calls async and improve API

### DIFF
--- a/bindings/nodejs/src/functions/oic-server.cc
+++ b/bindings/nodejs/src/functions/oic-server.cc
@@ -232,14 +232,22 @@ NAN_METHOD(bind_sol_oic_server_del_resource) {
     Nan::SetInternalFieldPointer(jsResourceInfo, 0, 0);
 }
 
-NAN_METHOD(bind_sol_oic_notify_observers) {
+NAN_METHOD(bind_sol_oic_server_notify_observers) {
     VALIDATE_ARGUMENT_COUNT(info, 2);
     VALIDATE_ARGUMENT_TYPE(info, 0, IsObject);
     VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 1, IsObject);
+    struct sol_oic_server_response *notification;
+    bool result = true;
     struct ResourceInfo *resourceInfo = (struct ResourceInfo *)
         SolOicServerResource::Resolve(
             Nan::To<Object>(info[0]).ToLocalChecked());
     if (!resourceInfo) {
+        return;
+    }
+
+    notification = sol_oic_server_create_notification(resourceInfo->resource);
+    if (!notification) {
+        info.GetReturnValue().Set(Nan::New(false));
         return;
     }
 
@@ -249,9 +257,15 @@ NAN_METHOD(bind_sol_oic_notify_observers) {
             Nan::To<Object>(info[1]).ToLocalChecked());
     }
 
-    info.GetReturnValue().Set(Nan::New(
-        sol_oic_notify_observers(resourceInfo->resource,
-            (jsPayload ? oic_map_writer_callback : 0), jsPayload)));
+    if (jsPayload) {
+        result = oic_map_writer_callback(jsPayload, sol_oic_server_response_get_data(notification));
+    }
+
+    if (result)
+        result = sol_oic_server_notify_observers(notification) == 0;
+    else
+        sol_oic_server_response_free(notification);
+    info.GetReturnValue().Set(Nan::New(result));
 
     if (jsPayload) {
         jsPayload->Reset();

--- a/bindings/nodejs/src/functions/oic-server.cc
+++ b/bindings/nodejs/src/functions/oic-server.cc
@@ -87,51 +87,59 @@ public:
 };
 
 #define ENTITY_HANDLER_SIGNATURE \
-    const struct sol_network_link_addr *cliaddr, \
-    const void *data, \
-    const struct sol_oic_map_reader *input, \
-    struct sol_oic_map_writer *output
+    struct sol_oic_server_request *request, \
+    void *data
 
-static sol_coap_responsecode_t entityHandler(ENTITY_HANDLER_SIGNATURE,
+static int entityHandler(ENTITY_HANDLER_SIGNATURE,
     enum OicServerMethod method) {
     Nan::HandleScope scope;
     sol_coap_responsecode_t returnValue = SOL_COAP_RSPCODE_NOT_IMPLEMENTED;
     struct ResourceInfo *info = (struct ResourceInfo *)data;
+    struct sol_oic_server_response *response = NULL;
     Local<Object> outputPayload = Nan::New<Object>();
-    Local<Value> arguments[3] = {
-        js_sol_network_link_addr(cliaddr),
-        js_sol_oic_map_reader(input),
+    Local<Value> arguments[2] = {
+        js_sol_oic_map_reader(sol_oic_server_request_get_data(request)),
         outputPayload
     };
+    //TODO: Make JS API Async
     Nan::Callback *callback = info->handlers[method];
     if (callback) {
-        Local<Value> jsReturnValue = callback->Call(3, arguments);
+        Local<Value> jsReturnValue = callback->Call(2, arguments);
         VALIDATE_CALLBACK_RETURN_VALUE_TYPE(jsReturnValue, IsUint32,
             "entity handler", returnValue);
         returnValue = (sol_coap_responsecode_t)
             Nan::To<uint32_t>(jsReturnValue).FromJust();
 
-        if (!c_sol_oic_map_writer(outputPayload, output)) {
+        response = sol_oic_server_create_response(request);
+        if (!response) {
+            sol_oic_server_request_free(request);
+            Nan::ThrowError("entity handler: Failed to create response");
+        }
+        if (!c_sol_oic_map_writer(outputPayload,
+            sol_oic_server_response_get_data(response))) {
+            sol_oic_server_request_free(request);
+            sol_oic_server_response_free(response);
             Nan::ThrowError("entity handler: Failed to encode output payload");
         }
+
     }
-    return returnValue;
+    return sol_oic_server_send_response(request, response, returnValue);
 }
 
-static sol_coap_responsecode_t defaultGet(ENTITY_HANDLER_SIGNATURE) {
-    return entityHandler(cliaddr, data, input, output, OIC_SERVER_GET);
+static int defaultGet(ENTITY_HANDLER_SIGNATURE) {
+    return entityHandler(request, data, OIC_SERVER_GET);
 }
 
-static sol_coap_responsecode_t defaultPut(ENTITY_HANDLER_SIGNATURE) {
-    return entityHandler(cliaddr, data, input, output, OIC_SERVER_PUT);
+static int defaultPut(ENTITY_HANDLER_SIGNATURE) {
+    return entityHandler(request, data, OIC_SERVER_PUT);
 }
 
-static sol_coap_responsecode_t defaultPost(ENTITY_HANDLER_SIGNATURE) {
-    return entityHandler(cliaddr, data, input, output, OIC_SERVER_POST);
+static int defaultPost(ENTITY_HANDLER_SIGNATURE) {
+    return entityHandler(request, data, OIC_SERVER_POST);
 }
 
-static sol_coap_responsecode_t defaultDel(ENTITY_HANDLER_SIGNATURE) {
-    return entityHandler(cliaddr, data, input, output, OIC_SERVER_DEL);
+static int defaultDel(ENTITY_HANDLER_SIGNATURE) {
+    return entityHandler(request, data, OIC_SERVER_DEL);
 }
 
 #define ASSIGN_STR_SLICE_MEMBER_FROM_PROPERTY(to, from, message, member) \

--- a/bindings/nodejs/tests/observation-server.js
+++ b/bindings/nodejs/tests/observation-server.js
@@ -34,7 +34,7 @@ theResource = soletta.sol_oic_server_add_resource( _.extend( {
 		interface: "oic.if.baseline",
 		resource_type: "core.light",
 		path: "/a/" + uuid,
-		put: function putHandler( clientAddress, input, output ) {
+		put: function putHandler( input, output ) {
 			if ( input.finished === uuid ) {
 				observationCount++;
 				output.clientsFinished = observationCount;
@@ -45,7 +45,7 @@ theResource = soletta.sol_oic_server_add_resource( _.extend( {
 			return soletta.sol_coap_responsecode_t.SOL_COAP_RSPCODE_OK;
 		},
 	}, setObservable ? {} : {
-		get: function getHandler( clientAddress, input, output ) {
+		get: function getHandler( input, output ) {
 			_.extend( output, payload.generate() );
 			return soletta.sol_coap_responsecode_t.SOL_COAP_RSPCODE_OK;
 		}

--- a/bindings/nodejs/tests/observation-server.js
+++ b/bindings/nodejs/tests/observation-server.js
@@ -58,7 +58,7 @@ console.log( JSON.stringify( { ready: true } ) );
 
 if ( !setObservable ) {
 	theInterval = setInterval( function() {
-		soletta.sol_oic_notify_observers( theResource, payload.generate() );
+		soletta.sol_oic_server_notify_observers( theResource, payload.generate() );
 	}, 200 );
 }
 

--- a/bindings/nodejs/tests/tests/OIC Discovery/server.js
+++ b/bindings/nodejs/tests/tests/OIC Discovery/server.js
@@ -28,7 +28,7 @@ theResource = soletta.sol_oic_server_add_resource( {
 		interface: "oic.if.baseline",
 		resource_type: "core.light",
 		path: "/a/" + process.argv[ 2 ],
-		put: function putHandler( clientAddress, input, output ) {
+		put: function putHandler( input, output ) {
 			testUtils.assert( "deepEqual", input, { uuid: process.argv[ 2 ] },
 				"Server: PUT request payload is as expected" );
 			output.putRequests = ++putRequests;

--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -1370,39 +1370,57 @@ server_resource_schedule_update(struct server_resource *resource)
         server_resource_perform_update, resource);
 }
 
-static sol_coap_responsecode_t
-server_handle_update(const struct sol_network_link_addr *cliaddr, const void *data,
-    const struct sol_oic_map_reader *repr_map, struct sol_oic_map_writer *output)
+static int
+server_handle_update(struct sol_oic_server_request *request, void *data)
 {
+    sol_coap_responsecode_t code;
     struct server_resource *resource = (struct server_resource *)data;
+    struct sol_oic_map_reader *input;
     int r;
 
-    if (!resource->funcs->from_repr_vec)
-        return SOL_COAP_RSPCODE_NOT_IMPLEMENTED;
+    if (!resource->funcs->from_repr_vec) {
+        code = SOL_COAP_RSPCODE_NOT_IMPLEMENTED;
+        goto end;
+    }
 
-    r = resource->funcs->from_repr_vec(resource, repr_map);
+    input = sol_oic_server_request_get_data(request);
+    r = resource->funcs->from_repr_vec(resource, input);
     if (r > 0) {
         server_resource_schedule_update(resource);
-        return SOL_COAP_RSPCODE_CHANGED;
+        code = SOL_COAP_RSPCODE_CHANGED;
     } else if (r == 0)
-        return SOL_COAP_RSPCODE_OK;
+        code = SOL_COAP_RSPCODE_OK;
     else
-        return SOL_COAP_RSPCODE_PRECONDITION_FAILED;
+        code = SOL_COAP_RSPCODE_PRECONDITION_FAILED;
+
+end:
+    return sol_oic_server_send_response(request, NULL, code);
 }
 
-static sol_coap_responsecode_t
-server_handle_get(const struct sol_network_link_addr *cliaddr, const void *data,
-    const struct sol_oic_map_reader *repr_map, struct sol_oic_map_writer *output)
+static int
+server_handle_get(struct sol_oic_server_request *request, void *data)
 {
     const struct server_resource *resource = data;
+    struct sol_oic_server_response *response;
+    struct sol_oic_map_writer *output;
 
     if (!resource->funcs->to_repr_vec)
-        return SOL_COAP_RSPCODE_NOT_IMPLEMENTED;
+        return sol_oic_server_send_response(request, NULL,
+            SOL_COAP_RSPCODE_NOT_IMPLEMENTED);
 
+    response = sol_oic_server_create_response(request);
+    SOL_NULL_CHECK_GOTO(response, error);
+    output = sol_oic_server_response_get_data(response);
     if (!resource->funcs->to_repr_vec((void *)resource, output))
-        return SOL_COAP_RSPCODE_INTERNAL_ERROR;
+        goto error;
 
-    return SOL_COAP_RSPCODE_CONTENT;
+    return sol_oic_server_send_response(request, response,
+        SOL_COAP_RSPCODE_CONTENT);
+
+error:
+    sol_oic_server_response_free(response);
+    return sol_oic_server_send_response(request, NULL,
+        SOL_COAP_RSPCODE_INTERNAL_ERROR);
 }
 
 // log_init() implementation happens within oic-gen.c

--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -1198,8 +1198,8 @@ found_resource(struct sol_oic_client *oic_cli, struct sol_oic_resource *oic_res,
     SOL_INF("Found resource matching device_id");
     resource->resource = sol_oic_resource_ref(oic_res);
 
-    if (!sol_oic_client_resource_set_observable(oic_cli, resource->resource,
-        state_changed, resource, true)) {
+    if (sol_oic_client_resource_set_observable(oic_cli, resource->resource,
+        state_changed, resource, true) < 0) {
         SOL_WRN("Could not observe resource as requested, will try again");
     }
 
@@ -1508,8 +1508,8 @@ client_connect(struct client_resource *resource, const char *device_id)
         sol_timeout_del(resource->find_timeout);
 
     if (resource->resource) {
-        if (!sol_oic_client_resource_set_observable(resource->client,
-            resource->resource, NULL, NULL, false)) {
+        if (sol_oic_client_resource_set_observable(resource->client,
+            resource->resource, NULL, NULL, false) < 0) {
             SOL_WRN("Could not unobserve resource");
         }
 
@@ -1567,9 +1567,8 @@ client_resource_close(struct client_resource *resource)
         sol_timeout_del(resource->update_schedule_timeout);
 
     if (resource->resource) {
-        bool r = sol_oic_client_resource_set_observable(resource->client, resource->resource,
-            NULL, NULL, false);
-        if (!r)
+        if (sol_oic_client_resource_set_observable(resource->client,
+            resource->resource, NULL, NULL, false) < 0)
             SOL_WRN("Could not unobserve resource");
 
         sol_oic_resource_unref(resource->resource);
@@ -1592,13 +1591,21 @@ static bool
 client_resource_perform_update(void *data)
 {
     struct client_resource *resource = data;
+    struct sol_oic_client_request *request;
     int r;
 
     SOL_NULL_CHECK_GOTO(resource->resource, disable_timeout);
     SOL_NULL_CHECK_GOTO(resource->funcs->to_repr_vec, disable_timeout);
 
-    r = sol_oic_client_resource_request(resource->client, resource->resource,
-        SOL_COAP_METHOD_PUT, resource->funcs->to_repr_vec, resource,
+    request = sol_oic_client_create_request(SOL_COAP_METHOD_PUT, resource->resource);
+    if (!request ||
+        !resource->funcs->to_repr_vec(resource,
+        sol_oic_client_request_get_data(request))) {
+        SOL_WRN("Failed to create request. Will try again");
+        return true;
+    }
+
+    r = sol_oic_client_resource_request(resource->client, request,
         client_resource_update_ack, data);
     if (r < 0) {
         SOL_WRN("Could not send update request to resource, will try again");

--- a/src/lib/comms/include/sol-oic-client.h
+++ b/src/lib/comms/include/sol-oic-client.h
@@ -113,6 +113,18 @@ struct sol_oic_resource {
 };
 
 /**
+ * @struct sol_oic_client_request
+ *
+ * @brief Information about a client request.
+ *
+ * @see sol_oic_client_create_request
+ * @see sol_oic_client_create_non_confirmable_request
+ * @see sol_oic_client_request_free
+ * @see sol_oic_client_resource_request
+ */
+struct sol_oic_client_request;
+
+/**
  * @brief Creates a new OIC client intance.
  *
  * @return A new OIC client instance, or NULL in case of failure.
@@ -304,22 +316,14 @@ bool sol_oic_client_get_server_info_by_addr(struct sol_oic_client *client,
     const void *data);
 
 /**
- * @brief Send a request packet to server for specific @a resource.
+ * @brief Send a @a request packet to server.
  *
- * Send a CoAP confirmable request packet to server that contains the
- * @a resource and wait for a response. When the response arrives, @a callback
- * will be called.
+ * Send a CoAP @a request packet to server and wait for a response. When the
+ * response arrives, @a callback will be called.
  *
  * @param client An oic client instance.
- * @param res The resource that is going to receive the request.
- * @param method The coap request method as documented in @ref
- *        sol_coap_method_t.
- * @param fill_repr_map A callback to be called to fill the request data.
- *        Parameter @a data is a pointer to user's @a fill_repr_map_data and
- *        @a repr_map is a handler to write data to request packet. Use @ref
- *        sol_oic_map_append() to append data to @a repr_map. If @c NULL,
- *        no data will be added to request.
- * @param fill_repr_map_data User's data to be passed to @a fill_repr_map.
+ * @param request A request created using @ref sol_oic_client_create_request()
+ *        or sol_oic_client_create_non_confirmable_request().
  * @param callback Callback to be called when a response from this request
  *        arrives. Parameter @a response_code is the header response code of
  *        this request, @a cli is the @a client used to perform the
@@ -328,59 +332,52 @@ bool sol_oic_client_get_server_info_by_addr(struct sol_oic_client *client,
  *        macro. @a data is the user's @a callback_data. When timeout is reached
  *        and no packet has arrived, callback is called with @c NULL @a addr and
  *        @c NULL repr_vec so any clean up can be performed.
- *
  * @param callback_data User's data to be passed to @a callback.
  *
- * @return True if packet was successfully sent. False otherwise.
+ * @return @c 0 on success or a negative number on errors.
  */
-bool sol_oic_client_resource_request(struct sol_oic_client *client, struct sol_oic_resource *res,
-    sol_coap_method_t method,
-    bool (*fill_repr_map)(void *data, struct sol_oic_map_writer *repr_map),
-    void *fill_repr_map_data,
-    void (*callback)(sol_coap_responsecode_t response_code, struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_oic_map_reader *repr_vec, void *data),
-    const void *callback_data);
+int sol_oic_client_resource_request(struct sol_oic_client *client, struct sol_oic_client_request *request, void (*callback)(sol_coap_responsecode_t response_code, struct sol_oic_client *cli, const struct sol_network_link_addr *addr, const struct sol_oic_map_reader *repr_vec, void *data), const void *callback_data);
 
 /**
- * @brief Send a request packet to server for specific @a resource, using
- * non-confirmable packets.
+ * @brief Create an oic client request for an specific @a resource, using a
+ * confirmable CoAP packet.
  *
- * Send a CoAP non-confirmable request packet to server that contains the
- * @a resource and wait for a response. When the response arrives, @a callback
- * will be called.
- *
- * The only difference from @ref sol_oic_client_resource_request() to this
- * function is that it uses CoAP non-confirmable packets to make the request.
- *
- * @param client An oic client instance.
- * @param res The resource that is going to receive the request.
  * @param method The coap request method as documented in @ref
  *        sol_coap_method_t.
- * @param fill_repr_map A callback to be called to fill the request data.
- *        Parameter @a data is a pointer to user's @a fill_repr_map_data and
- *        @a repr_map is a handler to write data to request packet. Use @ref
- *        sol_oic_map_append() to append data to @a repr_map. If @c NULL, no
- *        data will be added to request.
- * @param fill_repr_map_data User's data to be passed to @a fill_repr_map.
- * @param callback Callback to be called when a response from this request
- *        arrives. Parameter @a response_code is the header response code of
- *        this request, @a cli is the @a client used to perform the
- *        request, @a addr is the address of the server and repr_vec is a
- *        handler to access data from response, using @ref SOL_OIC_MAP_LOOP()
- *        macro. @a data is the user's @a callback_data. When timeout is reached
- *        and no packet has arrived, callback is called with @c NULL @a addr and
- *        @c NULL repr_vec so any clean up can be performed.
- * @param callback_data User's data to be passed to @a callback.
+ * @param res The resource that is going to receive the request.
  *
- * @return True if packet was successfully sent. False otherwise.
+ * @return A valid client request on success or @c NULL on errors.
  */
-bool sol_oic_client_resource_non_confirmable_request(struct sol_oic_client *client, struct sol_oic_resource *res,
-    sol_coap_method_t method,
-    bool (*fill_repr_map)(void *data, struct sol_oic_map_writer *repr_map),
-    void *fill_repr_map_data,
-    void (*callback)(sol_coap_responsecode_t response_code, struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
-    const struct sol_oic_map_reader *repr_vec, void *data),
-    const void *callback_data);
+struct sol_oic_client_request *sol_oic_client_create_request(sol_coap_method_t method, struct sol_oic_resource *res);
+
+/**
+ * @brief Create an oic client request for an specific @a resource, using a
+ * non-confirmable CoAP packet.
+ *
+ * @param method The coap request method as documented in @ref
+ *        sol_coap_method_t.
+ * @param res The resource that is going to receive the request.
+ *
+ * @return A valid client request on success or @c NULL on errors.
+ */
+struct sol_oic_client_request *sol_oic_client_create_non_confirmable_request(sol_coap_method_t method, struct sol_oic_resource *res);
+
+/**
+ * @brief Release memory from a request.
+ *
+ * @param request A pointer to the request to be released.
+ */
+void sol_oic_client_request_free(struct sol_oic_client_request *request);
+
+/**
+ * @brief Get the packet data from a client request.
+ *
+ * @param request The request to retrieve the data.
+ *
+ * @return The packet data from this request.
+ */
+struct sol_oic_map_writer *sol_oic_client_request_get_data(struct sol_oic_client_request *request);
+
 
 /**
  * @brief Set this resource as observable for this client.
@@ -409,9 +406,9 @@ bool sol_oic_client_resource_non_confirmable_request(struct sol_oic_client *clie
  * @param data A pointer to user's data.
  * @param observe If server will be obeserved or unobserved.
  *
- * @return True if packet was successfully sent. False otherwise.
+ * @return @c 0 on success or a negative number on errors.
  */
-bool sol_oic_client_resource_set_observable(struct sol_oic_client *client, struct sol_oic_resource *res,
+int sol_oic_client_resource_set_observable(struct sol_oic_client *client, struct sol_oic_resource *res,
     void (*callback)(sol_coap_responsecode_t response_code, struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
     const struct sol_oic_map_reader *repr_map, void *data),
     const void *data, bool observe);
@@ -448,9 +445,9 @@ bool sol_oic_client_resource_set_observable(struct sol_oic_client *client, struc
  * @param data A pointer to user's data.
  * @param observe If server will be obeserved or unobserved.
  *
- * @return True if packet was successfully sent. False otherwise.
+ * @return @c 0 on success or a negative number on errors.
  */
-bool sol_oic_client_resource_set_observable_non_confirmable(struct sol_oic_client *client, struct sol_oic_resource *res,
+int sol_oic_client_resource_set_observable_non_confirmable(struct sol_oic_client *client, struct sol_oic_resource *res,
     void (*callback)(sol_coap_responsecode_t response_code, struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
     const struct sol_oic_map_reader *repr_map, void *data),
     const void *data, bool observe);

--- a/src/lib/comms/include/sol-oic-common.h
+++ b/src/lib/comms/include/sol-oic-common.h
@@ -372,7 +372,7 @@ struct sol_oic_repr_field {
  * This structure is used in callback parameters so users can add fields to an
  * oic packet using @ref sol_oic_map_append().
  *
- * @see sol_oic_notify_observers()
+ * @see sol_oic_server_notify_observers()
  * @see sol_oic_client_resource_request()
  */
 struct sol_oic_map_writer;
@@ -482,7 +482,7 @@ bool sol_oic_map_loop_next(struct sol_oic_repr_field *repr, struct sol_oic_map_r
  * @return true if the element was added successfully. False if an error
  *         occurred and the element was not added.
  *
- * @see sol_oic_notify_observers()
+ * @see sol_oic_server_notify_observers()
  * @see sol_oic_client_resource_request()
  * @note As this function adds elements to @a oic_map_writer, it will update
  * its type to SOL_OIC_MAP_CONTENT when needed.

--- a/src/lib/comms/include/sol-oic-server.h
+++ b/src/lib/comms/include/sol-oic-server.h
@@ -335,21 +335,27 @@ void sol_oic_server_del_resource(struct sol_oic_server_resource *resource);
 /**
  * @brief Send notification to all clients in observe list.
  *
- * Send a notification packet with data filled by @a fill_repr_map callback
- * to all clients that have registered in the @a resource as an observer.
+ * Send a notification packet with data filled in @a notification to all
+ * observing clients of the resouce used to create @a notification.
  *
- * @param resource The target resource
- * @param fill_repr_map Callback to fill notification data. Callback parameters
- *        are @a data, the user's data pointer, @a oic_map_writer, the write
- *        handler to be used with @ref sol_oic_map_append to fill the
- *        notification data
- * @param data Pointer to user's data to be passed to @a fill_repr_map callback
+ * @param notification The notification response created using
+ * sol_oic_server_create_notification() function.
  *
- * @return True on success, false on failure.
+ * @return @c 0 on success or a negative number on errors.
  */
-bool sol_oic_notify_observers(struct sol_oic_server_resource *resource,
-    bool (*fill_repr_map)(void *data, struct sol_oic_map_writer *oic_map_writer),
-    const void *data);
+int sol_oic_server_notify_observers(struct sol_oic_server_response *notification);
+
+/**
+ * @brief Create a notification response to send to observing clients of
+ * @a resource.
+ *
+ * @param resource The resource that will be used to create this notification.
+ *
+ * @return A notification response on success or NULL on errors.
+ *
+ * @see sol_oic_server_notify_observers
+ */
+struct sol_oic_server_response *sol_oic_server_create_notification(struct sol_oic_server_resource *resource);
 
 /**
  * @brief Release memory from a request.

--- a/src/lib/comms/include/sol-oic-server.h
+++ b/src/lib/comms/include/sol-oic-server.h
@@ -183,6 +183,28 @@ extern "C" {
 struct sol_oic_server_resource;
 
 /**
+ * @struct sol_oic_server_request
+ *
+ * @brief Information about a server request.
+ *
+ * @see sol_oic_server_create_response
+ * @see sol_oic_server_send_response
+ * @see sol_oic_server_request_free
+ */
+struct sol_oic_server_request;
+
+/**
+ * @struct sol_oic_server_response
+ *
+ * @brief Information about a server response.
+ *
+ * @see sol_oic_server_create_response
+ * @see sol_oic_server_send_response
+ * @see sol_oic_server_request_free
+ */
+struct sol_oic_server_response;
+
+/**
  * @struct sol_oic_resource_type
  *
  * @brief structure defining the type of a resource.
@@ -215,59 +237,66 @@ struct sol_oic_resource_type {
     struct sol_str_slice path;
 
     struct {
-        sol_coap_responsecode_t (*handle)(const struct sol_network_link_addr *cliaddr,
-            const void *data, const struct sol_oic_map_reader *input, struct sol_oic_map_writer *output);
+        int (*handle)(struct sol_oic_server_request *request, void *data);
     }
     /**
      * @brief Callback handle to GET requests
      *
-     * @param cliaddr The client address.
+     * @param request Information about this request. To be used to create and
+     *        send a response. Memory must be freed using
+     *        sol_oic_server_request_free if not sending a response.
      * @param data The user's data pointer.
-     * @param input Always NULL because GET requests shouldn't cointain payload
-     *        data. Parameter kept for compatibility reasons.
-     * @param output Handler to write data to response packet using, for
-     *        example, @ref sol_oic_map_append().
      *
-     * @return The coap response code of this request.
+     * @return @c 0 on success or a negative number on errors.
+     *
+     * @see sol_oic_server_create_response
+     * @see sol_oic_server_send_response
+     * @see sol_oic_server_request_free
      */
     get,
     /**
      * @brief Callback handle to PUT requests
      *
-     * @param cliaddr The client address.
+     * @param request Information about this request. To be used to create and
+     *        send a response. Memory must be freed using
+     *        sol_oic_server_request_free if not sending a response.
      * @param data The user's data pointer.
-     * @param input Handler to read request packet data using, for example,
-     *        @ref SOL_OIC_MAP_LOOP() macro.
-     * @param output Handler to write data to response packet using, for
-     *        example, @ref sol_oic_map_append().
      *
-     * @return The coap response code of this request.
+     * @return @c 0 on success or a negative number on errors.
+     *
+     * @see sol_oic_server_create_response
+     * @see sol_oic_server_send_response
+     * @see sol_oic_server_request_free
      */
         put,
     /**
      * @brief Callback handle to POST requests
      *
-     * @param cliaddr The client address.
+     * @param request Information about this request. To be used to create and
+     *        send a response. Memory must be freed using
+     *        sol_oic_server_request_free if not sending a response.
      * @param data The user's data pointer.
-     * @param input Handler to read request packet data using, for example,
-     *        @ref SOL_OIC_MAP_LOOP() macro.
-     * @param output Handler to write data to response packet using, for
-     *        example, @ref sol_oic_map_append().
      *
-     * @return The coap response code of this request.
+     * @return @c 0 on success or a negative number on errors.
+     *
+     * @see sol_oic_server_create_response
+     * @see sol_oic_server_send_response
+     * @see sol_oic_server_request_free
      */
         post,
     /**
      * @brief Callback handle to DELETE requests
      *
-     * @param cliaddr The client address.
+     * @param request Information about this request. To be used to create and
+     *        send a response. Memory must be freed using
+     *        sol_oic_server_request_free if not sending a response.
      * @param data The user's data pointer.
-     * @param input Always NULL because DELETE requests shouldn't cointain
-     *        payload data. Parameter kept for compatibility reasons.
-     * @param output Handler to write data to response packet using, for
-     *        example, @ref sol_oic_map_append().
      *
-     * @return The coap response code of this request.
+     * @return @c 0 on success or a negative number on errors.
+     *
+     * @see sol_oic_server_create_response
+     * @see sol_oic_server_send_response
+     * @see sol_oic_server_request_free
      */
         del;
 };
@@ -321,6 +350,59 @@ void sol_oic_server_del_resource(struct sol_oic_server_resource *resource);
 bool sol_oic_notify_observers(struct sol_oic_server_resource *resource,
     bool (*fill_repr_map)(void *data, struct sol_oic_map_writer *oic_map_writer),
     const void *data);
+
+/**
+ * @brief Release memory from a request.
+ *
+ * @param request A pointer to the request to be released.
+ */
+void sol_oic_server_request_free(struct sol_oic_server_request *request);
+
+/**
+ * @brief Release memory from a response.
+ *
+ * @param response A pointer to the response to be released.
+ */
+void sol_oic_server_response_free(struct sol_oic_server_response *response);
+
+/**
+ * @brief Create a response to a oic server request.
+ *
+ * @param request The request that the created response will be used to reply.
+ *
+ * @return On success a new reponse element. @c NULL on errors.
+ */
+struct sol_oic_server_response *sol_oic_server_create_response(struct sol_oic_server_request *request);
+
+/**
+ * @brief Send a reponse as a reply to a request.
+ *
+ * @param request The request that created this response.
+ * @param response The response to be sent. If @c NULL, an empty response will
+ *        be sent.
+ * @param code The CoAP code to be used in response.
+ *
+ * @return @c 0 on success or a negative number on errors.
+ */
+int sol_oic_server_send_response(struct sol_oic_server_request *request, struct sol_oic_server_response *response, sol_coap_responsecode_t code);
+
+/**
+ * @brief Get the packet data from a response.
+ *
+ * @param response The response to retrieve the data.
+ *
+ * @return The packet data from this response.
+ */
+struct sol_oic_map_writer *sol_oic_server_response_get_data(struct sol_oic_server_response *response);
+
+/**
+ * @brief Get the packet data from a request.
+ *
+ * @param request The request to retrieve the data.
+ *
+ * @return The packet data from this request.
+ */
+struct sol_oic_map_reader *sol_oic_server_request_get_data(struct sol_oic_server_request *request);
 
 /**
  * @}

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -559,6 +559,7 @@ sol_coap_packet_new(struct sol_coap_packet *old)
     return pkt;
 
 err:
+    errno = -r;
     free(pkt);
     return NULL;
 }

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -50,6 +50,18 @@ struct sol_oic_server {
     int refcnt;
 };
 
+struct sol_oic_server_response {
+    struct sol_coap_packet *pkt;
+    struct sol_oic_map_writer data;
+};
+
+struct sol_oic_server_request {
+    const struct sol_network_link_addr *cliaddr;
+    struct sol_oic_map_reader data;
+    struct sol_coap_server *server;
+    struct sol_coap_packet *pkt;
+};
+
 struct sol_oic_server_resource {
     struct sol_coap_resource *coap;
 
@@ -60,9 +72,7 @@ struct sol_oic_server_resource {
 
     struct {
         struct {
-            sol_coap_responsecode_t (*handle)(const struct sol_network_link_addr *cliaddr,
-                const void *data, const struct sol_oic_map_reader *input,
-                struct sol_oic_map_writer *output);
+            int (*handle)(struct sol_oic_server_request *request, void *data);
         } get, put, post, del;
         const void *data;
     } callback;
@@ -87,21 +97,24 @@ static void sol_oic_server_unref(void);
 
 #define APPEND_KEY_VALUE(info, k, v) \
     do { \
-        ret = sol_oic_map_append(output, &SOL_OIC_REPR_TEXT_STRING(k, \
+        ret = sol_oic_map_append(&response->data, &SOL_OIC_REPR_TEXT_STRING(k, \
             oic_server.info->v.data, oic_server.info->v.len)); \
     } while (0)
 
-static sol_coap_responsecode_t
-_sol_oic_server_d(const struct sol_network_link_addr *cliaddr, const void *data,
-    const struct sol_oic_map_reader *input, struct sol_oic_map_writer *output)
+static int
+_sol_oic_server_d(struct sol_oic_server_request *request, void *data)
 {
     SOL_BUFFER_DECLARE_STATIC(dev_id, 37);
+    struct sol_oic_server_response *response;
     bool ret;
     int r;
 
     r = sol_util_uuid_string_from_bytes(true, true,
         sol_platform_get_machine_id_as_bytes(), &dev_id);
     SOL_INT_CHECK_GOTO(r, < 0, error);
+
+    response = sol_oic_server_create_response(request);
+    SOL_NULL_CHECK_GOTO(response, error);
 
     APPEND_KEY_VALUE(server_info, SOL_OIC_KEY_DEVICE_NAME, device_name);
     SOL_EXP_CHECK_GOTO(!ret, error);
@@ -111,21 +124,27 @@ _sol_oic_server_d(const struct sol_network_link_addr *cliaddr, const void *data,
         data_model_version);
     SOL_EXP_CHECK_GOTO(!ret, error);
 
-    ret = sol_oic_map_append(output, &SOL_OIC_REPR_TEXT_STRING(
+    ret = sol_oic_map_append(&response->data, &SOL_OIC_REPR_TEXT_STRING(
         SOL_OIC_KEY_DEVICE_ID, dev_id.data, dev_id.used));
-    return SOL_COAP_RSPCODE_CONTENT;
+    SOL_EXP_CHECK_GOTO(!ret, error);
+
+    return sol_oic_server_send_response(request, response,
+        SOL_COAP_RSPCODE_CONTENT);
 
 error:
-    return SOL_COAP_RSPCODE_INTERNAL_ERROR;
-
+    return sol_oic_server_send_response(request, NULL,
+        SOL_COAP_RSPCODE_INTERNAL_ERROR);
 }
 
-static sol_coap_responsecode_t
-_sol_oic_server_p(const struct sol_network_link_addr *cliaddr, const void *data,
-    const struct sol_oic_map_reader *input, struct sol_oic_map_writer *output)
+static int
+_sol_oic_server_p(struct sol_oic_server_request *request, void *data)
 {
     const char *os_version;
     bool ret;
+    struct sol_oic_server_response *response;
+
+    response = sol_oic_server_create_response(request);
+    SOL_NULL_CHECK_GOTO(response, error);
 
     APPEND_KEY_VALUE(plat_info, SOL_OIC_KEY_MANUF_NAME, manufacturer_name);
     SOL_EXP_CHECK_GOTO(!ret, error);
@@ -149,21 +168,23 @@ _sol_oic_server_p(const struct sol_network_link_addr *cliaddr, const void *data,
     APPEND_KEY_VALUE(plat_info, SOL_OIC_KEY_SYSTEM_TIME, platform_id);
     SOL_EXP_CHECK_GOTO(!ret, error);
 
-    ret = sol_oic_map_append(output, &SOL_OIC_REPR_TEXT_STRING(
+    ret = sol_oic_map_append(&response->data, &SOL_OIC_REPR_TEXT_STRING(
         SOL_OIC_KEY_SYSTEM_TIME, NULL, 0));
     SOL_EXP_CHECK_GOTO(!ret, error);
 
     os_version = sol_platform_get_os_version();
     if (!os_version)
         os_version = "Unknown";
-    ret = sol_oic_map_append(output, &SOL_OIC_REPR_TEXT_STRING(
+    ret = sol_oic_map_append(&response->data, &SOL_OIC_REPR_TEXT_STRING(
         SOL_OIC_KEY_OS_VER, os_version, strlen(os_version)));
     SOL_EXP_CHECK_GOTO(!ret, error);
 
-    return SOL_COAP_RSPCODE_CONTENT;
+    return sol_oic_server_send_response(request, response,
+        SOL_COAP_RSPCODE_CONTENT);
 
 error:
-    return SOL_COAP_RSPCODE_INTERNAL_ERROR;
+    return sol_oic_server_send_response(request, NULL,
+        SOL_COAP_RSPCODE_INTERNAL_ERROR);
 }
 
 #undef APPEND_KEY_VALUE
@@ -615,52 +636,148 @@ sol_oic_server_unref(void)
 
 static int
 _sol_oic_resource_type_handle(
-    sol_coap_responsecode_t (*handle_fn)(const struct sol_network_link_addr *cliaddr, const void *data,
-    const struct sol_oic_map_reader *input, struct sol_oic_map_writer *output),
+    int (*handle_fn)(struct sol_oic_server_request *request, void *data),
     struct sol_coap_server *server, struct sol_coap_packet *req,
     const struct sol_network_link_addr *cliaddr,
     struct sol_oic_server_resource *res, bool expect_payload)
 {
     struct sol_coap_packet *response;
-    struct sol_oic_map_reader input, *input_ptr = NULL;
-    struct sol_oic_map_writer output;
-    sol_coap_responsecode_t code = SOL_COAP_RSPCODE_INTERNAL_ERROR;
+    struct sol_oic_server_request *request;
+    sol_coap_responsecode_t code;
     CborParser parser;
 
     OIC_SERVER_CHECK(-ENOTCONN);
 
-    response = sol_coap_packet_new(req);
-    if (!response) {
-        SOL_WRN("Could not build response packet.");
-        return -1;
-    }
+    request = calloc(1, sizeof(struct sol_oic_server_request));
+    SOL_NULL_CHECK(request, -ENOMEM);
+
+    request->cliaddr = cliaddr;
+    request->server = server;
+    request->pkt = sol_coap_packet_ref(req);
 
     if (!handle_fn) {
         code = SOL_COAP_RSPCODE_NOT_IMPLEMENTED;
-        goto done;
+        goto error;
     }
 
     if (expect_payload) {
         if (!sol_oic_pkt_has_cbor_content(req)) {
             code = SOL_COAP_RSPCODE_BAD_REQUEST;
-            goto done;
+            goto error;
         }
-        if (sol_oic_packet_cbor_extract_repr_map(req, &parser, (CborValue *)&input) != CborNoError) {
+        if (sol_oic_packet_cbor_extract_repr_map(req, &parser,
+            (CborValue *)&request->data) != CborNoError) {
             code = SOL_COAP_RSPCODE_BAD_REQUEST;
-            goto done;
+            goto error;
         }
-        input_ptr = &input;
-    }
+    } else
+        ((CborValue *)&request->data)->type = CborInvalidType;
 
-    sol_oic_packet_cbor_create(response, &output);
-    code = handle_fn(cliaddr, res->callback.data, input_ptr, &output);
-    if (sol_oic_packet_cbor_close(response, &output) != CborNoError)
-        code = SOL_COAP_RSPCODE_INTERNAL_ERROR;
+    return handle_fn(request, (void *)res->callback.data);
 
-done:
+error:
+    response = sol_coap_packet_new(req);
+    SOL_NULL_CHECK(response, -errno);
     sol_coap_header_set_code(response, code);
+    sol_oic_server_request_free(request);
 
     return sol_coap_send_packet(server, response, cliaddr);
+}
+
+SOL_API void
+sol_oic_server_request_free(struct sol_oic_server_request *request)
+{
+    SOL_NULL_CHECK(request);
+
+    if (request->pkt)
+        sol_coap_packet_unref(request->pkt);
+    free(request);
+}
+
+SOL_API void
+sol_oic_server_response_free(struct sol_oic_server_response *response)
+{
+    SOL_NULL_CHECK(response);
+
+    if (response->pkt)
+        sol_coap_packet_unref(response->pkt);
+    free(response);
+}
+
+SOL_API struct sol_oic_map_writer *
+sol_oic_server_response_get_data(struct sol_oic_server_response *response)
+{
+    SOL_NULL_CHECK(response, NULL);
+
+    return &response->data;
+}
+
+SOL_API struct sol_oic_map_reader *
+sol_oic_server_request_get_data(struct sol_oic_server_request *request)
+{
+    SOL_NULL_CHECK(request, NULL);
+
+    return &request->data;
+}
+
+SOL_API struct sol_oic_server_response *
+sol_oic_server_create_response(struct sol_oic_server_request *request)
+{
+    struct sol_oic_server_response *response;
+
+    SOL_NULL_CHECK(request, NULL);
+
+    response = calloc(1, sizeof(struct sol_oic_server_response));
+    SOL_NULL_CHECK(response, NULL);
+
+    response->pkt = sol_coap_packet_new(request->pkt);
+    SOL_NULL_CHECK_GOTO(response->pkt, error);
+
+    sol_oic_packet_cbor_create(response->pkt, &response->data);
+
+    return response;
+
+error:
+    free(response);
+    return NULL;
+}
+
+SOL_API int
+sol_oic_server_send_response(struct sol_oic_server_request *request, struct sol_oic_server_response *response, sol_coap_responsecode_t code)
+{
+    struct sol_coap_packet *pkt;
+    int r = -EINVAL;
+
+    OIC_SERVER_CHECK(-ENOTCONN);
+    SOL_NULL_CHECK_GOTO(request, error);
+
+    if (response) {
+        if (sol_oic_packet_cbor_close(response->pkt,
+            &response->data) != CborNoError) {
+            r = -EINVAL;
+            goto error;
+        }
+        pkt = response->pkt;
+        free(response);
+    } else
+        pkt = sol_coap_packet_new(request->pkt);
+
+    r = sol_coap_header_set_code(pkt, code);
+    SOL_INT_CHECK_GOTO(r, < 0, error_pkt);
+
+    r = sol_coap_send_packet(request->server, pkt, request->cliaddr);
+    SOL_INT_CHECK(r, < 0, r);
+
+    sol_oic_server_request_free(request);
+    return 0;
+
+error:
+    sol_oic_server_response_free(response);
+    return r;
+
+error_pkt:
+    sol_coap_packet_unref(pkt);
+    return r;
 }
 
 #define DEFINE_RESOURCE_TYPE_CALLBACK_FOR_METHOD(method, expect_payload) \

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -53,6 +53,7 @@ struct sol_oic_server {
 struct sol_oic_server_response {
     struct sol_coap_packet *pkt;
     struct sol_oic_map_writer data;
+    struct sol_oic_server_resource *resource;
 };
 
 struct sol_oic_server_request {
@@ -977,57 +978,71 @@ sol_oic_server_del_resource(struct sol_oic_server_resource *resource)
     sol_oic_server_unref();
 }
 
-static bool
-send_notification_to_server(struct sol_oic_server_resource *resource,
-    struct sol_coap_server *server,
-    bool (*fill_repr_map)(void *data, struct sol_oic_map_writer *oic_map_writer),
-    const void *data)
+static int
+send_notification_to_server(struct sol_oic_server_response *notification,
+    struct sol_coap_server *server)
 {
-    struct sol_coap_packet *pkt;
-    struct sol_oic_map_writer oic_map_writer;
     uint8_t code = SOL_COAP_RSPCODE_INTERNAL_ERROR;
     CborError err;
     int r;
 
-    pkt = sol_coap_packet_notification_new(oic_server.server, resource->coap);
-    SOL_NULL_CHECK(pkt, false);
-
-    sol_oic_packet_cbor_create(pkt, &oic_map_writer);
-    if (!fill_repr_map((void *)data, &oic_map_writer))
-        goto end;
-    err = sol_oic_packet_cbor_close(pkt, &oic_map_writer);
+    err = sol_oic_packet_cbor_close(notification->pkt, &notification->data);
     SOL_INT_CHECK_GOTO(err, != CborNoError, end);
 
     code = SOL_COAP_RSPCODE_CONTENT;
 end:
-    r = sol_coap_header_set_code(pkt, code);
-    SOL_INT_CHECK_GOTO(r, < 0, err);
-    r = sol_coap_header_set_type(pkt, SOL_COAP_TYPE_ACK);
-    SOL_INT_CHECK_GOTO(r, < 0, err);
+    r = sol_coap_header_set_code(notification->pkt, code);
+    SOL_INT_CHECK_GOTO(r, < 0, error);
+    r = sol_coap_header_set_type(notification->pkt, SOL_COAP_TYPE_ACK);
+    SOL_INT_CHECK_GOTO(r, < 0, error);
 
-    return !sol_coap_packet_send_notification(oic_server.server, resource->coap, pkt);
+    return sol_coap_packet_send_notification(server,
+        notification->resource->coap, notification->pkt);
 
-err:
-    sol_coap_packet_unref(pkt);
-    return false;
+error:
+    return r;
 }
 
-SOL_API bool
-sol_oic_notify_observers(struct sol_oic_server_resource *resource,
-    bool (*fill_repr_map)(void *data, struct sol_oic_map_writer *oic_map_writer),
-    const void *data)
+SOL_API struct sol_oic_server_response *
+sol_oic_server_create_notification(struct sol_oic_server_resource *resource)
 {
-    bool sent_server = false;
-    bool sent_dtls_server = false;
+    struct sol_oic_server_response *notification;
 
-    SOL_NULL_CHECK(resource, false);
-    SOL_NULL_CHECK(fill_repr_map, false);
+    notification = calloc(1, sizeof(struct sol_oic_server_response));
+    SOL_NULL_CHECK(notification, NULL);
 
-    OIC_SERVER_CHECK(false);
+    notification->resource = resource;
+    notification->pkt = sol_coap_packet_notification_new(oic_server.server,
+        resource->coap);
+    SOL_NULL_CHECK_GOTO(notification->pkt, error);
+    sol_oic_packet_cbor_create(notification->pkt, &notification->data);
 
-    sent_server = send_notification_to_server(resource, oic_server.server, fill_repr_map, data);
+    return notification;
+
+error:
+    free(notification);
+    return NULL;
+}
+
+SOL_API int
+sol_oic_server_notify_observers(struct sol_oic_server_response *notification)
+{
+    int r = 0;
+
+    SOL_NULL_CHECK(notification, -EINVAL);
+    OIC_SERVER_CHECK(-ENOTCONN);
+
+    if (!notification->resource) {
+        SOL_WRN("Response is not a notification response.");
+        return -EINVAL;
+    }
+    r = send_notification_to_server(notification, oic_server.server);
+    SOL_INT_CHECK_GOTO(r, < 0, end);
     if (oic_server.dtls_server)
-        sent_dtls_server = send_notification_to_server(resource, oic_server.dtls_server, fill_repr_map, data);
+        r = send_notification_to_server(notification, oic_server.dtls_server);
 
-    return sent_server || sent_dtls_server;
+end:
+    notification->pkt = NULL;
+    sol_oic_server_response_free(notification);
+    return r;
 }

--- a/src/samples/coap/iotivity-test-client.c
+++ b/src/samples/coap/iotivity-test-client.c
@@ -207,7 +207,7 @@ check_post_request(sol_coap_responsecode_t response_code, struct sol_oic_client 
 }
 
 static bool
-post_fill_repr_map(void *data, struct sol_oic_map_writer *repr_map)
+post_fill_repr_map(struct sol_oic_map_writer *repr_map)
 {
     int ret;
 
@@ -301,6 +301,7 @@ print_response(sol_coap_responsecode_t response_code, struct sol_oic_client *cli
     struct sol_oic_map_reader iterator;
     struct Context *ctx = data;
     struct sol_buffer buf = SOL_BUFFER_INIT_EMPTY;
+    struct sol_oic_client_request *request;
 
     SOL_BUFFER_DECLARE_STATIC(addr, SOL_INET_ADDR_STRLEN);
 
@@ -324,8 +325,9 @@ print_response(sol_coap_responsecode_t response_code, struct sol_oic_client *cli
 
     if (ctx->test_number == TEST_NON_CONFIRMABLE_DELETE ||
         ctx->test_number == TEST_CONFIRMABLE_DELETE) {
-        sol_oic_client_resource_request(cli, ctx->res, SOL_COAP_METHOD_GET,
-            NULL, NULL, check_delete_request, NULL);
+        request = sol_oic_client_create_request(SOL_COAP_METHOD_GET, ctx->res);
+        sol_oic_client_resource_request(cli, request, check_delete_request,
+            NULL);
         return;
     }
 
@@ -381,15 +383,20 @@ print_response(sol_coap_responsecode_t response_code, struct sol_oic_client *cli
     }
 
     if (ctx->test_number == TEST_NON_CONFIRMABLE_PUT) {
-        sol_oic_client_resource_request(cli, ctx->res, SOL_COAP_METHOD_GET,
-            NULL, NULL, check_put_request, NULL);
+        request = sol_oic_client_create_request(SOL_COAP_METHOD_GET, ctx->res);
+        if (!request)
+            goto error;
+        sol_oic_client_resource_request(cli, request, check_put_request, NULL);
     } else if (ctx->test_number == TEST_NON_CONFIRMABLE_POST ||
         ctx->test_number == TEST_CONFIRMABLE_POST) {
-        sol_oic_client_resource_request(cli, ctx->res, SOL_COAP_METHOD_GET,
-            NULL, NULL, check_post_request, NULL);
+        request = sol_oic_client_create_request(SOL_COAP_METHOD_GET, ctx->res);
+        if (!request)
+            goto error;
+        sol_oic_client_resource_request(cli, request, check_post_request, NULL);
     } else if (map_reader)
         sol_quit();
     else {
+error:
         SOL_WRN("Invalid response: empty payload.");
         sol_quit_with_code(EXIT_FAILURE);
     }
@@ -445,7 +452,7 @@ platform_info_cb(struct sol_oic_client *cli, const struct sol_oic_platform_infor
 }
 
 static bool
-put_fill_repr_map(void *data, struct sol_oic_map_writer *repr_map)
+put_fill_repr_map(struct sol_oic_map_writer *repr_map)
 {
     int ret;
 
@@ -468,8 +475,9 @@ found_resource(struct sol_oic_client *cli, struct sol_oic_resource *res, void *d
     const char *method_str = "GET";
     sol_coap_method_t method = SOL_COAP_METHOD_GET;
 
-    bool (*fill_repr_map)(void *data, struct sol_oic_map_writer *repr_map) = NULL;
+    bool (*fill_repr_map)(struct sol_oic_map_writer *repr_map) = NULL;
     struct sol_str_slice href;
+    struct sol_oic_client_request *request;
 
     if (!res)
         return false;
@@ -557,12 +565,14 @@ found_resource(struct sol_oic_client *cli, struct sol_oic_resource *res, void *d
             sol_oic_client_resource_set_observable_non_confirmable(cli, res,
                 resource_notify, data, true);
     } else {
-        if (non_confirmable)
-            sol_oic_client_resource_non_confirmable_request(cli, res, method,
-                fill_repr_map, NULL, print_response, data);
-        else
-            sol_oic_client_resource_request(cli, res, method, fill_repr_map,
-                NULL, print_response, data);
+        if (non_confirmable) {
+            request = sol_oic_client_create_request(method, res);
+        } else {
+            request = sol_oic_client_create_non_confirmable_request(method, res);
+        }
+        if (fill_repr_map)
+            fill_repr_map(sol_oic_client_request_get_data(request));
+        sol_oic_client_resource_request(cli, request, print_response, data);
     }
 
     if (ctx->test_number == TEST_NON_CONFIRMABLE_INVALID_GET)

--- a/src/samples/coap/oic-client.c
+++ b/src/samples/coap/oic-client.c
@@ -91,6 +91,7 @@ found_resource(struct sol_oic_client *cli, struct sol_oic_resource *res, void *d
 {
     static const char digits[] = "0123456789abcdef";
     struct sol_str_slice *slice;
+    struct sol_oic_client_request *request;
     uint16_t idx;
 
     SOL_BUFFER_DECLARE_STATIC(addr, SOL_INET_ADDR_STRLEN);
@@ -138,8 +139,10 @@ found_resource(struct sol_oic_client *cli, struct sol_oic_resource *res, void *d
         printf("\t\t%.*s\n", SOL_STR_SLICE_PRINT(*slice));
 
     printf("Issuing GET %.*s on resource...\n", SOL_STR_SLICE_PRINT(res->href));
-    sol_oic_client_resource_request(cli, res, SOL_COAP_METHOD_GET, NULL,
-        NULL, got_get_response, data);
+    request = sol_oic_client_create_request(SOL_COAP_METHOD_GET, res);
+    if (!request)
+        return false;
+    sol_oic_client_resource_request(cli, request, got_get_response, data);
 
     printf("\n");
 


### PR DESCRIPTION
 - Oic server requests are now ASYNC
 - Improve server and client API so we won't need a callback to fill data in packets. The packets are first created and then sent.

JS bindings were updated and tests are not broken, but the API is still async and using same API. I'll count on people that are working on JS api to improve that.


Fixes #1821