### PR TITLE
gpio: Adapt the Zephyr changes in GPIO callbacks

### DIFF
--- a/src/lib/io/sol-gpio-impl-zephyr.c
+++ b/src/lib/io/sol-gpio-impl-zephyr.c
@@ -22,6 +22,7 @@
 /* Zephyr includes */
 #include "atomic.h"
 #include "gpio.h"
+#include "misc/util.h"
 
 #define SOL_LOG_DOMAIN &_log_domain
 #include "sol-gpio.h"
@@ -33,35 +34,37 @@
 
 SOL_LOG_INTERNAL_DECLARE_STATIC(_log_domain, "gpio");
 
-static atomic_val_t int_flag = 0;
-static uint32_t irq_pins;
-
-static struct sol_ptr_vector opened_pins = SOL_PTR_VECTOR_INIT;
-
-/* Zephyr structure used as a "bank of gpio pins" */
-static struct device *device;
+struct sol_gpio_port {
+    struct device *device;
+    struct gpio_callback cb;
+    struct sol_ptr_vector opened_pins;
+    uint32_t irq_pins;
+    atomic_val_t int_flag;
+};
 
 struct sol_gpio {
     uint32_t pin;
-    bool active_low;
+    struct sol_gpio_port *port;
     void (*cb)(void *data, struct sol_gpio *gpio, bool value);
     const void *cb_data;
+    bool active_low;
 };
 
 static void
 sol_gpio_interrupt_process(void *data)
 {
+    struct sol_gpio_port *port = data;
     struct sol_gpio *g;
     uint32_t irq;
     uint16_t i;
 
-    if (!atomic_cas(&int_flag, 1, 0))
+    if (!atomic_cas(&port->int_flag, 1, 0))
         return;
 
-    irq = irq_pins;
-    irq_pins = 0;
+    irq = port->irq_pins;
+    port->irq_pins = 0;
 
-    SOL_PTR_VECTOR_FOREACH_IDX (&opened_pins, g, i) {
+    SOL_PTR_VECTOR_FOREACH_IDX (&port->opened_pins, g, i) {
         if (irq & (1U << g->pin)) {
             bool val = sol_gpio_read(g);
             g->cb((void *)g->cb_data, g, val);
@@ -71,24 +74,46 @@ sol_gpio_interrupt_process(void *data)
 
 /* Run in interrupt context */
 static void
-gpio_isr_cb(struct device *port, uint32_t pin)
+gpio_isr_cb(struct device *dev, struct gpio_callback *cb, uint32_t pins)
 {
+    struct sol_gpio_port *port = CONTAINER_OF(cb, struct sol_gpio_port, cb);
     struct mainloop_event w = {
         .cb = sol_gpio_interrupt_process,
-        .data = NULL
+        .data = port
     };
 
-    irq_pins |= 1U << pin;
+    port->irq_pins |= pins;
 
-    if (!atomic_cas(&int_flag, 0, 1))
+    if (!atomic_cas(&port->int_flag, 0, 1))
         return;
 
     sol_mainloop_event_post(&w);
 }
 
+static struct sol_gpio_port *
+gpio_get_port(uint32_t pin)
+{
+    /* We only support a single port for the time being */
+    static struct sol_gpio_port port = {
+        .opened_pins = SOL_PTR_VECTOR_INIT
+    };
+
+    if (!port.device) {
+        port.device = device_get_binding("GPIO_0");
+        SOL_NULL_CHECK(port.device, NULL);
+        gpio_init_callback(&port.cb, gpio_isr_cb, 0);
+        /* For simplicity, add the callback here. It won't be called if
+         * the pin mask is 0 */
+        gpio_add_callback(port.device, &port.cb);
+    }
+
+    return &port;
+}
+
 SOL_API struct sol_gpio *
 sol_gpio_open_raw(uint32_t pin, const struct sol_gpio_config *config)
 {
+    struct sol_gpio_port *port;
     struct sol_gpio *g, *gpio;
     int flags = 0;
     uint16_t i;
@@ -104,17 +129,13 @@ sol_gpio_open_raw(uint32_t pin, const struct sol_gpio_config *config)
     }
 #endif
 
-    if (opened_pins.base.len == 0) {
-        if (!device) {
-            device = device_get_binding("GPIO_0");
-            SOL_NULL_CHECK(device, NULL);
-        }
-    } else {
-        SOL_PTR_VECTOR_FOREACH_IDX (&opened_pins, g, i) {
-            if (g->pin == pin) {
-                SOL_WRN("GPIO pin %" PRIu32 " is already opened", pin);
-                return NULL;
-            }
+    port = gpio_get_port(pin);
+    SOL_NULL_CHECK(port, NULL);
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&port->opened_pins, g, i) {
+        if (g->pin == pin) {
+            SOL_WRN("GPIO pin %" PRIu32 " is already opened", pin);
+            return NULL;
         }
     }
 
@@ -122,12 +143,13 @@ sol_gpio_open_raw(uint32_t pin, const struct sol_gpio_config *config)
     SOL_NULL_CHECK(gpio, NULL);
 
     gpio->pin = pin;
+    gpio->port = port;
     gpio->active_low = config->active_low;
 
     if (config->dir == SOL_GPIO_DIR_IN) {
         if (config->in.trigger_mode == SOL_GPIO_EDGE_NONE) {
             flags = flags | GPIO_DIR_IN;
-            if (gpio_pin_configure(device, gpio->pin, flags) < 0) {
+            if (gpio_pin_configure(port->device, gpio->pin, flags) < 0) {
                 SOL_WRN("Couldn't configure gpio");
                 goto error;
             }
@@ -140,23 +162,20 @@ sol_gpio_open_raw(uint32_t pin, const struct sol_gpio_config *config)
             gpio->cb = config->in.cb;
             gpio->cb_data = (void *)config->in.user_data;
 
-            if (gpio_pin_configure(device, gpio->pin, flags) < 0) {
+            if (gpio_pin_configure(port->device, gpio->pin, flags) < 0) {
                 SOL_WRN("Couldn't configure gpio");
                 goto error;
             }
 
-            if (gpio_set_callback(device, gpio_isr_cb) < 0) {
+            if (gpio_pin_enable_callback(port->device, gpio->pin) < 0) {
                 SOL_WRN("Couldn't set callback to gpio");
                 goto error;
             }
 
-            if (gpio_pin_enable_callback(device, gpio->pin) < 0) {
-                SOL_WRN("Couldn't set callback to gpio");
-                goto error;
-            }
+            port->cb.pin_mask |= BIT(pin);
         }
     } else {
-        if (gpio_pin_configure(device, gpio->pin, GPIO_DIR_OUT) < 0) {
+        if (gpio_pin_configure(port->device, gpio->pin, GPIO_DIR_OUT) < 0) {
             SOL_WRN("Couldn't configure gpio");
             goto error;
         }
@@ -164,7 +183,7 @@ sol_gpio_open_raw(uint32_t pin, const struct sol_gpio_config *config)
         sol_gpio_write(gpio, config->out.value);
     }
 
-    if (sol_ptr_vector_append(&opened_pins, gpio) < 0) {
+    if (sol_ptr_vector_append(&port->opened_pins, gpio) < 0) {
         SOL_WRN("Couldn't configure gpio");
         goto error;
     }
@@ -179,21 +198,14 @@ error:
 SOL_API void
 sol_gpio_close(struct sol_gpio *gpio)
 {
-    struct sol_gpio *g;
-    uint16_t i;
+    struct sol_gpio_port *port;
 
-    SOL_NULL_CHECK(device);
     SOL_NULL_CHECK(gpio);
 
-    SOL_PTR_VECTOR_FOREACH_IDX (&opened_pins, g, i) {
-        if (g->pin == gpio->pin) {
-            if (gpio_pin_disable_callback(device, g->pin) < 0) {
-                SOL_WRN("Couldn't disable gpio callback");
-            }
-            sol_ptr_vector_del(&opened_pins, i);
-            break;
-        }
-    }
+    port = gpio->port;
+    port->cb.pin_mask &= ~BIT(gpio->pin);
+    gpio_pin_disable_callback(port->device, gpio->pin);
+    sol_ptr_vector_remove(&port->opened_pins, gpio);
 
     free(gpio);
 }
@@ -201,10 +213,9 @@ sol_gpio_close(struct sol_gpio *gpio)
 SOL_API bool
 sol_gpio_write(struct sol_gpio *gpio, bool value)
 {
-    SOL_NULL_CHECK(device, false);
     SOL_NULL_CHECK(gpio, false);
 
-    if (gpio_pin_write(device, gpio->pin, gpio->active_low ^ value) < 0) {
+    if (gpio_pin_write(gpio->port->device, gpio->pin, gpio->active_low ^ value) < 0) {
         SOL_WRN("Couldn't write to gpio pin:%" PRIu32, gpio->pin);
         return false;
     }
@@ -217,10 +228,9 @@ sol_gpio_read(struct sol_gpio *gpio)
 {
     uint32_t value;
 
-    SOL_NULL_CHECK(device, -EINVAL);
     SOL_NULL_CHECK(gpio, -EINVAL);
 
-    if (gpio_pin_read(device, gpio->pin, &value) < 0) {
+    if (gpio_pin_read(gpio->port->device, gpio->pin, &value) < 0) {
         SOL_WRN("Couldn't read gpio pin:%" PRIu32, gpio->pin);
         return -EINVAL;
     }


### PR DESCRIPTION
Zephyr now supports adding multiple callbacks to a port, so we make use
of the new API.
As a bonus, change the implementation to make it ready to work with
more than one port, so when we have a way of knowing how many there are
(and how to identify them), most of the code is ready for it.

Signed-off-by: Iván Briano <ivan.briano@intel.com>