### PR TITLE
dependency-resolver: split args to parse the compiler name for Yocto

### DIFF
--- a/data/scripts/dependency-resolver.py
+++ b/data/scripts/dependency-resolver.py
@@ -540,7 +540,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    if args.compiler != default_compiler and not which(args.compiler):
+    if args.compiler != default_compiler and not which(args.compiler.split()[0]):
         print("ERROR: Invalid --compiler argument, no such file: %s" % args.compiler)
         exit(1)
 


### PR DESCRIPTION
Yocto's TARGETCC does not only contain the compiler information but yet it
comes with some flags to crosscompile.

Example:
TARGETCC=i586-ostro-linux-gcc -m32 -march=i586 -Wa,-momit-lock-prefix=yes

Signed-off-by: Bruno Bottazzini <bruno.bottazzini@intel.com>