### PR TITLE
flow:si114x: Remove unused header

### DIFF
--- a/src/modules/flow/si114x/si114x.c
+++ b/src/modules/flow/si114x/si114x.c
@@ -18,7 +18,6 @@
 
 #include <errno.h>
 #include <limits.h>
-#include <regex.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
This header breaks the zephyr's build