### PR TITLE
Node.js bindings: Add basic examples for GPIO JS bindings

### DIFF
--- a/src/samples/nodejs/gpio_monitor.js
+++ b/src/samples/nodejs/gpio_monitor.js
@@ -1,0 +1,78 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Sample code to turn on/off an LED connected to Edison by
+ * using button.
+ *
+ * Pin configuration:
+ * LED pin -> 48 (D7 on the Grove base shield)
+ * Button pin -> 49 (D8 on the Grove base shield)
+ */
+var gpio = require( "soletta/gpio" ),
+    ledState = false,
+    ledPin = null,
+    buttonPin = null;
+
+// Configure LED pin.
+function setupLEDPin() {
+    gpio.open( {
+        pin: 48 // LED pin 48
+    } ).then( function( pin ) {
+        ledPin = pin;
+
+        // Setup 'onchange' event handler. The handler will
+        // be called whenever the button pin value changes.
+        buttonPin.onchange = function( event ) {
+            ledState = !ledState;
+            ledPin.write( ledState ).then( function() {
+                console.log( "LED state changed" );
+            } ).catch( function( error ) {
+                console.log( "Failed to write on GPIO device: ", error );
+                process.exit();
+            } );
+        };
+    } ).catch( function( error ) {
+        console.log( "Could not open LED pin for writing." );
+        process.exit();
+    } );
+}
+
+// Configure button pin.
+gpio.open( {
+    pin: 49, // Button pin 49
+    direction: "in", // Set the gpio direction to input
+    edge: "rising"
+} ).then( function( pin ) {
+    buttonPin = pin;
+
+    // Configure LED pin
+    setupLEDPin();
+} ).catch( function( error ) {
+    console.log( "Could not open button pin for reading." );
+} );
+
+process.on( "exit", function() {
+    if ( ledPin ) {
+        ledPin.close();
+    }
+
+    if ( buttonPin ) {
+        buttonPin.close();
+    }
+} );

--- a/src/samples/nodejs/gpio_read.js
+++ b/src/samples/nodejs/gpio_read.js
@@ -1,0 +1,67 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This sample code demonstrates the usage of GPIO JS bindings for
+ * configuring and reading the value of the digital input connected
+ * to the Edison.
+ *
+ * Pin configuration:
+ * Digital input device (e.g. Grove Button) -> 49 (D8 on the base shield)
+ *
+ * Press Ctrl+C to exit the process.
+ */
+var gpio = require( "soletta/gpio" ),
+    gpioPin = null,
+    readInterval;
+
+gpio.open( {
+    pin: 49, // Setup pin 49 for reading
+    direction: "in" // Set the gpio direction to input
+} ).then( function( pin ) {
+    gpioPin = pin;
+
+    readInterval = setInterval( function() {
+
+        // Read the value of the digital input in every one second.
+        gpioPin.read().then( function( value ) {
+            console.log( "GPIO value is ", value );
+        } ).catch( function( error ) {
+            console.log( "Failed to read the value: ", error );
+            process.exit();
+        } );
+    }, 1000 );
+} ).catch( function( error ) {
+    console.log( "Could not open GPIO: ", error );
+    process.exit();
+} );
+
+// Press Ctrl+C to exit the process
+process.on( "SIGINT", function() {
+    process.exit();
+} );
+
+process.on( "exit", function() {
+    if ( readInterval ) {
+        clearInterval( readInterval );
+    }
+
+    if ( gpioPin ) {
+        gpioPin.close();
+    }
+} );

--- a/src/samples/nodejs/gpio_write.js
+++ b/src/samples/nodejs/gpio_write.js
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This sample code blinks an LED connected to Edison GPIO pin 48 in every
+ * one second.
+ *
+ * Pin configuration:
+ * Digital output device (e.g. Grove LED) -> 48 (D7 on the Grove base shield)
+ *
+ * Press Ctrl+C to exit the process.
+ */
+var gpio = require( "soletta/gpio" ),
+    ledPin = null,
+    state = false,
+    changeInterval;
+
+// Change the LED state
+function changeState() {
+    state = !state;
+    ledPin.write( state ).then( function() {
+        console.log( "LED state changed" );
+    } ).catch( function( error ) {
+        console.log( "Failed to write on GPIO device: ", error );
+        process.exit();
+    } );
+}
+
+// Configure LED pin.
+gpio.open( {
+    pin: 48
+} ).then( function( pin ) {
+    ledPin = pin; // Save the handle
+
+    // Change the LED state in every one second.
+    changeInterval = setInterval( changeState, 1000 );
+} ).catch( function( error ) {
+    console.log( "Could not open GPIO: ", error );
+    process.exit();
+} );
+
+// Press Ctrl+C to exit the process
+process.on( "SIGINT", function() {
+    process.exit();
+} );
+
+process.on( "exit", function() {
+    if ( changeInterval ) {
+        clearInterval( changeInterval );
+    }
+
+    if ( ledPin ) {
+        ledPin.close();
+    }
+} );


### PR DESCRIPTION
This adds the following basic examples for GPIO JS bindings.
 - gpio_write.js: Blinks an LED connected to Edison GPIO pin
 - gpio_read.js: Read the value of the GPIO pin
 - gpio_monitor.js: Monitor the button press state and turn
   on/off an LED connected to Edison GPIO pin.

Replaces #1937 

Changes from previous version #1937:
- Changed the read sample to get the value from a digital input device in every one second.
- Added pin configuration details.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>