### PR TITLE
Node.js bindings: Add examples for AIO and PWM JS bindings

### DIFF
--- a/src/samples/nodejs/aio_read.js
+++ b/src/samples/nodejs/aio_read.js
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This sample code demonstrates the usage of AIO JS bindings for
+ * configuring and reading the value of analog device connected to
+ * the Edison.
+ *
+ * Pin configuration:
+ * Analog input device (e.g. Grove Light Sensor) -> A0
+ *
+ * Press Ctrl+C to exit the process.
+ */
+var aio = require( "soletta/aio" ),
+    aioPin = null,
+    readInterval;
+
+// Configure analog pin #0 (A0)
+aio.open( {
+    device: 1,
+    pin: 0
+} ).then( function( pin ) {
+    aioPin = pin;
+
+    readInterval = setInterval( function() {
+
+        // Read the value of analog input in every one second
+        pin.read().then( function( data ) {
+            console.log( "Value of the analog input device: ", data );
+        } ).catch( function( error ) {
+            console.log( "Failed to read the value ", error );
+            process.exit();
+        } );
+    }, 1000 );
+} ).catch( function( error ) {
+    console.log( "Could not open AIO: ", error );
+    process.exit();
+} );
+
+// Press Ctrl+C to exit the process
+process.on( "SIGINT", function() {
+    process.exit();
+} );
+
+process.on( "exit", function() {
+    if ( readInterval ) {
+        clearInterval( readInterval );
+    }
+
+    if ( aioPin ) {
+        aioPin.close();
+    }
+} );

--- a/src/samples/nodejs/pwm_led.js
+++ b/src/samples/nodejs/pwm_led.js
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Sample code to demonstrate the usage of PWM JS bindings for
+ * configuring and using PWM pins.
+ *
+ * This example changes the brightness of an LED in a loop.
+ *
+ * Pin configuration:
+ * LED (e.g. Grove LED) -> PWM pin
+ *
+ * Press Ctrl+C to exit the process.
+ */
+var pwm = require( "soletta/pwm" ),
+    pwmPin = null,
+    dutyCycle = 0,
+    delta = 0.1,
+    changeInterval;
+
+// Change brightness of an LED
+function changeLEDBrightness() {
+    if ( dutyCycle <= 0 ) {
+        // Increase the brightness
+        delta = 0.1;
+    } else if ( dutyCycle >= 1 ) {
+        // Decrease the brightness
+        delta = -0.1;
+    }
+
+    dutyCycle = parseFloat( ( dutyCycle + delta ).toFixed( 1 ) );
+    pwmPin.setDutyCycle( dutyCycle * 10000 ).then( function() {
+        console.log( "LED brightness changed" );
+    } ).catch( function( error ) {
+        console.log( "PWM error: ", error );
+        process.exit();
+    } );
+}
+
+// Configure PWM pin
+pwm.open( {
+    device: 0,
+    channel: 0,
+    period: 10000,
+    dutyCycle: 0,
+    enabled: true
+} ).then( function( pin ) {
+    pwmPin = pin;
+    changeInterval = setInterval( changeLEDBrightness, 300 );
+} ).catch( function( error ) {
+    console.log( "PWM error: ", error );
+    process.exit();
+} );
+
+// Press Ctrl+C to exit the process
+process.on( "SIGINT", function() {
+    process.exit();
+} );
+
+process.on( "exit", function() {
+    if ( changeInterval ) {
+        clearInterval( changeInterval );
+    }
+
+    // Close the PWM pin
+    if ( pwmPin ) {
+        pwmPin.close();
+    }
+} );


### PR DESCRIPTION
This adds the examples for AIO and PWM JS bindings.
- aio_read.js: Read the value of analog device(e.g. Light sensor)  in every one second.
- pwm_led.js: Using PWM, change the brightness of an LED in every 300ms.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>