### PR TITLE
Node.js bindings: Fix errors in resolving promises

### DIFF
--- a/bindings/nodejs/lib/aio.js
+++ b/bindings/nodejs/lib/aio.js
@@ -28,7 +28,7 @@ exports.open = function( init ) {
 		if (init.precision)
 			precision = init.precision;
 
-		if (init.name && init.name != "") {
+		if ( typeof init.name === "string" && init.name !== "" ) {
 			aio = soletta.sol_aio_open_by_label( init.name, precision );
 		} else if (init.raw) {
 			aio = soletta.sol_aio_open_raw( init.device, init.pin, precision );
@@ -60,23 +60,20 @@ _.extend( AIOPin.prototype, {
 			this._pending = soletta.sol_aio_get_value( this._pin, function( value ) {
 				fulfill( value );
 			});
+			if (!this._pending)
+				reject( new Error( "Failed to read the value from AIO device" ) );
+
 		}, this ) );
 	},
 
 	close: function() {
-		return new Promise( _.bind( function( fulfill, reject ) {
-			soletta.sol_aio_close( this._pin);
-			this._pending = null;
-			fulfill();
-		}, this ) );
+		soletta.sol_aio_close( this._pin);
+		this._pending = null;
 	},
 
 	abort: function() {
-		return new Promise( _.bind( function( fulfill, reject ) {
-			soletta.sol_aio_pending_cancel( this._pin, _this._pending );
-			this._pending = null;
-			fulfill();
-		}, this ) );
+		soletta.sol_aio_pending_cancel( this._pin, this._pending );
+		this._pending = null;
 	}
 });
 

--- a/bindings/nodejs/lib/gpio.js
+++ b/bindings/nodejs/lib/gpio.js
@@ -83,14 +83,21 @@ _.extend( GPIOPin.prototype, {
 
     read: function() {
         return new Promise( _.bind( function( fulfill, reject ) {
-
-            fulfill( soletta.sol_gpio_read( this._pin ) );
+            var returnValue = soletta.sol_gpio_read( this._pin );
+            if ( returnValue >= 0 )
+                fulfill(returnValue);
+            else
+                reject( new Error( "Failed to read the value from GPIO device" ) );
         }, this ) );
     },
 
     write: function( value ) {
         return new Promise( _.bind( function( fulfill, reject ) {
-            fulfill( soletta.sol_gpio_write( this._pin, value ) );
+            var returnValue = soletta.sol_gpio_write( this._pin, value );
+            if ( returnValue )
+                fulfill();
+            else
+                reject( new Error( "Failed to write on GPIO device" ) );
         }, this ) );
     },
 

--- a/bindings/nodejs/lib/pwm.js
+++ b/bindings/nodejs/lib/pwm.js
@@ -65,27 +65,37 @@ _.extend(PWMPin.prototype, {
 
     setEnabled: function( value ) {
         return new Promise( _.bind( function( fulfill, reject ) {
-            fulfill( soletta.sol_pwm_set_enabled( this._pin, value) );
+            var returnValue = soletta.sol_pwm_set_enabled( this._pin, value);
+            if ( returnValue )
+                fulfill();
+            else
+                reject( new Error( "Failed to enable PWM pin" ) );
         }, this ) );
     },
 
     setDutyCycle: function( value ) {
         return new Promise( _.bind( function( fulfill, reject ) {
-            fulfill( soletta.sol_pwm_set_duty_cycle( this._pin, value ) );
+            var returnValue = soletta.sol_pwm_set_duty_cycle( this._pin, value );
+            if ( returnValue )
+                fulfill();
+            else
+                reject( new Error( "Failed to set PWM duty cycle" ) );
         }, this ) );
     },
 
     setPeriod: function( value ) {
         return new Promise( _.bind( function( fulfill, reject ) {
-            fulfill( soletta.sol_pwm_set_period( this._pin, value ) );
+            var returnValue = soletta.sol_pwm_set_period( this._pin, value );
+            if ( returnValue )
+                fulfill();
+            else
+                reject( new Error( "Failed to set PWM period" ) );
         }, this ) );
     },
 
     close: function() {
-        return new Promise( _.bind( function( fulfill, reject ) {
-            fulfill( soletta.sol_pwm_close( this._pin) );
-        }, this ) );
-    },
+       soletta.sol_pwm_close( this._pin);
+    }
 });
 
 exports.PWMPin = PWMPin;

--- a/bindings/nodejs/lib/spi.js
+++ b/bindings/nodejs/lib/spi.js
@@ -75,10 +75,8 @@ _.extend( SPIBus.prototype, {
     },
 
     close: function() {
-        return new Promise( _.bind( function( fulfill, reject ) {
-            fulfill( soletta.sol_spi_close( this._bus ) );
-        }, this ) );
-    },
+        soletta.sol_spi_close( this._bus );
+    }
 });
 
 exports.SPIBus = SPIBus;

--- a/bindings/nodejs/lib/uart.js
+++ b/bindings/nodejs/lib/uart.js
@@ -87,9 +87,7 @@ _.extend( UARTConnection.prototype, {
     },
 
     close: function() {
-        return new Promise( _.bind( function( fulfill, reject ) {
-            fulfill( soletta.sol_uart_close( this._connection) );
-        }, this ) );
+        soletta.sol_uart_close( this._connection);
     },
 
     addEventListener: UARTConnection.prototype.addListener,
@@ -101,8 +99,7 @@ _.extend( UARTConnection.prototype, {
         if ( typeof this[ "on" + event ] === "function" ) {
             this[ "on" + event ]( request );
         }
-    },
-
+    }
 });
 
 exports.UARTConnection = UARTConnection;


### PR DESCRIPTION
Resolve promises based on the return value of sol APIs. Also, remove promises for abort()/close() as specified in the spec.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>