### PR TITLE
oic: Use sol-cert API to load pre shared keys

### DIFF
--- a/src/lib/common/include/sol-certificate.h
+++ b/src/lib/common/include/sol-certificate.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "sol-buffer.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -41,6 +43,15 @@ extern "C" {
  * This object is the abstraction of certificate.
  */
 struct sol_cert;
+
+/**
+ * @brief Create a certificate located in @a path.
+ *
+ * @param path Absolute path to the certificate file.
+ *
+ * @return sol_cert object on success, NULL otherwise
+ */
+struct sol_cert *sol_cert_new(const char *path);
 
 /**
  * @brief Load a certificate from a file
@@ -71,6 +82,36 @@ void sol_cert_unref(struct sol_cert *cert);
  * @return sol_cert object on success, NULL otherwise
  */
 const char *sol_cert_get_filename(const struct sol_cert *cert);
+
+/**
+ * @brief Read data from @a cert.
+ *
+ * @param cert Certificate object.
+ * @param buffer The buffer to write the read data.
+ *
+ * @return 0 on success or a negative error number on errors.
+ */
+int sol_cert_read_data(const struct sol_cert *cert, struct sol_buffer *buffer);
+
+/**
+ * @brief Write data to @a cert.
+ *
+ * @param cert Certificate object.
+ * @param buffer The buffer to be written to certificate.
+ *
+ * @return 0 on success or a negative error code on errors.
+ */
+int sol_cert_write_data(const struct sol_cert *cert, struct sol_buffer *buffer);
+
+/**
+ * @brief Get the size in bytes occupied by the certificate.
+ *
+ * @param cert The certificate object.
+ *
+ * @return The size in bytes occupied by this certificate or a negative error
+ *         code on errors.
+ */
+ssize_t sol_cert_size(const struct sol_cert *cert);
 
 /**
  * @}

--- a/src/lib/common/sol-certificate-impl-linux.c
+++ b/src/lib/common/sol-certificate-impl-linux.c
@@ -92,17 +92,18 @@ sol_cert_load_from_file(const char *filename)
 
     SOL_NULL_CHECK(filename, NULL);
 
-    SOL_PTR_VECTOR_FOREACH_IDX (&storage, cert, idx) {
-        if (streq(cert->filename, filename)) {
-            cert->refcnt++;
-            return cert;
-        }
-    }
-
     path = find_cert(filename, search_paths);
     if (path == NULL) {
         SOL_WRN("Certificate not found: %s", filename);
         return NULL;
+    }
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&storage, cert, idx) {
+        if (streq(cert->filename, path)) {
+            cert->refcnt++;
+            free(path);
+            return cert;
+        }
     }
 
     cert = calloc(1, sizeof(*cert));

--- a/src/shared/include/sol-util-file.h
+++ b/src/shared/include/sol-util-file.h
@@ -65,7 +65,7 @@ enum sol_util_iterate_dir_reason {
 };
 
 /**
- * @brief Write the formatted string in the file pointed by @c path.
+ * @brief Write the formatted string in the file pointed by @a path.
  *
  * @param path The path to a valid file.
  * @param fmt The string format.
@@ -78,9 +78,9 @@ enum sol_util_iterate_dir_reason {
 int sol_util_write_file(const char *path, const char *fmt, ...) SOL_ATTR_PRINTF(2, 3);
 
 /**
- * @brief Write the formatted string in the file pointed by @c path.
+ * @brief Write the formatted string in the file pointed by @a path.
  *
- * It is equivalent to @c sol_util_write_file except it receives @c
+ * It is equivalent to @a sol_util_write_file except it receives @a
  * va_list instead of a variable number of arguments.
  *
  * @param path The path to a valid file.
@@ -93,6 +93,17 @@ int sol_util_write_file(const char *path, const char *fmt, ...) SOL_ATTR_PRINTF(
  * @see sol_util_write_file
  */
 int sol_util_vwrite_file(const char *path, const char *fmt, va_list args) SOL_ATTR_PRINTF(2, 0);
+
+/**
+ * @brief Write the buffer content the file pointed by @a path.
+ *
+ * @param path The path to a valid file.
+ * @param buffer The buffer to be written.
+ *
+ * @return The number of written characters, if an error is encountered a
+ * negative value with the error code.
+ */
+ssize_t sol_util_write_file_buffer(const char *path, const struct sol_buffer *buffer);
 
 /**
  * @brief Reads from a file the contents according with the formatted string.

--- a/src/shared/sol-util-file.c
+++ b/src/shared/sol-util-file.c
@@ -593,3 +593,32 @@ sol_util_busy_wait_file(const char *path, uint64_t nanoseconds)
 
     return true;
 }
+
+SOL_API ssize_t
+sol_util_write_file_buffer(const char *path, const struct sol_buffer *buffer)
+{
+    FILE *fp;
+    size_t bytes;
+    int r;
+
+    SOL_NULL_CHECK(path, -EINVAL);
+    SOL_NULL_CHECK(buffer, -EINVAL);
+
+    errno = 0;
+    fp = fopen(path, "we");
+    if (!fp)
+        return -errno;
+
+    bytes = fwrite(buffer->data, 1, buffer->used, fp);
+
+    errno = 0;
+    r = fclose(fp);
+
+    if (bytes != buffer->used)
+        return -EIO;
+
+    if (r != 0)
+        return -errno;
+
+    return bytes;
+}

--- a/src/test/test-certificate.c
+++ b/src/test/test-certificate.c
@@ -83,4 +83,36 @@ load_certificate(void)
     remove("dummy.pem");
 }
 
+DEFINE_TEST(read_write_certificate);
+
+static void
+read_write_certificate(void)
+{
+    struct sol_cert *cert, *cert2;
+    struct sol_buffer buf = SOL_BUFFER_INIT_EMPTY,
+        buf2 = SOL_BUFFER_INIT_EMPTY;
+
+    create_dummy_certificate();
+
+    cert = sol_cert_load_from_file("dummy.pem");
+    ASSERT(cert != NULL);
+
+    cert2 = sol_cert_new("dummy2.pem");
+    ASSERT(cert2 != NULL);
+
+    ASSERT(sol_cert_read_data(cert, &buf) == 0);
+    ASSERT(streq(buf.data, dummy_cert));
+
+    ASSERT(sol_cert_write_data(cert2, &buf) == 0);
+    ASSERT(sol_cert_read_data(cert2, &buf2) == 0);
+    ASSERT(streq(buf2.data, dummy_cert));
+
+    sol_cert_unref(cert);
+    sol_cert_unref(cert2);
+    sol_buffer_fini(&buf);
+    sol_buffer_fini(&buf2);
+    remove("dummy.pem");
+    remove("dummy2.pem");
+}
+
 TEST_MAIN();


### PR DESCRIPTION
Remove dependencies from sol-util-file in sol-security and use proposed API from sol-certificate.
Sol-certificate only have implementation for linux, using files to store/load certificates, but implementations for OS without filesystem support are possible.