### PR TITLE
modules/hc-sr04: expose a single 'raw' option for both pins

### DIFF
--- a/src/modules/flow/hc-sr04/hc-sr04.c
+++ b/src/modules/flow/hc-sr04/hc-sr04.c
@@ -101,9 +101,9 @@ hc_sr04_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_
         return -EINVAL;
     }
 
-    if (opts->trigger_raw) {
+    if (opts->raw) {
         if (!sscanf(opts->trigger, "%" SCNu32, &pin)) {
-            SOL_WRN("'trigger_raw' option was set, but 'pin' "
+            SOL_WRN("'raw' option was set, but 'pin' "
                 "value=%s couldn't be parsed as integer.", opts->trigger);
         } else {
             mdata->trig_gpio = sol_gpio_open(pin, &trig_gpio_conf);
@@ -117,9 +117,9 @@ hc_sr04_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_
         return -EIO;
     }
 
-    if (opts->echo_raw) {
+    if (opts->raw) {
         if (!sscanf(opts->echo, "%" SCNu32, &pin)) {
-            SOL_WRN("'echo_raw' option was set, but 'pin' "
+            SOL_WRN("'raw' option was set, but 'pin' "
                 "value=%s couldn't be parsed as integer.", opts->echo);
         } else {
             mdata->echo_gpio = sol_gpio_open(pin, &echo_gpio_conf);

--- a/src/modules/flow/hc-sr04/hc-sr04.json
+++ b/src/modules/flow/hc-sr04/hc-sr04.json
@@ -29,25 +29,19 @@
         "members": [
           {
             "data_type": "string",
-            "description": "Label of the 'Trigger' pin on the board. This pin will receive a pulse to emit the wave. If raw is set to true, this should be the pin number as recognized by the platform.",
+            "description": "Label of the 'Trigger' pin on the board. This pin will receive a pulse to emit the wave. If 'raw' is set to true, this should be the pin number as recognized by the platform.",
             "name": "trigger"
           },
           {
-            "data_type": "boolean",
-            "default": false,
-            "description": "Change 'trigger' meaning to be the system parameters needed to address the desired pin. Use it if you know what you are doing.",
-            "name": "trigger_raw"
-          },
-          {
             "data_type": "string",
-            "description": "Label of the 'Echo' pin on the board. This pin will read a pulse and based on its width distance is calculated. If raw is set to true, this should be the pin number as recognized by the platform.",
+            "description": "Label of the 'Echo' pin on the board. This pin will read a pulse and based on its width distance is calculated. If 'raw' is set to true, this should be the pin number as recognized by the platform.",
             "name": "echo"
           },
           {
             "data_type": "boolean",
             "default": false,
-            "description": "Change 'echo' meaning to be the system parameters needed to address the desired pin. Use it if you know what you are doing.",
-            "name": "echo_raw"
+            "description": "Change 'trigger' and 'echo' meaning to be the system parameters needed to address the desired pin. Use it if you know what you are doing.",
+            "name": "raw"
           },
           {
             "data_type": "int",


### PR DESCRIPTION
No use cases for some pins on raw mode and other
on label mode.

So let's make it simpler to users.

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>