### PR TITLE
scripts/dependency-resolver: check for exec versions

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -533,7 +533,9 @@
     {
       "dependency": "nodejs",
       "type": "exec",
-      "exec": "node"
+      "exec": "node",
+      "version-command": "node --version",
+      "atleast-version": "v4.0"
     },
     {
       "dependency": "nodejs_npm",


### PR DESCRIPTION
Add options to check for specific exec versions.

Require at least LTS version of node (v4.4.4).

On old versions, like v0.10.x it wasn't able to build,
it was re-triggering builds on loop.

@glima please review it when possible ^

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>