### PR TITLE
Fix incorrect string empty check in validators

### DIFF
--- a/src/modules/flow/test/byte-validator.c
+++ b/src/modules/flow/test/byte-validator.c
@@ -84,7 +84,7 @@ byte_validator_open(struct sol_flow_node *node, void *data,
         -EINVAL);
     mdata->done = false;
 
-    if (opts->sequence == NULL || opts->sequence == '\0') {
+    if (opts->sequence == NULL || *opts->sequence == '\0') {
         SOL_ERR("Option 'sequence' is either NULL or empty.");
         return -EINVAL;
     }

--- a/src/modules/flow/test/int-validator.c
+++ b/src/modules/flow/test/int-validator.c
@@ -79,7 +79,7 @@ int_validator_open(
         -EINVAL);
     mdata->done = false;
 
-    if (opts->sequence == NULL || opts->sequence == '\0') {
+    if (opts->sequence == NULL || *opts->sequence == '\0') {
         SOL_ERR("Option 'sequence' is either NULL or empty.");
         return -EINVAL;
     }


### PR DESCRIPTION
Int and byte validators were not checking correctly for empty validator string.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>