### PR TITLE
oic: Fix memory leak when string fields are not changed in server update

### DIFF
--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -416,10 +416,14 @@ def generate_object_from_repr_vec_fn_common_c(name, props):
        "c_check_updated": JSON_TO_FLOW_CHECK_UPDATED["integer"]})
 
         update_state.append("""\
-        state->%(name)s = fields.%(name)s;
+        state->%(name)s = fields.%(name)s;""" % {"name": field_name})
+        if not 'enum' in field_props and field_props.get('type') == 'string':
+            update_state.append("""\
+        fields.%(name)s = NULL;""" % {"name": field_name})
+        update_state.append("""\
         updated = true;
     }
-""" % {"name": field_name})
+""")
 
     return '''static int
 %(struct_name)s_from_repr_vec(struct %(struct_name)s *state,
@@ -442,10 +446,7 @@ def generate_object_from_repr_vec_fn_common_c(name, props):
 
 %(update_state)s
 
-    if (!updated)
-        goto out;
-
-    return 1;
+    ret = updated ? 1 : 0;
 
 out:
 %(free_fields)s

--- a/src/samples/flow/oic/light-server.fbp
+++ b/src/samples/flow/oic/light-server.fbp
@@ -23,3 +23,4 @@
 
 light(oic/server-light)
 light STATE -> IN LightState(console)
+_(constant/string:value="My Lamp") OUT -> NAME light


### PR DESCRIPTION
When a from_repr_vec method is called, the oic server resource contains
a string, but this string is not updated, we had a memory leak.

Also add a name to Light Server sample to have string fields tested.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>