### PR TITLE
Flow option uint

### DIFF
--- a/data/schemas/node-type-genspec.schema
+++ b/data/schemas/node-type-genspec.schema
@@ -9,6 +9,13 @@
       ]
     },
 
+    "uint_or_limit": {
+      "oneOf": [
+        { "type": "integer" },
+        { "enum": [ "UINT32_MAX" ] }
+      ]
+    },
+
     "float_or_limit": {
       "oneOf": [
         { "type": "number" },
@@ -67,7 +74,8 @@
         "int",
         "irange-spec",
         "rgb",
-        "string"
+        "string",
+        "uint"
       ]
     },
 
@@ -322,6 +330,13 @@
       }
     },
 
+    "options_members_uint": {
+      "properties": {
+        "data_type": { "enum": [ "uint" ] },
+        "default": { "$ref": "#/definitions/uint_or_limit" }
+      }
+    },
+
     "options_members_by_type": {
       "allOf": [
         { "$ref": "#/definitions/options_members_common" },
@@ -336,7 +351,8 @@
             { "$ref": "#/definitions/options_members_int" },
             { "$ref": "#/definitions/options_members_irange_spec" },
             { "$ref": "#/definitions/options_members_rgb" },
-            { "$ref": "#/definitions/options_members_string" }
+            { "$ref": "#/definitions/options_members_string" },
+            { "$ref": "#/definitions/options_members_uint" }
           ]
         }
       ]

--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -246,7 +246,8 @@ data_type_to_c_map = {
     "direction-vector": "struct sol_direction_vector",
     "string": "const char *",
     "location": "struct sol_location",
-    "timestamp": "struct timespec"
+    "timestamp": "struct timespec",
+    "uint": "uint32_t"
     }
 def data_type_to_c(typename):
     return data_type_to_c_map[typename]
@@ -260,7 +261,8 @@ data_type_to_default_member_map = {
     "irange-spec": "irange_spec",
     "string": "s",
     "rgb": "rgb",
-    "direction-vector": "direction_vector"
+    "direction-vector": "direction_vector",
+    "uint": "u"
     }
 composed_types_signatures = {}
 

--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -1122,6 +1122,8 @@ get_type_data_by_name(const char *type)
         return "bool";
     if (streq(type, "byte"))
         return "unsigned char";
+    if (streq(type, "uint"))
+        return "uint32_t";
     return NULL;
 }
 

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -565,6 +565,7 @@ enum sol_flow_node_options_member_type {
     SOL_FLOW_NODE_OPTIONS_MEMBER_IRANGE_SPEC,
     SOL_FLOW_NODE_OPTIONS_MEMBER_RGB,
     SOL_FLOW_NODE_OPTIONS_MEMBER_STRING,
+    SOL_FLOW_NODE_OPTIONS_MEMBER_UINT
 };
 
 /**
@@ -602,6 +603,7 @@ struct sol_flow_node_named_options_member {
         struct sol_direction_vector direction_vector; /**< @brief Value of a direction vector member */
         const char *string; /**< @brief Value of a string member */
         double f; /**< @brief Value of a float member */
+        uint32_t u; /**< @brief Value of a uint member */
     };
 };
 
@@ -711,6 +713,7 @@ struct sol_flow_node_options_member_description {
         const char *s; /**< @brief Option member's default string value */
         const void *ptr; /**< @brief Option member's default "blob" value */
         double f; /**< @brief Option member's default float value */
+        uint32_t u; /**< @brief Option member's default uint value */
     } defvalue; /**< @brief Option member's default value, according to its #data_type */
     uint16_t offset; /**< @brief Option member's offset inside the final options blob for a node */
     uint16_t size; /**< @brief Option member's size inside the final options blob for a node */

--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -1252,6 +1252,7 @@ get_member_alignment(const struct sol_flow_node_options_member_description *memb
             __alignof__(member->defvalue.irange_spec)),
         SOL_STR_TABLE_ITEM("rgb", __alignof__(member->defvalue.rgb)),
         SOL_STR_TABLE_ITEM("string", __alignof__(member->defvalue.s)),
+        SOL_STR_TABLE_ITEM("uint", __alignof__(member->defvalue.u)),
         { }
     };
 

--- a/src/lib/flow/sol-flow-node-options.c
+++ b/src/lib/flow/sol-flow-node-options.c
@@ -35,6 +35,8 @@ static const char INT_MAX_STR[] = "INT32_MAX";
 static const char INT_MIN_STR[] = "INT32_MIN";
 static const size_t INT_LIMIT_STR_LEN = sizeof(INT_MAX_STR) - 1;
 
+static const char UINT_MAX_STR[] = "UINT32_MAX";
+
 static const char DBL_MAX_STR[] = "DBL_MAX";
 static const char DBL_MIN_STR[] = "-DBL_MAX";
 static const size_t DBL_MAX_STR_LEN = sizeof(DBL_MAX_STR) - 1;
@@ -511,6 +513,31 @@ int_parse(const char *value, struct sol_flow_node_named_options_member *m)
     return 0;
 }
 
+static int
+uint_parse(const char *value, struct sol_flow_node_named_options_member *m)
+{
+    char *endptr;
+    int64_t v;
+
+    if (!strcmp(UINT_MAX_STR, value)) {
+        m->u = UINT32_MAX;
+        return 0;
+    }
+
+    errno = 0;
+    v = strtoll(value, &endptr, 0);
+
+    if (value == endptr)
+        return -EINVAL;
+    if (errno != 0)
+        return -errno;
+    if (v < 0 || v > UINT32_MAX)
+        return -ERANGE;
+
+    m->u = v;
+    return 0;
+}
+
 static int(*const options_parse_functions[]) (const char *, struct sol_flow_node_named_options_member *) = {
     [SOL_FLOW_NODE_OPTIONS_MEMBER_UNKNOWN] = NULL,
     [SOL_FLOW_NODE_OPTIONS_MEMBER_BOOLEAN] = boolean_parse,
@@ -522,6 +549,7 @@ static int(*const options_parse_functions[]) (const char *, struct sol_flow_node
     [SOL_FLOW_NODE_OPTIONS_MEMBER_IRANGE_SPEC] = irange_spec_parse,
     [SOL_FLOW_NODE_OPTIONS_MEMBER_RGB] = rgb_parse,
     [SOL_FLOW_NODE_OPTIONS_MEMBER_STRING] = string_parse,
+    [SOL_FLOW_NODE_OPTIONS_MEMBER_UINT] = uint_parse
 };
 
 /* Options with suboptions may have only some fields overriden.
@@ -649,6 +677,10 @@ set_member(
         s = mem;
         free(*s);
         *s = strdup(m->string);
+        break;
+    case SOL_FLOW_NODE_OPTIONS_MEMBER_UINT:
+        *(uint32_t *)mem = m->u;
+        break;
     default:
         /* Not reached. */
         /* TODO: Create ASSERT_NOT_REACHED() macro.*/
@@ -666,6 +698,7 @@ static const struct sol_str_table member_str_to_type[] = {
     SOL_STR_TABLE_ITEM("irange-spec", SOL_FLOW_NODE_OPTIONS_MEMBER_IRANGE_SPEC),
     SOL_STR_TABLE_ITEM("rgb", SOL_FLOW_NODE_OPTIONS_MEMBER_RGB),
     SOL_STR_TABLE_ITEM("string", SOL_FLOW_NODE_OPTIONS_MEMBER_STRING),
+    SOL_STR_TABLE_ITEM("uint", SOL_FLOW_NODE_OPTIONS_MEMBER_UINT),
     {}
 };
 

--- a/src/modules/flow/form/form-common.c
+++ b/src/modules/flow/form/form-common.c
@@ -273,9 +273,9 @@ format_send(struct sol_flow_node *node,
 
 int
 common_form_init(struct sol_buffer *buf,
-    int32_t in_rows,
+    uint32_t in_rows,
     size_t *out_rows,
-    int32_t in_cols,
+    uint32_t in_cols,
     size_t *out_cols,
     const char *in_format,
     char **out_format,
@@ -290,7 +290,7 @@ common_form_init(struct sol_buffer *buf,
 
     SOL_NULL_CHECK(in_format, -EINVAL);
 
-    if (in_rows <= 0) {
+    if (in_rows == 0) {
         SOL_WRN("Form rows number must be a positive integer, "
             "but %" PRId32 " was given. Fallbacking to minimum value of 1.",
             in_rows);
@@ -298,7 +298,7 @@ common_form_init(struct sol_buffer *buf,
     } else
         *out_rows = in_rows;
 
-    if (in_cols <= 0) {
+    if (in_cols == 0) {
         SOL_WRN("Boolean columns number must be a positive integer, "
             "but %" PRId32 " was given. Fallbacking to minimum value of 1.",
             in_cols);

--- a/src/modules/flow/form/form-common.h
+++ b/src/modules/flow/form/form-common.h
@@ -89,7 +89,7 @@ int format_post_value(struct sol_buffer *buf, size_t n_rows, size_t n_cols, size
 
 int format_send(struct sol_flow_node *node, struct sol_buffer *buf, uint16_t out_port);
 
-int common_form_init(struct sol_buffer *buf, int32_t in_rows, size_t *out_rows,  int32_t in_cols, size_t *out_cols, const char *in_format, char **out_format, const char *in_title, char **out_title, char **out_title_tag, char **out_value_tag, char **out_text_mem);
+int common_form_init(struct sol_buffer *buf, uint32_t in_rows, size_t *out_rows,  uint32_t in_cols, size_t *out_cols, const char *in_format, char **out_format, const char *in_title, char **out_title, char **out_title_tag, char **out_value_tag, char **out_text_mem);
 
 int go_to_new_line(struct sol_buffer *buf, size_t n_rows, size_t n_cols, size_t *row, size_t *col);
 

--- a/src/modules/flow/form/form.c
+++ b/src/modules/flow/form/form.c
@@ -1733,20 +1733,7 @@ string_open(struct sol_flow_node *node,
     }
 
     mdata->min_length = opts->min_length;
-    if (opts->min_length < 0) {
-        SOL_WRN("Invalid minimum output size (%" PRId32 "), "
-            "that must be positive. Setting to %" PRId32 ".",
-            opts->min_length, def_opts->min_length);
-        mdata->min_length = def_opts->min_length;
-    }
-
     mdata->max_length = opts->max_length;
-    if (opts->max_length < 0) {
-        SOL_WRN("Invalid maximum output size (%" PRId32 "), "
-            "that must be positive. Setting to %" PRId32 ".",
-            opts->max_length, def_opts->max_length);
-        mdata->max_length = def_opts->max_length;
-    }
 
     if (mdata->max_length && mdata->max_length < mdata->min_length) {
         SOL_WRN("Invalid maximum output size (%" PRId32 "), "

--- a/src/modules/flow/form/form.json
+++ b/src/modules/flow/form/form.json
@@ -76,12 +76,12 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available columns to lay out the output string with. It must be a positive integer.",
             "name": "columns"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available rows to lay out the output string with. It must be a positive integer.",
             "name": "rows"
           },
@@ -178,12 +178,12 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available columns to lay out the output string with. It must be a positive integer.",
             "name": "columns"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available rows to lay out the output string with. It must be a positive integer.",
             "name": "rows"
           },
@@ -282,12 +282,12 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available columns to lay out the output string with. It must be a positive integer.",
             "name": "columns"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available rows to lay out the output string with. It must be a positive integer.",
             "name": "rows"
           },
@@ -425,12 +425,12 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available columns to lay out the output string with. It must be a positive integer.",
             "name": "columns"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available rows to lay out the output string with. It must be a positive integer.",
             "name": "rows"
           },
@@ -568,12 +568,12 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available columns to lay out the output string with. It must be a positive integer.",
             "name": "columns"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available rows to lay out the output string with. It must be a positive integer.",
             "name": "rows"
           },
@@ -584,13 +584,13 @@
             "name": "blink_time"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "Minimum output string length (must be non-negative and less than or equal to 'max_length' option's value).",
             "name": "min_length"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "Maximum output string length (must be non-negative and greater than or equal to 'min_length' option's value). The special value of 0 means no maximum will be applied.",
             "name": "max_length"

--- a/src/modules/flow/ipm/ipm.json
+++ b/src/modules/flow/ipm/ipm.json
@@ -26,7 +26,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Readers will use this ID to receive messages. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -64,7 +64,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Only messages written with this ID will be received. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -100,7 +100,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Readers will use this ID to receive messages. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -138,7 +138,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Only messages written with this ID will be received. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -174,7 +174,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Readers will use this ID to receive messages. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -212,7 +212,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Only messages written with this ID will be received. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -248,7 +248,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Readers will use this ID to receive messages. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -286,7 +286,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Only messages written with this ID will be received. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -322,7 +322,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Readers will use this ID to receive messages. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -360,7 +360,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Only messages written with this ID will be received. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -396,7 +396,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Readers will use this ID to receive messages. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -434,7 +434,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Only messages written with this ID will be received. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -470,7 +470,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Readers will use this ID to receive messages. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -508,7 +508,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Only messages written with this ID will be received. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -544,7 +544,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Readers will use this ID to receive messages. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -582,7 +582,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Only messages written with this ID will be received. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }

--- a/src/test-stub-gen/dummy.json
+++ b/src/test-stub-gen/dummy.json
@@ -243,6 +243,12 @@
          "default": "Hello World",
          "description": "Dummy string option.",
          "name": "opt_string"
+        },
+        {
+         "data_type": "uint",
+         "default": 42,
+         "description": "Dummy uint option.",
+         "name": "opt_uint"
         }
        ],
        "version": 1


### PR DESCRIPTION
Currently, we are using `int` data_type on flow node options for some options whose range is naturally unsigned. This PR presents a `uint` data_type - mapped to `uint32_t`.
A bonus is that it also checks range, so no need for node types check `if (opts.x > 0)`.
In this PR, I've changed options of two node types: IPM and Form. This is more of a sample of usage than an extensive change. 