### PR TITLE
pin-mux: Pass the full gpio config to pin-mux

### DIFF
--- a/src/lib/common/include/sol-pin-mux-modules.h
+++ b/src/lib/common/include/sol-pin-mux-modules.h
@@ -96,17 +96,17 @@ struct sol_pin_mux {
     int (*aio)(const int device, const int pin);
 
     /**
-     * @brief Callback to setup the given pin to operate as GPIO in the given direction (in or out).
+     * @brief Callback to setup the given pin to operate in the given GPIO configuration.
      *
      * Soletta will call this function so the module can execute the instructions
-     * needed to configure @c pin to operate as GPIO in direction @c dir.
+     * needed to configure @c pin to operate as configured by @c config.
      *
      * @param pin the gpio pin number.
-     * @param dir direction (in or out) that the pin should operate.
+     * @param config Desired configuration for the pin.
      *
      * @return @c 0 on success, error code (always negative) otherwise.
      */
-    int (*gpio)(const uint32_t pin, const enum sol_gpio_direction dir);
+    int (*gpio)(const uint32_t pin, const struct sol_gpio_config *config);
 
     /**
      * @brief Callback to setup the pins used of the given i2c bus number to operate in I2C mode.

--- a/src/lib/common/include/sol-pin-mux.h
+++ b/src/lib/common/include/sol-pin-mux.h
@@ -89,18 +89,17 @@ int sol_pin_mux_map(const char *label, const enum sol_io_protocol prot, ...);
 int sol_pin_mux_setup_aio(const int device, const int pin);
 
 /**
- * @brief Setup the given pin to operate as GPIO in the given direction (in or out).
+ * @brief Setup the given pin to operate in the given GPIO configuration.
  *
  * If a pin multiplexer is loaded (from a successfully call to sol_pin_mux_select_mux),
- * execute the instructions needed to configure 'pin' to operate as GPIO in direction
- * 'dir'.
+ * execute the instructions needed to configure 'pin' to operate as configured by 'config'.
  *
  * @param pin the gpio pin number.
- * @param dir direction (in or out) that the pin should operate.
+ * @param config Desired configuration for the pin.
  *
  * @return '0' on success, error code (always negative) otherwise.
  */
-int sol_pin_mux_setup_gpio(const uint32_t pin, const enum sol_gpio_direction dir);
+int sol_pin_mux_setup_gpio(const uint32_t pin, const struct sol_gpio_config *config);
 
 /**
  * @brief Setup the pins used of the given i2c bus number to operate in I2C mode.

--- a/src/lib/common/sol-pin-mux.c
+++ b/src/lib/common/sol-pin-mux.c
@@ -191,9 +191,9 @@ sol_pin_mux_setup_aio(const int device, const int pin)
 }
 
 SOL_API int
-sol_pin_mux_setup_gpio(const uint32_t pin, const enum sol_gpio_direction dir)
+sol_pin_mux_setup_gpio(const uint32_t pin, const struct sol_gpio_config *config)
 {
-    return (mux && mux->gpio) ? mux->gpio(pin, dir) : 0;
+    return (mux && mux->gpio) ? mux->gpio(pin, config) : 0;
 }
 
 SOL_API int

--- a/src/lib/io/sol-gpio-common.c
+++ b/src/lib/io/sol-gpio-common.c
@@ -68,7 +68,7 @@ sol_gpio_open(uint32_t pin, const struct sol_gpio_config *config)
 
     gpio = sol_gpio_open_raw(pin, config);
 #ifdef USE_PIN_MUX
-    if (gpio && sol_pin_mux_setup_gpio(pin, config->dir)) {
+    if (gpio && sol_pin_mux_setup_gpio(pin, config)) {
         SOL_ERR("Pin Multiplexer Recipe for gpio=%d found, but couldn't be applied.", pin);
         sol_gpio_close(gpio);
         gpio = NULL;

--- a/src/modules/pin-mux/intel-common/intel-common.c
+++ b/src/modules/pin-mux/intel-common/intel-common.c
@@ -252,14 +252,24 @@ mux_set_aio(const int device, const int pin, const struct mux_controller *const 
 }
 
 int
-mux_set_gpio(const uint32_t pin, const enum sol_gpio_direction dir,
+mux_set_gpio(const uint32_t pin, const struct sol_gpio_config *config,
     const struct mux_description *const *desc_list, const uint32_t s)
 {
+    unsigned int mode = MODE_GPIO_OUTPUT;
+
     if (pin >= s || !desc_list[pin])
         return 0;
 
-    return apply_mux_desc(desc_list[pin], dir == SOL_GPIO_DIR_OUT ?
-        MODE_GPIO_OUTPUT : MODE_GPIO_INPUT_PULLUP);
+    if (config->dir == SOL_GPIO_DIR_IN) {
+        if (config->drive_mode == SOL_GPIO_DRIVE_NONE)
+            mode = MODE_GPIO_INPUT_HIZ;
+        else if (config->drive_mode == SOL_GPIO_DRIVE_PULL_UP)
+            mode = MODE_GPIO_INPUT_PULLUP;
+        else if (config->drive_mode == SOL_GPIO_DRIVE_PULL_DOWN)
+            mode = MODE_GPIO_INPUT_PULLDOWN;
+    }
+
+    return apply_mux_desc(desc_list[pin], mode);
 }
 
 int

--- a/src/modules/pin-mux/intel-common/intel-common.h
+++ b/src/modules/pin-mux/intel-common/intel-common.h
@@ -98,7 +98,7 @@ int mux_pin_map(const struct mux_pin_map *map, const char *label, const enum sol
 int mux_set_aio(const int device, const int pin, const struct mux_controller *const ctl_list,
     const int s);
 
-int mux_set_gpio(const uint32_t pin, const enum sol_gpio_direction dir,
+int mux_set_gpio(const uint32_t pin, const struct sol_gpio_config *config,
     const struct mux_description *const *desc_list, const uint32_t s);
 
 int mux_set_i2c(const uint8_t bus, const struct mux_description *const (*desc_list)[2],

--- a/src/modules/pin-mux/intel-edison-rev-c/intel-edison-rev-c.c
+++ b/src/modules/pin-mux/intel-edison-rev-c/intel-edison-rev-c.c
@@ -441,10 +441,10 @@ _set_aio(const int device, const int pin)
 }
 
 static int
-_set_gpio(const uint32_t pin, const enum sol_gpio_direction dir)
+_set_gpio(const uint32_t pin, const struct sol_gpio_config *config)
 {
     if (ardu_breakout)
-        return mux_set_gpio(pin, dir, gpio_dev_0, (uint32_t)sol_util_array_size(gpio_dev_0));
+        return mux_set_gpio(pin, config, gpio_dev_0, (uint32_t)sol_util_array_size(gpio_dev_0));
 
     return 0;
 }

--- a/src/modules/pin-mux/intel-galileo-rev-d/intel-galileo-rev-d.c
+++ b/src/modules/pin-mux/intel-galileo-rev-d/intel-galileo-rev-d.c
@@ -166,9 +166,9 @@ _set_aio(const int device, const int pin)
 }
 
 static int
-_set_gpio(const uint32_t pin, const enum sol_gpio_direction dir)
+_set_gpio(const uint32_t pin, const struct sol_gpio_config *config)
 {
-    return mux_set_gpio(pin, dir, gpio_dev_0, (uint32_t)sol_util_array_size(gpio_dev_0));
+    return mux_set_gpio(pin, config, gpio_dev_0, (uint32_t)sol_util_array_size(gpio_dev_0));
 }
 
 static int

--- a/src/modules/pin-mux/intel-galileo-rev-g/intel-galileo-rev-g.c
+++ b/src/modules/pin-mux/intel-galileo-rev-g/intel-galileo-rev-g.c
@@ -337,9 +337,9 @@ _set_aio(const int device, const int pin)
 }
 
 static int
-_set_gpio(const uint32_t pin, const enum sol_gpio_direction dir)
+_set_gpio(const uint32_t pin, const struct sol_gpio_config *config)
 {
-    return mux_set_gpio(pin, dir, gpio_dev_0, (uint32_t)sol_util_array_size(gpio_dev_0));
+    return mux_set_gpio(pin, config, gpio_dev_0, (uint32_t)sol_util_array_size(gpio_dev_0));
 }
 
 static int


### PR DESCRIPTION
Since 'drive' mode is back as part of our GPIO API (and config)
we can use it again to set the driver mode during pin mux execution.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>