### PR TITLE
Flow option uint v2

### DIFF
--- a/data/schemas/node-type-genspec.schema
+++ b/data/schemas/node-type-genspec.schema
@@ -9,6 +9,16 @@
       ]
     },
 
+    "uint_or_limit": {
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 0
+        },
+        { "enum": [ "UINT32_MAX" ] }
+      ]
+    },
+
     "float_or_limit": {
       "oneOf": [
         { "type": "number" },
@@ -67,7 +77,8 @@
         "int",
         "irange-spec",
         "rgb",
-        "string"
+        "string",
+        "uint"
       ]
     },
 
@@ -322,6 +333,13 @@
       }
     },
 
+    "options_members_uint": {
+      "properties": {
+        "data_type": { "enum": [ "uint" ] },
+        "default": { "$ref": "#/definitions/uint_or_limit" }
+      }
+    },
+
     "options_members_by_type": {
       "allOf": [
         { "$ref": "#/definitions/options_members_common" },
@@ -336,7 +354,8 @@
             { "$ref": "#/definitions/options_members_int" },
             { "$ref": "#/definitions/options_members_irange_spec" },
             { "$ref": "#/definitions/options_members_rgb" },
-            { "$ref": "#/definitions/options_members_string" }
+            { "$ref": "#/definitions/options_members_string" },
+            { "$ref": "#/definitions/options_members_uint" }
           ]
         }
       ]

--- a/data/scripts/sol-flow-node-type-gen.py.in
+++ b/data/scripts/sol-flow-node-type-gen.py.in
@@ -246,7 +246,8 @@ data_type_to_c_map = {
     "direction-vector": "struct sol_direction_vector",
     "string": "const char *",
     "location": "struct sol_location",
-    "timestamp": "struct timespec"
+    "timestamp": "struct timespec",
+    "uint": "uint32_t"
     }
 def data_type_to_c(typename):
     return data_type_to_c_map[typename]
@@ -260,7 +261,8 @@ data_type_to_default_member_map = {
     "irange-spec": "irange_spec",
     "string": "s",
     "rgb": "rgb",
-    "direction-vector": "direction_vector"
+    "direction-vector": "direction_vector",
+    "uint": "u"
     }
 composed_types_signatures = {}
 

--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -1122,6 +1122,8 @@ get_type_data_by_name(const char *type)
         return "bool";
     if (streq(type, "byte"))
         return "unsigned char";
+    if (streq(type, "uint"))
+        return "uint32_t";
     return NULL;
 }
 

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -565,6 +565,7 @@ enum sol_flow_node_options_member_type {
     SOL_FLOW_NODE_OPTIONS_MEMBER_IRANGE_SPEC,
     SOL_FLOW_NODE_OPTIONS_MEMBER_RGB,
     SOL_FLOW_NODE_OPTIONS_MEMBER_STRING,
+    SOL_FLOW_NODE_OPTIONS_MEMBER_UINT
 };
 
 /**
@@ -602,6 +603,7 @@ struct sol_flow_node_named_options_member {
         struct sol_direction_vector direction_vector; /**< @brief Value of a direction vector member */
         const char *string; /**< @brief Value of a string member */
         double f; /**< @brief Value of a float member */
+        uint32_t u; /**< @brief Value of a uint member */
     };
 };
 
@@ -711,6 +713,7 @@ struct sol_flow_node_options_member_description {
         const char *s; /**< @brief Option member's default string value */
         const void *ptr; /**< @brief Option member's default "blob" value */
         double f; /**< @brief Option member's default float value */
+        uint32_t u; /**< @brief Option member's default uint value */
     } defvalue; /**< @brief Option member's default value, according to its #data_type */
     uint16_t offset; /**< @brief Option member's offset inside the final options blob for a node */
     uint16_t size; /**< @brief Option member's size inside the final options blob for a node */

--- a/src/lib/flow/sol-flow-builder.c
+++ b/src/lib/flow/sol-flow-builder.c
@@ -1252,6 +1252,7 @@ get_member_alignment(const struct sol_flow_node_options_member_description *memb
             __alignof__(member->defvalue.irange_spec)),
         SOL_STR_TABLE_ITEM("rgb", __alignof__(member->defvalue.rgb)),
         SOL_STR_TABLE_ITEM("string", __alignof__(member->defvalue.s)),
+        SOL_STR_TABLE_ITEM("uint", __alignof__(member->defvalue.u)),
         { }
     };
 

--- a/src/modules/flow/aio/aio.c
+++ b/src/modules/flow/aio/aio.c
@@ -129,12 +129,12 @@ aio_reader_open(struct sol_flow_node *node, void *data, const struct sol_flow_no
         return -EINVAL;
     }
 
-    if (opts->mask <= 0) {
+    if (opts->mask == 0) {
         SOL_WRN("aio (%s): Invalid bit mask value=%" PRId32 ".", opts->pin, opts->mask);
         return -EINVAL;
     }
 
-    if (opts->poll_timeout <= 0) {
+    if (opts->poll_timeout == 0) {
         SOL_WRN("aio (%s): Invalid polling time=%" PRId32 ".", opts->pin, opts->poll_timeout);
         return -EINVAL;
     }

--- a/src/modules/flow/aio/aio.json
+++ b/src/modules/flow/aio/aio.json
@@ -29,13 +29,13 @@
             "name": "raw"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 12,
             "description": "Number of valid bits. This number is used to filter data received from hardware (which is manufacturer dependent), therefore should not be used as a way to change the output range because the mask is applied to the least significant bits.",
             "name": "mask"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 1000,
             "description": "Polling time in milliseconds. This option will take no effect if hardware interruptions for GPIO is supported by the underlying system. Use it if you know that you don't have those interruptions available.",
             "name": "poll_timeout"

--- a/src/modules/flow/boolean/boolean.c
+++ b/src/modules/flow/boolean/boolean.c
@@ -532,18 +532,13 @@ boolean_buffer_open(struct sol_flow_node *node, void *data,
         -EINVAL);
 
     mdata->n_samples = opts->samples;
-    if (opts->samples <= 0) {
+    if (opts->samples == 0) {
         SOL_WRN("Invalid samples (%" PRId32 "). Must be positive. "
             "Set to %" PRId32 ".", opts->samples, def_opts->samples);
         mdata->n_samples = def_opts->samples;
     }
 
     mdata->timeout = opts->timeout;
-    if (opts->timeout < 0) {
-        SOL_WRN("Invalid timeout (%" PRId32 "). Must be non negative. "
-            "Set to 0.", opts->timeout);
-        mdata->timeout = 0;
-    }
 
     mdata->normalize_cb = sol_str_table_ptr_lookup_fallback
             (table, sol_str_slice_from_str(opts->operation), NULL);

--- a/src/modules/flow/form/form-common.c
+++ b/src/modules/flow/form/form-common.c
@@ -273,9 +273,9 @@ format_send(struct sol_flow_node *node,
 
 int
 common_form_init(struct sol_buffer *buf,
-    int32_t in_rows,
+    uint32_t in_rows,
     size_t *out_rows,
-    int32_t in_cols,
+    uint32_t in_cols,
     size_t *out_cols,
     const char *in_format,
     char **out_format,
@@ -290,7 +290,7 @@ common_form_init(struct sol_buffer *buf,
 
     SOL_NULL_CHECK(in_format, -EINVAL);
 
-    if (in_rows <= 0) {
+    if (in_rows == 0) {
         SOL_WRN("Form rows number must be a positive integer, "
             "but %" PRId32 " was given. Fallbacking to minimum value of 1.",
             in_rows);
@@ -298,7 +298,7 @@ common_form_init(struct sol_buffer *buf,
     } else
         *out_rows = in_rows;
 
-    if (in_cols <= 0) {
+    if (in_cols == 0) {
         SOL_WRN("Boolean columns number must be a positive integer, "
             "but %" PRId32 " was given. Fallbacking to minimum value of 1.",
             in_cols);

--- a/src/modules/flow/form/form-common.h
+++ b/src/modules/flow/form/form-common.h
@@ -89,7 +89,7 @@ int format_post_value(struct sol_buffer *buf, size_t n_rows, size_t n_cols, size
 
 int format_send(struct sol_flow_node *node, struct sol_buffer *buf, uint16_t out_port);
 
-int common_form_init(struct sol_buffer *buf, int32_t in_rows, size_t *out_rows,  int32_t in_cols, size_t *out_cols, const char *in_format, char **out_format, const char *in_title, char **out_title, char **out_title_tag, char **out_value_tag, char **out_text_mem);
+int common_form_init(struct sol_buffer *buf, uint32_t in_rows, size_t *out_rows,  uint32_t in_cols, size_t *out_cols, const char *in_format, char **out_format, const char *in_title, char **out_title, char **out_title_tag, char **out_value_tag, char **out_text_mem);
 
 int go_to_new_line(struct sol_buffer *buf, size_t n_rows, size_t n_cols, size_t *row, size_t *col);
 

--- a/src/modules/flow/form/form.c
+++ b/src/modules/flow/form/form.c
@@ -1117,10 +1117,7 @@ integer_custom_open(struct sol_flow_node *node,
     int n_max, n_min;
     struct integer_custom_data *mdata = data;
     const struct sol_flow_node_type_form_int_custom_options *opts =
-        (const struct sol_flow_node_type_form_int_custom_options *)options,
-    *def_opts;
-
-    def_opts = node->type->default_options;
+        (const struct sol_flow_node_type_form_int_custom_options *)options;
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options,
         SOL_FLOW_NODE_TYPE_FORM_INT_OPTIONS_API_VERSION, -EINVAL);
@@ -1131,11 +1128,6 @@ integer_custom_open(struct sol_flow_node *node,
     SOL_INT_CHECK_GOTO(r, < 0, err);
 
     mdata->blink_time = opts->blink_time;
-    if (opts->blink_time < 0) {
-        SOL_WRN("Invalid blink_time (%" PRId32 "), that must be positive. "
-            "Setting to %" PRId32 ".", opts->blink_time, def_opts->blink_time);
-        mdata->blink_time = def_opts->blink_time;
-    }
 
     mdata->blink_on = true;
 
@@ -1726,27 +1718,9 @@ string_open(struct sol_flow_node *node,
     mdata->enabled = true;
 
     mdata->blink_time = opts->blink_time;
-    if (opts->blink_time < 0) {
-        SOL_WRN("Invalid blink_time (%" PRId32 "), that must be positive. "
-            "Setting to %" PRId32 "", opts->blink_time, def_opts->blink_time);
-        mdata->blink_time = def_opts->blink_time;
-    }
 
     mdata->min_length = opts->min_length;
-    if (opts->min_length < 0) {
-        SOL_WRN("Invalid minimum output size (%" PRId32 "), "
-            "that must be positive. Setting to %" PRId32 ".",
-            opts->min_length, def_opts->min_length);
-        mdata->min_length = def_opts->min_length;
-    }
-
     mdata->max_length = opts->max_length;
-    if (opts->max_length < 0) {
-        SOL_WRN("Invalid maximum output size (%" PRId32 "), "
-            "that must be positive. Setting to %" PRId32 ".",
-            opts->max_length, def_opts->max_length);
-        mdata->max_length = def_opts->max_length;
-    }
 
     if (mdata->max_length && mdata->max_length < mdata->min_length) {
         SOL_WRN("Invalid maximum output size (%" PRId32 "), "

--- a/src/modules/flow/form/form.json
+++ b/src/modules/flow/form/form.json
@@ -76,12 +76,12 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available columns to lay out the output string with. It must be a positive integer.",
             "name": "columns"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available rows to lay out the output string with. It must be a positive integer.",
             "name": "rows"
           },
@@ -178,12 +178,12 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available columns to lay out the output string with. It must be a positive integer.",
             "name": "columns"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available rows to lay out the output string with. It must be a positive integer.",
             "name": "rows"
           },
@@ -282,12 +282,12 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available columns to lay out the output string with. It must be a positive integer.",
             "name": "columns"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available rows to lay out the output string with. It must be a positive integer.",
             "name": "rows"
           },
@@ -425,12 +425,12 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available columns to lay out the output string with. It must be a positive integer.",
             "name": "columns"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available rows to lay out the output string with. It must be a positive integer.",
             "name": "rows"
           },
@@ -568,12 +568,12 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available columns to lay out the output string with. It must be a positive integer.",
             "name": "columns"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "The number of available rows to lay out the output string with. It must be a positive integer.",
             "name": "rows"
           },
@@ -584,13 +584,13 @@
             "name": "blink_time"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "Minimum output string length (must be non-negative and less than or equal to 'max_length' option's value).",
             "name": "min_length"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "Maximum output string length (must be non-negative and greater than or equal to 'min_length' option's value). The special value of 0 means no maximum will be applied.",
             "name": "max_length"

--- a/src/modules/flow/format/format.c
+++ b/src/modules/flow/format/format.c
@@ -146,7 +146,7 @@ struct string_formatted_data {
     struct sol_buffer text_grid, formatted_value;
     struct sol_vector chunks;
     struct sol_timeout *timer;
-    int blink_time;
+    uint32_t blink_time;
     bool circular : 1;
     bool enabled : 1;
     bool blink_on : 1;
@@ -571,11 +571,6 @@ string_formatted_open(struct sol_flow_node *node,
     mdata->enabled = true;
 
     mdata->blink_time = opts->blink_time;
-    if (opts->blink_time < 0) {
-        SOL_WRN("Invalid blink_time (%" PRId32 "), that must be positive. "
-            "Setting to 1ms.", opts->blink_time);
-        mdata->blink_time = 1;
-    }
 
     mdata->blink_on = true;
     mdata->state_changed = true;

--- a/src/modules/flow/http-client/http-client.c
+++ b/src/modules/flow/http-client/http-client.c
@@ -1601,7 +1601,6 @@ request_node_open(struct sol_flow_node *node, void *data,
 
     SOL_FLOW_NODE_OPTIONS_SUB_API_CHECK(options, SOL_FLOW_NODE_TYPE_HTTP_CLIENT_REQUEST_OPTIONS_API_VERSION,
         -EINVAL);
-    SOL_INT_CHECK(opts->timeout, < 0, -EINVAL);
     mdata->timeout = opts->timeout;
 
     sol_http_params_init(&mdata->base.url_params);
@@ -2081,7 +2080,6 @@ create_url_open(struct sol_flow_node *node, void *data,
         -EINVAL);
 
     mdata->params = SOL_HTTP_REQUEST_PARAMS_INIT;
-    SOL_INT_CHECK(opts->port, < 0, -EINVAL);
     mdata->port = opts->port;
     r = -ENOMEM;
 

--- a/src/modules/flow/http-client/http-client.json
+++ b/src/modules/flow/http-client/http-client.json
@@ -783,7 +783,7 @@
             "name": "method"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "The number of milliseconds to wait for the request to be completed",
             "name": "timeout"
@@ -1028,7 +1028,7 @@
             "name": "scheme"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "The server port",
             "name": "port"

--- a/src/modules/flow/int/int.c
+++ b/src/modules/flow/int/int.c
@@ -758,18 +758,13 @@ irange_buffer_open(struct sol_flow_node *node, void *data,
         (options, SOL_FLOW_NODE_TYPE_INT_BUFFER_OPTIONS_API_VERSION, -EINVAL);
 
     mdata->n_samples = opts->samples;
-    if (opts->samples <= 0) {
+    if (opts->samples == 0) {
         SOL_WRN("Invalid samples (%" PRId32 "). Must be positive. "
             "Set to %" PRId32 ".", opts->samples, def_opts->samples);
         mdata->n_samples = def_opts->samples;
     }
 
     mdata->timeout = opts->timeout;
-    if (opts->timeout < 0) {
-        SOL_WRN("Invalid timeout (%" PRId32 "). Must be non negative."
-            "Set to 0.", opts->timeout);
-        mdata->timeout = 0;
-    }
 
     mdata->normalize_cb = sol_str_table_ptr_lookup_fallback
             (table, sol_str_slice_from_str(opts->operation), NULL);

--- a/src/modules/flow/int/int.json
+++ b/src/modules/flow/int/int.json
@@ -572,13 +572,13 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 4,
             "description": "Number of samples that the buffer should hold.",
             "name": "samples"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "Timeout time in milliseconds. Default is zero which means that timeout is disabled.",
             "name": "timeout"

--- a/src/modules/flow/ipm/ipm.json
+++ b/src/modules/flow/ipm/ipm.json
@@ -26,7 +26,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Readers will use this ID to receive messages. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -64,7 +64,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Only messages written with this ID will be received. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -100,7 +100,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Readers will use this ID to receive messages. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -138,7 +138,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Only messages written with this ID will be received. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -174,7 +174,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Readers will use this ID to receive messages. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -212,7 +212,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Only messages written with this ID will be received. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -248,7 +248,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Readers will use this ID to receive messages. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -286,7 +286,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Only messages written with this ID will be received. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -322,7 +322,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Readers will use this ID to receive messages. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -360,7 +360,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Only messages written with this ID will be received. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -396,7 +396,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Readers will use this ID to receive messages. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -434,7 +434,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Only messages written with this ID will be received. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -470,7 +470,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Readers will use this ID to receive messages. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -508,7 +508,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Only messages written with this ID will be received. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -544,7 +544,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Readers will use this ID to receive messages. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }
@@ -582,7 +582,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "ID of message. Only messages written with this ID will be received. Must be greater than 0 and smaller than platform maximum id number.",
             "name": "id"
           }

--- a/src/modules/flow/led-strip/led-strip.json
+++ b/src/modules/flow/led-strip/led-strip.json
@@ -56,7 +56,7 @@
             "name": "chip_select"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 32,
             "description": "Pixel count. How many LEDs are on the strip.",
             "name": "pixel_count"

--- a/src/modules/flow/led-strip/lpd8806.c
+++ b/src/modules/flow/led-strip/lpd8806.c
@@ -72,7 +72,6 @@ led_strip_controler_open(struct sol_flow_node *node, void *data, const struct so
 
     opts = (const struct sol_flow_node_type_led_strip_lpd8806_options *)options;
 
-    SOL_INT_CHECK(opts->pixel_count, < 0, -EINVAL);
     mdata->pixel_count = opts->pixel_count;
 
     data_bytes = mdata->pixel_count * 3;

--- a/src/modules/flow/pwm/pwm.c
+++ b/src/modules/flow/pwm/pwm.c
@@ -129,13 +129,8 @@ pwm_open(struct sol_flow_node *node, void *data, const struct sol_flow_node_opti
         SOL_FLOW_NODE_TYPE_PWM_OPTIONS_API_VERSION, -EINVAL);
 
     // Use values from options. Period = 0 considered invalid.
-    if (opts->period <= 0) {
+    if (opts->period == 0) {
         SOL_WRN("Invalid value for period - pwm (%s)", opts->pin);
-        return -EINVAL;
-    }
-
-    if (opts->duty_cycle < 0) {
-        SOL_WRN("Invalid value for duty_cycle - pwm (%s)", opts->pin);
         return -EINVAL;
     }
 

--- a/src/modules/flow/pwm/pwm.json
+++ b/src/modules/flow/pwm/pwm.json
@@ -76,7 +76,6 @@
    },
    {
     "data_type": "uint",
-    "default": 0,
     "description": "Initial duty cycle",
     "name": "duty_cycle"
    }

--- a/src/modules/flow/pwm/pwm.json
+++ b/src/modules/flow/pwm/pwm.json
@@ -69,13 +69,13 @@
     "name": "inversed_polarity"
    },
    {
-    "data_type": "int",
+    "data_type": "uint",
     "default": 0,
     "description": "Initial period",
     "name": "period"
    },
    {
-    "data_type": "int",
+    "data_type": "uint",
     "default": 0,
     "description": "Initial duty cycle",
     "name": "duty_cycle"

--- a/src/modules/flow/regexp/regexp.c
+++ b/src/modules/flow/regexp/regexp.c
@@ -30,7 +30,7 @@ struct string_regexp_search_data {
     size_t max_regexp_search;
     char *string;
     char *regexp;
-    int index;
+    uint32_t index;
 };
 
 struct string_regexp_replace_data {
@@ -38,7 +38,7 @@ struct string_regexp_replace_data {
     char *orig_string;
     char *regexp;
     char *to_regexp;
-    int32_t max_regexp_replace;
+    uint32_t max_regexp_replace;
     bool forward_on_no_match;
 };
 
@@ -183,7 +183,7 @@ static int
 send_regexp_substring(struct string_regexp_search_data *mdata)
 {
     struct sol_str_slice *sub_slice;
-    int len;
+    uint16_t len;
 
     len = mdata->substrings.len;
     if (!len)
@@ -357,16 +357,6 @@ string_regexp_search_open(struct sol_flow_node *node,
         -EINVAL);
     opts = (const struct sol_flow_node_type_regexp_search_options *)options;
 
-    if (opts->index < 0) {
-        SOL_WRN("Index (%" PRId32 ") must be a non-negative value",
-            opts->index);
-        return -EINVAL;
-    }
-    if (opts->max_regexp_search < 0) {
-        SOL_WRN("Max regexp matches (%" PRId32 ") must be"
-            " a non-negative value", opts->max_regexp_search);
-        return -EINVAL;
-    }
     if (!opts->regexp || !strlen(opts->regexp)) {
         SOL_WRN("A non-empty regular expression string must be provided");
         return -EINVAL;
@@ -514,11 +504,6 @@ string_regexp_replace_open(struct sol_flow_node *node,
     mdata->node = node;
     mdata->forward_on_no_match = opts->forward_on_no_match;
 
-    if (opts->max_regexp_replace < 0) {
-        SOL_WRN("Max regexp matches (%" PRId32 ") must be"
-            " a non-negative value", opts->max_regexp_replace);
-        return -EINVAL;
-    }
     mdata->max_regexp_replace = opts->max_regexp_replace > 0 ?
         (size_t)opts->max_regexp_replace : INT32_MAX;
 

--- a/src/modules/flow/regexp/regexp.json
+++ b/src/modules/flow/regexp/regexp.json
@@ -55,13 +55,13 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "This value defines which substring match (by index, starting from 0) inside the one that was fed to the 'IN' port should be output in the 'OUT' port. It must be non-negative. It can be overriden by values received on 'INDEX' port.",
             "name": "index"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "The regular expression matching against the input string can result in various substring matches. This value defines the maximum number of them to generate and make available for selection by the 'INDEX' port. This option can be overriden by values received on the 'MAX_REGEXP_SEARCH' port. The value of zero (default one) will be interpreted as to generate all possible matches.",
             "name": "max_regexp_search"
@@ -137,7 +137,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "The regular expression matching against the input string can result in various substring matches. This value defines the maximum number of them to replace for the string given in the 'to' option. This option can be overriden by values received on the 'MAX_REGEXP_REPLACE' port. The value of zero (default one) will be interpreted as to replace all possible matches.",
             "name": "max_regexp_replace"

--- a/src/modules/flow/robotics/robotics.c
+++ b/src/modules/flow/robotics/robotics.c
@@ -197,8 +197,6 @@ quadrature_encoder_open(struct sol_flow_node *node, void *data,
     const struct sol_flow_node_type_robotics_quadrature_encoder_options *opts =
         (const struct sol_flow_node_type_robotics_quadrature_encoder_options *)options;
 
-    SOL_INT_CHECK(opts->period, < 0, -EINVAL);
-
     priv->old_index = priv->new_index = 0;
     priv->input_a = priv->input_b = 0;
     priv->ticks = 0;

--- a/src/modules/flow/robotics/robotics.json
+++ b/src/modules/flow/robotics/robotics.json
@@ -96,7 +96,7 @@
         "version": 1,
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "Time to wait before sending the tick delta, in ms. Default is 100ms.",
             "name": "period",
             "default": 100
@@ -158,7 +158,7 @@
             "name": "axle_length"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "Update period, in ms. Default is 100ms.",
             "name": "update_period",
             "default": 100

--- a/src/modules/flow/string/string-ascii.c
+++ b/src/modules/flow/string/string-ascii.c
@@ -31,7 +31,7 @@
 #include "string-uuid.h"
 
 struct string_data {
-    int32_t n;
+    uint32_t n;
     char *string[2];
 };
 
@@ -192,14 +192,7 @@ string_compare_open(struct sol_flow_node *node,
 
     opts = (const struct sol_flow_node_type_string_compare_options *)options;
 
-    if (opts->chars < 0) {
-        SOL_WRN("Option 'chars' (%" PRId32 ") must be a positive "
-            "amount of chars to be compared or zero if whole strings "
-            "should be compared. Considering zero.", opts->chars);
-        mdata->base.n = 0;
-    } else
-        mdata->base.n = opts->chars;
-
+    mdata->base.n = opts->chars;
     mdata->ignore_case = opts->ignore_case;
 
     return 0;
@@ -372,13 +365,7 @@ string_length_open(struct sol_flow_node *node,
 
     opts = (const struct sol_flow_node_type_string_length_options *)options;
 
-    if (opts->maxlen < 0) {
-        SOL_WRN("Option 'maxlen' (%" PRId32 ") must be a positive "
-            "or zero if the whole string should be measured. "
-            "Considering zero.", opts->maxlen);
-        mdata->n = 0;
-    } else
-        mdata->n = opts->maxlen;
+    mdata->n = opts->maxlen;
 
     return 0;
 }
@@ -411,7 +398,7 @@ struct string_split_data {
     struct sol_vector substrings;
     char *string;
     char *separator;
-    int32_t index, max_split;
+    uint32_t index, max_split;
 };
 
 static int
@@ -427,16 +414,6 @@ string_split_open(struct sol_flow_node *node,
         -EINVAL);
     opts = (const struct sol_flow_node_type_string_split_options *)options;
 
-    if (opts->index < 0) {
-        SOL_WRN("Index (%" PRId32 ") must be a non-negative value",
-            opts->index);
-        return -EINVAL;
-    }
-    if (opts->max_split < 0) {
-        SOL_WRN("Max split (%" PRId32 ") must be a non-negative value",
-            opts->max_split);
-        return -EINVAL;
-    }
     mdata->index = opts->index;
     mdata->max_split = opts->max_split;
 
@@ -486,7 +463,7 @@ calculate_substrings(struct string_split_data *mdata,
 static int
 send_substring(struct string_split_data *mdata, struct sol_flow_node *node)
 {
-    int32_t len;
+    uint32_t len;
     struct sol_str_slice *sub_slice;
 
     if (!(mdata->string && mdata->separator))
@@ -670,7 +647,7 @@ struct string_replace_data {
     char *orig_string;
     char *from_string;
     char *to_string;
-    int32_t max_replace;
+    uint32_t max_replace;
     bool forward_on_no_match;
 };
 
@@ -689,12 +666,7 @@ string_replace_open(struct sol_flow_node *node,
 
     mdata->node = node;
     mdata->forward_on_no_match = opts->forward_on_no_match;
-    if (opts->max_replace < 0) {
-        SOL_WRN("Max replace (%" PRId32 ") must be a non-negative value",
-            opts->max_replace);
-        return -EINVAL;
-    }
-    mdata->max_replace = opts->max_replace ? : INT32_MAX;
+    mdata->max_replace = opts->max_replace ? : UINT32_MAX;
 
     mdata->from_string = strdup(opts->from_string);
     if (!opts->from_string)

--- a/src/modules/flow/string/string-icu.c
+++ b/src/modules/flow/string/string-icu.c
@@ -97,7 +97,7 @@ utf8_from_icu_str_slice(const UChar *icu_str,
 #endif
 
 struct string_data {
-    int32_t n;
+    uint32_t n;
     UChar *string[2];
 };
 
@@ -281,14 +281,7 @@ string_compare_open(struct sol_flow_node *node,
 
     opts = (const struct sol_flow_node_type_string_compare_options *)options;
 
-    if (opts->chars < 0) {
-        SOL_WRN("Option 'chars' (%" PRId32 ") must be a positive "
-            "amount of chars to be compared or zero if whole strings "
-            "should be compared. Considering zero.", opts->chars);
-        mdata->base.n = 0;
-    } else
-        mdata->base.n = opts->chars;
-
+    mdata->base.n = opts->chars;
     mdata->ignore_case = opts->ignore_case;
 
     return 0;
@@ -488,13 +481,7 @@ string_length_open(struct sol_flow_node *node,
 
     opts = (const struct sol_flow_node_type_string_length_options *)options;
 
-    if (opts->maxlen < 0) {
-        SOL_WRN("Option 'maxlen' (%" PRId32 ") must be a positive "
-            "or zero if the whole string should be measured. "
-            "Considering zero.", opts->maxlen);
-        mdata->n = 0;
-    } else
-        mdata->n = opts->maxlen;
+    mdata->n = opts->maxlen;
 
     return 0;
 }
@@ -534,7 +521,7 @@ struct string_split_data {
     struct sol_vector substrings;
     UChar *string;
     UChar *separator;
-    int index, max_split;
+    uint32_t index, max_split;
 };
 
 static int
@@ -550,16 +537,6 @@ string_split_open(struct sol_flow_node *node,
         -EINVAL);
     opts = (const struct sol_flow_node_type_string_split_options *)options;
 
-    if (opts->index < 0) {
-        SOL_WRN("Index (%" PRId32 ") must be a non-negative value",
-            opts->index);
-        return -EINVAL;
-    }
-    if (opts->max_split < 0) {
-        SOL_WRN("Max split (%" PRId32 ") must be a non-negative value",
-            opts->max_split);
-        return -EINVAL;
-    }
     mdata->index = opts->index;
     mdata->max_split = opts->max_split;
 
@@ -666,7 +643,8 @@ send_substring(struct string_split_data *mdata, struct sol_flow_node *node)
     struct sol_str_slice *sub_slice;
     char *outstr = NULL;
     UErrorCode err;
-    int len, r;
+    uint16_t len;
+    int r;
 
     if (!(mdata->string && mdata->separator))
         return 0;
@@ -908,7 +886,7 @@ struct string_replace_data {
     UChar *orig_string;
     UChar *from_string;
     UChar *to_string;
-    int32_t max_replace;
+    uint32_t max_replace;
     bool forward_on_no_match;
 };
 
@@ -929,12 +907,7 @@ string_replace_open(struct sol_flow_node *node,
 
     mdata->node = node;
     mdata->forward_on_no_match = opts->forward_on_no_match;
-    if (opts->max_replace < 0) {
-        SOL_WRN("Max replace (%" PRId32 ") must be a non-negative value",
-            opts->max_replace);
-        return -EINVAL;
-    }
-    mdata->max_replace = opts->max_replace ? : INT32_MAX;
+    mdata->max_replace = opts->max_replace ? : UINT32_MAX;
 
     r = icu_str_from_utf8(opts->from_string, &mdata->from_string, &err);
     SOL_INT_CHECK(r, < 0, r);

--- a/src/modules/flow/string/string.json
+++ b/src/modules/flow/string/string.json
@@ -28,7 +28,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "Amount of chars to be compared between strings. If zero, the whole strings will be compared.",
             "name": "chars"
@@ -117,7 +117,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "Maximum length to be checked. If a string is greater than that, maxlen value will be sent. If zero, no limit is applied.",
             "name": "maxlen"
@@ -241,13 +241,13 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "A string can be split in many substrings. This value defines which substring should be sent. It must be non-negative. It can be overriden by values received on 'INDEX' port.",
             "name": "index"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "A string can be split in many substrings. This value defines the maximum number of splits (separated by the separator option) to generate, and must be non-negative. The default value of zero means to generate all substrings between the given separator. This option can be overriden by values received on the 'MAX_SPLIT' port.",
             "name": "max_split"
@@ -515,7 +515,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "A string can have a substring replaced in many points. This value defines the maximum number of replacements to attempt, and must be non-negative. The default value of zero means to replace all possible substrings. This option can be overriden by values received on the 'MAX_REPLACE' port.",
             "name": "max_replace"

--- a/src/modules/flow/test/boolean-generator.c
+++ b/src/modules/flow/test/boolean-generator.c
@@ -77,10 +77,7 @@ boolean_generator_open(
     mdata->it = mdata->sequence = strdup(opts->sequence);
     SOL_NULL_CHECK(mdata->sequence, -errno);
 
-    if (opts->interval < 0)
-        SOL_WRN("Option 'interval' < 0, setting it to 0.");
-
-    mdata->interval = opts->interval >= 0 ? opts->interval : 0;
+    mdata->interval = opts->interval;
     mdata->timer = sol_timeout_add(mdata->interval, timer_tick, node);
     SOL_NULL_CHECK_GOTO(mdata->timer, error);
 

--- a/src/modules/flow/test/byte-generator.c
+++ b/src/modules/flow/test/byte-generator.c
@@ -67,10 +67,7 @@ byte_generator_open(struct sol_flow_node *node, void *data,
     }
     it = opts->sequence;
 
-    if (opts->interval < 0)
-        SOL_WRN("Option 'interval' < 0, setting it to 0.");
-
-    mdata->interval = opts->interval >= 0 ? opts->interval : 0;
+    mdata->interval = opts->interval;
     mdata->next_index = 0;
 
     sol_vector_init(&mdata->values, sizeof(unsigned char));

--- a/src/modules/flow/test/float-generator.c
+++ b/src/modules/flow/test/float-generator.c
@@ -68,10 +68,7 @@ float_generator_open(
     }
     it = opts->sequence;
 
-    if (opts->interval < 0)
-        SOL_WRN("Option 'interval' < 0, setting it to 0.");
-
-    mdata->interval = opts->interval >= 0 ? opts->interval : 0;
+    mdata->interval = opts->interval;
     mdata->next_index = 0;
 
     sol_vector_init(&mdata->values, sizeof(double));

--- a/src/modules/flow/test/int-generator.c
+++ b/src/modules/flow/test/int-generator.c
@@ -70,10 +70,7 @@ int_generator_open(
     }
     it = opts->sequence;
 
-    if (opts->interval < 0)
-        SOL_WRN("Option 'interval' < 0, setting it to 0.");
-
-    mdata->interval = opts->interval >= 0 ? opts->interval : 0;
+    mdata->interval = opts->interval;
     mdata->next_index = 0;
 
     sol_vector_init(&mdata->values, sizeof(int32_t));

--- a/src/modules/flow/test/string-generator.c
+++ b/src/modules/flow/test/string-generator.c
@@ -66,10 +66,7 @@ string_generator_open(
     mdata->sequence = strdup(opts->sequence);
     SOL_NULL_CHECK_GOTO(mdata->sequence, no_memory);
 
-    if (opts->interval < 0)
-        SOL_WRN("Option 'interval' < 0, setting it to 0.");
-
-    mdata->interval = opts->interval >= 0 ? opts->interval : 0;
+    mdata->interval = opts->interval;
     mdata->next_index = 0;
 
     mdata->values = sol_str_slice_split(sol_str_slice_from_str

--- a/src/modules/flow/test/test.json
+++ b/src/modules/flow/test/test.json
@@ -109,7 +109,7 @@
             "name": "sequence"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "Interval between packets, in miliseconds.",
             "name": "interval"
@@ -181,7 +181,7 @@
             "name": "sequence"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "Interval between packets, in miliseconds.",
             "name": "interval"
@@ -253,7 +253,7 @@
             "name": "sequence"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "Interval between packets, in miliseconds.",
             "name": "interval"
@@ -287,7 +287,7 @@
             "name": "sequence"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "Interval between packets, in miliseconds.",
             "name": "interval"
@@ -409,7 +409,7 @@
             "name": "separator"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 0,
             "description": "Interval between packets, in miliseconds.",
             "name": "interval"

--- a/src/modules/flow/thingspeak/thingspeak.json
+++ b/src/modules/flow/thingspeak/thingspeak.json
@@ -34,7 +34,7 @@
             "name": "endpoint"
           },
           {
-            "data_type": "int",
+            "data_type": "uint",
             "default": 1000,
             "description": "Poll interval in milliseconds. Default to one request every 1000ms.",
             "name": "interval"

--- a/src/modules/flow/timer/timer.c
+++ b/src/modules/flow/timer/timer.c
@@ -26,7 +26,7 @@
 struct timer_data {
     struct sol_flow_node *node;
     struct sol_timeout *timer;
-    int32_t interval;
+    uint32_t interval;
 };
 
 static bool
@@ -75,7 +75,7 @@ timer_interval_process(struct sol_flow_node *node, void *data, uint16_t port, ui
     r = sol_flow_packet_get_irange(packet, &val);
     SOL_INT_CHECK(r, < 0, r);
 
-    if (mdata->interval == val.val)
+    if ((int32_t)mdata->interval == val.val)
         return 0;
 
     mdata->interval = val.val;

--- a/src/modules/flow/wallclock/wallclock.c
+++ b/src/modules/flow/wallclock/wallclock.c
@@ -46,7 +46,7 @@ enum sol_flow_node_wallclock_type {
 struct wallclock_timeblock_data {
     struct sol_timeout *timer;
     struct sol_flow_node *node;
-    int interval;
+    uint16_t interval;
 };
 
 struct wallclock_data {

--- a/src/modules/flow/wallclock/wallclock.json
+++ b/src/modules/flow/wallclock/wallclock.json
@@ -252,7 +252,7 @@
       "options": {
         "members": [
           {
-            "data_type": "int",
+            "data_type": "uint",
             "description": "Time block interval. Defines the length of a frame in minutes. Last block may be smaller than others. For example, if interval is set to 50 minutes, it would tick 29 times a day, but interval for last one is just 48 minutes.",
             "name": "interval"
           },

--- a/src/test-stub-gen/dummy.json
+++ b/src/test-stub-gen/dummy.json
@@ -243,6 +243,12 @@
          "default": "Hello World",
          "description": "Dummy string option.",
          "name": "opt_string"
+        },
+        {
+         "data_type": "uint",
+         "default": 42,
+         "description": "Dummy uint option.",
+         "name": "opt_uint"
         }
        ],
        "version": 1

--- a/src/test/test-flow.c
+++ b/src/test/test-flow.c
@@ -1238,12 +1238,12 @@ named_options_init_from_strv(void)
 
         m++;
         ASSERT_STR_EQ(m->name, "period");
-        ASSERT(m->type == SOL_FLOW_NODE_OPTIONS_MEMBER_INT);
+        ASSERT(m->type == SOL_FLOW_NODE_OPTIONS_MEMBER_UINT);
         ASSERT_INT_EQ(m->i, 42);
 
         m++;
         ASSERT_STR_EQ(m->name, "duty_cycle");
-        ASSERT(m->type == SOL_FLOW_NODE_OPTIONS_MEMBER_INT);
+        ASSERT(m->type == SOL_FLOW_NODE_OPTIONS_MEMBER_UINT);
         ASSERT_INT_EQ(m->i, 88);
 
         sol_flow_node_named_options_fini(&named_opts);
@@ -1293,8 +1293,8 @@ node_options_new(void)
         { .name = "pin", .type = SOL_FLOW_NODE_OPTIONS_MEMBER_STRING, .string = "2 7" },
         { .name = "raw", .type = SOL_FLOW_NODE_OPTIONS_MEMBER_BOOLEAN, .boolean = true },
         { .name = "enabled", .type = SOL_FLOW_NODE_OPTIONS_MEMBER_BOOLEAN, .boolean = true },
-        { .name = "period", .type = SOL_FLOW_NODE_OPTIONS_MEMBER_INT, .i = 42 },
-        { .name = "duty_cycle", .type = SOL_FLOW_NODE_OPTIONS_MEMBER_INT, .i = 88 },
+        { .name = "period", .type = SOL_FLOW_NODE_OPTIONS_MEMBER_UINT, .i = 42 },
+        { .name = "duty_cycle", .type = SOL_FLOW_NODE_OPTIONS_MEMBER_UINT, .i = 88 },
     };
 
     struct sol_flow_node_named_options_member string_options[] = {


### PR DESCRIPTION
v2: 
Many more places were changed to use new type.
Small fix for PWM node type

Currently, we are using int data_type on flow node options for some options whose range is naturally unsigned. This PR presents a uint data_type - mapped to uint32_t.
A bonus is that it also checks range, so no need for node types check if (opts.x > 0).