### PR TITLE
HTTP: sol_http_progressive_response_feed() should receive a blob. v3

### DIFF
--- a/src/bin/sol-fbp-runner/web-inspector.c
+++ b/src/bin/sol-fbp-runner/web-inspector.c
@@ -36,6 +36,48 @@ static struct sol_http_progressive_response *events_response;
 
 static struct timespec start;
 
+static struct sol_blob sse_prefix = {
+    .type = &SOL_BLOB_TYPE_NO_FREE,
+    .parent = NULL,
+    .mem = (void *)"data: ",
+    .size = sizeof("data: ") - 1,
+    .refcnt = 1
+};
+
+static struct sol_blob sse_suffix = {
+    .type = &SOL_BLOB_TYPE_NO_FREE,
+    .parent = NULL,
+    .mem = (void *)"\n\n",
+    .size = sizeof("\n\n") - 1,
+    .refcnt = 1
+};
+
+static int
+web_inspector_send_sse_data(struct sol_http_progressive_response *client, struct sol_buffer *buf)
+{
+    int r;
+    struct sol_blob *blob;
+
+    blob = sol_buffer_to_blob(buf);
+    if (!blob)
+        return -ENOMEM;
+
+    r = sol_http_progressive_response_feed(client, &sse_prefix);
+    if (r < 0)
+        return r;
+
+    r = sol_http_progressive_response_feed(client, blob);
+    if (r < 0)
+        return r;
+
+    r = sol_http_progressive_response_feed(client, &sse_suffix);
+    if (r < 0)
+        return r;
+
+    sol_blob_unref(blob);
+    return 0;
+}
+
 static int
 web_inspector_add_json_key_value(struct sol_buffer *buf, const char *k, const char *v)
 {
@@ -95,13 +137,13 @@ web_inspector_open_event(struct sol_buffer *buf, const char *event)
     sol_util_timespec_sub(&now, &start, &diff);
 
     return sol_buffer_append_printf(buf,
-        "data: {\"event\": \"%s\",\"timestamp\":%ld.%010ld,\"payload\":", event, diff.tv_sec, diff.tv_nsec);
+        "{\"event\": \"%s\",\"timestamp\":%ld.%010ld,\"payload\":", event, diff.tv_sec, diff.tv_nsec);
 }
 
 static int
 web_inspector_close_event(struct sol_buffer *buf)
 {
-    return sol_buffer_append_slice(buf, sol_str_slice_from_str("}\n\n"));
+    return sol_buffer_append_slice(buf, sol_str_slice_from_str("}"));
 }
 
 static const char *
@@ -569,7 +611,7 @@ web_inspector_did_open_node(const struct sol_flow_inspector *inspector, const st
     if (r < 0)
         goto end;
 
-    r = sol_http_progressive_response_feed(events_response, sol_buffer_get_slice(&buf));
+    r = web_inspector_send_sse_data(events_response, &buf);
     if (r < 0)
         goto end;
 
@@ -603,7 +645,7 @@ web_inspector_will_close_node(const struct sol_flow_inspector *inspector, const 
     if (r < 0)
         goto end;
 
-    r = sol_http_progressive_response_feed(events_response, sol_buffer_get_slice(&buf));
+    r = web_inspector_send_sse_data(events_response, &buf);
     if (r < 0)
         goto end;
 
@@ -698,7 +740,7 @@ web_inspector_did_connect_port(const struct sol_flow_inspector *inspector, const
     if (r < 0)
         goto end;
 
-    r = sol_http_progressive_response_feed(events_response, sol_buffer_get_slice(&buf));
+    r = web_inspector_send_sse_data(events_response, &buf);
     if (r < 0)
         goto end;
 
@@ -751,7 +793,7 @@ web_inspector_will_disconnect_port(const struct sol_flow_inspector *inspector, c
     if (r < 0)
         goto end;
 
-    r = sol_http_progressive_response_feed(events_response, sol_buffer_get_slice(&buf));
+    r = web_inspector_send_sse_data(events_response, &buf);
     if (r < 0)
         goto end;
 
@@ -1318,7 +1360,7 @@ web_inspector_will_send_packet(const struct sol_flow_inspector *inspector, const
     if (r < 0)
         goto end;
 
-    r = sol_http_progressive_response_feed(events_response, sol_buffer_get_slice(&buf));
+    r = web_inspector_send_sse_data(events_response, &buf);
     if (r < 0)
         goto end;
 
@@ -1388,7 +1430,7 @@ web_inspector_will_deliver_packet(const struct sol_flow_inspector *web_inspector
     if (r < 0)
         goto end;
 
-    r = sol_http_progressive_response_feed(events_response, sol_buffer_get_slice(&buf));
+    r = web_inspector_send_sse_data(events_response, &buf);
     if (r < 0)
         goto end;
 
@@ -1452,6 +1494,10 @@ on_events(void *data, struct sol_http_request *request)
         .response_code = SOL_HTTP_STATUS_OK,
         .content = SOL_BUFFER_INIT_EMPTY
     };
+    struct sol_http_server_progressive_config config = {
+        SOL_SET_API_VERSION(.api_version = SOL_HTTP_SERVER_PROGRESSIVE_CONFIG_API_VERSION, )
+        .on_close = on_events_closed
+    };
     int r;
 
     if (events_response) {
@@ -1468,7 +1514,7 @@ on_events(void *data, struct sol_http_request *request)
         return r;
     }
 
-    events_response = sol_http_server_send_progressive_response(request, &response, on_events_closed, NULL);
+    events_response = sol_http_server_send_progressive_response(request, &response, &config);
     sol_http_params_clear(&response.param);
     if (!events_response)
         return -1;

--- a/src/lib/comms/include/sol-http-client.h
+++ b/src/lib/comms/include/sol-http-client.h
@@ -87,11 +87,11 @@ struct sol_http_request_interface {
      * @li @c connection the connection returned in @c sol_http_client_request_with_interface
      * @li @c buffer the data received
      *
-     * @note it is @b NOT @b ALLOWED to cancel the connection handle from
+     * @note it is allowed to cancel the connection handle from
      *       inside this callback.
      */
-    ssize_t (*recv_cb)(void *userdata, const struct sol_http_client_connection *connection,
-        struct sol_buffer *buffer);
+    ssize_t (*recv_cb)(void *userdata, struct sol_http_client_connection *connection,
+        const struct sol_buffer *buffer);
     /**
      * This callback is called data should be written, it's commonly used for @c POST.
      * When it's used, it's @b MANDATORY either the header @c Content-Length with the correct
@@ -109,10 +109,10 @@ struct sol_http_request_interface {
      * @li @c buffer the buffer where the data should be written, the buffer's capacity indicates
      * the amount of data that should be set.
      *
-     * @note it is @b NOT @b ALLOWED to cancel the connection handle from
+     * @note it is allowed to cancel the connection handle from
      *       inside this callback.
      */
-    ssize_t (*send_cb)(void *userdata, const struct sol_http_client_connection *connection,
+    ssize_t (*send_cb)(void *userdata, struct sol_http_client_connection *connection,
         struct sol_buffer *buffer);
     /**
      * This callback is called when the request finishes, the result of request is available on
@@ -122,11 +122,16 @@ struct sol_http_request_interface {
      * @li @c connection the connection returned in @c sol_http_client_request_with_interface
      * @li @c response the result of the request
      *
-     * @note it is @b NOT @b ALLOWED to cancel the connection handle from
+     * @note it is allowed to cancel the connection handle from
      *       inside this callback.
      */
-    void (*response_cb)(void *userdata, const struct sol_http_client_connection *connection,
+    void (*response_cb)(void *userdata, struct sol_http_client_connection *connection,
         struct sol_http_response *response);
+
+    /**
+     * The recv buffer size - 0 for unlimited.
+     */
+    size_t recv_buffer_size;
 };
 
 /**
@@ -152,7 +157,7 @@ struct sol_http_request_interface {
  */
 struct sol_http_client_connection *sol_http_client_request(enum sol_http_method method,
     const char *url, const struct sol_http_params *params,
-    void (*cb)(void *data, const struct sol_http_client_connection *connection,
+    void (*cb)(void *data, struct sol_http_client_connection *connection,
     struct sol_http_response *response),
     const void *data) SOL_ATTR_WARN_UNUSED_RESULT SOL_ATTR_NONNULL(2, 4);
 

--- a/src/lib/comms/include/sol-http-server.h
+++ b/src/lib/comms/include/sol-http-server.h
@@ -278,6 +278,44 @@ sol_http_response_set_sse_headers(struct sol_http_response *response)
 }
 
 /**
+ * @brief Progressive server response configuration.
+ * @struct sol_http_server_progressive_config
+ * @see sol_http_server_send_progressive_response()
+ */
+struct sol_http_server_progressive_config {
+#ifndef SOL_NO_API_VERSION
+#define SOL_HTTP_SERVER_PROGRESSIVE_CONFIG_API_VERSION (1)
+    /**
+     * api_version must match SOL_HTTP_REQUEST_INTERFACE_API_VERSION
+     * at runtime.
+     */
+    uint16_t api_version;
+#endif
+    /**
+     * @brief Callback used to inform that a struct @ref sol_blob was sent
+     * @param data The user data
+     * @param progressive The progressive response
+     * @param blob The blob that was transfered
+     * @note The blob will unref for you automatically
+     * @note It's safe to call sol_http_progressive_response_del() inside this callback.
+     */
+    void (*on_feed)(void *data, struct sol_http_progressive_response *progressive, struct sol_blob *blob, int status);
+    /**
+     * @brief Callback used to inform that the client has closed the connection.
+     *
+     * @param data The user data
+     * @param progressive The progressive response
+     */
+    void (*on_close)(void *data, const struct sol_http_progressive_response *progressive);
+    const void *user_data; /*<< User data to @c on_feed and @c on_close*/
+    /**
+     * The output buffer size - 0 means unlimited data.
+     * @see sol_http_progressive_response_feed()
+     */
+    size_t tx_size;
+};
+
+/**
  * @brief Send the response and keep connection alive to request given in the
  * callback registered on sol_http_server_register_handler().
  *
@@ -288,26 +326,27 @@ sol_http_response_set_sse_headers(struct sol_http_response *response)
  * sol_http_server_register_handler().
  * @param response The response for the request containing the data
  * and parameters (e.g http headers)
- * @param on_close Callback called when the connection is closed.
- * @param cb_data The data pointer to be passed to @a cb.
+ * @param config The progressive connection configuration.
  *
  * @return @c sol_http_progressive_response on success, @c NULL otherwise.
  *
  * @see sol_http_server_send_response()
  * @see sol_http_progressive_response_del()
  * @see sol_http_progressive_response_feed()
+ * @see @ref sol_http_server_progressive_config
  */
 struct sol_http_progressive_response *sol_http_server_send_progressive_response(struct sol_http_request *request,
-    const struct sol_http_response *response,
-    void (*on_close)(void *data, const struct sol_http_progressive_response *progressive),
-    const void *cb_data);
+    const struct sol_http_response *response, const struct sol_http_server_progressive_config *config);
 
 /**
  * @brief Send data for the progressive response.
  *
+ * If the sum of all blobs plus the new >= @ref sol_http_server_progressive_config::max_bytes
+ * this function will return -ENOSPC and the blob will not be sent.
+ *
  * @param progressive The progressive response created with
  * sol_http_server_send_progressive_response()
- * @param data The data to be sent.
+ * @param blob The blob to be sent.
  *
  * @return @c 0 on success, error code (always negative) otherwise.
  *
@@ -315,7 +354,7 @@ struct sol_http_progressive_response *sol_http_server_send_progressive_response(
  * @see sol_http_server_send_progressive_response()
  */
 int sol_http_progressive_response_feed(struct sol_http_progressive_response *progressive,
-    const struct sol_str_slice data);
+    struct sol_blob *blob);
 
 /**
  * @brief Delete the progressive response.

--- a/src/lib/comms/sol-http-client-impl-curl.c
+++ b/src/lib/comms/sol-http-client-impl-curl.c
@@ -70,6 +70,7 @@ struct sol_http_client_connection {
     CURL *curl;
     struct curl_slist *headers;
     struct curl_httppost *formpost;
+    struct sol_timeout *del_timeout;
     struct sol_buffer buffer;
     struct sol_vector watches;
     struct sol_http_params response_params;
@@ -77,7 +78,21 @@ struct sol_http_client_connection {
     const void *data;
 
     bool error;
+    bool in_use;
 };
+
+static void destroy_connection(struct sol_http_client_connection *c);
+
+static bool
+schedule_del(void *data)
+{
+    struct sol_http_client_connection *c = data;
+
+    c->del_timeout = NULL;
+    sol_ptr_vector_remove(&global.connections, c);
+    destroy_connection(c);
+    return false;
+}
 
 static void
 destroy_connection(struct sol_http_client_connection *c)
@@ -98,6 +113,9 @@ destroy_connection(struct sol_http_client_connection *c)
         sol_fd_del(cwatch->watch);
 
     sol_vector_clear(&c->watches);
+
+    if (c->del_timeout)
+        sol_timeout_del(c->del_timeout);
 
     free(c);
     sol_http_client_shutdown_lazy();
@@ -170,13 +188,19 @@ call_connection_finish_cb(struct sol_http_client_connection *connection)
 
     response->param = connection->response_params;
 
-    if (connection->interface.response_cb)
+    if (connection->interface.response_cb) {
+        connection->in_use = true;
         connection->interface.response_cb((void *)connection->data, connection, response);
+        connection->in_use = false;
+    }
     goto end;
 
 err:
-    if (connection->interface.response_cb)
+    if (connection->interface.response_cb) {
+        connection->in_use = true;
         connection->interface.response_cb((void *)connection->data, connection, NULL);
+        connection->in_use = false;
+    }
 end:
     sol_buffer_fini(&response->content);
     destroy_connection(connection);
@@ -199,7 +223,9 @@ write_cb(char *data, size_t size, size_t nmemb, void *connp)
     if (connection->interface.recv_cb) {
         ssize_t ret;
 
+        connection->in_use = true;
         ret = connection->interface.recv_cb((void *)connection->data, connection, &connection->buffer);
+        connection->in_use = false;
         if (ret < 0)
             return 0;
 
@@ -226,8 +252,10 @@ read_cb(char *data, size_t size, size_t nitems, void *connp)
     buffer = SOL_BUFFER_INIT_FLAGS(data, data_size,
         SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED | SOL_BUFFER_FLAGS_NO_NUL_BYTE);
 
+    connection->in_use = true;
     ret = connection->interface.send_cb((void *)connection->data,
         connection, &buffer);
+    connection->in_use = false;
 
     sol_buffer_fini(&buffer);
 
@@ -558,6 +586,8 @@ perform_multi(CURL *curl, struct curl_slist *headers,
     const void *data)
 {
     struct sol_http_client_connection *connection;
+    void *buf;
+    size_t recv_size;
     int running;
 
     SOL_INT_CHECK(global.ref, <= 0, NULL);
@@ -574,7 +604,16 @@ perform_multi(CURL *curl, struct curl_slist *headers,
     connection->error = false;
     sol_vector_init(&connection->watches, sizeof(struct connection_watch));
 
-    sol_buffer_init(&connection->buffer);
+    recv_size = interface->recv_buffer_size;
+    if (recv_size) {
+        buf = malloc(recv_size);
+        SOL_NULL_CHECK_GOTO(buf, err_buf);
+
+        sol_buffer_init_flags(&connection->buffer, buf, recv_size,
+            SOL_BUFFER_FLAGS_NO_NUL_BYTE | SOL_BUFFER_FLAGS_FIXED_CAPACITY);
+    } else
+        sol_buffer_init_flags(&connection->buffer, NULL, 0,
+            SOL_BUFFER_FLAGS_NO_NUL_BYTE | SOL_BUFFER_FLAGS_DEFAULT);
     sol_http_params_init(&connection->response_params);
 
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
@@ -635,6 +674,7 @@ remove_handle:
 
 free_buffer:
     sol_buffer_fini(&connection->buffer);
+err_buf:
     free(connection);
     return NULL;
 }
@@ -1037,7 +1077,7 @@ failed_easy_init:
 SOL_API struct sol_http_client_connection *
 sol_http_client_request(enum sol_http_method method,
     const char *url, const struct sol_http_params *params,
-    void (*cb)(void *data, const struct sol_http_client_connection *connection,
+    void (*cb)(void *data, struct sol_http_client_connection *connection,
     struct sol_http_response *response),
     const void *data)
 {
@@ -1058,6 +1098,12 @@ SOL_API void
 sol_http_client_connection_cancel(struct sol_http_client_connection *pending)
 {
     SOL_NULL_CHECK(pending);
+
+    if (pending->in_use) {
+        pending->del_timeout = sol_timeout_add(0, schedule_del, pending);
+        SOL_NULL_CHECK(pending->del_timeout);
+        return;
+    }
 
     SOL_INT_CHECK(sol_ptr_vector_remove(&global.connections, pending), < 0);
     destroy_connection(pending);

--- a/src/lib/comms/sol-http-server-impl-microhttpd.c
+++ b/src/lib/comms/sol-http-server-impl-microhttpd.c
@@ -90,9 +90,13 @@ struct sol_http_request {
 
 struct sol_http_progressive_response {
     struct sol_http_request *request;
-    void (*on_del)(void *data, const struct sol_http_progressive_response *progressive);
+    void (*on_close)(void *data, const struct sol_http_progressive_response *progressive);
+    void (*on_feed)(void *data, struct sol_http_progressive_response *progressive, struct sol_blob *blob, int status);
     const void *cb_data;
-    struct sol_buffer buffer;
+    struct sol_ptr_vector pending_blobs;
+    size_t written;
+    size_t tx_size;
+    size_t accumulated_bytes;
     bool delete_me;
     bool graceful_del;
 };
@@ -458,39 +462,55 @@ build_mhd_response(const struct sol_http_response *response, time_t last_modifie
 static void
 progressive_response_del_cb(void *data)
 {
+    struct sol_blob *blob;
+    uint16_t i;
     struct sol_http_progressive_response *progressive = data;
 
-    if (progressive->on_del)
-        progressive->on_del((void *)progressive->cb_data, progressive);
+    SOL_PTR_VECTOR_FOREACH_IDX (&progressive->pending_blobs, blob, i) {
+        if (progressive->on_feed)
+            progressive->on_feed((void *)progressive->cb_data, progressive, blob, -ECANCELED);
+        sol_blob_unref(blob);
+    }
 
-    sol_buffer_fini(&progressive->buffer);
+    if (progressive->on_close)
+        progressive->on_close((void *)progressive->cb_data, progressive);
+
+    sol_ptr_vector_clear(&progressive->pending_blobs);
     free(progressive);
 }
 
 static ssize_t
 progressive_response_cb(void *data, uint64_t pos, char *buf, size_t size)
 {
-    int r;
-    ssize_t len;
+    size_t len;
+    struct sol_blob *blob;
     struct sol_http_progressive_response *progressive = data;
 
     if (progressive->delete_me) {
         if (!progressive->graceful_del ||
-            (progressive->graceful_del && !progressive->buffer.used))
+            (progressive->graceful_del && !sol_ptr_vector_get_len(&progressive->pending_blobs)))
             return MHD_CONTENT_READER_END_OF_STREAM;
     }
 
-    if (!progressive->buffer.used) {
+    if (!sol_ptr_vector_get_len(&progressive->pending_blobs)) {
         MHD_suspend_connection(progressive->request->connection);
         progressive->request->suspended = true;
         return 0;
     }
 
-    len = sol_util_min(size, progressive->buffer.used);
-    memcpy(buf, progressive->buffer.data, len);
+    blob = sol_ptr_vector_get_no_check(&progressive->pending_blobs, 0);
+    len = sol_util_min(size, blob->size);
+    memcpy(buf, (char *)blob->mem + progressive->written, len);
+    progressive->written += len;
 
-    r = sol_buffer_remove_data(&progressive->buffer, 0, len);
-    SOL_INT_CHECK(r, < 0, MHD_CONTENT_READER_END_WITH_ERROR);
+    if (progressive->written == blob->size) {
+        progressive->accumulated_bytes -= blob->size;
+        sol_ptr_vector_del(&progressive->pending_blobs, 0);
+        progressive->written = 0;
+        if (progressive->on_feed)
+            progressive->on_feed((void *)progressive->cb_data, progressive, blob, 0);
+        sol_blob_unref(blob);
+    }
 
     return len;
 }
@@ -1246,9 +1266,7 @@ sol_http_server_send_response(struct sol_http_request *request, struct sol_http_
 
 SOL_API struct sol_http_progressive_response *
 sol_http_server_send_progressive_response(struct sol_http_request *request,
-    const struct sol_http_response *response,
-    void (*on_del)(void *data, const struct sol_http_progressive_response *progressive),
-    const void *cb_data)
+    const struct sol_http_response *response, const struct sol_http_server_progressive_config *config)
 {
     int ret;
     struct sol_http_progressive_response *progressive;
@@ -1257,11 +1275,20 @@ sol_http_server_send_progressive_response(struct sol_http_request *request,
     SOL_NULL_CHECK(request, NULL);
     SOL_NULL_CHECK(request->connection, NULL);
     SOL_NULL_CHECK(response, NULL);
+    SOL_NULL_CHECK(config, NULL);
+
+#ifndef SOL_NO_API_VERSION
+    if (config->api_version != SOL_HTTP_SERVER_PROGRESSIVE_CONFIG_API_VERSION) {
+        SOL_WRN("Incorrect API version for struct sol_http_server_progressive_config."
+            "Expected '%u' - Received: '%u'", SOL_HTTP_SERVER_PROGRESSIVE_CONFIG_API_VERSION, config->api_version);
+        return 0;
+    }
+#endif
 
     progressive = calloc(1, sizeof(*progressive));
     SOL_NULL_CHECK(progressive, NULL);
 
-    sol_buffer_init(&progressive->buffer);
+    sol_ptr_vector_init(&progressive->pending_blobs);
     progressive->request = request;
 
     if (request->suspended) {
@@ -1278,14 +1305,15 @@ sol_http_server_send_progressive_response(struct sol_http_request *request,
 
     SOL_INT_CHECK_GOTO(ret, != MHD_YES, err);
 
-    progressive->on_del = on_del;
-    progressive->cb_data = cb_data;
+    progressive->on_close = config->on_close;
+    progressive->cb_data = config->user_data;
+    progressive->on_feed = config->on_feed;
+    progressive->tx_size = config->tx_size;
 
     return progressive;
 
 err:
     MHD_destroy_response(mhd_response);
-    sol_buffer_fini(&progressive->buffer);
     free(progressive);
     return NULL;
 }
@@ -1307,20 +1335,32 @@ sol_http_progressive_response_del(struct sol_http_progressive_response *progress
 
 SOL_API int
 sol_http_progressive_response_feed(struct sol_http_progressive_response *progressive,
-    const struct sol_str_slice data)
+    struct sol_blob *blob)
 {
     int ret;
+    size_t total;
 
     SOL_NULL_CHECK(progressive, -EINVAL);
     SOL_EXP_CHECK(progressive->delete_me == true, -EINVAL);
+    SOL_NULL_CHECK(blob, -EINVAL);
 
-    ret = sol_buffer_append_slice(&progressive->buffer, data);
+    ret = sol_util_size_add(progressive->accumulated_bytes, blob->size, &total);
     SOL_INT_CHECK(ret, < 0, ret);
+
+    if (progressive->tx_size && total >= progressive->tx_size)
+        return -ENOSPC;
+
+    ret = sol_ptr_vector_append(&progressive->pending_blobs, blob);
+    SOL_INT_CHECK(ret, < 0, ret);
+
+    sol_blob_ref(blob);
 
     if (progressive->request->suspended) {
         progressive->request->suspended = false;
         MHD_resume_connection(progressive->request->connection);
     }
+
+    progressive->accumulated_bytes += total;
 
     return 0;
 }

--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -22,6 +22,7 @@
 
 #include <errno.h>
 #include <sol-str-slice.h>
+#include <sol-types.h>
 #include <stdarg.h>
 
 #ifdef __cplusplus
@@ -976,6 +977,17 @@ int sol_buffer_ensure_nul_byte(struct sol_buffer *buf);
  * the data is not released. If that is wanted, one should call @ref sol_buffer_trim
  */
 int sol_buffer_remove_data(struct sol_buffer *buf, size_t offset, size_t size);
+
+
+/**
+ * @brief Convert a buffer to a struct @ref sol_blob
+ *
+ * The buffer will be stolen by the created blob.
+ *
+ * @param buf The buf to be transformed in a blob
+ * @return a blob or NULL on error
+ */
+struct sol_blob *sol_buffer_to_blob(struct sol_buffer *buf);
 
 /**
  * @}

--- a/src/lib/datatypes/sol-buffer.c
+++ b/src/lib/datatypes/sol-buffer.c
@@ -876,3 +876,24 @@ sol_buffer_fini(struct sol_buffer *buf)
     buf->used = 0;
     buf->capacity = 0;
 }
+
+SOL_API struct sol_blob *
+sol_buffer_to_blob(struct sol_buffer *buf)
+{
+    struct sol_blob *blob;
+    size_t s;
+    void *v;
+
+    SOL_NULL_CHECK(buf, NULL);
+
+    v = sol_buffer_steal_or_copy(buf, &s);
+    SOL_NULL_CHECK(v, NULL);
+
+    blob = sol_blob_new(&SOL_BLOB_TYPE_DEFAULT, NULL, v, s);
+    SOL_NULL_CHECK_GOTO(blob, err_blob);
+    return blob;
+
+err_blob:
+    free(v);
+    return NULL;
+}

--- a/src/modules/flow-metatype/http-composed-client/http-composed-client-code.h
+++ b/src/modules/flow-metatype/http-composed-client/http-composed-client-code.h
@@ -131,7 +131,7 @@
     "}\n" \
     "static void\n" \
     "http_composed_client_request_finished(void *data,\n" \
-    "    const struct sol_http_client_connection *connection,\n" \
+    "    struct sol_http_client_connection *connection,\n" \
     "    struct sol_http_response *response)\n" \
     "{\n" \
     "    int r = 0;\n" \

--- a/src/modules/flow-metatype/http-composed-client/http-composed-client.c
+++ b/src/modules/flow-metatype/http-composed-client/http-composed-client.c
@@ -266,7 +266,7 @@ http_composed_client_create_packet(const struct sol_flow_packet_type *type,
 
 static void
 http_composed_client_request_finished(void *data,
-    const struct sol_http_client_connection *connection,
+    struct sol_http_client_connection *connection,
     struct sol_http_response *response)
 {
     int r = 0;

--- a/src/modules/flow/flower-power/flower-power.c
+++ b/src/modules/flow/flower-power/flower-power.c
@@ -203,7 +203,7 @@ http_get_close(struct sol_flow_node *node, void *data)
 
 static void
 generate_token_cb(void *data,
-    const struct sol_http_client_connection *connection,
+    struct sol_http_client_connection *connection,
     struct sol_http_response *response)
 {
     struct http_get_data *mdata = data;
@@ -516,7 +516,7 @@ sol_flower_power_sensor_send_packet_components(struct sol_flow_node *src,
 }
 
 static void
-http_get_cb(void *data, const struct sol_http_client_connection *connection,
+http_get_cb(void *data, struct sol_http_client_connection *connection,
     struct sol_http_response *response)
 {
     struct http_get_data *mdata = data;

--- a/src/modules/flow/http-client/http-client.c
+++ b/src/modules/flow/http-client/http-client.c
@@ -78,7 +78,7 @@ struct http_client_node_type {
     void (*close_node)(struct sol_flow_node *node, void *data);
     int (*setup_params)(struct http_data *mdata, struct sol_http_params *params);
     void (*http_response)(void *data,
-        const struct sol_http_client_connection *conn,
+        struct sol_http_client_connection *conn,
         struct sol_http_response *response);
 };
 
@@ -253,7 +253,7 @@ common_url_process(struct sol_flow_node *node, void *data, uint16_t port, uint16
 
 static void
 remove_connection(struct http_data *mdata,
-    const struct sol_http_client_connection *connection)
+    struct sol_http_client_connection *connection)
 {
     if (sol_ptr_vector_remove(&mdata->pending_conns, connection) < 0)
         SOL_WRN("Failed to find pending connection %p", connection);
@@ -265,7 +265,7 @@ remove_connection(struct http_data *mdata,
  */
 static int
 check_response(struct http_data *mdata, struct sol_flow_node *node,
-    const struct sol_http_client_connection *connection,
+    struct sol_http_client_connection *connection,
     struct sol_http_response *response)
 {
 
@@ -356,7 +356,7 @@ is_accepted_content_type(const char *content_type, const char *accept)
 
 static void
 request_finished(void *data,
-    const struct sol_http_client_connection *connection,
+    struct sol_http_client_connection *connection,
     struct sol_http_response *response, bool accept_empty_response)
 {
     int ret;
@@ -415,15 +415,15 @@ err:
 
 static void
 common_request_finished(void *data,
-    const struct sol_http_client_connection *connection,
+    struct sol_http_client_connection *connection,
     struct sol_http_response *response)
 {
     request_finished(data, connection, response, false);
 }
 
 static ssize_t
-sse_received_data_cb(void *data, const struct sol_http_client_connection *conn,
-    struct sol_buffer *buf)
+sse_received_data_cb(void *data, struct sol_http_client_connection *conn,
+    const struct sol_buffer *buf)
 {
     struct sol_flow_node *node = data;
     const struct http_client_node_type *type;
@@ -483,7 +483,7 @@ exit:
 
 static void
 sse_response_end_cb(void *data,
-    const struct sol_http_client_connection *conn,
+    struct sol_http_client_connection *conn,
     struct sol_http_response *response)
 {
     struct sol_flow_node *node = data;
@@ -1523,7 +1523,7 @@ clear_sol_key_value_vector(struct sol_vector *vector)
 
 static void
 request_node_http_response(void *data,
-    const struct sol_http_client_connection *conn,
+    struct sol_http_client_connection *conn,
     struct sol_http_response *response)
 {
     struct sol_flow_node *node = data;

--- a/src/modules/flow/location/location.c
+++ b/src/modules/flow/location/location.c
@@ -37,7 +37,7 @@ struct freegeoip_data {
 
 static void
 freegeoip_query_finished(void *data,
-    const struct sol_http_client_connection *connection,
+    struct sol_http_client_connection *connection,
     struct sol_http_response *response)
 {
     struct freegeoip_data *mdata = data;

--- a/src/modules/flow/oauth/oauth.c
+++ b/src/modules/flow/oauth/oauth.c
@@ -81,7 +81,7 @@ server_unref(void)
 
 static void
 v1_access_finished(void *data,
-    const struct sol_http_client_connection *connection,
+    struct sol_http_client_connection *connection,
     struct sol_http_response *response)
 {
     int r;
@@ -296,7 +296,7 @@ err:
 
 static void
 v1_request_finished(void *data,
-    const struct sol_http_client_connection *connection,
+    struct sol_http_client_connection *connection,
     struct sol_http_response *response)
 {
     int r;

--- a/src/modules/flow/thingspeak/thingspeak.c
+++ b/src/modules/flow/thingspeak/thingspeak.c
@@ -111,7 +111,7 @@ thingspeak_execute_close(struct sol_flow_node *node, void *data)
 
 static void
 thingspeak_execute_poll_finished(void *data,
-    const struct sol_http_client_connection *connection,
+    struct sol_http_client_connection *connection,
     struct sol_http_response *response)
 {
     struct thingspeak_execute_data *mdata = data;
@@ -215,7 +215,7 @@ thingspeak_execute_open(struct sol_flow_node *node, void *data, const struct sol
 
 static void
 thingspeak_add_request_finished(void *data,
-    const struct sol_http_client_connection *connection,
+    struct sol_http_client_connection *connection,
     struct sol_http_response *response)
 {
     struct thingspeak_add_data *mdata = data;
@@ -350,7 +350,7 @@ thingspeak_add_open(struct sol_flow_node *node, void *data, const struct sol_flo
 
 static void
 thingspeak_channel_update_finished(void *data,
-    const struct sol_http_client_connection *connection,
+    struct sol_http_client_connection *connection,
     struct sol_http_response *response)
 {
     struct thingspeak_channel_update_data *mdata = data;

--- a/src/modules/flow/twitter/twitter.c
+++ b/src/modules/flow/twitter/twitter.c
@@ -92,7 +92,7 @@ end:
 
 static void
 twitter_request_finished(void *data,
-    const struct sol_http_client_connection *connection,
+    struct sol_http_client_connection *connection,
     struct sol_http_response *response)
 {
     int r = EINVAL;

--- a/src/modules/update/update-common/http.c
+++ b/src/modules/update/update-common/http.c
@@ -87,7 +87,7 @@ err_size:
 }
 
 static void
-task_get_metadata_response(void *data, const struct sol_http_client_connection *conn,
+task_get_metadata_response(void *data, struct sol_http_client_connection *conn,
     struct sol_http_response *http_response)
 {
     struct update_http_handle *handle = data;
@@ -173,7 +173,7 @@ err_url:
 }
 
 static void
-task_fetch_response(void *data, const struct sol_http_client_connection *conn,
+task_fetch_response(void *data, struct sol_http_client_connection *conn,
     struct sol_http_response *http_response)
 {
     struct update_http_handle *handle = data;
@@ -204,8 +204,8 @@ task_fetch_response(void *data, const struct sol_http_client_connection *conn,
 }
 
 static ssize_t
-task_fetch_recv(void *data, const struct sol_http_client_connection *conn,
-    struct sol_buffer *buffer)
+task_fetch_recv(void *data, struct sol_http_client_connection *conn,
+    const struct sol_buffer *buffer)
 {
     struct update_http_handle *handle = data;
 

--- a/src/samples/http/client.c
+++ b/src/samples/http/client.c
@@ -37,7 +37,7 @@
 static bool verbose = false;
 
 static void
-response_cb(void *userdata, const struct sol_http_client_connection *connection,
+response_cb(void *userdata, struct sol_http_client_connection *connection,
     struct sol_http_response *response)
 {
 

--- a/src/samples/http/download.c
+++ b/src/samples/http/download.c
@@ -29,8 +29,8 @@ static FILE *fd;
 struct sol_http_client_connection *pending;
 
 static ssize_t
-recv_func(void *userdata, const struct sol_http_client_connection *connection,
-    struct sol_buffer *buffer)
+recv_func(void *userdata, struct sol_http_client_connection *connection,
+    const struct sol_buffer *buffer)
 {
     ssize_t ret;
 
@@ -44,7 +44,7 @@ recv_func(void *userdata, const struct sol_http_client_connection *connection,
 }
 
 static void
-response_func(void *userdata, const struct sol_http_client_connection *connection,
+response_func(void *userdata, struct sol_http_client_connection *connection,
     struct sol_http_response *response)
 {
     fclose(fd);

--- a/src/samples/http/server-sse.c
+++ b/src/samples/http/server-sse.c
@@ -72,14 +72,28 @@ static struct sol_ptr_vector responses = SOL_PTR_VECTOR_INIT;
 static int port = 8080;
 static bool should_quit = false;
 
+static struct sol_blob sse_prefix = {
+    .type = &SOL_BLOB_TYPE_NO_FREE,
+    .parent = NULL,
+    .mem = (void *)"data: ",
+    .size = sizeof("data: ") - 1,
+    .refcnt = 1
+};
+
+static struct sol_blob sse_suffix = {
+    .type = &SOL_BLOB_TYPE_NO_FREE,
+    .parent = NULL,
+    .mem = (void *)"\n\n",
+    .size = sizeof("\n\n") - 1,
+    .refcnt = 1
+};
+
 static bool
 on_stdin(void *data, int fd, uint32_t flags)
 {
     uint16_t i;
     struct sol_http_progressive_response *sse;
     struct sol_buffer value = SOL_BUFFER_INIT_EMPTY;
-    static const struct sol_str_slice begin = SOL_STR_SLICE_LITERAL("data: ");
-    static const struct sol_str_slice end = SOL_STR_SLICE_LITERAL("\n\n");
 
     if (flags & (SOL_FD_FLAGS_ERR | SOL_FD_FLAGS_HUP)) {
         fprintf(stderr, "ERROR: Something wrong happened with file descriptor: %d\n", fd);
@@ -88,6 +102,7 @@ on_stdin(void *data, int fd, uint32_t flags)
 
     if (flags & SOL_FD_FLAGS_IN) {
         int err;
+        struct sol_blob *blob;
 
         /* this will loop trying to read as much data as possible to buffer. */
         err = sol_util_load_file_fd_buffer(fd, &value);
@@ -104,24 +119,19 @@ on_stdin(void *data, int fd, uint32_t flags)
             SOL_PTR_VECTOR_FOREACH_IDX (&responses, sse, i)
                 sol_http_progressive_response_del(sse, true);
             goto end;
-        } else {
-            err = sol_buffer_insert_slice(&value, 0, begin);
-            if (err < 0) {
-                fprintf(stderr, "ERROR: failed to append the data prefix: %s\n",
-                    sol_util_strerrora(-err));
-                goto err;
-            }
-
-            err = sol_buffer_append_slice(&value, end);
-            if (err < 0) {
-                fprintf(stderr, "ERROR: Could not prepend data to buffer: %s\n",
-                    sol_util_strerrora(-err));
-                goto err;
-            }
         }
 
-        SOL_PTR_VECTOR_FOREACH_IDX (&responses, sse, i)
-            sol_http_progressive_response_feed(sse, sol_buffer_get_slice(&value));
+        blob = sol_buffer_to_blob(&value);
+        if (!blob) {
+            fprintf(stderr, "Could not alloc the blob data\n");
+            goto err;
+        }
+        SOL_PTR_VECTOR_FOREACH_IDX (&responses, sse, i) {
+            sol_http_progressive_response_feed(sse, &sse_prefix);
+            sol_http_progressive_response_feed(sse, blob);
+            sol_http_progressive_response_feed(sse, &sse_suffix);
+        }
+        sol_blob_unref(blob);
     }
 
     sol_buffer_fini(&value);
@@ -144,6 +154,18 @@ delete_cb(void *data, const struct sol_http_progressive_response *sse)
         sol_quit();
 }
 
+static void
+on_feed_cb(void *data, struct sol_http_progressive_response *sse, struct sol_blob *blob, int status)
+{
+    struct sol_str_slice slice = sol_str_slice_from_blob(blob);
+
+    if (sol_str_slice_str_eq(slice, "data: ") || sol_str_slice_str_eq(slice, "\n\n"))
+        return;
+    if (isspace(slice.data[slice.len - 1]))
+        slice.len--;
+    printf("Blob data *%.*s* sent\n", SOL_STR_SLICE_PRINT(slice));
+}
+
 static int
 request_events_cb(void *data, struct sol_http_request *request)
 {
@@ -155,12 +177,17 @@ request_events_cb(void *data, struct sol_http_request *request)
         .response_code = SOL_HTTP_STATUS_OK,
         .content = SOL_BUFFER_INIT_EMPTY
     };
+    struct sol_http_server_progressive_config config = {
+        SOL_SET_API_VERSION(.api_version = SOL_HTTP_SERVER_PROGRESSIVE_CONFIG_API_VERSION, )
+        .on_close = delete_cb,
+        .on_feed = on_feed_cb
+    };
 
     ret = sol_http_response_set_sse_headers(&response);
     if (ret < 0)
         return ret;
 
-    sse = sol_http_server_send_progressive_response(request, &response, delete_cb, NULL);
+    sse = sol_http_server_send_progressive_response(request, &response, &config);
     sol_http_params_clear(&response.param);
     if (!sse)
         return -1;


### PR DESCRIPTION
Signed-off-by: Guilherme Iscaro <guilherme.iscaro@intel.com>

CHanges since v2:
* Minor fixes pointed by @barbieri 
* The user is now able to delete the `sol_http_client_connection` from the callbacks `send_cb` `response_cb` `recv_cb`