### PR TITLE
Fix a memory issues in coap and oic.

### DIFF
--- a/bindings/nodejs/src/functions/oic-server.cc
+++ b/bindings/nodejs/src/functions/oic-server.cc
@@ -230,7 +230,7 @@ NAN_METHOD(bind_sol_oic_server_unregister_resource) {
     Nan::SetInternalFieldPointer(jsResourceInfo, 0, 0);
 }
 
-NAN_METHOD(bind_sol_oic_server_send_notification_to_observers) {
+NAN_METHOD(bind_sol_oic_server_notify) {
     VALIDATE_ARGUMENT_COUNT(info, 2);
     VALIDATE_ARGUMENT_TYPE(info, 0, IsObject);
     VALIDATE_ARGUMENT_TYPE_OR_NULL(info, 1, IsObject);
@@ -260,7 +260,7 @@ NAN_METHOD(bind_sol_oic_server_send_notification_to_observers) {
     }
 
     if (result)
-        result = sol_oic_server_send_notification_to_observers(notification) == 0;
+        result = sol_oic_server_notify(notification) == 0;
     else
         sol_oic_server_response_free(notification);
     info.GetReturnValue().Set(Nan::New(result));

--- a/bindings/nodejs/tests/helpers/observation-server.js
+++ b/bindings/nodejs/tests/helpers/observation-server.js
@@ -58,7 +58,7 @@ console.log( JSON.stringify( { ready: true } ) );
 
 if ( !setObservable ) {
 	theInterval = setInterval( function() {
-		soletta.sol_oic_server_send_notification_to_observers( theResource, payload.generate() );
+		soletta.sol_oic_server_notify( theResource, payload.generate() );
 	}, 200 );
 }
 

--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -1409,7 +1409,7 @@ server_resource_perform_update(void *data)
         return false;
     }
 
-    if (sol_oic_server_send_notification_to_observers(notification) < 0) {
+    if (sol_oic_server_notify(notification) < 0) {
         SOL_WRN("Error while serializing update message");
     } else {
         resource->funcs->inform_flow(resource);

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -688,7 +688,8 @@ int sol_coap_find_options(const struct sol_coap_packet *pkt, uint16_t code, stru
  * If a response is expected, then sol_coap_send_packet_with_reply() should
  * be used instead.
  *
- * @note This function will take the reference of the given @a pkt.
+ * @note This function will take the reference of the given @a pkt and do a
+ * release its memory even on errors.
  *
  * @param server The server through which the packet will be sent.
  * @param pkt The packet to send.
@@ -756,6 +757,9 @@ int sol_coap_send_packet_with_reply(struct sol_coap_server *server, struct sol_c
  * @param pkt The notification packet to send.
  *
  * @return 0 on success, -errno on failure.
+ *
+ * @note This function will take the reference of the given @a pkt and do a
+ * release its memory even on errors.
  *
  * @see sol_coap_send_packet()
  * @see sol_coap_send_packet_with_reply()

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -560,7 +560,7 @@ struct sol_coap_packet *sol_coap_packet_new_request(enum sol_coap_method method,
  * simplifies the creation of the notification packet by handling the management
  * of the resource age (and setting the id) and type of the packet.
  *
- * It should be used along sol_coap_packet_send_notification() to ensure that
+ * It should be used along sol_coap_notify() to ensure that
  * the correct token is added to the packet sent to the clients.
  *
  * @param server The server holding the resource that changed.
@@ -568,7 +568,7 @@ struct sol_coap_packet *sol_coap_packet_new_request(enum sol_coap_method method,
  *
  * @return A new packet, with @c id and @c type set accordingly, or NULL on failure.
  *
- * @see sol_coap_packet_send_notification()
+ * @see sol_coap_notify()
  */
 struct sol_coap_packet *sol_coap_packet_new_notification(struct sol_coap_server *server,
     struct sol_coap_resource *resource);
@@ -764,7 +764,7 @@ int sol_coap_send_packet_with_reply(struct sol_coap_server *server, struct sol_c
  * @see sol_coap_send_packet()
  * @see sol_coap_send_packet_with_reply()
  */
-int sol_coap_packet_send_notification(struct sol_coap_server *server,
+int sol_coap_notify(struct sol_coap_server *server,
     struct sol_coap_resource *resource, struct sol_coap_packet *pkt);
 
 /**

--- a/src/lib/comms/include/sol-oic-server.h
+++ b/src/lib/comms/include/sol-oic-server.h
@@ -196,7 +196,7 @@ void sol_oic_server_unregister_resource(struct sol_oic_server_resource *resource
  *
  * @return @c 0 on success or a negative number on errors.
  */
-int sol_oic_server_send_notification_to_observers(struct sol_oic_response *notification);
+int sol_oic_server_notify(struct sol_oic_response *notification);
 
 /**
  * @brief Create a notification response to send to observing clients of
@@ -206,7 +206,7 @@ int sol_oic_server_send_notification_to_observers(struct sol_oic_response *notif
  *
  * @return A notification response on success or NULL on errors.
  *
- * @see sol_oic_server_send_notification_to_observers
+ * @see sol_oic_server_notify
  */
 struct sol_oic_response *sol_oic_server_notification_new(struct sol_oic_server_resource *resource);
 

--- a/src/lib/comms/include/sol-oic.h
+++ b/src/lib/comms/include/sol-oic.h
@@ -370,7 +370,7 @@ struct sol_oic_repr_field {
  * This structure is used in callback parameters so users can add fields to an
  * oic packet using @ref sol_oic_map_append().
  *
- * @see sol_oic_server_send_notification_to_observers()
+ * @see sol_oic_server_notify()
  * @see sol_oic_client_resource_request()
  */
 struct sol_oic_map_writer;
@@ -504,7 +504,7 @@ bool sol_oic_map_loop_next(struct sol_oic_repr_field *repr, struct sol_oic_map_r
  *
  * @return @c 0 on success, error code (always negative) otherwise.
  *
- * @see sol_oic_server_send_notification_to_observers()
+ * @see sol_oic_server_notify()
  * @see sol_oic_client_resource_request()
  * @note As this function adds elements to @a oic_map_writer, it will update
  * its type to SOL_OIC_MAP_CONTENT when needed.

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -960,7 +960,7 @@ find_context(struct sol_coap_server *server, const struct sol_coap_resource *res
 }
 
 SOL_API int
-sol_coap_packet_send_notification(struct sol_coap_server *server,
+sol_coap_notify(struct sol_coap_server *server,
     struct sol_coap_resource *resource, struct sol_coap_packet *pkt)
 {
     struct resource_observer *o;

--- a/src/lib/comms/sol-lwm2m.c
+++ b/src/lib/comms/sol-lwm2m.c
@@ -2865,7 +2865,7 @@ send_notification_pkt(struct sol_lwm2m_client *client,
     ret = handle_read(client, obj_ctx, obj_instance, resource_id, pkt);
     SOL_INT_CHECK_GOTO(ret, != SOL_COAP_RESPONSE_CODE_CONTENT, err_exit);
 
-    return sol_coap_packet_send_notification(client->coap_server,
+    return sol_coap_notify(client->coap_server,
         resource, pkt) == 0;
 
 err_exit:

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -1125,7 +1125,7 @@ error:
 }
 
 SOL_API int
-sol_oic_server_send_notification_to_observers(struct sol_oic_response *notification)
+sol_oic_server_notify(struct sol_oic_response *notification)
 {
     int r = -ENOTCONN;
 

--- a/src/samples/coap/simple-server.c
+++ b/src/samples/coap/simple-server.c
@@ -188,7 +188,7 @@ update_light(void *data)
     r = light_resource_to_rep(resource, get_scrolllock_led(), buf);
     SOL_INT_CHECK_GOTO(r, < 0, err);
 
-    return !sol_coap_packet_send_notification(server, resource, pkt);
+    return !sol_coap_notify(server, resource, pkt);
 
 err:
     sol_coap_packet_unref(pkt);


### PR DESCRIPTION
 - Fix a invalid memory access in Oic server
 - Fix memory leaks in CoAP
 - Rename notification functions in OIC and CoAP to a proper name

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>