### PR TITLE
Crypto: It should follow the stream design pattern. V2

### DIFF
--- a/src/samples/crypto/message-digest.c
+++ b/src/samples/crypto/message-digest.c
@@ -89,7 +89,7 @@ print_time(const struct feed_ctx *ctx, size_t amount, const char *prefix)
 }
 
 static void
-on_feed_done(void *data, struct sol_message_digest *handle, struct sol_blob *input)
+on_feed_done(void *data, struct sol_message_digest *handle, struct sol_blob *input, int status)
 {
     struct feed_ctx *ctx = data;
 

--- a/src/test/test-message-digest.c
+++ b/src/test/test-message-digest.c
@@ -174,7 +174,7 @@ on_timeout_do_chunked_internal(void *data)
 }
 
 static void
-on_feed_done_chunked(void *data, struct sol_message_digest *handle, struct sol_blob *input)
+on_feed_done_chunked(void *data, struct sol_message_digest *handle, struct sol_blob *input, int status)
 {
     /* feed more after we're done with our previous data */
     on_timeout_do_chunked_internal(data);


### PR DESCRIPTION
Changes since v1:
* Renamed `tx_size` to `feed_size`
* The function `_sol_message_digest_thread_fini` now callback `on_feed_done` with `-ECANCELED`