### PR TITLE
iio: set the shift data as 64 bit

### DIFF
--- a/src/lib/io/sol-iio.c
+++ b/src/lib/io/sol-iio.c
@@ -953,7 +953,7 @@ sol_iio_add_channel(struct sol_iio_device *device, const char *name, const struc
             goto error;
         }
 
-        channel->mask = (1 << channel->bits) - 1;
+        channel->mask = ((uint64_t)1 << channel->bits) - 1;
     }
 
     r = sol_ptr_vector_append(&channel->device->channels, channel);


### PR DESCRIPTION
When the bits is 32, the shift data must be cast to 64 bit for correct mask value

issue #2058

Signed-off-by: Yong Li <yong.b.li@intel.com>