### PR TITLE
Node.js bindings: Adapt UART JS bindings to the latest API changes

### DIFF
--- a/bindings/nodejs/configure-bindings.js
+++ b/bindings/nodejs/configure-bindings.js
@@ -94,14 +94,13 @@ for ( oneVariable in process.env ) {
 			] );
 			break;
 		case "USE_UART":
-			/* FIXME: Remove this comment once uart bindings are fixed !
-                          sources = sources.concat( [
+			sources = sources.concat( [
 				"../src/functions/uart.cc",
 				"../src/structures/sol-js-uart.cc"
 			] );
 			headers = headers.concat( [
 				"sol-uart.h"
-			] );*/
+			] );
 			break;
 		case "USE_PWM":
 			sources = sources.concat( [

--- a/bindings/nodejs/lib/uart.js
+++ b/bindings/nodejs/lib/uart.js
@@ -36,17 +36,22 @@ exports.open = function( init ) {
             parity: soletta.sol_uart_parity_from_str( parity ),
             stop_bits: soletta.sol_uart_stop_bits_from_str( stopBits ),
             flow_control: flowControl,
-            callback: function( data ) {
+            on_data: function( data ) {
                 callback_data[0].dispatchEvent( "read", {
                     type: "read",
                     data: data
+                } );
+            },
+            on_feed_done: function( cb_status ) {
+                callback_data[0].dispatchEvent( "write", {
+                    type: "write"
                 } );
             },
         }
 
         var uart = soletta.sol_uart_open( init.port, config );
         if ( !uart ) {
-            reject( new Error( "Could not open SPI device" ) );
+            reject( new Error( "Could not open UART device" ) );
             return;
         }
         connection = UARTConnection( uart );
@@ -75,13 +80,17 @@ _.extend( UARTConnection.prototype, {
             else
                 buffer = new Buffer( value );
 
-            var returnStatus = soletta.sol_uart_write( this._connection, buffer,
-                function( data, dataSize ) {
+            var returnStatus = soletta.sol_uart_feed( this._connection, buffer,
+                function( cb_status ) {
+                if ( cb_status < 0 ) {
+                    reject( new Error( "UART write failed" ) );
+                } else {
                     fulfill();
+                }
             });
 
-            if ( !returnStatus ) {
-                reject( new Error( "UART transmission failed" ) );
+            if ( ( typeof returnStatus === 'undefined' ) || returnStatus < 0) {
+                reject( new Error( "UART write failed" ) );
             }
         }, this ) );
     },

--- a/bindings/nodejs/src/structures/sol-js-uart.cc
+++ b/bindings/nodejs/src/structures/sol-js-uart.cc
@@ -38,15 +38,26 @@ bool c_sol_uart_config(v8::Local<v8::Object> jsUARTConfig,
     VALIDATE_AND_ASSIGN((*config), stop_bits, sol_uart_stop_bits, IsInt32,
         "(Amount of stop bits)", false, jsUARTConfig, Int32Value);
 
-    Local<Value> read_cb = Nan::Get(jsUARTConfig,
-        Nan::New("callback").ToLocalChecked()).ToLocalChecked();
-    if (read_cb->IsFunction()) {
-        Nan::Callback *rx_cb =
-            new Nan::Callback(Local<Function>::Cast(read_cb));
+    Local<Value> on_data_cb = Nan::Get(jsUARTConfig,
+        Nan::New("on_data").ToLocalChecked()).ToLocalChecked();
+    if (on_data_cb->IsFunction()) {
+        Nan::Callback *on_data =
+            new Nan::Callback(Local<Function>::Cast(on_data_cb));
 
-        uart_data->rx_cb = rx_cb;
-        config->rx_cb_user_data = uart_data;
+        uart_data->on_data_cb = on_data;
     }
+
+    Local<Value> on_feed_done_cb = Nan::Get(jsUARTConfig,
+        Nan::New("on_feed_done").ToLocalChecked()).ToLocalChecked();
+    if (on_feed_done_cb->IsFunction()) {
+        Nan::Callback *on_feed_done =
+            new Nan::Callback(Local<Function>::Cast(on_feed_done_cb));
+
+        uart_data->on_feed_done_cb = on_feed_done;
+    }
+    config->user_data = uart_data;
+    config->feed_size = 0;
+    config->data_buffer_size = 0;
 
     VALIDATE_AND_ASSIGN((*config), flow_control, bool, IsBoolean,
         "(Enable software flow control)", false, jsUARTConfig,

--- a/bindings/nodejs/src/structures/sol-js-uart.h
+++ b/bindings/nodejs/src/structures/sol-js-uart.h
@@ -21,11 +21,18 @@
 
 #include <v8.h>
 #include <sol-uart.h>
+#include <map>
+
+struct CallbackInfo {
+  Nan::Callback *callback;
+  Nan::Persistent<v8::Value> *js_buffer;
+};
 
 struct sol_uart_data {
     sol_uart *uart;
-    Nan::Callback *rx_cb;
-    Nan::Callback *tx_cb;
+    Nan::Callback *on_data_cb;
+    Nan::Callback *on_feed_done_cb;
+    std::map<sol_blob *, CallbackInfo *> feed_callbacks_map;
 };
 
 bool c_sol_uart_config(v8::Local<v8::Object> UARTConfig, sol_uart_data *data,

--- a/src/samples/nodejs/uart_sample.js
+++ b/src/samples/nodejs/uart_sample.js
@@ -1,0 +1,130 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This sample code demonstrates the usage of UART JS bindings for
+ * reading and writing data to a UART accessible device.
+ *
+ * Setup:
+ * Use two UART cables and connect RX/TX pins in the cable #1 to
+ * TX/RX pins in the cable #2.
+ */
+
+var uart = require( "soletta/uart" ),
+    args = process.argv.slice( 2 ),
+    uartproducer = null,
+    uartConsumer = null;
+
+var options = {
+    help: false,
+    producer,
+    consumer
+};
+
+const usage = "Usage: node uart_sample.js -p <producerUART> -c <consumerUART>\n" +
+    "options: \n" +
+    "  -h, --help \n" +
+    "  -p, --producer <producerUART>\n" +
+    "  -c, --consumer <consumerUART>\n";
+
+for ( var i = 0; i < args.length; i++ ) {
+    var arg = args[ i ];
+
+    switch ( arg ) {
+        case "-h":
+        case "--help":
+            options.help = true;
+            break;
+        case "-p":
+        case "--producer":
+            var producer = args[ i + 1 ];
+            if ( typeof producer == "undefined" ) {
+                console.log( usage );
+                process.exit( 0 );
+            }
+            options.producer = producer;
+            break;
+        case "-c":
+        case "--consumer":
+            var consumer = args[ i + 1 ];
+            if ( typeof consumer == "undefined" ) {
+                console.log( usage );
+                process.exit( 0 );
+            }
+            options.consumer = consumer;
+            break;
+        default:
+            break;
+    }
+}
+
+if ( options.help == true ) {
+    console.log( usage );
+    process.exit( 0 );
+}
+
+if ( !options.producer || !options.consumer ) {
+    console.log( usage );
+    process.exit( 0 );
+}
+
+// Setup UART for writing
+uart.open( {
+    port: options.producer
+} ).then( function( connection ) {
+    uartproducer = connection;
+
+    // Send the data
+    connection.write( "UART test " ).then( function() {
+        connection.write( [ 0x62, 0x75, 0x66, 0x66, 0x65, 0x72 ] ).then( function() {
+            console.log( "UART Producer: Data sent successfully!" );
+        } );
+    } ).catch( function( error ) {
+        console.log( "UART error: ", error );
+        process.exit();
+    } );
+} ).catch( function( error ) {
+    console.log( "UART error: ", error );
+    process.exit();
+} );
+
+// Setup UART for reading
+uart.open( {
+    port: options.consumer
+} ).then( function( connection ) {
+    uartConsumer = connection;
+
+    // Setup 'onread' event handler to receive the data.
+    connection.onread = function( event ) {
+        console.log( "UART Consumer: Received data:", event.data.toString( "utf-8" ) );
+    };
+} );
+
+// Press Ctrl+C to exit the process
+process.on( "SIGINT", function() {
+    process.exit();
+} );
+
+process.on( "exit", function() {
+    if ( uartproducer ) {
+        uartproducer.close();
+    }
+    if ( uartConsumer ) {
+        uartConsumer.close();
+    }
+} );


### PR DESCRIPTION
Adapt UART JS bindings to the latest API changes and enable them by default. Also, add a sample that demonstrates the usage of bindings for reading and writing.

Replaces #2060

Signed-off-by: Sudarsana Nagineni sudarsana.nagineni@intel.com