### PR TITLE
Comms sanity [v2] partially addresses https://github.com/solettaproject/soletta/issues/1820

### DIFF
--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -1744,7 +1744,7 @@ check_updated_boolean(const bool a, const bool b)
 static inline bool
 check_updated_number(const double a, const double b)
 {
-    return !sol_util_double_equal(a, b);
+    return !sol_util_double_eq(a, b);
 }
 
 static inline int

--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -430,7 +430,7 @@ def generate_object_from_repr_vec_fn_common_c(name, props):
     const struct sol_oic_map_reader *repr_vec, uint32_t decode_mask)
 {
     struct sol_oic_repr_field field;
-    enum sol_oic_map_loop_status end_status;
+    enum sol_oic_map_loop_reason end_reason;
     struct sol_oic_map_reader iterator;
     struct %(struct_name)s fields = {
 %(fields_init)s
@@ -438,10 +438,10 @@ def generate_object_from_repr_vec_fn_common_c(name, props):
     bool updated = false;
     int ret = 0;
 
-    SOL_OIC_MAP_LOOP(repr_vec, &field, &iterator, end_status) {
+    SOL_OIC_MAP_LOOP(repr_vec, &field, &iterator, end_reason) {
 %(fields)s
     }
-    if (end_status != SOL_OIC_MAP_LOOP_OK)
+    if (end_reason != SOL_OIC_MAP_LOOP_OK)
         goto out;
 
 %(update_state)s

--- a/src/lib/common/include/sol-platform.h
+++ b/src/lib/common/include/sol-platform.h
@@ -79,7 +79,7 @@ const char *sol_platform_get_board_name(void);
  * the 16 bytes-long (128 bits) UUID encoded as hexadecimal ASCII characters.
  *
  * @note: If the environment variable SOL_MACHINE_ID is set and is
- * properly formatted as an UUID string, its value is returned by this call.
+ * properly formatted as a UUID string, its value is returned by this call.
  *
  * @return On success, it returns the machine id string, that must not be
  * modified. On error, it returns @c NULL.

--- a/src/lib/common/include/sol-types.h
+++ b/src/lib/common/include/sol-types.h
@@ -138,7 +138,7 @@ struct sol_direction_vector {
  *
  * @return @c true if both are equal, @c false otherwise.
  */
-bool sol_direction_vector_equal(const struct sol_direction_vector *var0, const struct sol_direction_vector *var1);
+bool sol_direction_vector_eq(const struct sol_direction_vector *var0, const struct sol_direction_vector *var1);
 
 /**
  * @brief Data type to describe a location.
@@ -169,7 +169,7 @@ struct sol_rgb {
  *
  * @return @c true if both are equal, @c false otherwise.
  */
-bool sol_rgb_equal(const struct sol_rgb *var0, const struct sol_rgb *var1);
+bool sol_rgb_eq(const struct sol_rgb *var0, const struct sol_rgb *var1);
 
 /**
  * @brief Set a maximum value for all components of a RGB color
@@ -308,7 +308,7 @@ int sol_drange_sub(const struct sol_drange *var0, const struct sol_drange *var1,
  *
  * @return @c true if both are equal, @c false otherwise.
  */
-bool sol_drange_equal(const struct sol_drange *var0, const struct sol_drange *var1);
+bool sol_drange_eq(const struct sol_drange *var0, const struct sol_drange *var1);
 
 /**
  * @brief Initializes @c result with the given @c spec and @c value.
@@ -447,7 +447,7 @@ int sol_irange_sub(const struct sol_irange *var0, const struct sol_irange *var1,
  *
  * @return @c true if both are equal, @c false otherwise.
  */
-bool sol_irange_equal(const struct sol_irange *var0, const struct sol_irange *var1);
+bool sol_irange_eq(const struct sol_irange *var0, const struct sol_irange *var1);
 
 /**
  * @brief Initializes @c result with the given @c spec and @c value.

--- a/src/lib/common/sol-types.c
+++ b/src/lib/common/sol-types.c
@@ -110,15 +110,15 @@ sol_drange_sub(const struct sol_drange *var0, const struct sol_drange *var1, str
 }
 
 SOL_API bool
-sol_drange_equal(const struct sol_drange *var0, const struct sol_drange *var1)
+sol_drange_eq(const struct sol_drange *var0, const struct sol_drange *var1)
 {
     SOL_NULL_CHECK(var0, false);
     SOL_NULL_CHECK(var1, false);
 
-    if (sol_util_double_equal(var0->val, var1->val) &&
-        sol_util_double_equal(var0->min, var1->min) &&
-        sol_util_double_equal(var0->max, var1->max) &&
-        sol_util_double_equal(var0->step, var1->step))
+    if (sol_util_double_eq(var0->val, var1->val) &&
+        sol_util_double_eq(var0->min, var1->min) &&
+        sol_util_double_eq(var0->max, var1->max) &&
+        sol_util_double_eq(var0->step, var1->step))
         return true;
 
     return false;
@@ -198,7 +198,7 @@ sol_irange_add(const struct sol_irange *var0, const struct sol_irange *var1, str
 }
 
 SOL_API bool
-sol_irange_equal(const struct sol_irange *var0, const struct sol_irange *var1)
+sol_irange_eq(const struct sol_irange *var0, const struct sol_irange *var1)
 {
     SOL_NULL_CHECK(var0, false);
     SOL_NULL_CHECK(var1, false);
@@ -406,7 +406,7 @@ sol_rgb_set_max(struct sol_rgb *color, uint32_t max_value)
 }
 
 SOL_API bool
-sol_rgb_equal(const struct sol_rgb *var0, const struct sol_rgb *var1)
+sol_rgb_eq(const struct sol_rgb *var0, const struct sol_rgb *var1)
 {
     SOL_NULL_CHECK(var0, false);
     SOL_NULL_CHECK(var1, false);
@@ -423,17 +423,17 @@ sol_rgb_equal(const struct sol_rgb *var0, const struct sol_rgb *var1)
 }
 
 SOL_API bool
-sol_direction_vector_equal(const struct sol_direction_vector *var0,
+sol_direction_vector_eq(const struct sol_direction_vector *var0,
     const struct sol_direction_vector *var1)
 {
     SOL_NULL_CHECK(var0, false);
     SOL_NULL_CHECK(var1, false);
 
-    if (sol_util_double_equal(var0->x, var1->x) &&
-        sol_util_double_equal(var0->y, var1->y) &&
-        sol_util_double_equal(var0->z, var1->z) &&
-        sol_util_double_equal(var0->min, var1->min) &&
-        sol_util_double_equal(var0->max, var1->max))
+    if (sol_util_double_eq(var0->x, var1->x) &&
+        sol_util_double_eq(var0->y, var1->y) &&
+        sol_util_double_eq(var0->z, var1->z) &&
+        sol_util_double_eq(var0->min, var1->min) &&
+        sol_util_double_eq(var0->max, var1->max))
         return true;
     return false;
 }

--- a/src/lib/comms/include/sol-bluetooth.h
+++ b/src/lib/comms/include/sol-bluetooth.h
@@ -114,7 +114,7 @@ int sol_bt_uuid_to_str(const struct sol_bt_uuid *uuid, struct sol_buffer *buffer
  *
  * @return True if UUIDs are equal, False otherwise.
  */
-bool sol_bt_uuid_equal(const struct sol_bt_uuid *u1, const struct sol_bt_uuid *u2);
+bool sol_bt_uuid_eq(const struct sol_bt_uuid *u1, const struct sol_bt_uuid *u2);
 
 /**
  * @brief Represents an active connection to a Bluetooth device.

--- a/src/lib/comms/include/sol-bluetooth.h
+++ b/src/lib/comms/include/sol-bluetooth.h
@@ -67,7 +67,7 @@ enum sol_bt_uuid_type {
 /**
  * @brief Representation of a Bluetooth UUID.
  *
- * In Bluetooth, an UUID represents the type of an entity, for example,
+ * In Bluetooth, a UUID represents the type of an entity, for example,
  * if a service is encountered in a remote device with the 16-bit UUID '0x111F',
  * that service is a "HandsfreeAudioGateway".
  *
@@ -84,7 +84,7 @@ struct sol_bt_uuid {
 };
 
 /**
- * @brief Convert an string to an UUID.
+ * @brief Convert a string to a UUID.
  *
  * @param uuid The uuid in which to store the value.
  * @param str The string from which to convert.
@@ -94,7 +94,7 @@ struct sol_bt_uuid {
 int sol_bt_uuid_from_str(struct sol_bt_uuid *uuid, const struct sol_str_slice str);
 
 /**
- * @brief Convert an string to an UUID.
+ * @brief Convert a string to a UUID.
  *
  * @param uuid The uuid to convert.
  * @param buffer The buffer in which to store the string representation.
@@ -179,8 +179,10 @@ struct sol_bt_conn *sol_bt_connect(const struct sol_network_link_addr *addr,
 /**
  * @brief Terminates a connection, or connection attempt.
  *
- * In case the connection is not already established, the connection attempt
- * will be cancelled after this is called.
+ * In case the connection is not already established, the connection
+ * attempt will be cancelled after this is called, otherwise the @c
+ * on_disconnect() function provided on the call to sol_bt_connect()
+ * will be called.
  *
  * @param conn The reference to a connection.
  *
@@ -206,18 +208,23 @@ struct sol_bt_session;
  * In case the Bluetooth controller is already enabled, the enabled() callback
  * will be called before this function returns.
  *
- * @param enabled Function to be called when the controller changes state.
- * @param user_data User data to be provided to the enabled() callback.
+ * @param on_enabled Function to be called when the controller changes state.
+ * @param user_data User data to be provided to the @a on_enabled callback.
  *
  * @return a reference to a session, used for returning the system to its
  * previous state, @see sol_bt_disable().
  */
 struct sol_bt_session *sol_bt_enable(
-    void (*enabled)(void *data, bool powered),
+    void (*on_enabled)(void *data, bool powered),
     const void *user_data);
 
 /**
  * @brief Disables a session, returning the controller to its previous state.
+ *
+ * In case the session is not already enabled, the enabling attempt
+ * will be cancelled after this is called, otherwise the @c
+ * on_enabled() function provided on the call to sol_bt_enable() will
+ * be called with @c false @c powered argument value.
  *
  * @param session Reference to a session.
  *
@@ -306,8 +313,9 @@ struct sol_bt_scan_pending;
  * discovery will be stopped when the last user calls sol_bt_stop_scan().
  *
  * @param transport The transport in which to discover devices.
- * @param cb The callback to be called for each found device, it may be called
- *        multiple times, when the information about the device changes.
+ * @param on_found The callback to be called for each found device. It
+ *        may be called multiple times, when the information about the
+ *        device changes.
  * @param user_data User data to be passed to the callback.
  *
  * @return pointer to a pending scan session on success, NULL on error,
@@ -315,7 +323,7 @@ struct sol_bt_scan_pending;
  */
 struct sol_bt_scan_pending *sol_bt_start_scan(
     enum sol_bt_transport transport,
-    void (*cb)(void *user_data, const struct sol_bt_device_info *device),
+    void (*on_found)(void *user_data, const struct sol_bt_device_info *device),
     const void *user_data);
 
 /**

--- a/src/lib/comms/include/sol-gatt.h
+++ b/src/lib/comms/include/sol-gatt.h
@@ -176,7 +176,7 @@ struct sol_gatt_attr {
 };
 
 /**
- * @brief Returns a response to a async operation
+ * @brief Returns a response to an asynchronous operation
  *
  * When a operation is performed in a attribute, the response to the operation
  * is only returned when this function is called.
@@ -347,10 +347,12 @@ int sol_gatt_unsubscribe(bool (*cb)(void *user_data, const struct sol_gatt_attr 
     const void *user_data);
 
 /**
- * Sends an indication to the device represented by @a conn, if @a conn is NULL, send to all
- * devices that have registered themselves via the CCC attribute.
+ * Sends an indication to the device represented by @a conn. If @a
+ * conn is @c NULL, it sends to all devices that have registered
+ * themselves via the CCC attribute.
  *
- * The value to be indicated is the value retrieved by calling @a read callback of the attribute.
+ * The value to be indicated is the value retrieved by calling the @a
+ * read callback of the attribute.
  *
  * @param conn Connection in which to send notificatiions/indications.
  * @param attr Attribute to update.
@@ -360,10 +362,12 @@ int sol_gatt_unsubscribe(bool (*cb)(void *user_data, const struct sol_gatt_attr 
 int sol_gatt_indicate(struct sol_bt_conn *conn, const struct sol_gatt_attr *attr);
 
 /**
- * Sends an indication to the device represented by @a conn, if @a conn is NULL, send to all
- * devices that have registered themselves via the CCC attribute.
+ * Sends a notificatiion to the device represented by @a conn. If @a
+ * conn is @c NULL, it sends to all devices that have registered
+ * themselves via the CCC attribute.
  *
- * The value to be notified is the value retrieved by calling @a read callback of the attribute.
+ * The value to be notified is the value retrieved by calling the @a
+ * read callback of the attribute.
  *
  * @param conn Connection in which to send notificatiions/indications.
  * @param attr Attribute to update.

--- a/src/lib/comms/include/sol-http-client.h
+++ b/src/lib/comms/include/sol-http-client.h
@@ -28,18 +28,19 @@ extern "C" {
  * @file
  * @brief HTTP client
  *
- * Library to perform HTTP(s) requests. Buffers whole response in memory,
- * so it's more suitable to remote API calls rather than file transfer.
+ * API to perform HTTP(s) requests. It will buffer whole responses in
+ * memory, so it's more suitable to perform remote API calls than file
+ * transfers.
  */
 
 /**
  * @defgroup HTTP_CLIENT HTTP Client
  * @ingroup HTTP
  *
- * @brief Library to perform HTTP(s) requests.
+ * @brief API to perform HTTP(s) requests.
  *
- * Buffers whole response in memory,
- * so it's more suitable to remote API calls rather than file transfer.
+ * It will buffer whole responses in memory, so it's more suitable to
+ * perform remote API calls than file transfers.
  *
  * @{
  */
@@ -47,7 +48,7 @@ extern "C" {
 
 /**
  * @struct sol_http_client_connection
- * @brief Opaque handler for a HTTP client connection.
+ * @brief Opaque handler for an HTTP client connection.
  *
  * It's created when a request is made with
  * sol_http_client_request() or
@@ -58,9 +59,9 @@ extern "C" {
 struct sol_http_client_connection;
 
 /**
- * @brief The http request interface to use when creating a new request.
+ * @brief The HTTP request interface to use when creating a new request.
  *
- * It allows one have more control over the request, notifying when
+ * It allows one to have more control over the request, notifying when
  * data comes or when data should be sent.
  *
  * @see sol_http_client_request_with_interface()
@@ -84,14 +85,14 @@ struct sol_http_request_interface {
      *
      * The parameters are:
      *
-     * @li @c userdata the context data given in @c sol_http_client_request_with_interface
+     * @li @c user_data the context data given in @c sol_http_client_request_with_interface
      * @li @c connection the connection returned in @c sol_http_client_request_with_interface
      * @li @c buffer the data received
      *
      * @note it is allowed to cancel the connection handle from
      *       inside this callback.
      */
-    ssize_t (*on_data)(void *userdata, struct sol_http_client_connection *connection,
+    ssize_t (*on_data)(void *user_data, struct sol_http_client_connection *connection,
         const struct sol_buffer *buffer);
     /**
      * This callback is called data should be written, it's commonly used for @c POST.
@@ -105,7 +106,7 @@ struct sol_http_request_interface {
      *
      * The parameters are:
      *
-     * @li @c userdata the context data given in @c sol_http_client_request_with_interface
+     * @li @c user_data the context data given in @c sol_http_client_request_with_interface
      * @li @c connection the connection returned in @c sol_http_client_request_with_interface
      * @li @c buffer the buffer where the data should be written, the buffer's capacity indicates
      * the amount of data that should be set.
@@ -113,20 +114,20 @@ struct sol_http_request_interface {
      * @note it is allowed to cancel the connection handle from
      *       inside this callback.
      */
-    ssize_t (*on_send)(void *userdata, struct sol_http_client_connection *connection,
+    ssize_t (*on_send)(void *user_data, struct sol_http_client_connection *connection,
         struct sol_buffer *buffer);
     /**
      * This callback is called when the request finishes, the result of request is available on
      * @c response. @see sol_http_response
      *
-     * @li @c userdata the context data given in @c sol_http_client_request_with_interface
+     * @li @c user_data the context data given in @c sol_http_client_request_with_interface
      * @li @c connection the connection returned in @c sol_http_client_request_with_interface
      * @li @c response the result of the request
      *
      * @note it is allowed to cancel the connection handle from
      *       inside this callback.
      */
-    void (*on_response)(void *userdata, struct sol_http_client_connection *connection,
+    void (*on_response)(void *user_data, struct sol_http_client_connection *connection,
         struct sol_http_response *response);
 
     /**
@@ -138,11 +139,11 @@ struct sol_http_request_interface {
 };
 
 /**
- * @brief Create a request for the specified url using the given method. The result of
+ * @brief Create a request for the specified URL using the given method. The result of
  * the request is obtained in @c cb.
  *
  * One should check the response code on @c sol_http_response to check
- * if the request returned success or with some error. @see sol_http_status_code.
+ * if the request returned success or some error. @see sol_http_status_code.
  *
  * @note It should never be called from response callback given in
  *       sol_http_client_request().
@@ -165,11 +166,11 @@ struct sol_http_client_connection *sol_http_client_request(enum sol_http_method 
     const void *data) SOL_ATTR_WARN_UNUSED_RESULT SOL_ATTR_NONNULL(2, 4);
 
 /**
- * @brief Create a request for the specified url using the given method. The result of
+ * @brief Create a request for the specified URL using the given method. The result of
  * the request is obtained in @c cb.
  *
  * One should check the response code on @c sol_http_response to check
- * if the request returned success or with some error. @see sol_http_status_code.
+ * if the request returned success or some error. @see sol_http_status_code.
  *
  * @note It should never be called from response callback given in
  *       sol_http_client_request().

--- a/src/lib/comms/include/sol-http-server.h
+++ b/src/lib/comms/include/sol-http-server.h
@@ -32,23 +32,23 @@ extern "C" {
  * @file
  * @brief HTTP server
  *
- * Library to make possible run an HTTP server to deliver and
- * set values from others components.
+ * API to make it possible to run an HTTP server to deliver and
+ * set values from other components.
  */
 
 /**
  * @defgroup HTTP_SERVER HTTP Server
  * @ingroup HTTP
  *
- * @brief Library to make possible run an HTTP server to deliver and
- * set values from others components.
+ * @brief API to make it possible to run an HTTP server to deliver and
+ * set values from other components.
  *
  * @{
  */
 
 /**
  * @struct sol_http_server
- * @brief Opaque handler for a HTTP server instance.
+ * @brief Opaque handler for an HTTP server instance.
  *
  * It's created with sol_http_server_new() and should be later
  * deleted with sol_http_server_del()
@@ -80,7 +80,7 @@ struct sol_http_server_config {
 
 /**
  * @struct sol_http_request
- * @brief Opaque handler for a request made to a HTTP server.
+ * @brief Opaque handler for a request made to an HTTP server.
  *
  * Request properties can be queried with:
  * @li sol_http_request_get_url()
@@ -98,23 +98,23 @@ struct sol_http_request;
  *
  * Progressive responses can be used to create server sent events.
  *
- * This response is create with sol_http_server_send_progressive_response()
- * and data can be given using sol_http_progressive_response_feed(),
- * to delete it use sol_http_progressive_response_del().
+ * This response is created with sol_http_server_send_progressive_response()
+ * and data can be given using sol_http_progressive_response_feed().
+ * To delete it use sol_http_progressive_response_del().
  */
 struct sol_http_progressive_response;
 
 /**
- * @brief Creates a HTTP server, binding on all interfaces
+ * @brief Creates an HTTP server, binding on all interfaces
  * in the specified @a port.
  *
- * With the returned handle it's possible to register paths using
- * @c sol_http_server_register_handler()
- * and dirs with @c sol_http_server_add_dir().
+ * With the returned handle it's possible to register paths using @c
+ * sol_http_server_register_handler() and directories to be served
+ * with @c sol_http_server_add_dir().
  *
  * @note Only one instance of @c sol_http_server is possible per port.
- * Try to run a second instance in the
- * same port will result in fail.
+ * Trying to run a second instance in the same port will result in
+ * failure.
  *
  * @param config The parameters to setup the server.
  *
@@ -135,8 +135,9 @@ void sol_http_server_del(struct sol_http_server *server);
  * @brief Register a handler for a specific path.
  *
  * @param server The value got with @c sol_http_server_new()
- * @param path The path where the handler will serve, it means, when a request comes in this path the
- * callback set will be called and a response should be sent back
+ * @param path The path where the handler will serve, it means, when a
+ * request comes in this path the callback set will be called and a
+ * response should be sent back from it
  * @param request_cb The callback for the request received on the specified path
  * @param data The user data passed in the callback
  *

--- a/src/lib/comms/include/sol-http.h
+++ b/src/lib/comms/include/sol-http.h
@@ -103,7 +103,7 @@ enum sol_http_status_code {
  *
  * It's required to make requests, with
  * sol_http_client_request() or sol_http_client_request_with_interface()
- * or to create uris, with sol_http_create_uri() and variants.
+ * or to create URIs, with sol_http_create_uri() and variants.
  */
 struct sol_http_params {
 #ifndef SOL_NO_API_VERSION
@@ -125,17 +125,20 @@ struct sol_http_content_type_priority {
     struct sol_str_slice content_type; /**< The content type itself. Example: @c "text/html" */
     struct sol_str_slice type; /**< The type. Example @c "text" */
     struct sol_str_slice sub_type; /**< The sub type. Example @c "html"*/
-    struct sol_vector tokens; /**< An array of @ref sol_str_slice. For the following contet type @c "text/html;level=1;level2",
-                                 this array would contains @c "level=1" and @c "level=2" */
+    struct sol_vector tokens; /**< An array of @ref sol_str_slice. For
+                                 example, for the content type @c
+                                 "text/html;level=1;level2", this
+                                 array would contain @c "level=1" and
+                                 @c "level=2" */
     double qvalue; /**< The qvalue for the content type */
     uint16_t index; /**< The original index as found in the content type/accept HTTP header */
 };
 
 /**
- * @brief Used to define a HTTP parameter
+ * @brief Used to define an HTTP parameter
  *
- * A parameter is defined by it's type
- * (one of enum @ref sol_http_param_type) and it's value.
+ * A parameter is defined by its type
+ * (one of enum @ref sol_http_param_type) and its value.
  * It may be a key-value parameter, authentication (user-password),
  * or data.
  */
@@ -165,10 +168,10 @@ struct sol_http_param_value {
 };
 
 /**
- * @brief Handle for a HTTP response
+ * @brief Handle for an HTTP response
  *
  * A response is composed by a response code, that may be one of
- * enum @ref sol_http_status_code, a vector of parameters, url,
+ * enum @ref sol_http_status_code, a vector of parameters, URL,
  * definition of content type, like "text" or "application/json",
  * and the response content itself.
  */
@@ -186,7 +189,7 @@ struct sol_http_response {
 };
 
 /**
- * @brief Handle for a HTTP URL
+ * @brief Handle for an HTTP URL
  *
  * Uniform Resource Locator conforms to the following syntax:
  *
@@ -527,11 +530,11 @@ void sol_http_params_clear(struct sol_http_params *params);
 /**
  * @brief Encodes an URL string.
  *
- * If the string was not encoded this function will simple copy
- * the slices content to the buffer and set
- * @c SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED.
+ * If the string was not encoded this function will simply copy the
+ * slice's content to the buffer and set @c
+ * SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED on the buffer's flags.
  *
- * @param buf The buffer that will hold the encoded string - The buffer will be initialized by this function.
+ * @param buf The buffer that will hold the encoded string (it will be initialized by this function)
  * @param value A slice to be encoded.
  *
  * @note if it's required to keep or change the buffer contents
@@ -544,11 +547,11 @@ int sol_http_encode_slice(struct sol_buffer *buf, const struct sol_str_slice val
 /**
  * @brief Decodes an URL string.
  *
- * If the string was not decoded this function will simple copy
- * the slices contents to the buffer and set
- * @c SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED.
+ * If the string was not decoded this function will simply copy the
+ * slice's contents to the buffer and set @c
+ * SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED on the buffer's flags.
  *
- * @param buf The buffer that will hold the decoded string - The buffer will be initialized by this function.
+ * @param buf The buffer that will hold the decoded string (it will be initialized by this function)
  * @param value A slice to be decoded.
  *
  * @note if it's required to keep or change the buffer contents
@@ -559,10 +562,10 @@ int sol_http_encode_slice(struct sol_buffer *buf, const struct sol_str_slice val
 int sol_http_decode_slice(struct sol_buffer *buf, const struct sol_str_slice value);
 
 /**
- * @brief Creates an URI based on struct sol_http_url and its params
+ * @brief Creates an URI based on struct @ref sol_http_url and its parameters
  *
- * @param buf Where the create URI should be appended - The buffer must be already initialized.
- * @param url The url parameters.
+ * @param buf Where the created URI should be appended (the buffer must be already initialized)
+ * @param url The URL parameters.
  * @param params The query and cookies params.
  *
  * @return 0 on success, negative number on error.
@@ -573,8 +576,8 @@ int sol_http_create_uri(struct sol_buffer *buf, const struct sol_http_url url, c
  * @brief A simpler version of sol_http_create_uri().
  *
  *
- * @param buf Where the create URI should be appended - The buffer must be already initialized.
- * @param base_uri The base uri to be used.
+ * @param buf Where the created URI should be appended (the buffer must be already initialized)
+ * @param base_uri The base URI to be used.
  * @param params The query and cookies params.
  *
  * @return 0 on success, negative number on error.
@@ -582,7 +585,7 @@ int sol_http_create_uri(struct sol_buffer *buf, const struct sol_http_url url, c
 int sol_http_create_simple_uri(struct sol_buffer *buf, const struct sol_str_slice base_uri, const struct sol_http_params *params);
 
 /**
- * @brief Encodes http parameters of a given type.
+ * @brief Encodes HTTP parameters of a given type.
  *
  * @param buf Where the encoded parameters will be stored as string.
  * @param type The parameter that should be encoded.
@@ -595,7 +598,7 @@ int sol_http_create_simple_uri(struct sol_buffer *buf, const struct sol_str_slic
 int sol_http_encode_params(struct sol_buffer *buf, enum sol_http_param_type type, const struct sol_http_params *params);
 
 /**
- * @brief Decodes http parameters of a given type.
+ * @brief Decodes HTTP parameters of a given type.
  *
  * @param params_slice Where the decoded parameters will be stored as string.
  * @param type The parameter that should be decoded.
@@ -623,10 +626,10 @@ int sol_http_decode_params(const struct sol_str_slice params_slice, enum sol_htt
 int sol_http_split_uri(const struct sol_str_slice full_uri, struct sol_http_url *url);
 
 /**
- * @brief An wrapper of over sol_http_create_simple_uri()
+ * @brief A wrapper on top of sol_http_create_simple_uri()
  *
- * @param buf Where the create URI should be appended - The buffer must be already initialized.
- * @param base_url The base uri to be used.
+ * @param buf Where the created URI should be appended (the buffer must be already initialized)
+ * @param base_url The base URI to be used.
  * @param params The query and cookies params.
  *
  * @return 0 on success, negative number on error.
@@ -669,7 +672,7 @@ int sol_http_split_post_field(const char *query, struct sol_http_params *params)
  * For more information about how the content type is sorted check: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1
  *
  * @param content_type A content type slice. Example: @c "text/html, application/json;q=0.5"
- * @param priorities An array to store the content type prioriries - It will be initialized by this function.
+ * @param priorities An array to store the content type prioriries (it will be initialized by this function)
  * @see sol_http_content_type_priorities_array_clear()
  * @see @ref sol_http_content_type_priority
  */

--- a/src/lib/comms/include/sol-lwm2m.h
+++ b/src/lib/comms/include/sol-lwm2m.h
@@ -35,7 +35,7 @@ extern "C" {
 
 /**
  * @file
- * @brief Routines that handle LWM2M protocol.
+ * @brief Routines that handle the LWM2M protocol.
  *
  */
 
@@ -43,7 +43,7 @@ extern "C" {
  * @defgroup LWM2M LWM2M
  * @ingroup Comms
  *
- * @brief Routines that handle LWM2M protocol.
+ * @brief Routines that handle the LWM2M protocol.
  *
  * Supported features:
  * - Registration interface.
@@ -97,7 +97,7 @@ struct sol_lwm2m_client_object;
 /**
  * @brief LWM2M Client binding mode.
  *
- * A LWM2M server, may support multiple forms of binding.
+ * A LWM2M server may support multiple forms of binding.
  * The binding mode is requested by a client during its registration.
  *
  * In Queue binding mode a client flags to the server that it
@@ -154,7 +154,7 @@ enum sol_lwm2m_binding_mode {
 };
 
 /**
- * @brief Enum that express a LWM2M client lifecycle changes.
+ * @brief Enum that expresses a LWM2M client lifecycle changes.
  *
  * @see sol_lwm2m_server_add_registration_monitor()
  */
@@ -179,7 +179,7 @@ enum sol_lwm2m_registration_event {
 };
 
 /**
- * @brief Enum that represent a LWM2M response/request content type.
+ * @brief Enum that represents a LWM2M response/request content type.
  */
 enum sol_lwm2m_content_type {
     /**
@@ -203,7 +203,7 @@ enum sol_lwm2m_content_type {
 };
 
 /**
- * @brief Enum that represent the TLV type.
+ * @brief Enum that represents the TLV type.
  * @see #sol_lwm2m_tlv
  */
 enum sol_lwm2m_tlv_type {
@@ -212,7 +212,7 @@ enum sol_lwm2m_tlv_type {
      */
     SOL_LWM2M_TLV_TYPE_OBJECT_INSTANCE = 0,
     /**
-     * The TLV represents an resource instance.
+     * The TLV represents a resource instance.
      */
     SOL_LWM2M_TLV_TYPE_RESOURCE_INSTANCE = 64,
     /**
@@ -226,7 +226,7 @@ enum sol_lwm2m_tlv_type {
 };
 
 /**
- * @brief Enum that represents an LWM2M resource data type.
+ * @brief Enum that represents a LWM2M resource data type.
  * @see #sol_lwm2m_resource
  */
 enum sol_lwm2m_resource_data_type {
@@ -255,7 +255,7 @@ enum sol_lwm2m_resource_data_type {
      */
     SOL_LWM2M_RESOURCE_DATA_TYPE_TIME,
     /**
-     * The resource value is a object link.
+     * The resource value is an object link.
      */
     SOL_LWM2M_RESOURCE_DATA_TYPE_OBJ_LINK,
     /**
@@ -314,7 +314,7 @@ struct sol_lwm2m_tlv {
 };
 
 /**
- * @brief Struct that represents an LWM2M resource.
+ * @brief Struct that represents a LWM2M resource.
  * @see sol_lwm2m_resource_init()
  */
 struct sol_lwm2m_resource {
@@ -406,7 +406,7 @@ struct sol_lwm2m_resource {
  * location object, the create function will be called.
  * When a LWM2M object does not support a certain operation,
  * one must not implement the corresponding method.
- * In order words, if an LWM2M object can't be deleted,
+ * In order words, if a LWM2M object can't be deleted,
  * the @c del handle must be ponting to @c NULL
  *
  * @see sol_lwm2m_client_new()
@@ -467,8 +467,8 @@ struct sol_lwm2m_object {
     /**
      * @brief Writes a resource.
      *
-     * When the LWM2M server requests to write a resource and
-     * flags that the content type of the request is a text or
+     * When the LWM2M server requests to write a resource and flags
+     * that the content type of the request is text, a scalar type or
      * an opaque type, this function will be called.
      *
      * @param instance_data The instance data.
@@ -499,7 +499,7 @@ struct sol_lwm2m_object {
      * @param user_data The data provided during sol_lwm2m_client_new().
      * @param client The LWM2M client.
      * @param instance_id The instance id.
-     * @param tlvs An vector of #sol_lwm2m_tlv
+     * @param tlvs a vector of #sol_lwm2m_tlv
      * @return 0 on success or -errno on error.
      * @note Since TLV does not contains a field to express the
      * data type. It's the user responsibility to know which
@@ -511,10 +511,10 @@ struct sol_lwm2m_object {
     /**
      * @brief Executes a resource.
      *
-     * A LWM2M Object resource may be executable. An executable resource,
+     * A LWM2M Object resource may be executable. An executable resource
      * means that the LWM2M object instance will initiate some action
      * that was requested by the LWM2M server.
-     * As an example, If the LWM2M server wants that the client
+     * As an example, if the LWM2M server wants that the client
      * sends an update request, the LWM2M server will send
      * an execute command on the path "/1/AnServerInstanceId/8", this will
      * trigger the LWM2M client, which will send the update
@@ -639,8 +639,8 @@ int sol_lwm2m_client_send_update(struct sol_lwm2m_client *client);
  * @param client The LWM2M client.
  * @param paths The resource paths that were changed, must be @c NULL terminated.
  * @return 0 on success, -errno on error.
- * @note If a LWM2M server creates an object instance, write on a object instance or
- * write in a object resource, the LWM2M client infrastruct will automatically notify all
+ * @note If a LWM2M server creates an object instance, write on an object instance or
+ * write in an object resource, the LWM2M client infrastruct will automatically notify all
  * observing servers.
  */
 int sol_lwm2m_client_notify(struct sol_lwm2m_client *client, const char **paths);
@@ -654,7 +654,7 @@ int sol_lwm2m_client_notify(struct sol_lwm2m_client *client, const char **paths)
 void sol_lwm2m_resource_clear(struct sol_lwm2m_resource *resource);
 
 /**
- * @brief Initializes an LWM2M resource.
+ * @brief Initializes a LWM2M resource.
  *
  * This function makes it easier to init a LWM2M resource, it
  * will set the proper fields and fill its data. Note that
@@ -771,9 +771,10 @@ int sol_lwm2m_tlv_get_obj_link(struct sol_lwm2m_tlv *tlv, uint16_t *object_id, u
 /**
  * @brief Adds a registration monitor.
  *
- * This function register a monitor, making it easier to observe a LWM2M client's life cycle.
- * This means that every time a LWM2M client is registered, updated, deleted or timedout,
- * @c sol_lwm2m_server_registration_event_cb will be called.
+ * This function registers a monitor, making it easier to observe a
+ * LWM2M client's life cycle. This means that every time a LWM2M
+ * client is registered, updated, deleted or timed out, @a
+ * sol_lwm2m_server_registration_event_cb will be called.
  *
  * @param server The LWM2M server.
  * @param sol_lwm2m_server_registration_event_cb A callback that is used to inform a LWM2M client registration event - @c data User data; @c server The LWM2M server; @c cinfo The client that generated the registration event; @c event The registration event itself.
@@ -808,7 +809,7 @@ int sol_lwm2m_server_del_registration_monitor(struct sol_lwm2m_server *server,
  * @brief Gets all registerd clients.
  *
  * @param server The LWM2M Server.
- * @return An vector of #sol_lwm2m_client_info or @c NULL on error.
+ * @return a vector of #sol_lwm2m_client_info or @c NULL on error.
  * @note One must not add or remove elements from the returned vector.
  * @see sol_lwm2m_server_add_registration_monitor()
  */

--- a/src/lib/comms/include/sol-mavlink.h
+++ b/src/lib/comms/include/sol-mavlink.h
@@ -34,7 +34,7 @@ extern "C" {
  * @ingroup Comms
  *
  * MAVLink or Micro Air Vehicle Link is a protocol for communicating with
- * small unmanned vehicle. It is designed as a header-only message marshaling
+ * small unmanned vehicles. It is designed as a header-only message marshaling
  * library.
  *
  * @{
@@ -49,7 +49,7 @@ extern "C" {
  *
  * This object is the abstraction of a Mavlink connection. This is the base
  * structure for all Mavlink operations and is obtained through the
- * sol_mavlink_connect API.
+ * sol_mavlink_connect() API.
  */
 struct sol_mavlink;
 

--- a/src/lib/comms/include/sol-mqtt.h
+++ b/src/lib/comms/include/sol-mqtt.h
@@ -31,7 +31,7 @@ extern "C" {
 
 /**
  * @file
- * @brief Routines to handle MQTT protocol.
+ * @brief Routines to handle the MQTT protocol.
  *
  * Wrapper library for MQTT communication using the mosquitto MQTT
  * library.
@@ -127,7 +127,7 @@ enum sol_mqtt_conn_status {
  *
  * This object is the abstraction of a MQTT session. This is the base
  * structure for all MQTT operations and is obtained through the
- * sol_mqtt_connect API.
+ * sol_mqtt_connect() API.
  */
 struct sol_mqtt;
 

--- a/src/lib/comms/include/sol-network.h
+++ b/src/lib/comms/include/sol-network.h
@@ -49,7 +49,7 @@ extern "C" {
  *
  * @brief Network module provides a way to handle network link interfaces.
  *
- * It makes possible to observe events, to inquire available links
+ * It makes it possible to observe events, to inquire available links
  * and to set their states.
  *
  * @{
@@ -68,10 +68,11 @@ extern "C" {
 /**
  * @struct sol_network_hostname_pending
  *
- * @brief A handle to sol_network_get_hostname_address_info()
+ * @brief A handle returned by sol_network_get_hostname_address_info()
  *
- * This handle can be used to cancel get sol_network_get_hostname_address_info()
- * by calling sol_network_hostname_pending_cancel()
+ * This handle can be used to cancel the work of unfinished
+ * sol_network_get_hostname_address_info() calls, by calling
+ * sol_network_hostname_pending_cancel().
  *
  * @see sol_network_get_hostname_address_info()
  * @see sol_network_hostname_pending_cancel()
@@ -90,7 +91,8 @@ enum sol_network_event {
 };
 
 /**
- * @brief Bitwise OR-ed flags to represents the status of #sol_network_link.
+ * @brief Bitwise OR-ed flags to represent the status of a
+ * #sol_network_link.
  *
  * @see sol_network_link
  */
@@ -259,7 +261,7 @@ sol_network_link_addr_eq(const struct sol_network_link_addr *a,
 }
 
 /**
- * @brief Subscribes on to receive network link events.
+ * @brief Subscribes to receive network link events.
  *
  * This function register a callback given by the user that will be
  * called when a network event (@ref sol_network_event) occurrs in one
@@ -277,7 +279,7 @@ int sol_network_subscribe_events(void (*cb)(void *data, const struct sol_network
     const void *data);
 
 /**
- * @brief Stops receive the network events.
+ * @brief Stops receiving network link events.
  *
  * This function removes previous callbacks set (@ref
  * sol_network_subscribe_events()) to receive network events.
@@ -293,16 +295,17 @@ int sol_network_subscribe_events(void (*cb)(void *data, const struct sol_network
 int sol_network_unsubscribe_events(void (*cb)(void *data, const struct sol_network_link *link,
     enum sol_network_event event),
     const void *data);
+
 /**
- * @brief Retrieve the available network links on system.
+ * @brief Retrieve the available network links on a system.
  *
  * @return A vector containing the available links @see sol_network_link
  *
  * @note This vector is updated as soon as the SO notifies about a
- * network link. This is information is cached, so it's possible that
- * at the moment it is called the data is still not available. It's
- * recommended first subscribe to receive network events @see
- * sol_network_subscribe_events() and then call it.
+ * network link. This information is cached, so it's possible that at
+ * the moment it is called the data is still not available. It's
+ * recommended to first subscribe to receive network events (@see
+ * sol_network_subscribe_events()) and then call it.
  */
 const struct sol_vector *sol_network_get_available_links(void);
 
@@ -311,6 +314,8 @@ const struct sol_vector *sol_network_get_available_links(void);
  *
  * @param link The @ref sol_network_link structure which the name is desired.
  * @return The name of the interface on success, @c NULL on error.
+ *
+ * @note It @b must be freed by the user after usage.
  */
 char *sol_network_link_get_name(const struct sol_network_link *link);
 
@@ -343,16 +348,21 @@ int sol_network_link_down(uint16_t link_index);
 /**
  * @brief Gets a hostname address info.
  *
- * This function will fetch the address of a given hostname, since this may
- * take some time, this will be an async operation. When the address info
- * is ready the @c host_info_cb will called with the host's address info.
- * If an error happens or it was not possible to fetch the host address
- * information, @c addrs_list will be set to @c NULL.
- * The list @c addrs_list will contains a set of #sol_network_link_addr.
+ * This function will fetch the address of a given hostname. Since
+ * this may take some time to complete, this will be an asynchronous
+ * operation. When the address information is ready, @c host_info_cb
+ * will be called with it. If an error happens or it was not possible
+ * to fetch the host address information, @c addrs_list will be set to
+ * @c NULL. The list @c addrs_list will contain a set of
+ * #sol_network_link_addr.
+ *
+ * @note This operation may be cancelled by user with
+ * sol_network_hostname_pending_cancel() while @a host_info_cb has not
+ * been called yet.
  *
  * @param hostname The hostname to get the address info.
- * @param family The family the returned addresses should be, pass SOL_NETWORK_FAMILY_UNSPEC
- * to match them all.
+ * @param family The family the returned addresses should be, pass
+ * #SOL_NETWORK_FAMILY_UNSPEC to match them all.
  * @param host_info_cb A callback to be called with the address list.
  * @param data Data to @c host_info_cb.
  * @return A handle to a hostname or @c NULL on error.

--- a/src/lib/comms/include/sol-oic-client.h
+++ b/src/lib/comms/include/sol-oic-client.h
@@ -33,14 +33,14 @@ extern "C" {
 
 /**
  * @file
- * @brief Routines to create clients talking OIC protocol.
+ * @brief Routines to create clients talking the OIC protocol.
  */
 
 /**
  * @defgroup oic_client OIC Client
  * @ingroup OIC
  *
- * @brief Routines to create clients talking OIC protocol.
+ * @brief Routines to create clients talking the OIC protocol.
  *
  * @{
  */
@@ -66,7 +66,10 @@ struct sol_oic_client;
 struct sol_oic_pending;
 
 /**
- * @brief Structure defining an oic resource.
+ * @brief Structure defining an OIC resource. It's open to the API
+ * user to bypass the need for getters for everything, but all fields
+ * are marked as const to emphasize that the user must not alter any
+ * of them.
  */
 struct sol_oic_resource {
 #ifndef SOL_NO_API_VERSION
@@ -76,58 +79,33 @@ struct sol_oic_resource {
     /**
      * @brief The resource address.
      */
-    struct sol_network_link_addr addr;
+    const struct sol_network_link_addr addr;
     /**
      * @brief The path pointing at this resource.
      */
-    struct sol_str_slice path;
+    const struct sol_str_slice path;
     /**
-     * @brief The Device ID as UUID 16-byte array.
+     * @brief The Device ID as a UUID 16-byte array.
      */
-    struct sol_str_slice device_id;
+    const struct sol_str_slice device_id;
     /**
-     * @brief List of resource types from this resource.
+     * @brief List of resource types (#sol_str_slice entries)
+     * from this resource.
      */
-    struct sol_vector types;
-    /**
-     * @brief Buffer with types vector data.
-     */
-    char *types_data;
+    const struct sol_vector types;
     /**
      * @brief List of interfaces implemented by this resource.
      */
-    struct sol_vector interfaces;
-    /**
-     * @brief Buffer with interfaces vector data.
-     */
-    char *interfaces_data;
-    /**
-     * @brief Keep internal information to handle observating clients.
-     *
-     * Not expected to be used by clients.
-     */
-    struct {
-        struct sol_timeout *timeout; /** @brief Polling timeout handler */
-        int clear_data; /** @brief Polling counter. */
-        int64_t token; /** @brief Observation token, if in observe mode */
-    } observe;
-    int refcnt; /** @brief Reference counter. */
+    const struct sol_vector interfaces;
     /**
      * @brief True if server supports observe mode for this resource
      */
-    bool observable : 1;
+    const bool observable;
     /**
-     * @brief True if the connection stablished with this resource's server
-     * is secure.
+     * @brief True if the connection established with this resource's
+     * server is secure.
      */
-    bool secure : 1;
-    /**
-     * @brief True if this client is observing the resource.
-     *
-     * It is expected that clients that are observing a resource receives
-     * notifications when resource state changes.
-     */
-    bool is_observed : 1;
+    const bool secure;
 };
 
 /**
@@ -177,7 +155,7 @@ void sol_oic_pending_cancel(struct sol_oic_pending *pending);
  * for responses until next a new timeout window closes, otherwise @a
  * client will terminate response waiting.
  *
- * @param client An oic client instance.
+ * @param client An OIC client instance.
  * @param addr The address of the server that contains the desired resource.
  *        May be a multicast address if it is desired to look for resources in
  *        multiple servers.
@@ -187,10 +165,11 @@ void sol_oic_pending_cancel(struct sol_oic_pending *pending);
  * @param resource_interface A string representation of the interface of the desired
  *        resource. If empty or @c NULL, resources with all interfaces will be
  *        discovered.
- * @param resource_found_cb Callback to be called when a resource is found or
- *        when timeout is reached. Parameter cli is the sol_oic_client used to
- *        perform the request, res is the resource that was discovered and data
- *        is a pointer to the user's data parameter.
+ * @param resource_found_cb Callback to be called when a resource is
+ *        found or when an internal timeout is reached. Parameter @a
+ *        cli is the #sol_oic_client used to perform the request, @a
+ *        res is the resource that was discovered and data is a
+ *        pointer to the user's data parameter.
  * @param data A pointer to user's data.
  *
  * @return @c A pending call handle on success, @c NULL otherwise
@@ -218,7 +197,7 @@ struct sol_oic_pending *sol_oic_client_find_resources(struct sol_oic_client *cli
  * After an internal timeout is reached, @a info_received_cb will be
  * called with @c NULL @a info.
  *
- * @param client An oic client instance.
+ * @param client An OIC client instance.
  * @param resource The resource that is going to receive the request.
  * @param info_received_cb Callback to be called when response is received or
  *        when timeout is reached. Parameter cli is the sol_oic_client used to
@@ -254,7 +233,7 @@ struct sol_oic_pending *sol_oic_client_get_platform_info(struct sol_oic_client *
  * After internal timeout is reached @a info_received_cb will be
  * called with @c NULL @a info.
  *
- * @param client An oic client instance.
+ * @param client An OIC client instance.
  * @param addr The address of the server that contains the desired
  *        information.
  * @param info_received_cb Callback to be called when response is received or
@@ -291,7 +270,7 @@ struct sol_oic_pending *sol_oic_client_get_platform_info_by_addr(struct sol_oic_
  * After internal timeout is reached @a info_received_cb will be
  * called with @c NULL @a info.
  *
- * @param client An oic client instance.
+ * @param client An OIC client instance.
  * @param resource The resource that is going to receive the request.
  * @param info_received_cb Callback to be called when response is received or
  *        when timeout is reached. Parameter cli is the sol_oic_client used to
@@ -327,7 +306,7 @@ struct sol_oic_pending *sol_oic_client_get_server_info(struct sol_oic_client *cl
  * After internal timeout is reached @a info_received_cb will be
  * called with @c NULL @a info.
  *
- * @param client An oic client instance.
+ * @param client An OIC client instance.
  * @param addr The address of the server that contains the desired
  *        information.
  * @param info_received_cb Callback to be called when response is received or
@@ -355,7 +334,7 @@ struct sol_oic_pending *sol_oic_client_get_server_info_by_addr(struct sol_oic_cl
  * response arrives, @a callback will be called.
  * The @a request memory will be freed by this function on success or failure.
  *
- * @param client An oic client instance.
+ * @param client An OIC client instance.
  * @param request A request created using @ref sol_oic_client_request_new()
  *        or sol_oic_client_non_confirmable_request_new().
  * @param callback Callback to be called when a response from this request
@@ -380,7 +359,7 @@ struct sol_oic_pending *sol_oic_client_request(struct sol_oic_client *client,
     const struct sol_oic_map_reader *repr_vec), const void *callback_data);
 
 /**
- * @brief Create an oic client request for an specific @a resource, using a
+ * @brief Create an OIC client request for an specific @a resource, using a
  * confirmable CoAP packet.
  *
  * @param method The coap request method as documented in @ref
@@ -392,7 +371,7 @@ struct sol_oic_pending *sol_oic_client_request(struct sol_oic_client *client,
 struct sol_oic_request *sol_oic_client_request_new(enum sol_coap_method method, struct sol_oic_resource *res);
 
 /**
- * @brief Create an oic client request for an specific @a resource, using a
+ * @brief Create an OIC client request for an specific @a resource, using a
  * non-confirmable CoAP packet.
  *
  * @param method The coap request method as documented in @ref
@@ -436,7 +415,7 @@ struct sol_oic_map_writer *sol_oic_client_request_get_writer(struct sol_oic_requ
  * sol_oic_client_resource_set_observable() with @a observe as @c
  * false.
  *
- * @param client An oic client instance.
+ * @param client An OIC client instance.
  * @param res The resource that is going to be observed
  * @param callback A callback to be called when notification responses arrive.
  *        Parameter @a response_code is the header response code of this
@@ -476,7 +455,7 @@ int sol_oic_client_resource_set_observable(struct sol_oic_client *client, struct
  * this function is that it uses CoAP non-confirmable packets to make the
  * request.
  *
- * @param client An oic client instance.
+ * @param client An OIC client instance.
  * @param res The resource that is going to be observed
  * @param callback A callback to be called when notification responses arrive.
  *        Parameter @a response_code is the header response code of this

--- a/src/lib/comms/include/sol-oic-server.h
+++ b/src/lib/comms/include/sol-oic-server.h
@@ -29,14 +29,14 @@ extern "C" {
 
 /**
  * @file
- * @brief Routines to create servers talking OIC protocol.
+ * @brief Routines to create servers talking the OIC protocol.
  */
 
 /**
  * @defgroup oic_server OIC Server
  * @ingroup OIC
  *
- * @brief Routines to create servers talking OIC protocol.
+ * @brief Routines to create servers talking the OIC protocol.
  *
  * @{
  */
@@ -154,9 +154,9 @@ struct sol_oic_resource_type {
 };
 
 /**
- * @brief Add resource to oic-server.
+ * @brief Add resource to OIC server.
  *
- * Create a new sol_oic_server_resource and associate it to the oic-server.
+ * Create a new #sol_oic_server_resource and associate it to the OIC server.
  *
  * @param rt The @ref sol_oic_resource_type structure with information about the
  *        resource that is being added.
@@ -164,7 +164,8 @@ struct sol_oic_resource_type {
  *        defined in @a rt.
  * @param flags Resourse flags.
  *
- * @return On success, a pointer to the new resource created. On errors, NULL.
+ * @return On success, a pointer to the new resource created. On
+ * errors, @c NULL.
  *
  * @see sol_oic_server_unregister_resource
  */
@@ -173,10 +174,10 @@ struct sol_oic_server_resource *sol_oic_server_register_resource(
     enum sol_oic_resource_flag flags);
 
 /**
- * @brief Delete a resource from the oic-server.
+ * @brief Delete a resource from the OIC server.
  *
  * Remove a resource created using @ref sol_oic_server_register_resource from the
- * oic-server
+ * OIC server
  *
  * @param resource The resource to be removed from server.
  *

--- a/src/lib/comms/include/sol-oic.h
+++ b/src/lib/comms/include/sol-oic.h
@@ -31,8 +31,8 @@ extern "C" {
  * @defgroup OIC Open Interconnect Consortium
  * @ingroup Comms
  *
- * @brief Implementation of protocol defined by Open Interconnect Consortium
- * (OIC - http://openinterconnect.org/)
+ * @brief Implementation of the protocol defined by Open Interconnect
+ * Consortium (OIC - http://openinterconnect.org/)
  *
  * It's a common communication framework based on industry standard
  * technologies to wirelessly connect and intelligently manage
@@ -45,9 +45,12 @@ extern "C" {
  */
 
 /**
- * @brief Structure containing all fields that are retrived by
- * @ref sol_oic_client_get_platform_info() and @ref
- * sol_oic_client_get_platform_info_by_addr
+ * @brief Structure containing all fields that are retrieved by @ref
+ * sol_oic_client_get_platform_info() and @ref
+ * sol_oic_client_get_platform_info_by_addr(). It's open to the API
+ * user to bypass the need for getters for everything, but all
+ * callbacks returning an instance do so with a @c const modifier. The
+ * user must never change these fields, ever.
  */
 struct sol_oic_platform_info {
 #ifndef SOL_NO_API_VERSION
@@ -110,7 +113,7 @@ struct sol_oic_platform_info {
 };
 
 /**
- * @brief Flag to set when adding a new resource to a server.
+ * @brief Flags to set when adding a new resource to a server.
  *
  * Multiple flags can be set, just connect them using the | operator.
  *
@@ -162,9 +165,12 @@ enum sol_oic_resource_flag {
 };
 
 /**
- * @brief Structure containing all fields that are retrived by
- * @ref sol_oic_client_get_server_info() and @ref
- * sol_oic_client_get_server_info_by_addr
+ * @brief Structure containing all fields that are retrieved by @ref
+ * sol_oic_client_get_server_info() and @ref
+ * sol_oic_client_get_server_info_by_addr(). It's open to the API user
+ * to bypass the need for getters for everything, but all callbacks
+ * returning an instance do so with a @c const modifier. The user must
+ * never change these fields, ever.
  */
 struct sol_oic_device_info {
 #ifndef SOL_NO_API_VERSION
@@ -208,9 +214,9 @@ enum sol_oic_repr_type {
 /**
  * @brief Structure to keep a single oic-map's field.
  *
- * Use this structure to read fields using an sol_oic_map_reader and macro
- * @ref SOL_OIC_MAP_LOOP() or to write fields using an sol_oic_map_writer and
- * function sol_oic_map_append.
+ * Use this structure to read fields using a #sol_oic_map_reader and
+ * macro @ref SOL_OIC_MAP_LOOP() or to write fields using a
+ * #sol_oic_map_writer and function sol_oic_map_append().
  *
  * @see sol_oic_map_append()
  * @see SOL_OIC_MAP_LOOP()
@@ -266,7 +272,7 @@ struct sol_oic_repr_field {
 };
 
 /**
- * @brief Helper macro to create a sol_oic_repr_field.
+ * @brief Helper macro to create a #sol_oic_repr_field.
  *
  * @param key_ Field's key.
  * @param type_ Field's type.
@@ -276,7 +282,7 @@ struct sol_oic_repr_field {
     (struct sol_oic_repr_field){.type = (type_), .key = (key_), { __VA_ARGS__ } }
 
 /**
- * @brief Helper macro to create an unsigned integer sol_oic_repr_field.
+ * @brief Helper macro to create an unsigned integer #sol_oic_repr_field.
  *
  * @param key_ Field's key.
  * @param value_ The unsigned int value of this field.
@@ -285,7 +291,7 @@ struct sol_oic_repr_field {
     SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_UINT, .v_uint = (value_))
 
 /**
- * @brief Helper macro to create an signed integer sol_oic_repr_field.
+ * @brief Helper macro to create a signed integer #sol_oic_repr_field.
  *
  * @param key_ Field's key.
  * @param value_ The signed int value of this field.
@@ -294,7 +300,7 @@ struct sol_oic_repr_field {
     SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_INT, .v_int = (value_))
 
 /**
- * @brief Helper macro to create an boolean sol_oic_repr_field.
+ * @brief Helper macro to create a boolean #sol_oic_repr_field.
  *
  * @param key_ Field's key.
  * @param value_ The boolean value of this field.
@@ -303,7 +309,7 @@ struct sol_oic_repr_field {
     SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_BOOLEAN, .v_boolean = !!(value_))
 
 /**
- * @brief Helper macro to create an simple integer sol_oic_repr_field.
+ * @brief Helper macro to create a simple integer #sol_oic_repr_field.
  *
  * @param key_ Field's key.
  * @param value_ The 8-bit integer value of this field.
@@ -312,7 +318,7 @@ struct sol_oic_repr_field {
     SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_SIMPLE, .v_simple = (value_))
 
 /**
- * @brief Helper macro to create a text string sol_oic_repr_field.
+ * @brief Helper macro to create a text string #sol_oic_repr_field.
  *
  * @param key_ Field's key.
  * @param value_ A pointer to the string to be set as the string value of this
@@ -323,7 +329,7 @@ struct sol_oic_repr_field {
     SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_TEXT_STRING, .v_slice = SOL_STR_SLICE_STR((value_), (len_)))
 
 /**
- * @brief Helper macro to create a byte string sol_oic_repr_field.
+ * @brief Helper macro to create a byte string #sol_oic_repr_field.
  *
  * @param key_ Field's key.
  * @param value_ A pointer to the string to be set as the string value of this
@@ -335,7 +341,7 @@ struct sol_oic_repr_field {
 
 /**
  * @brief Helper macro to create a half-precision float number
- * sol_oic_repr_field.
+ * #sol_oic_repr_field.
  *
  * @param key_ Field's key.
  * @param value_ The value of the float number.
@@ -345,7 +351,7 @@ struct sol_oic_repr_field {
 
 /**
  * @brief Helper macro to create a single-precision float number
- * sol_oic_repr_field.
+ * #sol_oic_repr_field.
  *
  * @param key_ Field's key.
  * @param value_ The value of the float number.
@@ -354,7 +360,7 @@ struct sol_oic_repr_field {
     SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_FLOAT, .v_float = (value_))
 
 /**
- * @brief Helper macro to create a double-precision float sol_oic_repr_field.
+ * @brief Helper macro to create a double-precision float #sol_oic_repr_field.
  *
  * @param key_ Field's key.
  * @param value_ The value of the float number.
@@ -365,10 +371,10 @@ struct sol_oic_repr_field {
 /**
  * @struct sol_oic_map_writer
  *
- * @brief Opaque handler for an oic packet map writer.
+ * @brief Opaque handler for an OIC packet map writer.
  *
  * This structure is used in callback parameters so users can add fields to an
- * oic packet using @ref sol_oic_map_append().
+ * OIC packet using @ref sol_oic_map_append().
  *
  * @see sol_oic_server_notify()
  * @see sol_oic_client_resource_request()
@@ -385,26 +391,27 @@ enum sol_oic_map_type {
     /**
      * @brief Map with no content
      *
-     * When an oic map is used to create a packet and type is
-     * SOL_OIC_MAP_NO_CONTENT, no payload will be added to the packet.
+     * When an OIC map is used to create a packet and its type is
+     * #SOL_OIC_MAP_NO_CONTENT, no payload will be added to the
+     * packet.
      **/
     SOL_OIC_MAP_NO_CONTENT,
     /**
      * @brief Map with content.
      *
-     * When an oic map is used to create a packet and type is
-     * SOL_OIC_MAP_CONTENT, a payload will be created and elements
-     * from map will be added to payload. If map contains no elements,
-     * an empty map will be added to payload.
+     * When an OIC map is used to create a packet and its type is
+     * #SOL_OIC_MAP_CONTENT, a payload will be created and elements
+     * from the map will be added to payload. If the map contains no
+     * elements, an empty map will be added to payload.
      */
     SOL_OIC_MAP_CONTENT,
 };
 
 /**
- * @brief Handler for an oic packet map reader.
+ * @brief Handler for an OIC packet map reader.
  *
  * This structure is used in callback parameters so users can read fields from
- * an oic packet using @ref SOL_OIC_MAP_LOOP.
+ * an OIC packet using @ref SOL_OIC_MAP_LOOP.
  *
  * @param parser Internal Pointer. Not to be used.
  * @param ptr Internal Pointer. Not to be used.
@@ -413,7 +420,10 @@ enum sol_oic_map_type {
  * @param type Internal information. Not to be used.
  * @param flags Internal information. Not to be used.
  *
- * @note Fields from this structure are not expected to be accessed by clients.
+ * @note Fields from this structure are not expected to be accessed by
+ * clients. They are exposed only to make it possible for stack
+ * variable declarations of it.
+ *
  * @see SOL_OIC_MAP_LOOP.
  */
 struct sol_oic_map_reader {
@@ -446,7 +456,7 @@ struct sol_oic_response;
 /**
  * @brief Possible reasons a @ref SOL_OIC_MAP_LOOP was terminated.
  */
-enum sol_oic_map_loop_status {
+enum sol_oic_map_loop_reason {
     /**
      * @brief Success termination. Everything was OK.
      */
@@ -468,14 +478,14 @@ enum sol_oic_map_loop_status {
  * @param repr Initialize this element to be used by
  *        @ref sol_oic_map_loop_next() to hold @a map elements.
  *
- * @return @c SOL_OIC_MAP_LOOP_OK if initialization was a success or
- *         @c SOL_OIC_MAP_LOOP_ERROR if initialization failed.
+ * @return @ref SOL_OIC_MAP_LOOP_OK if initialization was a success or
+ *         @ref SOL_OIC_MAP_LOOP_ERROR if initialization failed.
  *
  * @note Prefer using @ref SOL_OIC_MAP_LOOP instead of calling this function directly.
  *
  * @see sol_oic_map_reader
  */
-enum sol_oic_map_loop_status sol_oic_map_loop_init(const struct sol_oic_map_reader *map, struct sol_oic_map_reader *iterator, struct sol_oic_repr_field *repr);
+enum sol_oic_map_loop_reason sol_oic_map_loop_init(const struct sol_oic_map_reader *map, struct sol_oic_map_reader *iterator, struct sol_oic_repr_field *repr);
 
 /**
  * @brief Get the next element from @a iterator.
@@ -493,7 +503,7 @@ enum sol_oic_map_loop_status sol_oic_map_loop_init(const struct sol_oic_map_read
  *
  * @see sol_oic_map_reader
  */
-bool sol_oic_map_loop_next(struct sol_oic_repr_field *repr, struct sol_oic_map_reader *iterator, enum sol_oic_map_loop_status *reason);
+bool sol_oic_map_loop_next(struct sol_oic_repr_field *repr, struct sol_oic_map_reader *iterator, enum sol_oic_map_loop_reason *reason);
 
 /**
  * @brief Append an element to @a oic_map_writer
@@ -515,7 +525,7 @@ int sol_oic_map_append(struct sol_oic_map_writer *oic_map_writer, struct sol_oic
  * @brief set current @a oic_map_writer type.
  *
  * Use this function if you want to change @a oic_map_writer type to
- * SOL_OIC_MAP_CONTENT without adding elements to it. This will force oic to
+ * SOL_OIC_MAP_CONTENT without adding elements to it. This will force OIC to
  * create a payload in packet with an empty list if map is empty.
  * Trying to change from SOL_OIC_MAP_CONTENT to SOL_OIC_MAP_NO_CONTENT will fail
  * if elements were already added to @a oic_map_writer.
@@ -547,7 +557,7 @@ int sol_oic_map_get_type(struct sol_oic_map_writer *oic_map_writer, enum sol_oic
 void sol_oic_repr_field_clear(struct sol_oic_repr_field *field);
 
 /**
- * @def SOL_OIC_MAP_LOOP(map_, current_, iterator_, end_status_)
+ * @def SOL_OIC_MAP_LOOP(map_, current_, iterator_, end_reason_)
  *
  * @brief Macro to be used to loop through all elements from a
  * sol_oic_map_reader
@@ -557,22 +567,22 @@ void sol_oic_repr_field_clear(struct sol_oic_repr_field *field);
  *        the current element data.
  * @param iterator_ A pointer to a struct sol_oic_map_reader to be used as an
  *        iterator
- * @param end_status_ A pointer to a enum sol_oic_map_loop_status to be filled
+ * @param end_reason_ A pointer to a enum sol_oic_map_loop_reason to be filled
  *        with the reason this loop has terminated.
  *
  * Example to read data from a struct sol_oic_map_reader using this macro:
  * @code
  *
  * struct sol_oic_repr_field field;
- * enum sol_oic_map_loop_status end_status;
+ * enum sol_oic_map_loop_reason end_reason;
  * struct sol_oic_map_reader iterator;
  *
- * SOL_OIC_MAP_LOOP(map_reader, &field, &iterator, end_status) {
+ * SOL_OIC_MAP_LOOP(map_reader, &field, &iterator, end_reason) {
  * {
  *      // do something
  * }
  *
- * if (end_status != SOL_OIC_MAP_LOOP_OK)
+ * if (end_reason != SOL_OIC_MAP_LOOP_OK)
  *     // Error handling
  * @endcode
  *
@@ -583,15 +593,15 @@ void sol_oic_repr_field_clear(struct sol_oic_repr_field *field);
  * @see sol_oic_map_loop_init
  * @see sol_oic_map_loop_next
  */
-#define SOL_OIC_MAP_LOOP(map_, current_, iterator_, end_status_) \
-    for (end_status_ = sol_oic_map_loop_init(map_, iterator_, current_); \
-        end_status_ == SOL_OIC_MAP_LOOP_OK && \
-        sol_oic_map_loop_next(current_, iterator_, &end_status_);)
+#define SOL_OIC_MAP_LOOP(map_, current_, iterator_, end_reason_) \
+    for (end_reason_ = sol_oic_map_loop_init(map_, iterator_, current_); \
+        end_reason_ == SOL_OIC_MAP_LOOP_OK && \
+        sol_oic_map_loop_next(current_, iterator_, &end_reason_);)
 
 /**
  * @brief Print the decoded cbor content of @a pkt.
  *
- * Checks if @a pkt is an oic packet with cbor content in payload and prints it
+ * Checks if @a pkt is an OIC packet with cbor content in payload and prints it
  * in a human readable way.
  *
  * Used only for debug purposes.

--- a/src/lib/comms/include/sol-socket.h
+++ b/src/lib/comms/include/sol-socket.h
@@ -28,13 +28,23 @@ extern "C" {
  * @defgroup Socket Socket
  * @ingroup Comms
  *
- * @brief API to create an endpoint communication using sockets.
+ * @brief API to create a communication endpoint using sockets.
  *
  * @{
  */
 
+/**
+ * @struct sol_socket
+ *
+ * @brief Opaque handler for a socket
+ */
 struct sol_socket;
 
+/**
+ * @struct sol_socket_options
+ *
+ * @brief Defines the behaviour of a socket instance
+ */
 struct sol_socket_options {
 #ifndef SOL_NO_API_VERSION
 #define SOL_SOCKET_OPTIONS_API_VERSION (1)  /**< compile time API version to be checked during runtime */
@@ -75,6 +85,12 @@ struct sol_socket_options {
     const void *data;
 };
 
+/**
+ * @struct sol_socket_options
+ *
+ * @brief Defines specific IP layer related behaviour of a socket
+ * instance
+ */
 struct sol_socket_ip_options {
     struct sol_socket_options base;
 #ifndef SOL_NO_API_VERSION
@@ -108,9 +124,9 @@ struct sol_socket_ip_options {
 /**
  * @brief Structure to represent a socket class.
  *
- * This struct contains the necessary information do deal with
- * a socket. This contains the methods necessaries to create
- * a new socket type.
+ * This struct contains the necessary information do deal with a
+ * socket. This contains the methods necessary to create a new socket
+ * type.
  */
 struct sol_socket_type {
 #ifndef SOL_NO_API_VERSION
@@ -181,7 +197,7 @@ struct sol_socket_type {
 
     /**
      * @brief Function to be called to join a multicast group.
-     * IPv4 and IPv6 address are possible.
+     * Both IPv4 and IPv6 addresses are possible.
      *
      * @li @c s the socket pointer (this)
      * @li @c ifindex the index of the interface to be used.
@@ -216,7 +232,8 @@ struct sol_socket {
 /**
  * @brief Creates an endpoint for communication.
  *
- * This function creates a socket using the system default implementation.
+ * This function creates a socket using the system's default
+ * implementation.
  *
  * @param options The socket's options.
  *
@@ -271,12 +288,12 @@ int sol_socket_set_write_monitor(struct sol_socket *s, bool on);
 /**
  * @brief Receive a message from a socket.
  *
- * If the socket's type is SOL_SOCKET_UDP, @a buf may be @c NULL, and
- * in this case the function will only peek the incoming packet queue
- * (not removing data from it), returning the number of bytes needed
- * to store the next datagram and ignoring the cliaddr argument. This
- * way, the user may allocate the exact number of bytes to hold the
- * message contents.
+ * If it's a datagram socket, @a buf may be @c NULL, and in this case
+ * the function will only peek the incoming packet queue (not removing
+ * data from it), returning the number of bytes needed to store the
+ * next datagram and ignoring the cliaddr argument. This way, the user
+ * may allocate the exact number of bytes to hold the message
+ * contents.
  *
  * @param s The value got with @c sol_socket_ip_new()
  * @param buffer the data buffer that will be used to receive the data.
@@ -310,7 +327,7 @@ ssize_t sol_socket_sendmsg(struct sol_socket *s, const struct sol_buffer *buffer
 
 /**
  * @brief Joins a multicast group.
- * IPv4 and IPv6 address are possible.
+ * Both IPv4 and IPv6 addresses are possible.
  *
  * @param s The value got with @c sol_socket_ip_new()
  * @param ifindex The index of the interface to be used.

--- a/src/lib/comms/sol-bluetooth-impl-bluez.c
+++ b/src/lib/comms/sol-bluetooth-impl-bluez.c
@@ -746,7 +746,7 @@ trigger_gatt_discover(struct pending_discovery *disc)
         if (type != SOL_GATT_ATTR_TYPE_INVALID && attr->type != type)
             continue;
 
-        if (uuid && !sol_bt_uuid_equal(&attr->uuid, uuid))
+        if (uuid && !sol_bt_uuid_eq(&attr->uuid, uuid))
             continue;
 
         if (!disc->func((void *)disc->user_data, disc->conn, attr)) {

--- a/src/lib/comms/sol-bluetooth.c
+++ b/src/lib/comms/sol-bluetooth.c
@@ -150,7 +150,7 @@ sol_bt_uuid_to_str(const struct sol_bt_uuid *uuid, struct sol_buffer *buffer)
 }
 
 SOL_API bool
-sol_bt_uuid_equal(const struct sol_bt_uuid *u1, const struct sol_bt_uuid *u2)
+sol_bt_uuid_eq(const struct sol_bt_uuid *u1, const struct sol_bt_uuid *u2)
 {
     struct sol_bt_uuid u1_128 = BASE_UUID;
     struct sol_bt_uuid u2_128 = BASE_UUID;

--- a/src/lib/comms/sol-http-client-impl-curl.c
+++ b/src/lib/comms/sol-http-client-impl-curl.c
@@ -743,12 +743,12 @@ set_auth_basic(CURL *curl, const struct sol_http_param_value *param)
     user = password = NULL;
 
     if (param->value.auth.user.len) {
-        user = sol_str_slice_to_string(param->value.auth.user);
+        user = sol_str_slice_to_str(param->value.auth.user);
         SOL_NULL_CHECK(user, false);
     }
 
     if (param->value.auth.password.len) {
-        password = sol_str_slice_to_string(param->value.auth.password);
+        password = sol_str_slice_to_str(param->value.auth.password);
         SOL_NULL_CHECK_GOTO(password, exit);
     }
 

--- a/src/lib/comms/sol-lwm2m.c
+++ b/src/lib/comms/sol-lwm2m.c
@@ -588,7 +588,7 @@ fill_client_info(struct sol_lwm2m_client_info *cinfo,
             }
             //Required info
             has_name = true;
-            cinfo->name = sol_str_slice_to_string(value);
+            cinfo->name = sol_str_slice_to_str(value);
             SOL_NULL_CHECK_GOTO(cinfo->name, err_cinfo_prop);
         } else if (sol_str_slice_str_eq(key, "lt")) {
             char *endptr;
@@ -3096,7 +3096,7 @@ split_path(const char *path, uint16_t *splitted_path_len)
     SOL_NULL_CHECK_GOTO(splitted_path, err_exit);
 
     SOL_VECTOR_FOREACH_IDX (&tokens, token, i) {
-        splitted_path[i] = sol_str_slice_to_string(*token);
+        splitted_path[i] = sol_str_slice_to_str(*token);
         SOL_NULL_CHECK_GOTO(splitted_path[i], err_cpy);
     }
 
@@ -3513,7 +3513,7 @@ register_reply(void *data, struct sol_coap_server *server,
         sol_util_array_size(path));
     SOL_INT_CHECK_GOTO(r, != 2, err_exit);
 
-    conn_ctx->location = sol_str_slice_to_string(path[1]);
+    conn_ctx->location = sol_str_slice_to_str(path[1]);
     SOL_NULL_CHECK_GOTO(conn_ctx->location, err_exit);
 
     SOL_DBG("Registered with server %.*s at location %s",

--- a/src/lib/comms/sol-lwm2m.c
+++ b/src/lib/comms/sol-lwm2m.c
@@ -268,7 +268,7 @@ send_ack_if_needed(struct sol_coap_server *coap, struct sol_coap_packet *msg,
 
     sol_coap_header_get_type(msg, &type);
 
-    if (type == SOL_COAP_TYPE_CON) {
+    if (type == SOL_COAP_MESSAGE_TYPE_CON) {
         ack = sol_coap_packet_new(msg);
         SOL_NULL_CHECK(ack);
         if (sol_coap_send_packet(coap, ack, cliaddr) < 0)
@@ -1464,7 +1464,7 @@ exit:
 
 static int
 add_coap_int_option(struct sol_coap_packet *pkt,
-    enum sol_coap_option_num opt, const void *data, uint16_t len)
+    enum sol_coap_option opt, const void *data, uint16_t len)
 {
     uint8_t buf[sizeof(int64_t)] = { };
 
@@ -1475,7 +1475,7 @@ add_coap_int_option(struct sol_coap_packet *pkt,
 
 static int
 get_coap_int_option(struct sol_coap_packet *pkt,
-    enum sol_coap_option_num opt, uint16_t *value)
+    enum sol_coap_option opt, uint16_t *value)
 {
     const void *v;
     uint16_t len;
@@ -1492,7 +1492,7 @@ get_coap_int_option(struct sol_coap_packet *pkt,
 
 static int
 setup_coap_packet(enum sol_coap_method method,
-    enum sol_coap_msgtype type, const char *objects_path, const char *path,
+    enum sol_coap_message_type type, const char *objects_path, const char *path,
     uint8_t *obs, int64_t *token, struct sol_lwm2m_resource *resources,
     size_t len,
     const char *execute_args,
@@ -1686,7 +1686,7 @@ sol_lwm2m_server_add_observer(struct sol_lwm2m_server *server,
     if (!send_msg)
         return 0;
 
-    r = setup_coap_packet(SOL_COAP_METHOD_GET, SOL_COAP_TYPE_CON,
+    r = setup_coap_packet(SOL_COAP_METHOD_GET, SOL_COAP_MESSAGE_TYPE_CON,
         client->objects_path, path, &obs, &entry->token, NULL, 0, NULL, &pkt);
     SOL_INT_CHECK(r, < 0, r);
 
@@ -1847,7 +1847,7 @@ send_management_packet(struct sol_lwm2m_server *server,
     struct sol_coap_packet *pkt;
     struct management_ctx *ctx;
 
-    r = setup_coap_packet(method, SOL_COAP_TYPE_CON,
+    r = setup_coap_packet(method, SOL_COAP_MESSAGE_TYPE_CON,
         client->objects_path, path, NULL, NULL, resources, len,
         execute_args, &pkt);
     SOL_INT_CHECK(r, < 0, r);
@@ -2858,7 +2858,7 @@ send_notification_pkt(struct sol_lwm2m_client *client,
     pkt = sol_coap_packet_new_notification(client->coap_server, resource);
     SOL_NULL_CHECK(pkt, false);
 
-    r = sol_coap_header_set_type(pkt, SOL_COAP_TYPE_CON);
+    r = sol_coap_header_set_type(pkt, SOL_COAP_MESSAGE_TYPE_CON);
     SOL_INT_CHECK_GOTO(r, < 0, err_exit);
     r = sol_coap_header_set_code(pkt, SOL_COAP_RESPONSE_CODE_CHANGED);
     SOL_INT_CHECK_GOTO(r, < 0, err_exit);
@@ -3577,7 +3577,7 @@ register_with_server(struct sol_lwm2m_client *client,
         &conn_ctx->lifetime, &binding);
     SOL_INT_CHECK_GOTO(r, < 0, err_exit);
 
-    pkt = sol_coap_packet_new_request(SOL_COAP_METHOD_POST, SOL_COAP_TYPE_CON);
+    pkt = sol_coap_packet_new_request(SOL_COAP_METHOD_POST, SOL_COAP_MESSAGE_TYPE_CON);
     r = -ENOMEM;
     SOL_NULL_CHECK_GOTO(pkt, err_exit);
 
@@ -3817,7 +3817,7 @@ send_client_delete_request(struct sol_lwm2m_client *client,
     }
 
     pkt = sol_coap_packet_new_request(SOL_COAP_METHOD_DELETE,
-        SOL_COAP_TYPE_NON_CON);
+        SOL_COAP_MESSAGE_TYPE_NON_CON);
     SOL_NULL_CHECK(pkt, -ENOMEM);
 
     r = sol_coap_add_option(pkt, SOL_COAP_OPTION_URI_PATH, "rd", strlen("rd"));

--- a/src/lib/comms/sol-mavlink.c
+++ b/src/lib/comms/sol-mavlink.c
@@ -506,7 +506,7 @@ sol_mavlink_init_tcp(struct sol_mavlink *mavlink)
         return -errno;
     }
 
-    hostname = sol_str_slice_to_string(*mavlink->address);
+    hostname = sol_str_slice_to_str(*mavlink->address);
     if (!hostname) {
         SOL_ERR("Could not format hostname string - %s",
             sol_util_strerrora(errno));
@@ -563,7 +563,7 @@ sol_mavlink_init_serial(struct sol_mavlink *mavlink)
         SOL_INF("No baud_rate config provided, setting default: 115200");
     }
 
-    portname = sol_str_slice_to_string(*mavlink->address);
+    portname = sol_str_slice_to_str(*mavlink->address);
     if (!portname) {
         SOL_ERR("Could not format portname string - %s",
             sol_util_strerrora(errno));

--- a/src/lib/comms/sol-network-impl-linux.c
+++ b/src/lib/comms/sol-network-impl-linux.c
@@ -692,7 +692,7 @@ sol_network_get_hostname_address_info(const struct sol_str_slice hostname,
     r = sol_ptr_vector_append(&network->hostname_handles, ctx);
     SOL_INT_CHECK_GOTO(r, < 0, err_append);
 
-    ctx->hostname = sol_str_slice_to_string(hostname);
+    ctx->hostname = sol_str_slice_to_str(hostname);
     SOL_NULL_CHECK_GOTO(ctx->hostname, err_hostname);
 
     ctx->cb = host_info_cb;

--- a/src/lib/comms/sol-oic-client.c
+++ b/src/lib/comms/sol-oic-client.c
@@ -527,7 +527,7 @@ client_get_info(struct sol_oic_client *client,
     memcpy(&ctx->base.addr, addr, sizeof(*addr));
 
     ctx->base.req = sol_coap_packet_new_request(SOL_COAP_METHOD_GET,
-        SOL_COAP_TYPE_CON);
+        SOL_COAP_MESSAGE_TYPE_CON);
     if (!ctx->base.req) {
         SOL_WRN("Could not create CoAP packet");
         r = -errno;
@@ -923,7 +923,7 @@ sol_oic_client_find_resources(struct sol_oic_client *client,
 
     /* Multicast discovery should be non-confirmable */
     ctx->base.req = sol_coap_packet_new_request(SOL_COAP_METHOD_GET,
-        SOL_COAP_TYPE_NON_CON);
+        SOL_COAP_MESSAGE_TYPE_NON_CON);
     if (!ctx->base.req) {
         SOL_WRN("Could not create CoAP packet");
         r = -errno;
@@ -1138,8 +1138,8 @@ request_new(enum sol_coap_method method,
     char *path;
     int ret = 0;
 
-    if (type != SOL_COAP_TYPE_CON && type != SOL_COAP_TYPE_NON_CON) {
-        SOL_WRN("Only SOL_COAP_TYPE_CON and SOL_COAP_TYPE_NON_CON requests are"
+    if (type != SOL_COAP_MESSAGE_TYPE_CON && type != SOL_COAP_MESSAGE_TYPE_NON_CON) {
+        SOL_WRN("Only SOL_COAP_MESSAGE_TYPE_CON and SOL_COAP_MESSAGE_TYPE_NON_CON requests are"
             " supported");
         errno = EINVAL;
         return NULL;
@@ -1197,7 +1197,7 @@ sol_oic_client_request_new(enum sol_coap_method method, struct sol_oic_resource 
 {
     OIC_RESOURCE_CHECK_API(res, EINVAL, NULL);
 
-    return request_new(method, SOL_COAP_TYPE_CON, res, false);
+    return request_new(method, SOL_COAP_MESSAGE_TYPE_CON, res, false);
 }
 
 SOL_API struct sol_oic_request *
@@ -1205,7 +1205,7 @@ sol_oic_client_non_confirmable_request_new(enum sol_coap_method method, struct s
 {
     OIC_RESOURCE_CHECK_API(res, EINVAL, NULL);
 
-    return request_new(method, SOL_COAP_TYPE_NON_CON, res, false);
+    return request_new(method, SOL_COAP_MESSAGE_TYPE_NON_CON, res, false);
 }
 
 SOL_API void
@@ -1363,8 +1363,8 @@ client_resource_set_observable(struct sol_oic_client *client,
             struct sol_oic_pending *tmp;
 
             request = request_new(SOL_COAP_METHOD_GET,
-                non_confirmable ? SOL_COAP_TYPE_NON_CON : SOL_COAP_TYPE_CON,
-                res, true);
+                non_confirmable ? SOL_COAP_MESSAGE_TYPE_NON_CON :
+                SOL_COAP_MESSAGE_TYPE_CON, r, true);
             SOL_NULL_CHECK(request, -ENOMEM);
 
             tmp = _resource_request((struct sol_oic_client_request *)request,

--- a/src/lib/comms/sol-oic-client.c
+++ b/src/lib/comms/sol-oic-client.c
@@ -82,6 +82,24 @@ struct ctx {
     struct sol_reentrant reentrant;
 };
 
+struct sol_oic_resource_internal {
+    struct sol_oic_resource base;
+    char *types_data; //Buffer with types vector data.
+    char *interfaces_data; //Buffer with interfaces vector data.
+    struct {
+        struct sol_timeout *timeout; //Polling timeout handler
+        int clear_data; //Polling counter.
+        int64_t token; //Observation token, if in observe mode
+    } observe;
+    int refcnt;
+    /*
+     * True if this client is observing the resource.
+     *
+     * It is expected that clients that are observing a resource
+     * receive notifications when the resource state changes. */
+    bool is_observed : 1;
+};
+
 struct find_resource_ctx {
     struct ctx base;
     bool (*cb)(void *data, struct sol_oic_client *cli, struct sol_oic_resource *res);
@@ -95,14 +113,14 @@ struct server_info_ctx {
 struct sol_oic_client_request {
     struct sol_oic_request base;
     bool (*cb)(void *data, struct sol_coap_server *server, struct sol_coap_packet *req, const struct sol_network_link_addr *addr);
-    struct sol_oic_resource *res;
+    struct sol_oic_resource_internal *res;
     int64_t token;
     struct sol_oic_map_writer writer;
 };
 
 struct resource_request_ctx {
     struct ctx base;
-    struct sol_oic_resource *res;
+    struct sol_oic_resource_internal *res;
     void (*cb)(void *data, enum sol_coap_response_code response_code, struct sol_oic_client *cli, const struct sol_network_link_addr *addr, const struct sol_oic_map_reader *repr_vec);
     const void *data;
     int64_t token;
@@ -112,7 +130,8 @@ SOL_LOG_INTERNAL_DECLARE(_sol_oic_client_log_domain, "oic-client");
 
 static struct sol_coap_server *
 _best_server_for_resource(const struct sol_oic_client *client,
-    const struct sol_oic_resource *res, struct sol_network_link_addr *addr)
+    struct sol_oic_resource *res,
+    struct sol_network_link_addr *addr)
 {
     *addr = res->addr;
 
@@ -187,10 +206,13 @@ _pkt_has_same_token(const struct sol_coap_packet *pkt, int64_t token)
 SOL_API struct sol_oic_resource *
 sol_oic_resource_ref(struct sol_oic_resource *r)
 {
+    struct sol_oic_resource_internal *res =
+        (struct sol_oic_resource_internal *)r;
+
     SOL_NULL_CHECK(r, NULL);
     OIC_RESOURCE_CHECK_API(r, EINVAL, NULL);
 
-    r->refcnt++;
+    res->refcnt++;
     return r;
 }
 
@@ -212,16 +234,20 @@ clear_vector_list(struct sol_vector *vector, void *data)
 SOL_API void
 sol_oic_resource_unref(struct sol_oic_resource *r)
 {
+    struct sol_oic_resource_internal *res =
+        (struct sol_oic_resource_internal *)r;
+
     SOL_NULL_CHECK(r);
     OIC_RESOURCE_CHECK_API(r, 0);
 
-    r->refcnt--;
-    if (!r->refcnt) {
+    res->refcnt--;
+    if (!res->refcnt) {
         free((char *)r->path.data);
         free((char *)r->device_id.data);
 
-        clear_vector_list(&r->types, r->types_data);
-        clear_vector_list(&r->interfaces, r->interfaces_data);
+        clear_vector_list((struct sol_vector *)&r->types, res->types_data);
+        clear_vector_list((struct sol_vector *)&r->interfaces,
+            res->interfaces_data);
 
         free(r);
     }
@@ -627,30 +653,38 @@ _has_observable_option(struct sol_coap_packet *pkt)
     return ptr && len == 1 && *ptr;
 }
 
-static struct sol_oic_resource *
+static struct sol_oic_resource_internal *
 _new_resource(void)
 {
-    struct sol_oic_resource *res = malloc(sizeof(*res));
+    struct sol_oic_resource_internal *res = malloc(sizeof(*res));
+    struct sol_str_slice *path = (struct sol_str_slice *)&res->base.path;
+    struct sol_str_slice *device_id =
+        (struct sol_str_slice *)&res->base.device_id;
+    bool *observable = (bool *)&res->base.observable;
+    bool *secure = (bool *)&res->base.secure;
 
     SOL_NULL_CHECK(res, NULL);
 
-    res->path = SOL_STR_SLICE_STR(NULL, 0);
-    res->device_id = SOL_STR_SLICE_STR(NULL, 0);
-    sol_vector_init(&res->types, sizeof(struct sol_str_slice));
+    path->len = 0;
+    path->data = NULL;
+    device_id->len = 0;
+    device_id->data = NULL;
+    sol_vector_init((struct sol_vector *)&res->base.types,
+        sizeof(struct sol_str_slice));
     res->types_data = NULL;
-    sol_vector_init(&res->interfaces, sizeof(struct sol_str_slice));
+    sol_vector_init((struct sol_vector *)&res->base.interfaces,
+        sizeof(struct sol_str_slice));
     res->interfaces_data = NULL;
 
     res->observe.timeout = NULL;
     res->observe.clear_data = 0;
 
-    res->observable = false;
-    res->secure = false;
+    *observable = *secure = false;
     res->is_observed = false;
 
     res->refcnt = 1;
 
-    SOL_SET_API_VERSION(res->api_version = SOL_OIC_RESOURCE_API_VERSION; )
+    SOL_SET_API_VERSION(res->base.api_version = SOL_OIC_RESOURCE_API_VERSION; )
 
     return res;
 }
@@ -679,18 +713,16 @@ _iterate_over_resource_reply_payload(struct sol_coap_packet *req,
     const struct sol_network_link_addr *addr,
     const struct find_resource_ctx *ctx, bool *cb_return)
 {
-    CborParser parser;
-    CborError err;
     CborValue root, devices_array, resources_array, value, map;
-    struct sol_buffer *buf;
-    size_t offset;
-    struct sol_buffer device_id;
-    struct sol_oic_resource *res = NULL;
+    struct sol_oic_resource_internal *res = NULL;
     CborValue bitmap_value, secure_value;
-    uint64_t bitmap;
-    bool secure;
     bool discovery_callback_result;
-
+    struct sol_buffer device_id;
+    struct sol_buffer *buf;
+    CborParser parser;
+    uint64_t bitmap;
+    CborError err;
+    size_t offset;
 
     *cb_return  = true;
 
@@ -723,19 +755,30 @@ _iterate_over_resource_reply_payload(struct sol_coap_packet *req,
         SOL_INT_CHECK_GOTO(err, != CborNoError, error);
         for (; cbor_value_is_map(&resources_array) && err == CborNoError;
             err = cbor_value_advance(&resources_array)) {
+            struct sol_network_link_addr *addr_ptr;
+            struct sol_str_slice *device_id_ptr;
+            bool is_secure = false;
+            bool *observable;
+            bool *secure;
+
             res = _new_resource();
             SOL_NULL_CHECK_GOTO(res, error);
+            observable = (bool *)&res->base.observable;
+            secure = (bool *)&res->base.secure;
+            addr_ptr = (struct sol_network_link_addr *)&res->base.addr;
+            device_id_ptr = (struct sol_str_slice *)&res->base.device_id;
 
             if (sol_cbor_map_get_str_value(&resources_array, SOL_OIC_KEY_HREF,
-                &res->path) < 0)
+                (struct sol_str_slice *)&res->base.path) < 0)
                 goto error;
 
             if (!extract_list_from_map(&resources_array,
-                SOL_OIC_KEY_RESOURCE_TYPES, &res->types_data, &res->types))
+                SOL_OIC_KEY_RESOURCE_TYPES, &res->types_data,
+                (struct sol_vector *)&res->base.types))
                 goto error;
             if (!extract_list_from_map(&resources_array,
                 SOL_OIC_KEY_INTERFACES, &res->interfaces_data,
-                &res->interfaces))
+                (struct sol_vector *)&res->base.interfaces))
                 goto error;
 
             err = cbor_value_map_find_value(&resources_array,
@@ -755,36 +798,37 @@ _iterate_over_resource_reply_payload(struct sol_coap_packet *req,
                 &secure_value);
             SOL_INT_CHECK(err, != CborNoError, false);
             if (!cbor_value_is_valid(&secure_value)) {
-                secure = false;
+                is_secure = false;
             } else {
                 if (!cbor_value_is_boolean(&secure_value))
                     goto error;
-                err = cbor_value_get_boolean(&secure_value, &secure);
+                err = cbor_value_get_boolean(&secure_value, &is_secure);
                 SOL_INT_CHECK_GOTO(err, != CborNoError, error);
             }
 
-            res->observable = (bitmap & SOL_OIC_FLAG_OBSERVABLE);
-            res->secure = secure;
-            res->observable = res->observable || _has_observable_option(req);
-            res->addr = *addr;
-            res->device_id.data = sol_util_memdup(device_id.data,
+            *observable = (bitmap & SOL_OIC_FLAG_OBSERVABLE);
+            *secure = is_secure;
+            *observable |= _has_observable_option(req);
+            *addr_ptr = *addr;
+            device_id_ptr->data = sol_util_memdup(device_id.data,
                 device_id.used);
-            if (!res->device_id.data)
+            if (!device_id_ptr->data)
                 goto error;
-            res->device_id.len = device_id.used;
+            device_id_ptr->len = device_id.used;
             SOL_REENTRANT_CALL((*(struct sol_reentrant *)(&(ctx->base.reentrant)))) {
                 discovery_callback_result =
-                    ctx->cb((void *)ctx->base.data, ctx->base.client, res);
+                    ctx->cb((void *)ctx->base.data, ctx->base.client,
+                    (struct sol_oic_resource *)res);
             }
 
             if (!discovery_callback_result || ctx->base.reentrant.delete_me) {
-                sol_oic_resource_unref(res);
+                sol_oic_resource_unref((struct sol_oic_resource *)res);
                 sol_buffer_fini(&device_id);
                 *cb_return  = false;
                 return true;
             }
 
-            sol_oic_resource_unref(res);
+            sol_oic_resource_unref((struct sol_oic_resource *)res);
         }
         sol_buffer_fini(&device_id);
     }
@@ -792,7 +836,7 @@ _iterate_over_resource_reply_payload(struct sol_coap_packet *req,
     return true;
 
 error:
-    sol_oic_resource_unref(res);
+    sol_oic_resource_unref((struct sol_oic_resource *)res);
     sol_buffer_fini(&device_id);
     return false;
 }
@@ -847,7 +891,7 @@ _find_resource_reply_cb(void *data, struct sol_coap_server *server,
         SOL_REENTRANT_FREE(ctx->base.reentrant) {
             free(ctx);
         }
-    return cb_return;
+        return cb_return;
 }
 
 SOL_API struct sol_oic_pending *
@@ -1012,10 +1056,12 @@ _resource_request_unobserve(struct sol_oic_client *client, struct sol_oic_resour
 {
     struct sol_coap_server *server;
     struct sol_network_link_addr addr;
+    struct sol_oic_resource_internal *r =
+        (struct sol_oic_resource_internal *)res;
 
     server = _best_server_for_resource(client, res, &addr);
     return sol_coap_unobserve_by_token(server, &addr,
-        (uint8_t *)&res->observe.token, (uint8_t)sizeof(res->observe.token));
+        (uint8_t *)&r->observe.token, (uint8_t)sizeof(r->observe.token));
 }
 
 static struct sol_oic_pending *
@@ -1049,7 +1095,8 @@ _resource_request(struct sol_oic_client_request *request,
         goto cbor_error;
     }
 
-    ctx->base.server = _best_server_for_resource(client, request->res, &addr);
+    ctx->base.server = _best_server_for_resource
+            (client, (struct sol_oic_resource *)request->res, &addr);
     ctx->base.req = request->base.pkt;
     request->base.pkt = NULL;
     r = sol_coap_send_packet_with_reply(ctx->base.server, ctx->base.req,
@@ -1080,11 +1127,16 @@ error:
 }
 
 static struct sol_oic_request *
-request_new(enum sol_coap_method method, enum sol_coap_msgtype type, struct sol_oic_resource *res, bool is_observe)
+request_new(enum sol_coap_method method,
+    enum sol_coap_message_type type,
+    struct sol_oic_resource *res,
+    bool is_observe)
 {
     struct sol_oic_client_request *request;
+    struct sol_oic_resource_internal *r =
+        (struct sol_oic_resource_internal *)res;
     char *path;
-    int r = 0;
+    int ret = 0;
 
     if (type != SOL_COAP_TYPE_CON && type != SOL_COAP_TYPE_NON_CON) {
         SOL_WRN("Only SOL_COAP_TYPE_CON and SOL_COAP_TYPE_NON_CON requests are"
@@ -1096,21 +1148,21 @@ request_new(enum sol_coap_method method, enum sol_coap_msgtype type, struct sol_
     request = calloc(1, sizeof(struct sol_oic_client_request));
     SOL_NULL_CHECK_ERRNO(request, ENOMEM, NULL);
 
-    request->res = res;
+    request->res = r;
     request->base.pkt = sol_coap_packet_new_request(method, type);
     if (!request->base.pkt) {
         SOL_WRN("Could not create CoAP packet");
-        r = -errno;
+        ret = -errno;
         goto error_pkt;
     }
 
-    r = _set_token_and_mid(request->base.pkt, &request->token);
-    SOL_INT_CHECK_GOTO(r, < 0, error;);
+    ret = _set_token_and_mid(request->base.pkt, &request->token);
+    SOL_INT_CHECK_GOTO(ret, < 0, error; );
 
     if (is_observe) {
         uint8_t reg = 0;
 
-        res->observe.token = request->token;
+        r->observe.token = request->token;
         sol_coap_add_option(request->base.pkt, SOL_COAP_OPTION_OBSERVE, &reg,
             sizeof(reg));
         request->cb = _resource_request_cb;
@@ -1119,11 +1171,11 @@ request_new(enum sol_coap_method method, enum sol_coap_msgtype type, struct sol_
 
     path = strndupa(res->path.data, res->path.len);
     if (!path) {
-        r = -ENOMEM;
+        ret = -ENOMEM;
         goto error;
     }
-    r = sol_coap_packet_add_uri_path_option(request->base.pkt, path);
-    if (r < 0) {
+    ret = sol_coap_packet_add_uri_path_option(request->base.pkt, path);
+    if (ret < 0) {
         SOL_WRN("Invalid URI: %s", path);
         goto error;
     }
@@ -1136,7 +1188,7 @@ error:
     sol_coap_packet_unref(request->base.pkt);
 error_pkt:
     free(request);
-    errno = -r;
+    errno = -ret;
     return NULL;
 }
 
@@ -1218,7 +1270,8 @@ _poll_resource(void *data)
     }
 
     /* FIXME: find a way to cancel any previous requests here */
-    request = sol_oic_client_request_new(SOL_COAP_METHOD_GET, ctx->res);
+    request = sol_oic_client_request_new(SOL_COAP_METHOD_GET,
+        (struct sol_oic_resource *)ctx->res);
     SOL_NULL_CHECK_GOTO(request, error);
 
     SOL_NULL_CHECK_GOTO(
@@ -1233,8 +1286,12 @@ error:
 }
 
 static int
-_observe_with_polling(struct sol_oic_client *client, struct sol_oic_resource *res,
-    void (*callback)(void *data, enum sol_coap_response_code response_code, struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
+_observe_with_polling(struct sol_oic_client *client,
+    struct sol_oic_resource_internal *res,
+    void (*callback)(void *data,
+    enum sol_coap_response_code response_code,
+    struct sol_oic_client *cli,
+    const struct sol_network_link_addr *addr,
     const struct sol_oic_map_reader *repr_vec),
     void *data)
 {
@@ -1257,12 +1314,12 @@ _observe_with_polling(struct sol_oic_client *client, struct sol_oic_resource *re
         return -ENOMEM;
     }
 
-    sol_oic_resource_ref(res);
+    sol_oic_resource_ref((struct sol_oic_resource *)res);
     return 0;
 }
 
 static bool
-_stop_observing_with_polling(struct sol_oic_resource *res)
+_stop_observing_with_polling(struct sol_oic_resource_internal *res)
 {
     SOL_INF("Deactivating resource polling timer");
 
@@ -1270,30 +1327,37 @@ _stop_observing_with_polling(struct sol_oic_resource *res)
     res->observe.timeout = NULL;
     res->observe.clear_data++;
 
-    sol_oic_resource_unref(res);
+    sol_oic_resource_unref((struct sol_oic_resource *)res);
 
     return true;
 }
 
 static int
-client_resource_set_observable(struct sol_oic_client *client, struct sol_oic_resource *res,
-    void (*callback)(void *data, enum sol_coap_response_code response_code, struct sol_oic_client *cli, const struct sol_network_link_addr *addr,
+client_resource_set_observable(struct sol_oic_client *client,
+    struct sol_oic_resource_internal *res,
+    void (*callback)(void *data,
+    enum sol_coap_response_code response_code,
+    struct sol_oic_client *cli,
+    const struct sol_network_link_addr *addr,
     const struct sol_oic_map_reader *repr_vec),
-    void *data, bool observe, bool non_confirmable)
+    void *data,
+    bool observe,
+    bool non_confirmable)
 {
-    int r = -EINVAL;
+    int ret = -EINVAL;
+    struct sol_oic_resource *r = (struct sol_oic_resource *)res;
 
     SOL_NULL_CHECK(client, -EINVAL);
     SOL_NULL_CHECK(res, -EINVAL);
-    OIC_RESOURCE_CHECK_API(res, 0, -EINVAL);
+    OIC_RESOURCE_CHECK_API(r, 0, -EINVAL);
 
     if (observe) {
         if (res->is_observed)
             return -EINVAL;
 
-        if (!res->observable) {
-            r = _observe_with_polling(client, res, callback, data);
-            res->is_observed = (r == 0);
+        if (!res->base.observable) {
+            ret = _observe_with_polling(client, res, callback, data);
+            res->is_observed = (ret == 0);
         } else {
             struct sol_oic_request *request;
             struct sol_oic_pending *tmp;
@@ -1306,9 +1370,9 @@ client_resource_set_observable(struct sol_oic_client *client, struct sol_oic_res
             tmp = _resource_request((struct sol_oic_client_request *)request,
                 client, callback, data);
             res->is_observed = (tmp != NULL);
-            r = res->is_observed ? 0 : -errno;
+            ret = res->is_observed ? 0 : -errno;
         }
-        return r;
+        return ret;
     }
 
     if (!res->is_observed) {
@@ -1319,14 +1383,14 @@ client_resource_set_observable(struct sol_oic_client *client, struct sol_oic_res
 
     if (res->observe.timeout) {
         res->is_observed = !_stop_observing_with_polling(res);
-        r = 0;
-    } else if (res->observable) {
-        r = _resource_request_unobserve(client, res);
-        if (r == 0)
+        ret = 0;
+    } else if (res->base.observable) {
+        ret = _resource_request_unobserve(client, r);
+        if (ret == 0)
             res->is_observed = false;
     }
 
-    return r;
+    return ret;
 }
 
 SOL_API int
@@ -1335,8 +1399,9 @@ sol_oic_client_resource_set_observable(struct sol_oic_client *client, struct sol
     const struct sol_oic_map_reader *repr_vec),
     const void *data, bool observe)
 {
-    return client_resource_set_observable(client, res, callback, (void *)data,
-        observe, false);
+    return client_resource_set_observable
+               (client, (struct sol_oic_resource_internal *)res, callback,
+               (void *)data, observe, false);
 }
 
 SOL_API int
@@ -1345,8 +1410,9 @@ sol_oic_client_resource_set_observable_non_confirmable(struct sol_oic_client *cl
     const struct sol_oic_map_reader *repr_vec),
     const void *data, bool observe)
 {
-    return client_resource_set_observable(client, res, callback, (void *)data,
-        observe, true);
+    return client_resource_set_observable
+               (client, (struct sol_oic_resource_internal *)res, callback,
+               (void *)data, observe, true);
 }
 
 SOL_API struct sol_oic_client *

--- a/src/lib/comms/sol-oic-common.c
+++ b/src/lib/comms/sol-oic-common.c
@@ -21,7 +21,7 @@
 #include "sol-log.h"
 #include <assert.h>
 
-SOL_API enum sol_oic_map_loop_status
+SOL_API enum sol_oic_map_loop_reason
 sol_oic_map_loop_init(const struct sol_oic_map_reader *map, struct sol_oic_map_reader *iterator, struct sol_oic_repr_field *repr)
 {
     SOL_NULL_CHECK(map, SOL_OIC_MAP_LOOP_ERROR);
@@ -57,7 +57,7 @@ sol_oic_repr_field_clear(struct sol_oic_repr_field *field)
 }
 
 SOL_API bool
-sol_oic_map_loop_next(struct sol_oic_repr_field *repr, struct sol_oic_map_reader *iterator, enum sol_oic_map_loop_status *reason)
+sol_oic_map_loop_next(struct sol_oic_repr_field *repr, struct sol_oic_map_reader *iterator, enum sol_oic_map_loop_reason *reason)
 {
     CborError err;
 

--- a/src/lib/comms/sol-oic-server.c
+++ b/src/lib/comms/sol-oic-server.c
@@ -1122,7 +1122,7 @@ sol_oic_server_notify(struct sol_oic_response *notification)
 close_error:
     r = sol_coap_header_set_code(notification->pkt, code);
     SOL_INT_CHECK_GOTO(r, < 0, error);
-    r = sol_coap_header_set_type(notification->pkt, SOL_COAP_TYPE_ACK);
+    r = sol_coap_header_set_type(notification->pkt, SOL_COAP_MESSAGE_TYPE_ACK);
     SOL_INT_CHECK_GOTO(r, < 0, error);
 
     //Keep reference to CoAP packet, because

--- a/src/lib/datatypes/include/sol-str-slice.h
+++ b/src/lib/datatypes/include/sol-str-slice.h
@@ -305,7 +305,7 @@ int sol_str_slice_to_int(const struct sol_str_slice s, int *value);
  * @return New string created from the slice
  */
 static inline char *
-sol_str_slice_to_string(const struct sol_str_slice slice)
+sol_str_slice_to_str(const struct sol_str_slice slice)
 {
     return strndup(slice.data, slice.len);
 }

--- a/src/lib/datatypes/sol-memdesc.c
+++ b/src/lib/datatypes/sol-memdesc.c
@@ -484,7 +484,7 @@ compare_content(const struct sol_memdesc *desc, const void *a_mem, const void *b
         const double *a = a_mem;
         const double *b = b_mem;
 
-        if (sol_util_double_equal(*a, *b))
+        if (sol_util_double_eq(*a, *b))
             return 0;
         else if (*a < *b)
             return -1;

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -574,7 +574,7 @@ enum sol_flow_node_options_member_type {
  *
  * @return String of the type's name, @c NULL on errors
  */
-const char *sol_flow_node_options_member_type_to_string(enum sol_flow_node_options_member_type type);
+const char *sol_flow_node_options_member_type_to_str(enum sol_flow_node_options_member_type type);
 
 /**
  * @brief Returns the option member type which name is @c data_type.

--- a/src/lib/flow/sol-flow-node-options.c
+++ b/src/lib/flow/sol-flow-node-options.c
@@ -600,7 +600,7 @@ sol_flow_node_named_options_parse_member(
         r = options_parse_functions[m->type](value, m);
         if (r < 0) {
             SOL_DBG("Invalid value '%s' for option name='%s' of type='%s'",
-                value, m->name, sol_flow_node_options_member_type_to_string(m->type));
+                value, m->name, sol_flow_node_options_member_type_to_str(m->type));
         }
     } else {
         r = -ENOTSUP;
@@ -682,7 +682,7 @@ sol_flow_node_options_member_type_from_string(const char *data_type)
 
 /* TODO: Make a reverse table? */
 SOL_API const char *
-sol_flow_node_options_member_type_to_string(enum sol_flow_node_options_member_type type)
+sol_flow_node_options_member_type_to_str(enum sol_flow_node_options_member_type type)
 {
     const struct sol_str_table *entry;
     const char *data_type = NULL;

--- a/src/lib/flow/sol-flow-parser.c
+++ b/src/lib/flow/sol-flow-parser.c
@@ -361,7 +361,7 @@ append_node_options(
         } else if (is_string_value) {
             sol_fbp_log_print(state->filename, meta->position.line, meta->position.column,
                 "Option '%.*s' (%s) of node '%.*s' must not be quoted since it's not a string",
-                SOL_STR_SLICE_PRINT(meta->key), sol_flow_node_options_member_type_to_string(m->type),
+                SOL_STR_SLICE_PRINT(meta->key), sol_flow_node_options_member_type_to_str(m->type),
                 SOL_STR_SLICE_PRINT(node->name));
             failed = true;
             continue;
@@ -374,7 +374,7 @@ append_node_options(
             sol_fbp_log_print(state->filename, meta->position.line, meta->position.column,
                 "Couldn't parse value '%.*s' for option '%.*s' (%s) of node '%.*s'",
                 SOL_STR_SLICE_PRINT(meta->value), SOL_STR_SLICE_PRINT(meta->key),
-                sol_flow_node_options_member_type_to_string(m->type), SOL_STR_SLICE_PRINT(node->name));
+                sol_flow_node_options_member_type_to_str(m->type), SOL_STR_SLICE_PRINT(node->name));
             failed = true;
             continue;
         }

--- a/src/lib/io/sol-iio.c
+++ b/src/lib/io/sol-iio.c
@@ -1312,11 +1312,11 @@ create_device_address(struct sol_str_slice *command)
             goto end;
         }
 
-        rel_path = sol_str_slice_to_string(
+        rel_path = sol_str_slice_to_str(
             *(const struct sol_str_slice *)sol_vector_get(&instructions, REL_PATH_IDX));
         SOL_NULL_CHECK_GOTO(rel_path, end);
 
-        dev_number_s = sol_str_slice_to_string(
+        dev_number_s = sol_str_slice_to_str(
             *(const struct sol_str_slice *)sol_vector_get(&instructions, DEV_NUMBER_IDX));
         SOL_NULL_CHECK_GOTO(dev_number_s, end);
 
@@ -1325,7 +1325,7 @@ create_device_address(struct sol_str_slice *command)
         if (errno || *end_ptr != '\0')
             goto end;
 
-        dev_name = sol_str_slice_to_string(
+        dev_name = sol_str_slice_to_str(
             *(const struct sol_str_slice *)sol_vector_get(&instructions, DEV_NAME_IDX));
         SOL_NULL_CHECK_GOTO(dev_name, end);
 
@@ -1373,7 +1373,7 @@ sol_iio_address_device(const char *commands)
         if (strstartswith(command->data, "create,"))
             command_s = create_device_address(command);
         else
-            command_s = sol_str_slice_to_string(*command);
+            command_s = sol_str_slice_to_str(*command);
 
         if (command_s) {
             r = resolve_device_address(command_s);

--- a/src/lib/io/sol-memmap-storage.c
+++ b/src/lib/io/sol-memmap-storage.c
@@ -572,11 +572,11 @@ resolve_i2c_path(const char *path, char **resolved_path)
         goto end;
     }
 
-    rel_path = sol_str_slice_to_string(
+    rel_path = sol_str_slice_to_str(
         *(const struct sol_str_slice *)sol_vector_get(&instructions, REL_PATH_IDX));
     SOL_NULL_CHECK_GOTO(rel_path, end);
 
-    dev_number_s = sol_str_slice_to_string(
+    dev_number_s = sol_str_slice_to_str(
         *(const struct sol_str_slice *)sol_vector_get(&instructions, DEV_NUMBER_IDX));
     SOL_NULL_CHECK_GOTO(dev_number_s, end);
 
@@ -585,7 +585,7 @@ resolve_i2c_path(const char *path, char **resolved_path)
     if (errno || *end_ptr != '\0')
         goto end;
 
-    dev_name = sol_str_slice_to_string(
+    dev_name = sol_str_slice_to_str(
         *(const struct sol_str_slice *)sol_vector_get(&instructions, DEV_NAME_IDX));
     SOL_NULL_CHECK_GOTO(dev_name, end);
 

--- a/src/modules/flow/byte/byte.c
+++ b/src/modules/flow/byte/byte.c
@@ -244,7 +244,7 @@ struct byte_comparison_data {
 };
 
 static bool
-byte_val_equal(unsigned char var0, unsigned char var1)
+byte_val_eq(unsigned char var0, unsigned char var1)
 {
     return var0 == var1;
 }
@@ -256,7 +256,7 @@ byte_val_less(unsigned char var0, unsigned char var1)
 }
 
 static bool
-byte_val_less_or_equal(unsigned char var0, unsigned char var1)
+byte_val_less_or_eq(unsigned char var0, unsigned char var1)
 {
     return var0 <= var1;
 }
@@ -268,13 +268,13 @@ byte_val_greater(unsigned char var0, unsigned char var1)
 }
 
 static bool
-byte_val_greater_or_equal(unsigned char var0, unsigned char var1)
+byte_val_greater_or_eq(unsigned char var0, unsigned char var1)
 {
     return var0 >= var1;
 }
 
 static bool
-byte_val_not_equal(unsigned char var0, unsigned char var1)
+byte_val_not_eq(unsigned char var0, unsigned char var1)
 {
     return var0 != var1;
 }

--- a/src/modules/flow/byte/byte.json
+++ b/src/modules/flow/byte/byte.json
@@ -231,7 +231,7 @@
         ],
         "data_type": "struct byte_comparison_node_type",
         "extra_methods": {
-          "func": "byte_val_equal"
+          "func": "byte_val_eq"
         }
       },
       "out_ports": [
@@ -297,7 +297,7 @@
         ],
         "data_type": "struct byte_comparison_node_type",
         "extra_methods": {
-          "func": "byte_val_greater_or_equal"
+          "func": "byte_val_greater_or_eq"
         }
       },
       "out_ports": [
@@ -363,7 +363,7 @@
         ],
         "data_type": "struct byte_comparison_node_type",
         "extra_methods": {
-          "func": "byte_val_less_or_equal"
+          "func": "byte_val_less_or_eq"
         }
       },
       "out_ports": [
@@ -396,7 +396,7 @@
         ],
         "data_type": "struct byte_comparison_node_type",
         "extra_methods": {
-          "func": "byte_val_not_equal"
+          "func": "byte_val_not_eq"
         }
       },
       "out_ports": [

--- a/src/modules/flow/compass/compass.c
+++ b/src/modules/flow/compass/compass.c
@@ -66,7 +66,7 @@ _calculate_result(struct compass_data *mdata)
     _normalize_data(mdata);
 
     pitch = asin(-mdata->accel.x);
-    if (!sol_util_double_equal(fabs(pitch), M_PI / 2))
+    if (!sol_util_double_eq(fabs(pitch), M_PI / 2))
         roll = asin(mdata->accel.y / cos(pitch));
     else
         roll = 0.0;

--- a/src/modules/flow/filter-repeated/filter-repeated.c
+++ b/src/modules/flow/filter-repeated/filter-repeated.c
@@ -148,7 +148,7 @@ float_filter(struct sol_flow_node *node, void *data, uint16_t port, uint16_t con
     r = sol_flow_packet_get_drange(packet, &in_value);
     SOL_INT_CHECK(r, < 0, r);
 
-    if (mdata->initialized && sol_drange_equal(&in_value, &mdata->value))
+    if (mdata->initialized && sol_drange_eq(&in_value, &mdata->value))
         return 0;
 
     mdata->initialized = true;
@@ -168,7 +168,7 @@ int_filter(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_
     r = sol_flow_packet_get_irange(packet, &in_value);
     SOL_INT_CHECK(r, < 0, r);
 
-    if (mdata->initialized && sol_irange_equal(&in_value, &mdata->value))
+    if (mdata->initialized && sol_irange_eq(&in_value, &mdata->value))
         return 0;
 
     mdata->initialized = true;

--- a/src/modules/flow/float/float.c
+++ b/src/modules/flow/float/float.c
@@ -141,7 +141,7 @@ multiple_operator_process(struct sol_flow_node *node, void *data, uint16_t port,
     SOL_INT_CHECK(r, < 0, r);
 
     if ((mdata->var_initialized & (1u << port)) &&
-        sol_drange_equal(&mdata->var[port], &value))
+        sol_drange_eq(&mdata->var[port], &value))
         return 0;
 
     mdata->var_initialized |= 1u << port;
@@ -458,7 +458,7 @@ drange_val_less(double var0, double var1)
 }
 
 static bool
-drange_val_less_or_equal(double var0, double var1)
+drange_val_less_or_eq(double var0, double var1)
 {
     return islessequal(var0, var1);
 }
@@ -470,15 +470,15 @@ drange_val_greater(double var0, double var1)
 }
 
 static bool
-drange_val_greater_or_equal(double var0, double var1)
+drange_val_greater_or_eq(double var0, double var1)
 {
     return isgreaterequal(var0, var1);
 }
 
 static bool
-drange_val_not_equal(double var0, double var1)
+drange_val_not_eq(double var0, double var1)
 {
-    return !sol_util_double_equal(var0, var1);
+    return !sol_util_double_eq(var0, var1);
 }
 
 static int
@@ -609,11 +609,11 @@ direction_check(struct drange_wave_generator_trapezoidal_data *mdata,
     struct sol_drange *v = &mdata->t_state.val;
     struct t_state *t_state = &mdata->t_state;
 
-    if (sol_util_double_equal(v->val, v->max)) {
+    if (sol_util_double_eq(v->val, v->max)) {
         if (reset_max_cnt)
             t_state->max_tick_cnt = mdata->ticks_at_max;
         direction_switch(mdata, true);
-    } else if (sol_util_double_equal(v->val, v->min)) {
+    } else if (sol_util_double_eq(v->val, v->min)) {
         if (reset_min_cnt)
             t_state->min_tick_cnt = mdata->ticks_at_min;
         direction_switch(mdata, false);

--- a/src/modules/flow/float/float.json
+++ b/src/modules/flow/float/float.json
@@ -485,7 +485,7 @@
         ],
         "data_type": "struct drange_comparison_node_type",
         "extra_methods": {
-          "func": "sol_util_double_equal"
+          "func": "sol_util_double_eq"
         }
       },
       "out_ports": [
@@ -518,7 +518,7 @@
         ],
         "data_type": "struct drange_comparison_node_type",
         "extra_methods": {
-          "func": "drange_val_greater_or_equal"
+          "func": "drange_val_greater_or_eq"
         }
       },
       "out_ports": [
@@ -584,7 +584,7 @@
         ],
         "data_type": "struct drange_comparison_node_type",
         "extra_methods": {
-          "func": "drange_val_less_or_equal"
+          "func": "drange_val_less_or_eq"
         }
       },
       "out_ports": [
@@ -650,7 +650,7 @@
         ],
         "data_type": "struct drange_comparison_node_type",
         "extra_methods": {
-          "func": "drange_val_not_equal"
+          "func": "drange_val_not_eq"
         }
       },
       "out_ports": [

--- a/src/modules/flow/format/string-format.c
+++ b/src/modules/flow/format/string-format.c
@@ -1507,7 +1507,7 @@ double_to_buffer(double val,
         SOL_INT_CHECK(r, < 0, r);
         t = DTST_NAN;
     } else if (fpclassify(val) == FP_INFINITE) {
-        if (sol_util_double_equal(copysign(1., val), 1.)) {
+        if (sol_util_double_eq(copysign(1., val), 1.)) {
             static struct sol_str_slice slice = SOL_STR_SLICE_LITERAL("nan");
             r = sol_buffer_append_slice(out, slice);
             SOL_INT_CHECK(r, < 0, r);

--- a/src/modules/flow/http-client/http-client.c
+++ b/src/modules/flow/http-client/http-client.c
@@ -718,7 +718,7 @@ string_process_json(struct sol_flow_node *node, const struct sol_str_slice slice
     if (sol_json_token_get_type(&value) == SOL_JSON_TYPE_STRING)
         result = sol_json_token_get_unescaped_string_copy(&value);
     else
-        result = sol_str_slice_to_string(slice);
+        result = sol_str_slice_to_str(slice);
     SOL_NULL_CHECK(result, -ENOMEM);
 
     return sol_flow_send_string_take_packet(node,
@@ -1495,9 +1495,9 @@ setup_response_headers_and_cookies(struct sol_http_params *params,
 
         resp_param = sol_vector_append(to_append);
         SOL_NULL_CHECK_GOTO(resp_param, err_exit);
-        resp_param->key = sol_str_slice_to_string(param->value.key_value.key);
+        resp_param->key = sol_str_slice_to_str(param->value.key_value.key);
         resp_param->value =
-            sol_str_slice_to_string(param->value.key_value.value);
+            sol_str_slice_to_str(param->value.key_value.value);
     }
 
     return 0;

--- a/src/modules/flow/http-server/http-server.c
+++ b/src/modules/flow/http-server/http-server.c
@@ -112,7 +112,7 @@ static struct sol_ptr_vector servers = SOL_PTR_VECTOR_INIT;
         if ((fpclassify(mdata->value.field_) == FP_ZERO) && (errno != 0)) { \
             return -errno; \
         } \
-        if (!sol_util_double_equal(mdata->value.field_, d)) { \
+        if (!sol_util_double_eq(mdata->value.field_, d)) { \
             mdata->value.field_ = d; \
             ret_ = 1; \
         } \
@@ -892,7 +892,7 @@ int_process_cb(struct http_data *mdata, const struct sol_flow_packet *packet)
     r = sol_flow_packet_get_irange(packet, &i);
     SOL_INT_CHECK(r, < 0, r);
 
-    if (sol_irange_equal(&mdata->value.i, &i))
+    if (sol_irange_eq(&mdata->value.i, &i))
         return 0;
 
     memcpy(&mdata->value.i, &i, sizeof(i));
@@ -978,7 +978,7 @@ float_process_cb(struct http_data *mdata, const struct sol_flow_packet *packet)
     r = sol_flow_packet_get_drange(packet, &d);
     SOL_INT_CHECK(r, < 0, r);
 
-    if (sol_drange_equal(&mdata->value.d, &d))
+    if (sol_drange_eq(&mdata->value.d, &d))
         return 0;
 
     memcpy(&mdata->value.d, &d, sizeof(d));
@@ -1043,7 +1043,7 @@ rgb_process_cb(struct http_data *mdata, const struct sol_flow_packet *packet)
     r = sol_flow_packet_get_rgb(packet, &rgb);
     SOL_INT_CHECK(r, < 0, r);
 
-    if (sol_rgb_equal(&mdata->value.rgb, &rgb))
+    if (sol_rgb_eq(&mdata->value.rgb, &rgb))
         return 0;
 
     memcpy(&mdata->value.rgb, &rgb, sizeof(struct sol_rgb));
@@ -1181,7 +1181,7 @@ direction_vector_process_cb(struct http_data *mdata,
     r = sol_flow_packet_get_direction_vector(packet, &dir);
     SOL_INT_CHECK(r, < 0, r);
 
-    if (sol_direction_vector_equal(&mdata->value.dir_vector, &dir))
+    if (sol_direction_vector_eq(&mdata->value.dir_vector, &dir))
         return 0;
 
     memcpy(&mdata->value.dir_vector, &dir, sizeof(struct sol_direction_vector));
@@ -1241,7 +1241,7 @@ blob_open(struct sol_flow_node *node, void *data,
 }
 
 static bool
-blob_is_equal(struct sol_blob *b1, struct sol_blob *b2)
+blob_is_eq(struct sol_blob *b1, struct sol_blob *b2)
 {
     return b1->size == b2->size && !memcmp(b1->mem, b2->mem, b2->size);
 }
@@ -1254,7 +1254,7 @@ replace_blob(struct http_data *mdata, struct sol_blob *blob)
     if (!mdata->value.blob)
         updated = 1;
     else {
-        if (!blob_is_equal(blob, mdata->value.blob)) {
+        if (!blob_is_eq(blob, mdata->value.blob)) {
             updated = 1;
             sol_blob_unref(mdata->value.blob);
         }
@@ -1529,7 +1529,7 @@ json_process_cb(struct http_data *mdata,
         aux.max = i.max;
         aux.step = i.step;
 
-        if (!sol_drange_equal(&mdata->value.d, &aux)) {
+        if (!sol_drange_eq(&mdata->value.d, &aux)) {
             r = 1;
             memcpy(&mdata->value.d, &aux, sizeof(struct sol_drange));
         } else

--- a/src/modules/flow/int/int.c
+++ b/src/modules/flow/int/int.c
@@ -42,7 +42,7 @@ struct irange_comparison_data {
 };
 
 static bool
-irange_val_equal(int32_t var0, int32_t var1)
+irange_val_eq(int32_t var0, int32_t var1)
 {
     return var0 == var1;
 }
@@ -54,7 +54,7 @@ irange_val_less(int32_t var0, int32_t var1)
 }
 
 static bool
-irange_val_less_or_equal(int32_t var0, int32_t var1)
+irange_val_less_or_eq(int32_t var0, int32_t var1)
 {
     return var0 <= var1;
 }
@@ -66,13 +66,13 @@ irange_val_greater(int32_t var0, int32_t var1)
 }
 
 static bool
-irange_val_greater_or_equal(int32_t var0, int32_t var1)
+irange_val_greater_or_eq(int32_t var0, int32_t var1)
 {
     return var0 >= var1;
 }
 
 static bool
-irange_val_not_equal(int32_t var0, int32_t var1)
+irange_val_not_eq(int32_t var0, int32_t var1)
 {
     return var0 != var1;
 }

--- a/src/modules/flow/int/int.json
+++ b/src/modules/flow/int/int.json
@@ -628,7 +628,7 @@
         ],
         "data_type": "struct irange_comparison_node_type",
         "extra_methods": {
-          "func": "irange_val_equal"
+          "func": "irange_val_eq"
         }
       },
       "out_ports": [
@@ -694,7 +694,7 @@
         ],
         "data_type": "struct irange_comparison_node_type",
         "extra_methods": {
-          "func": "irange_val_greater_or_equal"
+          "func": "irange_val_greater_or_eq"
         }
       },
       "out_ports": [
@@ -760,7 +760,7 @@
         ],
         "data_type": "struct irange_comparison_node_type",
         "extra_methods": {
-          "func": "irange_val_less_or_equal"
+          "func": "irange_val_less_or_eq"
         }
       },
       "out_ports": [
@@ -793,7 +793,7 @@
         ],
         "data_type": "struct irange_comparison_node_type",
         "extra_methods": {
-          "func": "irange_val_not_equal"
+          "func": "irange_val_not_eq"
         }
       },
       "out_ports": [

--- a/src/modules/flow/json/json.c
+++ b/src/modules/flow/json/json.c
@@ -758,7 +758,7 @@ json_object_get_or_create_child_element(struct json_element *element, const stru
 
     key_element = sol_vector_append(&element->children);
     SOL_NULL_CHECK(key_element, NULL);
-    key_element->key = sol_str_slice_to_string(key_slice);
+    key_element->key = sol_str_slice_to_str(key_slice);
     SOL_NULL_CHECK_GOTO(key_element->key, str_error);
 
     key_element->element.type = JSON_TYPE_UNKNOWN;

--- a/src/modules/flow/magnetometer/lsm303.c
+++ b/src/modules/flow/magnetometer/lsm303.c
@@ -62,31 +62,31 @@ timer_sched(struct magnetometer_lsm303_data *mdata, uint32_t timeout_ms, bool (*
 static bool
 _get_range_bits_and_gain(double range, uint8_t *range_bit, uint16_t *gain_xy, uint16_t *gain_z)
 {
-    if (sol_util_double_equal(range, 1.3)) {
+    if (sol_util_double_eq(range, 1.3)) {
         *range_bit = 0x01;
         *gain_xy = 1100;
         *gain_z = 980;
-    } else if (sol_util_double_equal(range, 1.9)) {
+    } else if (sol_util_double_eq(range, 1.9)) {
         *range_bit = 0x02;
         *gain_xy = 855;
         *gain_z = 760;
-    } else if (sol_util_double_equal(range, 2.5)) {
+    } else if (sol_util_double_eq(range, 2.5)) {
         *range_bit = 0x03;
         *gain_xy = 670;
         *gain_z = 600;
-    } else if (sol_util_double_equal(range, 4.0)) {
+    } else if (sol_util_double_eq(range, 4.0)) {
         *range_bit = 0x04;
         *gain_xy = 450;
         *gain_z = 400;
-    } else if (sol_util_double_equal(range, 4.5)) {
+    } else if (sol_util_double_eq(range, 4.5)) {
         *range_bit = 0x05;
         *gain_xy = 400;
         *gain_z = 355;
-    } else if (sol_util_double_equal(range, 5.6)) {
+    } else if (sol_util_double_eq(range, 5.6)) {
         *range_bit = 0x06;
         *gain_xy = 330;
         *gain_z = 295;
-    } else if (sol_util_double_equal(range, 8.1)) {
+    } else if (sol_util_double_eq(range, 8.1)) {
         *range_bit = 0x07;
         *gain_xy = 230;
         *gain_z = 205;

--- a/src/modules/flow/oauth/oauth.c
+++ b/src/modules/flow/oauth/oauth.c
@@ -161,9 +161,9 @@ v1_authorize_response_cb(void *data, struct sol_http_request *request)
         switch (value->type) {
         case SOL_HTTP_PARAM_QUERY_PARAM:
             if (sol_str_slice_str_eq(value->value.key_value.key, "oauth_verifier") && !verifier) {
-                verifier = sol_str_slice_to_string(value->value.key_value.value);
+                verifier = sol_str_slice_to_str(value->value.key_value.value);
             } else if (sol_str_slice_str_eq(value->value.key_value.key, "oauth_token") && !token) {
-                token = sol_str_slice_to_string(value->value.key_value.value);
+                token = sol_str_slice_to_str(value->value.key_value.value);
             }
             break;
         default:

--- a/src/modules/flow/persistence/persistence.c
+++ b/src/modules/flow/persistence/persistence.c
@@ -579,9 +579,9 @@ persist_drange_send_packet(struct sol_flow_node *node)
 {
     struct persist_drange_data *mdata = sol_flow_node_get_private_data(node);
     struct sol_drange *val = mdata->base.value_ptr;
-    bool no_defaults = sol_util_double_equal(val->step, 0) &&
-        sol_util_double_equal(val->min, 0) &&
-        sol_util_double_equal(val->min, 0);
+    bool no_defaults = sol_util_double_eq(val->step, 0) &&
+        sol_util_double_eq(val->min, 0) &&
+        sol_util_double_eq(val->min, 0);
 
     if (mdata->store_only_val || no_defaults) {
         struct sol_drange value = {

--- a/src/modules/flow/test/float-validator.c
+++ b/src/modules/flow/test/float-validator.c
@@ -104,7 +104,7 @@ float_validator_process(
     SOL_INT_CHECK(r, < 0, r);
     op = sol_vector_get(&mdata->values, mdata->next_index);
     SOL_NULL_CHECK(op, -EINVAL);
-    match = sol_util_double_equal(input.val, *op);
+    match = sol_util_double_eq(input.val, *op);
     mdata->next_index++;
 
     if (mdata->next_index == mdata->values.len || !match) {

--- a/src/modules/flow/timestamp/timestamp.c
+++ b/src/modules/flow/timestamp/timestamp.c
@@ -377,7 +377,7 @@ struct timestamp_comparison_data {
 };
 
 static bool
-timestamp_val_equal(struct timespec *var0, struct timespec *var1)
+timestamp_val_eq(struct timespec *var0, struct timespec *var1)
 {
     if (var0->tv_sec != var1->tv_sec)
         return false;
@@ -393,7 +393,7 @@ timestamp_val_less(struct timespec *var0, struct timespec *var1)
 }
 
 static bool
-timestamp_val_less_or_equal(struct timespec *var0, struct timespec *var1)
+timestamp_val_less_or_eq(struct timespec *var0, struct timespec *var1)
 {
     if (var0->tv_sec == var1->tv_sec)
         return var0->tv_nsec <= var1->tv_nsec;
@@ -409,7 +409,7 @@ timestamp_val_greater(struct timespec *var0, struct timespec *var1)
 }
 
 static bool
-timestamp_val_greater_or_equal(struct timespec *var0, struct timespec *var1)
+timestamp_val_greater_or_eq(struct timespec *var0, struct timespec *var1)
 {
     if (var0->tv_sec == var1->tv_sec)
         return var0->tv_nsec >= var1->tv_nsec;
@@ -417,7 +417,7 @@ timestamp_val_greater_or_equal(struct timespec *var0, struct timespec *var1)
 }
 
 static bool
-timestamp_val_not_equal(struct timespec *var0, struct timespec *var1)
+timestamp_val_not_eq(struct timespec *var0, struct timespec *var1)
 {
     if (var0->tv_sec != var1->tv_sec)
         return true;

--- a/src/modules/flow/timestamp/timestamp.json
+++ b/src/modules/flow/timestamp/timestamp.json
@@ -217,7 +217,7 @@
         ],
         "data_type": "struct timestamp_comparison_node_type",
         "extra_methods": {
-          "func": "timestamp_val_equal"
+          "func": "timestamp_val_eq"
         }
       },
       "out_ports": [
@@ -283,7 +283,7 @@
         ],
         "data_type": "struct timestamp_comparison_node_type",
         "extra_methods": {
-          "func": "timestamp_val_greater_or_equal"
+          "func": "timestamp_val_greater_or_eq"
         }
       },
       "out_ports": [
@@ -349,7 +349,7 @@
         ],
         "data_type": "struct timestamp_comparison_node_type",
         "extra_methods": {
-          "func": "timestamp_val_less_or_equal"
+          "func": "timestamp_val_less_or_eq"
         }
       },
       "out_ports": [
@@ -382,7 +382,7 @@
         ],
         "data_type": "struct timestamp_comparison_node_type",
         "extra_methods": {
-          "func": "timestamp_val_not_equal"
+          "func": "timestamp_val_not_eq"
         }
       },
       "out_ports": [

--- a/src/modules/linux-micro/kmod/kmod.c
+++ b/src/modules/linux-micro/kmod/kmod.c
@@ -63,7 +63,7 @@ kmod_apply_value(struct kmod_ctx *kmod, struct sol_str_slice modalias)
     int r = 0;
     char *alias = NULL;
 
-    alias = sol_str_slice_to_string(modalias);
+    alias = sol_str_slice_to_str(modalias);
     SOL_NULL_CHECK(alias, -ENOMEM);
 
     SOL_INF("Trying to load module for alias: %s", alias);

--- a/src/samples/coap/oic-client.c
+++ b/src/samples/coap/oic-client.c
@@ -27,7 +27,7 @@ static void
 got_get_response(void *data, enum sol_coap_response_code response_code, struct sol_oic_client *cli, const struct sol_network_link_addr *srv_addr, const struct sol_oic_map_reader *map_reader)
 {
     struct sol_oic_repr_field field;
-    enum sol_oic_map_loop_status end_status;
+    enum sol_oic_map_loop_reason end_reason;
     struct sol_oic_map_reader iterator;
 
     SOL_BUFFER_DECLARE_STATIC(addr, SOL_NETWORK_INET_ADDR_STR_LEN);
@@ -48,7 +48,7 @@ got_get_response(void *data, enum sol_coap_response_code response_code, struct s
     }
 
     printf("Dumping payload received from addr %.*s {\n", SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr)));
-    SOL_OIC_MAP_LOOP(map_reader, &field, &iterator, end_status) {
+    SOL_OIC_MAP_LOOP(map_reader, &field, &iterator, end_reason) {
         printf("\tkey: '%s', value: ", field.key);
 
         switch (field.type) {
@@ -87,7 +87,9 @@ got_get_response(void *data, enum sol_coap_response_code response_code, struct s
 }
 
 static bool
-found_resource(void *data, struct sol_oic_client *cli, struct sol_oic_resource *res)
+found_resource(void *data,
+    struct sol_oic_client *cli,
+    struct sol_oic_resource *res)
 {
     static const char digits[] = "0123456789abcdef";
     struct sol_str_slice *slice;

--- a/src/samples/coap/oic-server.c
+++ b/src/samples/coap/oic-server.c
@@ -110,7 +110,7 @@ static int
 user_handle_put(void *data, struct sol_oic_request *request)
 {
     enum sol_coap_response_code code = SOL_COAP_RESPONSE_CODE_BAD_REQUEST;
-    enum sol_oic_map_loop_status reason;
+    enum sol_oic_map_loop_reason reason;
     struct sol_oic_repr_field field;
     struct sol_oic_map_reader iter;
     struct sol_oic_map_reader *input;

--- a/src/samples/coap/simple-client.c
+++ b/src/samples/coap/simple-client.c
@@ -50,7 +50,7 @@ disable_observing(struct sol_coap_packet *req, struct sol_coap_server *server,
 
     r = sol_coap_header_set_code(pkt, SOL_COAP_METHOD_GET);
     SOL_INT_CHECK_GOTO(r, < 0, err);
-    r = sol_coap_header_set_type(pkt, SOL_COAP_TYPE_CON);
+    r = sol_coap_header_set_type(pkt, SOL_COAP_MESSAGE_TYPE_CON);
     SOL_INT_CHECK_GOTO(r, < 0, err);
     r = sol_coap_add_option(pkt, SOL_COAP_OPTION_OBSERVE, &observe, sizeof(observe));
     SOL_INT_CHECK_GOTO(r, < 0, err);
@@ -123,7 +123,7 @@ main(int argc, char *argv[])
         return -1;
     }
 
-    req = sol_coap_packet_new_request(SOL_COAP_METHOD_GET, SOL_COAP_TYPE_CON);
+    req = sol_coap_packet_new_request(SOL_COAP_METHOD_GET, SOL_COAP_MESSAGE_TYPE_CON);
     if (!req) {
         SOL_WRN("Could not make a GET request to resource %s", argv[2]);
         return -1;

--- a/src/samples/coap/simple-server.c
+++ b/src/samples/coap/simple-server.c
@@ -154,7 +154,7 @@ done:
         SOL_WRN("Could not build response packet");
         return -1;
     }
-    r = sol_coap_header_set_type(resp, SOL_COAP_TYPE_ACK);
+    r = sol_coap_header_set_type(resp, SOL_COAP_MESSAGE_TYPE_ACK);
     SOL_INT_CHECK_GOTO(r, < 0, err);
     r = sol_coap_header_set_code(resp, code);
     SOL_INT_CHECK_GOTO(r, < 0, err);
@@ -209,7 +209,7 @@ light_method_get(void *data, struct sol_coap_server *server,
         SOL_WRN("Could not build response packet");
         return -1;
     }
-    r = sol_coap_header_set_type(resp, SOL_COAP_TYPE_ACK);
+    r = sol_coap_header_set_type(resp, SOL_COAP_MESSAGE_TYPE_ACK);
     SOL_INT_CHECK_GOTO(r, < 0, err);
     r = sol_coap_header_set_code(resp, SOL_COAP_RESPONSE_CODE_CONTENT);
     SOL_INT_CHECK_GOTO(r, < 0, err);

--- a/src/shared/include/sol-util.h
+++ b/src/shared/include/sol-util.h
@@ -449,7 +449,7 @@ int sol_util_uuid_gen(bool uppercase, bool with_hyphens, struct sol_buffer *uuid
 bool sol_util_uuid_str_is_valid(const struct sol_str_slice uuid);
 
 /**
- * @brief Convert an UUID in byte format to UUID string format.
+ * @brief Convert a UUID in byte format to UUID string format.
  *
  * @param uppercase Whether to create the UUID string in uppercase or not
  * @param with_hyphens Format the resulting UUID string with hyphens
@@ -465,7 +465,7 @@ bool sol_util_uuid_str_is_valid(const struct sol_str_slice uuid);
 int sol_util_uuid_string_from_bytes(bool uppercase, bool with_hyphens, const uint8_t uuid_bytes[SOL_STATIC_ARRAY_SIZE(16)], struct sol_buffer *uuid_str);
 
 /**
- * @brief Convert an UUID in string format to a byte array with UUID bytes.
+ * @brief Convert a UUID in string format to a byte array with UUID bytes.
  *
  * @param uuid_str The UUID in string format, with or without hyphens, using
  *        lowercase or uppercase characters.
@@ -1143,7 +1143,7 @@ ssize_t sol_util_strftime(struct sol_buffer *buf, const char *format, const stru
  *
  * @return @c true if both values are equal, @c false otherwise.
  */
-bool sol_util_double_equal(double var0, double var1);
+bool sol_util_double_eq(double var0, double var1);
 
 /**
  * @}

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -412,7 +412,7 @@ sol_util_replace_str_from_slice_if_changed(char **str,
         tmp[slice.len] = '\0';
         *str = tmp;
     } else {
-        *str = sol_str_slice_to_string(slice);
+        *str = sol_str_slice_to_str(slice);
         SOL_NULL_CHECK(*str, -ENOMEM);
     }
 

--- a/src/shared/sol-util.c
+++ b/src/shared/sol-util.c
@@ -1071,7 +1071,7 @@ err_exit:
 }
 
 SOL_API bool
-sol_util_double_equal(double var0, double var1)
+sol_util_double_eq(double var0, double var1)
 {
     double abs_var0, abs_var1, diff;
 

--- a/src/test-cpp/headers.cc.in
+++ b/src/test-cpp/headers.cc.in
@@ -166,7 +166,7 @@ startup()
 #ifdef OIC
     float f = 2.3f;
     struct sol_oic_map_reader map = { 0, 0, 0, 0, 0, 0 };
-    enum sol_oic_map_loop_status end_status;
+    enum sol_oic_map_loop_reason end_reason;
     struct sol_oic_map_reader iterator = { 0, 0, 0, 0, 0, 0 };
     struct sol_oic_repr_field rep_field1 = SOL_OIC_REPR_UINT("1", 2);
     struct sol_oic_repr_field rep_field2 = SOL_OIC_REPR_INT("2", -2);
@@ -178,7 +178,7 @@ startup()
     struct sol_oic_repr_field rep_field9 = SOL_OIC_REPR_FLOAT("9", 2.3);
     struct sol_oic_repr_field rep_field10 = SOL_OIC_REPR_DOUBLE("10", 2.3);
     struct sol_oic_repr_field rep_field11 = SOL_OIC_REPR_FIELD("131231", SOL_OIC_REPR_TYPE_UINT, .v_uint = 123);
-    SOL_OIC_MAP_LOOP(&map, &rep_field1, &iterator, end_status);
+    SOL_OIC_MAP_LOOP(&map, &rep_field1, &iterator, end_reason);
 #endif
 
 #ifdef HTTP

--- a/src/test/test-bluetooth.c
+++ b/src/test/test-bluetooth.c
@@ -77,12 +77,12 @@ test_bluetooth_uuid_comparison(void)
     r = sol_bt_uuid_from_str(&u2, slice);
     ASSERT_INT_EQ(r, 0);
 
-    ASSERT(sol_bt_uuid_equal(&u1, &u2));
+    ASSERT(sol_bt_uuid_eq(&u1, &u2));
 
     u1.type = SOL_BT_UUID_TYPE_16;
     u1.val16 = 0x1802;
 
-    ASSERT(!sol_bt_uuid_equal(&u1, &u2));
+    ASSERT(!sol_bt_uuid_eq(&u1, &u2));
 
     r = sol_bt_uuid_to_str(&u2, &buffer);
     ASSERT_INT_EQ(r, 0);

--- a/src/test/test-coap.c
+++ b/src/test/test-coap.c
@@ -56,7 +56,7 @@ test_coap_parse_empty_pdu(void)
     sol_coap_header_get_id(pkt, &id);
 
     ASSERT_INT_EQ(ver, 1);
-    ASSERT_INT_EQ(type, SOL_COAP_TYPE_CON);
+    ASSERT_INT_EQ(type, SOL_COAP_MESSAGE_TYPE_CON);
     ASSERT_INT_EQ(code, SOL_COAP_METHOD_GET);
     ASSERT_INT_EQ(id, 0);
 
@@ -94,7 +94,7 @@ test_coap_parse_simple_pdu(void)
     sol_coap_header_get_type(pkt, &type);
 
     ASSERT_INT_EQ(ver, 1);
-    ASSERT_INT_EQ(type, SOL_COAP_TYPE_NON_CON);
+    ASSERT_INT_EQ(type, SOL_COAP_MESSAGE_TYPE_NON_CON);
 
     token = sol_coap_header_get_token(pkt, &tkl);
     ASSERT(token);

--- a/src/test/test-http.c
+++ b/src/test/test-http.c
@@ -96,7 +96,7 @@ test_http_content_type_priority(void)
             size_t k;
             struct sol_http_content_type_priority *pri = sol_vector_get_no_check(&array, j);
             ASSERT(sol_str_slice_eq(pri->content_type, test[i].result[j].content_type));
-            ASSERT(sol_util_double_equal(pri->qvalue, test[i].result[j].qvalue));
+            ASSERT(sol_util_double_eq(pri->qvalue, test[i].result[j].qvalue));
             ASSERT_INT_EQ(test[i].result[j].tokens_size, pri->tokens.len);
             for (k = 0; k < test[i].result[j].tokens_size; k++) {
                 struct sol_str_slice *token = sol_vector_get_no_check(&pri->tokens, k);

--- a/src/test/test-json.c
+++ b/src/test/test-json.c
@@ -527,7 +527,7 @@ test_json_token_get_double(void)
         token.end = buf + strlen(itr->str);
         retval = sol_json_token_get_double(&token, &value);
         if (itr->expected_return == 0 && retval == 0) {
-            if (sol_util_double_equal(itr->reference, value)) {
+            if (sol_util_double_eq(itr->reference, value)) {
                 SOL_DBG("OK: parsed '%s' as %g", itr->str, value);
             } else {
                 SOL_WRN("FAILED: parsed '%s' as %.64g where %.64g was expected"
@@ -554,7 +554,7 @@ test_json_token_get_double(void)
                     itr->expected_return, sol_util_strerrora(-itr->expected_return),
                     retval, sol_util_strerrora(-retval), value);
                 FAIL();
-            } else if (!sol_util_double_equal(itr->reference, value)) {
+            } else if (!sol_util_double_eq(itr->reference, value)) {
                 SOL_WRN("FAILED: parsing '%s' should result in %.64g"
                     ", but got %.64g (difference = %g)",
                     itr->str, itr->reference, value, itr->reference - value);

--- a/src/test/test-memdesc.c
+++ b/src/test/test-memdesc.c
@@ -121,11 +121,11 @@ test_simple_SOL_MEMDESC_TYPE_DOUBLE(void)
 
     r = sol_memdesc_init_defaults(&desc, &a);
     ASSERT_INT_EQ(r, 0);
-    ASSERT(sol_util_double_equal(a, desc.defcontent.d));
+    ASSERT(sol_util_double_eq(a, desc.defcontent.d));
 
     r = sol_memdesc_init_defaults(&desc, &b);
     ASSERT_INT_EQ(r, 0);
-    ASSERT(sol_util_double_equal(b, desc.defcontent.d));
+    ASSERT(sol_util_double_eq(b, desc.defcontent.d));
 
     r = sol_memdesc_compare(&desc, &a, &b);
     ASSERT_INT_EQ(r, 0);
@@ -134,7 +134,7 @@ test_simple_SOL_MEMDESC_TYPE_DOUBLE(void)
     c = a + 1;
     r = sol_memdesc_set_content(&desc, &a, &c);
     ASSERT_INT_EQ(r, 0);
-    ASSERT(sol_util_double_equal(a, c));
+    ASSERT(sol_util_double_eq(a, c));
 
     r = sol_memdesc_compare(&desc, &a, &c);
     ASSERT_INT_EQ(r, 0);

--- a/src/test/test-persistence-memmap.c
+++ b/src/test/test-persistence-memmap.c
@@ -224,15 +224,15 @@ read_one(void)
 
     r = sol_memmap_read_irange("irange", &irange);
     ASSERT_INT_EQ(r, 0);
-    ASSERT(sol_irange_equal(&irange, &irange_not_delayed));
+    ASSERT(sol_irange_eq(&irange, &irange_not_delayed));
 
     r = sol_memmap_read_drange("drange", &drange);
     ASSERT_INT_EQ(r, 0);
-    ASSERT(sol_drange_equal(&drange, &drange_not_delayed));
+    ASSERT(sol_drange_eq(&drange, &drange_not_delayed));
 
     r = sol_memmap_read_double("double_only_val", &d);
     ASSERT_INT_EQ(r, 0);
-    ASSERT(sol_util_double_equal(d, 97.36));
+    ASSERT(sol_util_double_eq(d, 97.36));
 
     r = sol_memmap_read_string("string", &string);
     ASSERT_INT_EQ(r, 0);
@@ -253,15 +253,15 @@ read_one(void)
 
     r = sol_memmap_read_irange("irange2", &irange);
     ASSERT_INT_EQ(r, 0);
-    ASSERT(sol_irange_equal(&irange, &irange_not_delayed));
+    ASSERT(sol_irange_eq(&irange, &irange_not_delayed));
 
     r = sol_memmap_read_drange("drange2", &drange);
     ASSERT_INT_EQ(r, 0);
-    ASSERT(sol_drange_equal(&drange, &drange_not_delayed));
+    ASSERT(sol_drange_eq(&drange, &drange_not_delayed));
 
     r = sol_memmap_read_double("double_only_val2", &d);
     ASSERT_INT_EQ(r, 0);
-    ASSERT(sol_util_double_equal(d, 97.36));
+    ASSERT(sol_util_double_eq(d, 97.36));
 
     r = sol_memmap_read_string("string2", &string);
     ASSERT_INT_EQ(r, 0);
@@ -342,15 +342,15 @@ read_two(void)
 
     r = sol_memmap_read_irange("irange", &irange);
     ASSERT_INT_EQ(r, 0);
-    ASSERT(sol_irange_equal(&irange, &irange_delayed));
+    ASSERT(sol_irange_eq(&irange, &irange_delayed));
 
     r = sol_memmap_read_drange("drange", &drange);
     ASSERT_INT_EQ(r, 0);
-    ASSERT(sol_drange_equal(&drange, &drange_delayed));
+    ASSERT(sol_drange_eq(&drange, &drange_delayed));
 
     r = sol_memmap_read_double("double_only_val", &d);
     ASSERT_INT_EQ(r, 0);
-    ASSERT(sol_util_double_equal(d, 107.36));
+    ASSERT(sol_util_double_eq(d, 107.36));
 
     r = sol_memmap_read_string("string", &string);
     ASSERT_INT_EQ(r, 0);
@@ -371,15 +371,15 @@ read_two(void)
 
     r = sol_memmap_read_irange("irange2", &irange);
     ASSERT_INT_EQ(r, 0);
-    ASSERT(sol_irange_equal(&irange, &irange_delayed));
+    ASSERT(sol_irange_eq(&irange, &irange_delayed));
 
     r = sol_memmap_read_drange("drange2", &drange);
     ASSERT_INT_EQ(r, 0);
-    ASSERT(sol_drange_equal(&drange, &drange_delayed));
+    ASSERT(sol_drange_eq(&drange, &drange_delayed));
 
     r = sol_memmap_read_double("double_only_val2", &d);
     ASSERT_INT_EQ(r, 0);
-    ASSERT(sol_util_double_equal(d, 107.36));
+    ASSERT(sol_util_double_eq(d, 107.36));
 
     r = sol_memmap_read_string("string2", &string);
     ASSERT_INT_EQ(r, 0);

--- a/src/test/test-str-slice.c
+++ b/src/test/test-str-slice.c
@@ -106,19 +106,19 @@ test_str_slice_str_eq(void)
 {
     unsigned int i;
 
-#define TEST_EQUAL(X, CMP) { SOL_STR_SLICE_LITERAL(X), CMP, true }
-#define TEST_NOT_EQUAL(X, CMP) { SOL_STR_SLICE_LITERAL(X), CMP, false }
+#define TEST_EQ(X, CMP) { SOL_STR_SLICE_LITERAL(X), CMP, true }
+#define TEST_NOT_EQ(X, CMP) { SOL_STR_SLICE_LITERAL(X), CMP, false }
 
     static const struct {
         struct sol_str_slice input;
         const char *cmp;
         bool output_value;
     } table[] = {
-        TEST_EQUAL("0", "0"),
-        TEST_EQUAL("wat", "wat"),
-        TEST_NOT_EQUAL("this", "that"),
-        TEST_NOT_EQUAL("thi", "this"),
-        TEST_NOT_EQUAL("whatever", NULL),
+        TEST_EQ("0", "0"),
+        TEST_EQ("wat", "wat"),
+        TEST_NOT_EQ("this", "that"),
+        TEST_NOT_EQ("thi", "this"),
+        TEST_NOT_EQ("whatever", NULL),
     };
 
     for (i = 0; i < sol_util_array_size(table); i++) {
@@ -126,8 +126,8 @@ test_str_slice_str_eq(void)
         ret = sol_str_slice_str_eq(table[i].input, table[i].cmp);
         ASSERT_INT_EQ(ret, table[i].output_value);
     }
-#undef TEST_EQUAL
-#undef TEST_NOT_EQUAL
+#undef TEST_EQ
+#undef TEST_NOT_EQ
 }
 
 DEFINE_TEST(test_str_slice_remove_leading_whitespace);
@@ -137,26 +137,26 @@ test_str_slice_remove_leading_whitespace(void)
 {
     unsigned int i;
 
-#define TEST_EQUAL(X) { SOL_STR_SLICE_LITERAL(X), true }
-#define TEST_NOT_EQUAL(X) { SOL_STR_SLICE_LITERAL(X), false }
-#define TEST_NOT_EQUAL_SHIFT(X, S) { SOL_STR_SLICE_LITERAL(X + S), false }
+#define TEST_EQ(X) { SOL_STR_SLICE_LITERAL(X), true }
+#define TEST_NOT_EQ(X) { SOL_STR_SLICE_LITERAL(X), false }
+#define TEST_NOT_EQ_SHIFT(X, S) { SOL_STR_SLICE_LITERAL(X + S), false }
 
     static const struct {
         struct sol_str_slice input;
         bool equal;
     } table[] = {
-        TEST_NOT_EQUAL(" with one leading whitespace"),
-        TEST_NOT_EQUAL("  with two leading whitespace"),
-        TEST_NOT_EQUAL(" "),
-        TEST_NOT_EQUAL("\twith one leading whitespace"),
-        TEST_NOT_EQUAL("\t\twith two leading whitespace"),
-        TEST_NOT_EQUAL("\t"),
-        TEST_NOT_EQUAL("\nwith one leading whitespace"),
-        TEST_NOT_EQUAL("\n\nwith two leading whitespace"),
-        TEST_NOT_EQUAL("\n"),
-        TEST_NOT_EQUAL_SHIFT("        with leading whitespace and shifted", 4),
-        TEST_EQUAL(""),
-        TEST_EQUAL("without leading whitespace"),
+        TEST_NOT_EQ(" with one leading whitespace"),
+        TEST_NOT_EQ("  with two leading whitespace"),
+        TEST_NOT_EQ(" "),
+        TEST_NOT_EQ("\twith one leading whitespace"),
+        TEST_NOT_EQ("\t\twith two leading whitespace"),
+        TEST_NOT_EQ("\t"),
+        TEST_NOT_EQ("\nwith one leading whitespace"),
+        TEST_NOT_EQ("\n\nwith two leading whitespace"),
+        TEST_NOT_EQ("\n"),
+        TEST_NOT_EQ_SHIFT("        with leading whitespace and shifted", 4),
+        TEST_EQ(""),
+        TEST_EQ("without leading whitespace"),
     };
 
     for (i = 0; i < sol_util_array_size(table); i++) {
@@ -165,8 +165,8 @@ test_str_slice_remove_leading_whitespace(void)
         ASSERT(sol_str_slice_eq(table[i].input, slice) == table[i].equal);
     }
 
-#undef TEST_EQUAL
-#undef TEST_NOT_EQUAL
+#undef TEST_EQ
+#undef TEST_NOT_EQ
 }
 
 DEFINE_TEST(test_str_slice_remove_trailing_whitespace);
@@ -176,24 +176,24 @@ test_str_slice_remove_trailing_whitespace(void)
 {
     unsigned int i;
 
-#define TEST_EQUAL(X) { SOL_STR_SLICE_LITERAL(X), true }
-#define TEST_NOT_EQUAL(X) { SOL_STR_SLICE_LITERAL(X), false }
+#define TEST_EQ(X) { SOL_STR_SLICE_LITERAL(X), true }
+#define TEST_NOT_EQ(X) { SOL_STR_SLICE_LITERAL(X), false }
 
     static const struct {
         struct sol_str_slice input;
         bool equal;
     } table[] = {
-        TEST_NOT_EQUAL("with one trailing whitespace "),
-        TEST_NOT_EQUAL("with two trailing whitespace  "),
-        TEST_NOT_EQUAL(" "),
-        TEST_NOT_EQUAL("with one trailing whitespace\t"),
-        TEST_NOT_EQUAL("with two trailing whitespace\t\t"),
-        TEST_NOT_EQUAL("\t"),
-        TEST_NOT_EQUAL("with one trailing whitespace\n"),
-        TEST_NOT_EQUAL("with two trailing whitespace\n\n"),
-        TEST_NOT_EQUAL("\n"),
-        TEST_EQUAL(""),
-        TEST_EQUAL("without trailing whitespace"),
+        TEST_NOT_EQ("with one trailing whitespace "),
+        TEST_NOT_EQ("with two trailing whitespace  "),
+        TEST_NOT_EQ(" "),
+        TEST_NOT_EQ("with one trailing whitespace\t"),
+        TEST_NOT_EQ("with two trailing whitespace\t\t"),
+        TEST_NOT_EQ("\t"),
+        TEST_NOT_EQ("with one trailing whitespace\n"),
+        TEST_NOT_EQ("with two trailing whitespace\n\n"),
+        TEST_NOT_EQ("\n"),
+        TEST_EQ(""),
+        TEST_EQ("without trailing whitespace"),
     };
 
     for (i = 0; i < sol_util_array_size(table); i++) {
@@ -202,8 +202,8 @@ test_str_slice_remove_trailing_whitespace(void)
         ASSERT(sol_str_slice_eq(table[i].input, slice) == table[i].equal);
     }
 
-#undef TEST_EQUAL
-#undef TEST_NOT_EQUAL
+#undef TEST_EQ
+#undef TEST_NOT_EQ
 }
 
 DEFINE_TEST(test_str_slice_trim);
@@ -213,30 +213,30 @@ test_str_slice_trim(void)
 {
     unsigned int i;
 
-#define TEST_EQUAL(X) { SOL_STR_SLICE_LITERAL(X), true }
-#define TEST_NOT_EQUAL(X) { SOL_STR_SLICE_LITERAL(X), false }
+#define TEST_EQ(X) { SOL_STR_SLICE_LITERAL(X), true }
+#define TEST_NOT_EQ(X) { SOL_STR_SLICE_LITERAL(X), false }
 
     static const struct {
         struct sol_str_slice input;
         bool equal;
     } table[] = {
-        TEST_NOT_EQUAL("with one trailing whitespace "),
-        TEST_NOT_EQUAL("with two trailing whitespace  "),
-        TEST_NOT_EQUAL(" "),
-        TEST_NOT_EQUAL("with one trailing whitespace\t"),
-        TEST_NOT_EQUAL("with two trailing whitespace\t\t"),
-        TEST_NOT_EQUAL("\t"),
-        TEST_NOT_EQUAL("with one trailing whitespace\n"),
-        TEST_NOT_EQUAL("with two trailing whitespace\n\n"),
-        TEST_NOT_EQUAL("\n"),
-        TEST_NOT_EQUAL(" with one whitespace "),
-        TEST_NOT_EQUAL("  with two whitespace  "),
-        TEST_NOT_EQUAL("\twith one whitespace\t"),
-        TEST_NOT_EQUAL("\t\twith two whitespace\t\t"),
-        TEST_NOT_EQUAL("\nwith one whitespace\n"),
-        TEST_NOT_EQUAL("\n\nwith two whitespace\n\n"),
-        TEST_EQUAL(""),
-        TEST_EQUAL("without trailing whitespace"),
+        TEST_NOT_EQ("with one trailing whitespace "),
+        TEST_NOT_EQ("with two trailing whitespace  "),
+        TEST_NOT_EQ(" "),
+        TEST_NOT_EQ("with one trailing whitespace\t"),
+        TEST_NOT_EQ("with two trailing whitespace\t\t"),
+        TEST_NOT_EQ("\t"),
+        TEST_NOT_EQ("with one trailing whitespace\n"),
+        TEST_NOT_EQ("with two trailing whitespace\n\n"),
+        TEST_NOT_EQ("\n"),
+        TEST_NOT_EQ(" with one whitespace "),
+        TEST_NOT_EQ("  with two whitespace  "),
+        TEST_NOT_EQ("\twith one whitespace\t"),
+        TEST_NOT_EQ("\t\twith two whitespace\t\t"),
+        TEST_NOT_EQ("\nwith one whitespace\n"),
+        TEST_NOT_EQ("\n\nwith two whitespace\n\n"),
+        TEST_EQ(""),
+        TEST_EQ("without trailing whitespace"),
     };
 
     for (i = 0; i < sol_util_array_size(table); i++) {
@@ -245,8 +245,8 @@ test_str_slice_trim(void)
         ASSERT(sol_str_slice_eq(table[i].input, slice) == table[i].equal);
     }
 
-#undef TEST_EQUAL
-#undef TEST_NOT_EQUAL
+#undef TEST_EQ
+#undef TEST_NOT_EQ
 }
 
 DEFINE_TEST(test_str_slice_to_string);

--- a/src/test/test-str-slice.c
+++ b/src/test/test-str-slice.c
@@ -273,7 +273,7 @@ test_str_slice_to_string(void)
     };
 
     for (i = 0; i < sol_util_array_size(input); i++) {
-        char *s = sol_str_slice_to_string(input[i]);
+        char *s = sol_str_slice_to_str(input[i]);
         ASSERT(sol_str_slice_str_eq(input[i], s));
         free(s);
     }

--- a/src/test/test-util.c
+++ b/src/test/test-util.c
@@ -238,7 +238,7 @@ test_strtodn(void)
             wanted_endptr_offset = slen;
 
         if (itr->expected_errno == 0 && reterr == 0) {
-            if (sol_util_double_equal(itr->reference, value)) {
+            if (sol_util_double_eq(itr->reference, value)) {
                 SOL_DBG("OK: parsed '%s' as %g (locale:%u)", itr->str, value,
                     itr->use_locale);
             } else {
@@ -267,7 +267,7 @@ test_strtodn(void)
                     itr->expected_errno, sol_util_strerrora(itr->expected_errno),
                     reterr, sol_util_strerrora(reterr), value, itr->use_locale);
                 FAIL();
-            } else if (!sol_util_double_equal(itr->reference, value)) {
+            } else if (!sol_util_double_eq(itr->reference, value)) {
                 SOL_WRN("FAILED: parsing '%s' should result in %.64g"
                     ", but got %.64g (difference = %g) (locale:%u)",
                     itr->str, itr->reference, value, itr->reference - value,

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -28,78 +28,78 @@ struct test {
     void (*func)(void);
 };
 
-#define DEFINE_TEST(_name)                                              \
-    static void _name(void);                                            \
-    static const struct test _name ## _test_info                          \
-    __attribute__((used, section("soletta_tests"), aligned(8))) = {      \
-        .name = #_name,                                                 \
-        .func = _name,                                                  \
+#define DEFINE_TEST(_name) \
+    static void _name(void); \
+    static const struct test _name ## _test_info \
+    __attribute__((used, section("soletta_tests"), aligned(8))) = { \
+        .name = # _name, \
+        .func = _name, \
     }
 
 int test_main(struct test *start, struct test *stop, void (*reset_func)(void), int argc, char *argv[]);
 
-#define TEST_MAIN_WITH_RESET_FUNC(_reset)                               \
+#define TEST_MAIN_WITH_RESET_FUNC(_reset) \
     extern struct test __start_soletta_tests[] __attribute__((weak, visibility("hidden"))); \
     extern struct test __stop_soletta_tests[] __attribute__((weak, visibility("hidden"))); \
-    int                                                                 \
-    main(int argc, char *argv[]) {                                      \
+    int \
+    main(int argc, char *argv[]) { \
         return test_main(__start_soletta_tests, __stop_soletta_tests, _reset, argc, argv); \
     }
 
-#define TEST_MAIN()                             \
+#define TEST_MAIN() \
     TEST_MAIN_WITH_RESET_FUNC(NULL)
 
 #define FAIL() exit(1);
 
-#define ASSERT(expr)                    \
-    do {                                \
-        if ((!(expr))) {                                                \
-            fprintf(stderr, "%s:%d: %s: Assertion: `" #expr "' failed.\n", \
-                __FILE__, __LINE__, __PRETTY_FUNCTION__);           \
-            exit(1);                                                    \
-        }                                                               \
+#define ASSERT(expr) \
+    do { \
+        if ((!(expr))) { \
+            fprintf(stderr, "%s:%d: %s: Assertion: `" # expr "' failed.\n", \
+                __FILE__, __LINE__, __PRETTY_FUNCTION__); \
+            exit(1); \
+        } \
     } while (0)
 
-#define ASSERT_INT_EQ(expr_a, expr_b)                                   \
-    do {                                                                \
-        const int __value_expr_a = expr_a;                              \
-        const int __value_expr_b = expr_b;                              \
-        if ((__value_expr_a) != (__value_expr_b)) {                     \
-            fprintf(stderr, "%s:%d: %s: Assertion `" #expr_a "' (%d) == `" #expr_b "' (%d) failed.\n", \
+#define ASSERT_INT_EQ(expr_a, expr_b) \
+    do { \
+        const int __value_expr_a = expr_a; \
+        const int __value_expr_b = expr_b; \
+        if ((__value_expr_a) != (__value_expr_b)) { \
+            fprintf(stderr, "%s:%d: %s: Assertion `" # expr_a "' (%d) == `" # expr_b "' (%d) failed.\n", \
                 __FILE__, __LINE__, __PRETTY_FUNCTION__, __value_expr_a, __value_expr_b); \
-            exit(-1);                                                   \
-        }                                                               \
+            exit(-1); \
+        } \
     } while (0)
 
-#define ASSERT_INT_NE(expr_a, expr_b)                                   \
-    do {                                                                \
-        const int __value_expr_a = expr_a;                              \
-        const int __value_expr_b = expr_b;                              \
-        if ((__value_expr_a) == (__value_expr_b)) {                     \
-            fprintf(stderr, "%s:%d: %s: Assertion `" #expr_a "' (%d) != `" #expr_b "' (%d) failed.\n", \
+#define ASSERT_INT_NE(expr_a, expr_b) \
+    do { \
+        const int __value_expr_a = expr_a; \
+        const int __value_expr_b = expr_b; \
+        if ((__value_expr_a) == (__value_expr_b)) { \
+            fprintf(stderr, "%s:%d: %s: Assertion `" # expr_a "' (%d) != `" # expr_b "' (%d) failed.\n", \
                 __FILE__, __LINE__, __PRETTY_FUNCTION__, __value_expr_a, __value_expr_b); \
-            exit(-1);                                                   \
-        }                                                               \
+            exit(-1); \
+        } \
     } while (0)
 
-#define ASSERT_STR_EQ(str_a, str_b)                                     \
-    do {                                                                \
-        ASSERT((str_a) != NULL);                                        \
-        ASSERT((str_b) != NULL);                                        \
-        if (strcmp((str_a), (str_b)) != 0) {                            \
-            fprintf(stderr, "%s:%d: %s: Assertion string_equal(\"%s\", \"%s\") failed.\n", \
+#define ASSERT_STR_EQ(str_a, str_b) \
+    do { \
+        ASSERT((str_a) != NULL); \
+        ASSERT((str_b) != NULL); \
+        if (strcmp((str_a), (str_b)) != 0) { \
+            fprintf(stderr, "%s:%d: %s: Assertion string_eq(\"%s\", \"%s\") failed.\n", \
                 __FILE__, __LINE__, __PRETTY_FUNCTION__, SOL_TYPE_CHECK(const char *, str_a), SOL_TYPE_CHECK(const char *, str_b)); \
-            exit(-1);                                                   \
-        }                                                               \
+            exit(-1); \
+        } \
     } while (0)
 
-#define ASSERT_STR_NE(str_a, str_b)                                     \
-    do {                                                                \
-        ASSERT((str_a) != NULL);                                        \
-        ASSERT((str_b) != NULL);                                        \
-        if (strcmp((str_a), (str_b)) == 0) {                            \
+#define ASSERT_STR_NE(str_a, str_b) \
+    do { \
+        ASSERT((str_a) != NULL); \
+        ASSERT((str_b) != NULL); \
+        if (strcmp((str_a), (str_b)) == 0) { \
             fprintf(stderr, "%s:%d: %s: Assertion string_different(\"%s\", \"%s\") failed.\n", \
                 __FILE__, __LINE__, __PRETTY_FUNCTION__, SOL_TYPE_CHECK(const char *, str_a), SOL_TYPE_CHECK(const char *, str_b)); \
-            exit(-1);                                                   \
-        }                                                               \
+            exit(-1); \
+        } \
     } while (0)


### PR DESCRIPTION
Partially because I edited it to contain some bullet points with more massive changes I found on my way and did not attack yet (someone else might do that afterwards).

The OIC changes regarding ``struct sol_oic_resource`` need love on the review. Is this way OK? Ideas?

Changes since v1:
- now ``struct sol_oic_resource`` has const members and the callbacks still have non-const modifiers for them.