### PR TITLE
iio: get absolute path from realpath() returned path

### DIFF
--- a/src/lib/io/sol-iio.c
+++ b/src/lib/io/sol-iio.c
@@ -1214,7 +1214,7 @@ resolve_absolute_path(const char *address)
         struct timespec elapsed, now;
 
         if (realpath(address, real_path)) {
-            result.path = address;
+            result.path = real_path;
             sol_util_iterate_dir(SYSFS_DEVICES_PATH, resolve_absolute_path_cb, &result);
         }
 


### PR DESCRIPTION
Instead of using the path input from user, change to use path returned from
realpath() function to eliminate looping issue.

Signed-off-by: Kweh, Hock Leong <hock.leong.kweh@intel.com>