### PR TITLE
build: Reorder setting of COMMON_CFLAGS

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -496,11 +496,6 @@
       "fragment": "strftime_l(0, 0, 0, 0, 0);"
     },
     {
-      "dependency": "getconf",
-      "type": "exec",
-      "exec": "getconf"
-    },
-    {
       "dependency": "get_current_dir_name",
       "type": "ccode",
       "headers": [

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -206,46 +206,13 @@ endif
 GDB_AUTOLOAD_PY_DEST := $(build_gdbautoload)libsoletta.so.$(VERSION)-gdb.py
 GDB_AUTOLOAD_PY := $(top_srcdir)data/gdb/libsoletta.so-gdb.py
 
-ifeq (y, $(HAVE_GETCONF))
-ifneq (64, $(shell getconf LONG_BIT))
-COMMON_CFLAGS += $(CFLAG_FLOAT_STORE)
-endif
-endif
+DEP_RESOLVER_CFLAGS := $(CFLAGS) -std=gnu99 -Werror=implicit-function-declaration
+DEP_RESOLVER_LDFLAGS := $(LDFLAGS)
 
-ifeq (y,$(CC_SANITIZE))
-ifeq (y,$(CC_SANITIZE_UNDEFINED))
-ifeq (y,$(SHARED_LIBRARY))
-COMMON_CFLAGS += $(DYNAMIC_SANITIZE_UNDEFINED_CFLAGS)
-COMMON_LDFLAGS += $(DYNAMIC_SANITIZE_UNDEFINED_LDFLAGS)
-else
-COMMON_CFLAGS += $(STATIC_SANITIZE_UNDEFINED_CFLAGS)
-COMMON_LDFLAGS += $(STATIC_SANITIZE_UNDEFINED_LDFLAGS)
-endif
-endif
-ifeq (y,$(CC_SANITIZE_ADDRESS))
-ifeq (y,$(SHARED_LIBRARY))
-ASAN_AUX_PATH = $(shell $(HOSTCC) -print-file-name=libasan.so)
-LIB_ASAN_PATH = $(shell $(top_srcdir)tools/build/libasan_path.sh $(ASAN_AUX_PATH))
-COMMON_CFLAGS += $(DYNAMIC_SANITIZE_ADDRESS_CFLAGS)
-COMMON_LDFLAGS += $(DYNAMIC_SANITIZE_ADDRESS_LDFLAGS)
-else
-COMMON_CFLAGS += $(STATIC_SANITIZE_ADDRESS_CFLAGS)
-COMMON_LDFLAGS += $(STATIC_SANITIZE_ADDRESS_LDFLAGS)
-endif
-endif
-else
-COMMON_LDFLAGS += $(LDFLAG_UNDEFINED)
-endif
-
-UNQUOTED_CONFIG_CFLAGS := $(shell echo $(CONFIG_CFLAGS))
-UNQUOTED_CONFIG_LDFLAGS := $(shell echo $(CONFIG_LDFLAGS))
-
-COMMON_CFLAGS += $(UNQUOTED_CONFIG_CFLAGS)
-COMMON_LDFLAGS += $(UNQUOTED_CONFIG_LDFLAGS)
-
-ifneq (,$(shell echo $(COMMON_CFLAGS) | grep -e "-O[s12345\ ]"))
-COMMON_CFLAGS += $(FLTO_CFLAGS)
-endif
+MISSING_H := $(top_srcdir)src/lib/common/sol-missing.h
+COMMON_CFLAGS += -include $(abspath $(KCONFIG_AUTOHEADER))
+COMMON_CFLAGS += -include $(abspath $(MISSING_H))
+COMMON_CFLAGS += $(addprefix -I,$(HEADERDIRS))
 
 ifeq (y,$(LOG))
 ifeq (y,$(MAXIMUM_LOG_LEVEL_CRITICAL))
@@ -278,30 +245,6 @@ ifneq (,$(BOARD_NAME))
 COMMON_CFLAGS += -DBOARD_NAME=\"$(BOARD_NAME)\"
 endif
 
-ifneq (,$(filter %coverage,$(MAKECMDGOALS)))
-COMMON_CFLAGS += -fprofile-arcs -ftest-coverage
-COMMON_LDFLAGS += -lgcov
-endif
-
-DEP_RESOLVER_CFLAGS := $(CFLAGS) -std=gnu99 -Werror=implicit-function-declaration
-DEP_RESOLVER_LDFLAGS := $(LDFLAGS)
-MISSING_H := $(top_srcdir)src/lib/common/sol-missing.h
-
-ifeq (y,$(SHARED_LIBRARY))
-COMMON_CFLAGS += -fPIC
-endif
-
-ifeq (y,$(BUILD_TYPE_DEBUG))
-COMMON_CFLAGS += -g -fno-lto -O0
-endif
-
-ifeq (y,$(BUILD_TYPE_RELEASE))
-COMMON_CFLAGS += $(RELEASE_COMMON_CFLAGS)
-endif
-
-COMMON_CFLAGS += -std=gnu99
-COMMON_CFLAGS += -include $(abspath $(KCONFIG_AUTOHEADER))
-
 COMMON_CFLAGS += \
 	-DVERSION="\"$(VERSION)\"" \
 	-DSYSCONF="\"$(SYSCONF)\"" \
@@ -315,8 +258,58 @@ COMMON_CFLAGS += \
 	-DUPDATEMODULESDIR="\"$(UPDATEMODULESDIR)\"" \
 	-DFLOWALIASESDIR="\"$(FLOWALIASESDIR)\""
 
-COMMON_CFLAGS += -include $(abspath $(MISSING_H))
-COMMON_CFLAGS += $(addprefix -I,$(HEADERDIRS))
+ifeq (y,$(CC_SANITIZE))
+ifeq (y,$(CC_SANITIZE_UNDEFINED))
+ifeq (y,$(SHARED_LIBRARY))
+COMMON_CFLAGS += $(DYNAMIC_SANITIZE_UNDEFINED_CFLAGS)
+COMMON_LDFLAGS += $(DYNAMIC_SANITIZE_UNDEFINED_LDFLAGS)
+else
+COMMON_CFLAGS += $(STATIC_SANITIZE_UNDEFINED_CFLAGS)
+COMMON_LDFLAGS += $(STATIC_SANITIZE_UNDEFINED_LDFLAGS)
+endif
+endif
+ifeq (y,$(CC_SANITIZE_ADDRESS))
+ifeq (y,$(SHARED_LIBRARY))
+ASAN_AUX_PATH = $(shell $(HOSTCC) -print-file-name=libasan.so)
+LIB_ASAN_PATH = $(shell $(top_srcdir)tools/build/libasan_path.sh $(ASAN_AUX_PATH))
+COMMON_CFLAGS += $(DYNAMIC_SANITIZE_ADDRESS_CFLAGS)
+COMMON_LDFLAGS += $(DYNAMIC_SANITIZE_ADDRESS_LDFLAGS)
+else
+COMMON_CFLAGS += $(STATIC_SANITIZE_ADDRESS_CFLAGS)
+COMMON_LDFLAGS += $(STATIC_SANITIZE_ADDRESS_LDFLAGS)
+endif
+endif
+else
+COMMON_LDFLAGS += $(LDFLAG_UNDEFINED)
+endif
+
+ifneq (,$(filter %coverage,$(MAKECMDGOALS)))
+COMMON_CFLAGS += -fprofile-arcs -ftest-coverage
+COMMON_LDFLAGS += -lgcov
+endif
+
+COMMON_CFLAGS += $(CFLAG_FLOAT_STORE)
+
+ifeq (y,$(SHARED_LIBRARY))
+COMMON_CFLAGS += -fPIC
+endif
+
+ifeq (y,$(BUILD_TYPE_DEBUG))
+COMMON_CFLAGS += -g
+endif
+
+ifeq (y,$(BUILD_TYPE_RELEASE))
+COMMON_CFLAGS += $(RELEASE_COMMON_CFLAGS)
+COMMON_CFLAGS += $(FLTO_CFLAGS)
+endif
+
+UNQUOTED_CONFIG_CFLAGS := $(shell echo $(CONFIG_CFLAGS))
+UNQUOTED_CONFIG_LDFLAGS := $(shell echo $(CONFIG_LDFLAGS))
+
+COMMON_CFLAGS += $(UNQUOTED_CONFIG_CFLAGS)
+COMMON_LDFLAGS += $(UNQUOTED_CONFIG_LDFLAGS)
+
+COMMON_CFLAGS += -std=gnu99
 
 EXEC_LDFLAGS := $(COMMON_LDFLAGS)
 LIB_LDFLAGS := $(COMMON_LDFLAGS) 


### PR DESCRIPTION
The idea is to allow CFLAGS that come from the user override those used
by Soletta, at least where it makes sense.
Things done include:
 - Always use -ffloat-store. The way it was checked if it was necessary
   before is not compatible with cross-compilers, and we want the
   effect of that flag always in any case.
 - Only use LTO flags in release mode. If the user wants to enable
   debug information, they should either set Soletta to a debug build
   or make sure to include -fno-lto in their CFLAGS
 - Set all Soletta CFLAGS first, then include the ones that come from
   the user/OS, so it allows users to override other flags or set
   optimization levels that match the target OS.
 - Set -std=gnu99 at the end of everything else. Unfortunately, some
   systems build with a different standard set that may enable
   __STRICT_ANSI__ and breaks building Soletta, so we need to always
   override this value to the one we expect.

Signed-off-by: Iván Briano <ivan.briano@intel.com>