### PR TITLE
oic: Fix null pointer exception

### DIFF
--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -951,8 +951,10 @@ done:
     return 0;
 
 error:
-    SOL_REENTRANT_FREE(reply->reentrant) {
-        pending_reply_free(reply);
+    if (reply) {
+        SOL_REENTRANT_FREE(reply->reentrant) {
+            pending_reply_free(reply);
+        }
     }
 error_pkt:
     sol_coap_packet_unref(pkt);


### PR DESCRIPTION
When sol_coap_send_packet_with_reply is called with a NULL reply
callback, reply element won't be created and then we don't need to free
it on errors.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>