### PR TITLE
iio: read the channel value as double format

### DIFF
--- a/src/lib/io/sol-iio.c
+++ b/src/lib/io/sol-iio.c
@@ -1034,7 +1034,7 @@ SOL_API bool
 sol_iio_read_channel_value(struct sol_iio_channel *channel, double *value)
 {
     int len;
-    int64_t raw_value;
+    double raw_value;
     char path[PATH_MAX];
     struct sol_iio_device *device;
     bool r;
@@ -1057,7 +1057,7 @@ sol_iio_read_channel_value(struct sol_iio_channel *channel, double *value)
         return false;
     }
 
-    len = sol_util_read_file(path, "%" SCNd64, &raw_value);
+    len = sol_util_read_file(path, "%lf", &raw_value);
     if (len < 0) {
         SOL_WRN("Could not read channel [%s] in device%d", channel->name,
             device->device_id);


### PR DESCRIPTION
Some sensor channels are using double format, by default read the data as double

issue #2095

Signed-off-by: Yong Li <yong.b.li@intel.com>