### PR TITLE
Node.js bindings: Organize node.js system constants like errno

### DIFF
--- a/bindings/nodejs/configure-bindings.js
+++ b/bindings/nodejs/configure-bindings.js
@@ -28,7 +28,8 @@ var sources = [
 	"../src/functions/simple.cc",
 	"../src/hijack.cc",
 	"../src/sol-uv-integration.c",
-	"../src/structures/js-handle.cc"
+	"../src/structures/js-handle.cc",
+	"../src/sys-constants.cc"
 ];
 
 // List containing the names of the header files in which to search for constants and enums

--- a/bindings/nodejs/src/sys-constants.cc
+++ b/bindings/nodejs/src/sys-constants.cc
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <nan.h>
+#include "sys-constants.h"
+
+using namespace v8;
+
+namespace node {void DefineConstants(Local<Object> target);}
+
+static Nan::Persistent<Object> forwardTable;
+static Nan::Persistent<Object> reverseTable;
+
+NAN_METHOD(bind__sysConstants) {
+	if (info.Length() < 1) {
+		Local<Object> raw = Nan::New<Object>();
+		node::DefineConstants(raw);
+		info.GetReturnValue().Set(raw);
+	} else {
+		Local<Object> constants = Nan::To<Object>(info[0]).ToLocalChecked();
+		Local<Object> forward = Nan::To<Object>(Nan::Get(constants,
+			Nan::New("forward").ToLocalChecked()).ToLocalChecked())
+				.ToLocalChecked();
+		Local<Object> reverse = Nan::To<Object>(Nan::Get(constants,
+			Nan::New("reverse").ToLocalChecked()).ToLocalChecked())
+				.ToLocalChecked();
+		forwardTable.Reset(forward);
+		reverseTable.Reset(reverse);
+	}
+}
+
+Local<Value> ReverseLookupConstant(const char *nameSpace, int value) {
+	Local<Value> returnValue = Nan::Undefined();
+
+	Local<Value> jsNameSpaceValue = Nan::Get(Nan::New<Object>(reverseTable),
+		Nan::New(nameSpace).ToLocalChecked()).ToLocalChecked();
+	if (jsNameSpaceValue->IsObject()) {
+		Local<Object> jsNameSpace =
+			Nan::To<Object>(jsNameSpaceValue).ToLocalChecked();
+		returnValue = Nan::Get(jsNameSpace, Nan::New(value)).ToLocalChecked();
+	}
+
+	return returnValue;
+}

--- a/bindings/nodejs/src/sys-constants.h
+++ b/bindings/nodejs/src/sys-constants.h
@@ -1,0 +1,23 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <v8.h>
+
+v8::Local<v8::Value> ReverseLookupConstant(const char *nameSpace, int value);

--- a/lowlevel.js
+++ b/lowlevel.js
@@ -16,4 +16,38 @@
  * limitations under the License.
  */
 
-module.exports = require( "bindings" )( "soletta" );
+var _ = require( "lodash" );
+var soletta = require( "bindings" )( "soletta" );
+
+var cookedConstants = { forward: {}, reverse: {} };
+
+var isInteresting = /^[A-Z0-9_]+$/;
+
+_.each( soletta._sysConstants(), function( value, key ) {
+	if ( !key.match( isInteresting ) ) {
+		return;
+	}
+
+	var forward = cookedConstants.forward;
+	var reverse = cookedConstants.reverse;
+	var ns = key.split( "_" )[ 0 ];
+
+	ns = ( ns === key ) ?
+		( ns.substr( 0, 1 ) === "E" ? "E" :
+		ns.substr( 0, 3 ) === "SIG" ? "SIG" : ns )
+		: ns;
+
+	if ( !forward[ ns ] ) {
+		forward[ ns ] = {};
+	}
+	forward[ ns ][ key ] = value;
+
+	if ( !reverse[ ns ] ) {
+		reverse[ ns ] = {};
+	}
+	reverse[ ns ][ value ] = key;
+} );
+
+soletta._sysConstants( cookedConstants );
+
+module.exports = soletta;


### PR DESCRIPTION
Also reverse-maps them for use in the bindings

We need these constants to return more legible errors from the bindings.