### PR TITLE
Node.js bindings: Fix error in spi JS bindings

### DIFF
--- a/bindings/nodejs/lib/spi.js
+++ b/bindings/nodejs/lib/spi.js
@@ -63,8 +63,7 @@ _.extend( SPIBus.prototype, {
            var returnStatus = soletta.sol_spi_transfer( this._bus, txBuffer,
                function( txData, rxData, count ) {
                    if ( rxData !== null ) {
-                       var rxBffer = new Buffer( rxData );
-                       fulfill( rxBffer );
+                       fulfill( rxData );
                    }
            });
 


### PR DESCRIPTION
Do not create a new Buffer instance for rxData since it is already a Buffer instance.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>