### PR TITLE
build: Change OS selection order to prioritize small OSes

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -6,9 +6,9 @@ source "tools/build/Kconfig.features"
 config BASE_OS
     string
     default "contiki" if HAVE_CONTIKI
-    default "linux" if HAVE_LINUX
     default "riot" if HAVE_RIOTOS
     default "zephyr" if HAVE_ZEPHYR
+    default "linux" if HAVE_LINUX
 
 source "tools/build/Kconfig.$BASE_OS"
 


### PR DESCRIPTION
Depending on how an OS builds for native, Soletta may still pass the
Linux detection test. Leaving Linux as the last OS to check for in
Kconfig allows any other OS to be used regardless of that test.