### PR TITLE
oic: Use sol-cert API to load pre shared keys - v3

### DIFF
--- a/src/lib/common/include/sol-certificate.h
+++ b/src/lib/common/include/sol-certificate.h
@@ -20,6 +20,7 @@
 
 #include <sol-common-buildopts.h>
 #include <sol-types.h>
+#include <sol-str-slice.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -52,9 +53,10 @@ struct sol_cert;
  *
  * In systems where file system is supported, the @a id is the name of the
  * certificate file. The @a id can be a relative or an absolute path to the
- * certificat file. If relative, function will look for it in default system
+ * certificat file. If relative, function will look for it at user home config
+ * directory (${HOME}/.config/{$APPNAME}/certs/), in default system
  * directories ($SYSCONF/ssl/certs, $SYSCONF/ssl/private, $SYSCONF/tls/certs
- * and $SYSCONF/tls/private), or in a directory specified by SSL_CERT_DIR
+ * and $SYSCONF/tls/private), and in a directory specified by SSL_CERT_DIR
  *
  * @return sol_cert object on success, NULL otherwise
  */
@@ -88,6 +90,20 @@ const char *sol_cert_get_file_name(const struct sol_cert *cert);
  * @return the contents of the certificate @a cert on success, NULL otherwise
  */
 struct sol_blob *sol_cert_get_contents(const struct sol_cert *cert);
+
+/**
+ * @brief Write @a contents to @a cert.
+ *
+ * Certificates are always saved in user context.
+ *
+ * @param file_name The name of the certificate file. The certificate file name
+ *        must be relative. File name with full path is not supported.
+ * @param contents A blob containing the contents to be written to the
+ *        certificate.
+ *
+ * @return 0 on success or a negative error number on errors.
+ */
+int sol_cert_write_contents(const char *file_name, struct sol_str_slice contents);
 
 /**
  * @}

--- a/src/lib/common/include/sol-platform.h
+++ b/src/lib/common/include/sol-platform.h
@@ -514,6 +514,16 @@ int sol_platform_del_locale_monitor(void (*cb)(void *data, enum sol_platform_loc
 int sol_platform_apply_locale(enum sol_platform_locale_category category);
 
 /**
+ * Get current app name.
+ *
+ * Generate current app name from sol_argv[0]. If argv is not set, app name
+ * will be soletta.
+ *
+ * @return The current app name.
+ */
+struct sol_str_slice sol_platform_get_appname(void);
+
+/**
  * @}
  */
 

--- a/src/lib/common/sol-certificate-impl-linux.c
+++ b/src/lib/common/sol-certificate-impl-linux.c
@@ -17,6 +17,7 @@
  */
 
 #include <sys/stat.h>
+#include <unistd.h>
 
 #include "sol-certificate.h"
 #define SOL_LOG_DOMAIN &_sol_certificate_log_domain
@@ -45,17 +46,33 @@ static const char *const search_paths[] = {
     NULL,
 };
 
+static int
+get_home_config_dir(struct sol_buffer *buffer)
+{
+    int r;
+
+    r = sol_util_get_user_config_dir(buffer);
+    SOL_INT_CHECK(r, < 0, r);
+
+    return sol_buffer_append_printf(buffer, "/certs");
+}
+
+static inline bool
+is_cert(const char *file)
+{
+    return access(file, R_OK) == 0;
+}
+
 static char *
 find_cert(const char *filename, const char *const paths[])
 {
     const char *ssl_cert_dir = getenv("SSL_CERT_DIR");
     struct sol_buffer buffer = SOL_BUFFER_INIT_EMPTY;
-    struct stat st;
     int idx;
     int r;
 
     /* Check absolute path */
-    if (stat(filename, &st) == 0 && S_ISREG(st.st_mode) && st.st_mode & S_IRUSR)
+    if (is_cert(filename))
         return strdup(filename);
 
     /* Check SSL_CERT_DIR */
@@ -63,18 +80,26 @@ find_cert(const char *filename, const char *const paths[])
         r = sol_buffer_append_printf(&buffer, "%s/%s", ssl_cert_dir, filename);
         SOL_INT_CHECK(r, != 0, NULL);
 
-        if (stat(buffer.data, &st) == 0 && S_ISREG(st.st_mode) && st.st_mode & S_IRUSR)
+        if (is_cert(buffer.data))
             return sol_buffer_steal(&buffer, NULL);
 
         sol_buffer_reset(&buffer);
     }
+
+    /* Search cert in HOME config dir */
+    r = get_home_config_dir(&buffer);
+    SOL_INT_CHECK(r, != 0, NULL);
+    r = sol_buffer_append_printf(&buffer, "/%s", filename);
+    SOL_INT_CHECK(r, != 0, NULL);
+    if (is_cert(buffer.data))
+        return sol_buffer_steal(&buffer, NULL);
 
     /* Search known paths */
     for (idx = 0; search_paths[idx] != 0; idx++) {
         r = sol_buffer_append_printf(&buffer, "%s/%s/%s", SYSCONF, search_paths[idx], filename);
         SOL_INT_CHECK(r, != 0, NULL);
 
-        if (stat(buffer.data, &st) == 0 && S_ISREG(st.st_mode) && st.st_mode & S_IRUSR)
+        if (is_cert(buffer.data))
             return sol_buffer_steal(&buffer, NULL);
 
         sol_buffer_reset(&buffer);
@@ -172,4 +197,31 @@ sol_cert_get_contents(const struct sol_cert *cert)
     SOL_NULL_CHECK(fr, NULL);
 
     return sol_file_reader_to_blob(fr);
+}
+
+SOL_API int
+sol_cert_write_contents(const char *file_name, struct sol_str_slice contents)
+{
+    SOL_BUFFER_DECLARE_STATIC(path, PATH_MAX);
+    ssize_t written;
+    int r;
+
+    SOL_NULL_CHECK(file_name, -EINVAL);
+
+    if (*file_name == '\0') {
+        SOL_WRN("File name shouldn't be empty");
+        return -EINVAL;
+    }
+
+    r = get_home_config_dir(&path);
+    SOL_INT_CHECK(r, != 0, r);
+
+    r = sol_util_create_recursive_dirs(sol_buffer_get_slice(&path), S_IRWXU);
+    SOL_INT_CHECK(r, != 0, r);
+
+    r = sol_buffer_append_printf(&path, "/%s", file_name);
+    SOL_INT_CHECK(r, != 0, r);
+
+    written = sol_util_write_file_slice(path.data, contents);
+    return written >= 0 ? 0 : (int)written;
 }

--- a/src/lib/common/sol-platform.c
+++ b/src/lib/common/sol-platform.c
@@ -36,6 +36,10 @@
 
 #define SOL_BOARD_NAME_ENVVAR "SOL_BOARD_NAME"
 
+#ifdef SOL_FEATURE_FILESYSTEM
+#include <sol-util-file.h>
+#endif
+
 SOL_LOG_INTERNAL_DECLARE(_sol_platform_log_domain, "platform");
 
 static char *board_name = NULL;
@@ -57,6 +61,9 @@ struct ctx {
     struct sol_monitors locale_monitors;
     struct sol_timeout *locale_timeout;
     char *locale_cache[SOL_PLATFORM_LOCALE_TIME + 1];
+#ifdef SOL_FEATURE_FILESYSTEM
+    struct sol_str_slice appname;
+#endif
 };
 
 static struct ctx _ctx;
@@ -95,6 +102,8 @@ sol_platform_init(void)
     _ctx.locale_timeout = NULL;
     sol_monitors_init_custom(&_ctx.service_monitors, sizeof(struct service_monitor), service_monitor_free);
 
+    _ctx.appname.data = NULL;
+    _ctx.appname.len = 0;
     return sol_platform_impl_init();
 
 err_exit:
@@ -794,6 +803,45 @@ sol_platform_apply_locale(enum sol_platform_locale_category category)
 {
     SOL_INT_CHECK(category, == SOL_PLATFORM_LOCALE_UNKNOWN, -EINVAL);
     return sol_platform_impl_apply_locale(category, _ctx.locale_cache[category] ? : "C");
+}
+
+SOL_API struct sol_str_slice
+sol_platform_get_appname(void)
+{
+    const struct sol_str_slice default_name = SOL_STR_SLICE_LITERAL("soletta");
+
+#ifdef SOL_FEATURE_FILESYSTEM
+#define SUFIX_LEN 4
+#define SUFIX ".fbp"
+
+    char **argv;
+
+    if (!_ctx.appname.data) {
+        argv = sol_argv();
+        if (!argv || sol_argc() == 0 || !argv[0]) {
+            _ctx.appname = default_name;
+            return _ctx.appname;
+        }
+
+        _ctx.appname = sol_util_file_get_basename(sol_str_slice_from_str(argv[0]));
+        if (!_ctx.appname.len || sol_str_slice_str_eq(_ctx.appname, "/")) {
+            _ctx.appname = default_name;
+            return _ctx.appname;
+        }
+
+        if (_ctx.appname.len >= SUFIX_LEN &&
+            strncmp(_ctx.appname.data + _ctx.appname.len - SUFIX_LEN, SUFIX,
+            SUFIX_LEN) == 0)
+            _ctx.appname.len -= 4;
+    }
+
+    return _ctx.appname;
+
+#undef SUFIX_LEN
+#undef SUFIX
+#endif //SOL_FEATURE_FILESYSTEM
+
+    return default_name;
 }
 
 int

--- a/src/lib/comms/sol-socket-dtls.h
+++ b/src/lib/comms/sol-socket-dtls.h
@@ -37,7 +37,7 @@ enum sol_socket_dtls_cipher {
 struct sol_socket_dtls_credential_cb {
     const void *data;
 
-    void *(*init)(const void *data);
+    int (*init)(const void *data);
     void (*clear)(void *creds);
 
     ssize_t (*get_id)(const void *creds, char *id, size_t id_len);

--- a/src/shared/include/sol-util-file.h
+++ b/src/shared/include/sol-util-file.h
@@ -368,6 +368,19 @@ int sol_util_create_recursive_dirs(const struct sol_str_slice path, mode_t mode)
 int sol_util_get_user_config_dir(struct sol_buffer *buffer);
 
 /**
+ * Encode string to be used as a file name.
+ *
+ * Encode all non alphanumerical character to '\\xXX', where XX is the character
+ * hexcode.
+ *
+ * @param buf An initialized buffer to append the encoded filename.
+ * @param value The string to be encoded.
+ *
+ * @return 0 on success or a negative error code on errors.
+ */
+int sol_util_file_encode_filename(struct sol_buffer *buf, const struct sol_str_slice value);
+
+/**
  * @}
  */
 

--- a/src/shared/include/sol-util-file.h
+++ b/src/shared/include/sol-util-file.h
@@ -326,6 +326,18 @@ int sol_util_move_file(const char *old_path, const char *new_path, mode_t mode);
 bool sol_util_busy_wait_file(const char *path, uint64_t nanoseconds);
 
 /**
+ * @brief Get the basename of a path.
+ *
+ * Get basename of file. It doesn't modify content of the string.
+ *
+ * @param path A path to get the basename.
+ *
+ * @return A pointer to a portion of the original string containing the basename
+ * of the @a path. Return will be an empty string if @a path is empty.
+ */
+struct sol_str_slice sol_util_file_get_basename(struct sol_str_slice path);
+
+/**
  * @}
  */
 

--- a/src/shared/include/sol-util-file.h
+++ b/src/shared/include/sol-util-file.h
@@ -65,7 +65,7 @@ enum sol_util_iterate_dir_reason {
 };
 
 /**
- * @brief Write the formatted string in the file pointed by @c path.
+ * @brief Write the formatted string in the file pointed by @a path.
  *
  * @param path The path to a valid file.
  * @param fmt The string format.
@@ -78,9 +78,9 @@ enum sol_util_iterate_dir_reason {
 int sol_util_write_file(const char *path, const char *fmt, ...) SOL_ATTR_PRINTF(2, 3);
 
 /**
- * @brief Write the formatted string in the file pointed by @c path.
+ * @brief Write the formatted string in the file pointed by @a path.
  *
- * It is equivalent to @c sol_util_write_file except it receives @c
+ * It is equivalent to sol_util_write_file() except it receives @a
  * va_list instead of a variable number of arguments.
  *
  * @param path The path to a valid file.
@@ -93,6 +93,17 @@ int sol_util_write_file(const char *path, const char *fmt, ...) SOL_ATTR_PRINTF(
  * @see sol_util_write_file
  */
 int sol_util_vwrite_file(const char *path, const char *fmt, va_list args) SOL_ATTR_PRINTF(2, 0);
+
+/**
+ * @brief Write the slice content the file pointed by @a path.
+ *
+ * @param path The path to a valid file.
+ * @param slice The slice to be written.
+ *
+ * @return The number of written characters, if an error is encountered a
+ * negative value with the error code.
+ */
+ssize_t sol_util_write_file_slice(const char *path, struct sol_str_slice slice);
 
 /**
  * @brief Reads from a file the contents according with the formatted string.
@@ -336,6 +347,25 @@ bool sol_util_busy_wait_file(const char *path, uint64_t nanoseconds);
  * of the @a path. Return will be an empty string if @a path is empty.
  */
 struct sol_str_slice sol_util_file_get_basename(struct sol_str_slice path);
+
+/**
+ * @brief Create directories recursively.
+ *
+ * @param path The path of the directory to be created.
+ * @param mode The mode of the directory as specified by stat function.
+ *
+ * @return 0 on success or a negative error code on errors.
+ */
+int sol_util_create_recursive_dirs(const struct sol_str_slice path, mode_t mode);
+
+/**
+ * @brief Get the user context config directory for current app.
+ *
+ * @param buffer The buffer where the user config dir will be written.
+ *
+ * @return 0 on success or a negative error code on errors.
+ */
+int sol_util_get_user_config_dir(struct sol_buffer *buffer);
 
 /**
  * @}

--- a/src/shared/sol-conffile.c
+++ b/src/shared/sol-conffile.c
@@ -838,31 +838,14 @@ _add_formated_lookup_path(struct sol_vector *vector, const char *fmt, ...)
     }
 }
 
-static char *
-_sanitize_appname(const char *appname)
-{
-    char *name, *lastdot;
-
-    if (!appname || *appname == '/')
-        return NULL;
-
-    lastdot = strrchr(appname, '.');
-    if (lastdot && !strcmp(".fbp", lastdot))
-        name = strndup(appname, lastdot - appname);
-    else
-        name = strdup(appname);
-
-    return name;
-}
-
 static void
-_add_lookup_path(struct sol_vector *vector, char *appname, char *appdir, const char *board_name)
+_add_lookup_path(struct sol_vector *vector, char *appdir, const char *board_name)
 {
     size_t i;
     struct sol_vector files = SOL_VECTOR_INIT(struct sol_str_slice);
     struct sol_str_slice *curr_file;
+    struct sol_str_slice appname;
     uint16_t idx;
-    char *sanitized_appname = NULL;
 
     const char *search_dirs[] = {
         ".", /* $PWD */
@@ -870,15 +853,14 @@ _add_lookup_path(struct sol_vector *vector, char *appname, char *appdir, const c
         PKGSYSCONFDIR, /* i.e /etc/soletta/ */
     };
 
-    sanitized_appname = _sanitize_appname(appname);
-
-    if (sanitized_appname && board_name) {
-        _add_formated_lookup_path(&files, "sol-flow-%s-%s.json", sanitized_appname, board_name);
+    appname = sol_platform_get_appname();
+    if (board_name) {
+        _add_formated_lookup_path(&files, "sol-flow-%.*s-%s.json",
+            SOL_STR_SLICE_PRINT(appname), board_name);
     }
 
-    if (sanitized_appname) {
-        _add_formated_lookup_path(&files, "sol-flow-%s.json", sanitized_appname);
-    }
+    _add_formated_lookup_path(&files, "sol-flow-%.*s.json",
+        SOL_STR_SLICE_PRINT(appname));
 
     if (board_name) {
         _add_formated_lookup_path(&files, "sol-flow-%s.json", board_name);
@@ -900,13 +882,12 @@ _add_lookup_path(struct sol_vector *vector, char *appname, char *appdir, const c
     }
 
     sol_vector_clear(&files);
-    free(sanitized_appname);
 }
 
 static void
 _load_vector_defaults(void)
 {
-    char *appdir = NULL, *appname = NULL, **argv;
+    char *appdir = NULL, **argv;
     char *dir_str = NULL, *name_str = NULL, *sol_conf = NULL;
     const char *board_name;
     uint16_t i;
@@ -924,11 +905,10 @@ _load_vector_defaults(void)
     if (argv && argv[0]) {
         dir_str = strdup(argv[0]);
         name_str = strdup(argv[0]);
-        appname = basename(name_str);
         appdir = dirname(dir_str);
     }
 
-    _add_lookup_path(&fallback_paths, appname, appdir, board_name);
+    _add_lookup_path(&fallback_paths, appdir, board_name);
     sol_conf = getenv("SOL_FLOW_MODULE_RESOLVER_CONFFILE");
     if (sol_conf) {
         env = sol_str_slice_from_str(sol_conf);

--- a/src/shared/sol-util-file.c
+++ b/src/shared/sol-util-file.c
@@ -593,3 +593,25 @@ sol_util_busy_wait_file(const char *path, uint64_t nanoseconds)
 
     return true;
 }
+
+SOL_API struct sol_str_slice
+sol_util_file_get_basename(struct sol_str_slice path)
+{
+    struct sol_str_slice basename;
+
+    while (path.len > 1 && path.data[path.len - 1] == '/')
+        path.len--;
+
+    if (path.len == 0 || path.len == 1)
+        return path;
+
+    basename.data = memrchr(path.data, '/', path.len);
+    if (basename.data == NULL)
+        return path;
+    basename.len = path.len - (basename.data - path.data);
+
+    basename.data += 1;
+    basename.len -= 1;
+
+    return basename;
+}

--- a/src/shared/sol-util-file.c
+++ b/src/shared/sol-util-file.c
@@ -694,3 +694,34 @@ sol_util_get_user_config_dir(struct sol_buffer *buffer)
     return sol_buffer_append_printf(buffer, "%s/.config/%.*s/", dir,
         SOL_STR_SLICE_PRINT(sol_platform_get_appname()));
 }
+
+SOL_API int
+sol_util_file_encode_filename(struct sol_buffer *buf, const struct sol_str_slice value)
+{
+    int r;
+    size_t i, last_append;
+
+    SOL_NULL_CHECK(buf, -EINVAL);
+
+    if (!value.len)
+        return 0;
+
+    last_append = 0;
+    for (i = 0; i < value.len; i++) {
+        unsigned char c = value.data[i];
+        if (!isalnum(c)) {
+            r = sol_buffer_append_slice(buf,
+                SOL_STR_SLICE_STR(value.data + last_append, i - last_append));
+            SOL_INT_CHECK(r, < 0, r);
+            last_append = i + 1;
+            r = sol_buffer_append_printf(buf, "\\x%02X", c);
+            SOL_INT_CHECK(r, < 0, r);
+        }
+    }
+
+    r = sol_buffer_append_slice(buf, SOL_STR_SLICE_STR(value.data + last_append,
+        value.len - last_append));
+    SOL_INT_CHECK(r, < 0, r);
+
+    return 0;
+}

--- a/src/test/Kconfig
+++ b/src/test/Kconfig
@@ -105,6 +105,11 @@ config TEST_UTIL
 	bool "util"
 	default y
 
+config TEST_UTIL_FILE
+       bool "util-file"
+       depends on FEATURE_FILESYSTEM
+       default y
+
 config TEST_COMPOSED_TYPE
 	bool "composed-type"
 	depends on USE_FLOW

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -78,6 +78,9 @@ test-test-json-$(TEST_JSON) := test.c test-json.c
 test-$(TEST_UTIL) += test-util
 test-test-util-$(TEST_UTIL) := test.c test-util.c
 
+test-$(TEST_UTIL_FILE) += test-util-file
+test-test-util-file-$(TEST_UTIL_FILE) := test.c test-util-file.c
+
 test-$(TEST_COMPOSED_TYPE) += test-composed-type
 test-test-composed-type-$(TEST_COMPOSED_TYPE) := test.c test-composed-type.c
 

--- a/src/test/test-certificate.c
+++ b/src/test/test-certificate.c
@@ -83,4 +83,37 @@ load_certificate(void)
     remove("dummy.pem");
 }
 
+DEFINE_TEST(read_write_certificate);
+
+static void
+read_write_certificate(void)
+{
+    struct sol_cert *cert;
+    struct sol_blob *blob;
+
+    create_dummy_certificate();
+
+    cert = sol_cert_load_from_id("dummy.pem");
+    ASSERT(cert != NULL);
+
+    blob = sol_cert_get_contents(cert);
+    ASSERT(blob != NULL);
+    ASSERT(streq(dummy_cert, blob->mem));
+
+    ASSERT(sol_cert_write_contents("dummy2.pem",
+        SOL_STR_SLICE_STR(blob->mem, blob->size)) == 0);
+    sol_blob_unref(blob);
+    sol_cert_unref(cert);
+
+    cert = sol_cert_load_from_id("dummy2.pem");
+    ASSERT(cert != NULL);
+    blob = sol_cert_get_contents(cert);
+    ASSERT(blob != NULL);
+    ASSERT(streq(dummy_cert, blob->mem));
+
+    sol_blob_unref(blob);
+    sol_cert_unref(cert);
+    remove("dummy.pem");
+}
+
 TEST_MAIN();

--- a/src/test/test-util-file.c
+++ b/src/test/test-util-file.c
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <libgen.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <float.h>
+#ifdef HAVE_LOCALE
+#include <locale.h>
+#endif
+
+#include "sol-util-internal.h"
+#include "sol-log.h"
+
+#include "test.h"
+
+DEFINE_TEST(test_basename);
+
+static void
+test_basename(void)
+{
+    const char *path[] = { "/", "../test1", "test2", "/test3/",
+                           "////foo////bar///test4////", "/a", "b/" };
+    char *tmp;
+    unsigned int i;
+    bool b;
+    struct sol_str_slice base;
+
+    for (i = 0; i < sizeof(path) / sizeof(char *); i++) {
+        tmp = strdup(path[i]);
+        base = sol_util_file_get_basename(sol_str_slice_from_str(path[i]));
+        b = sol_str_slice_str_eq(base, basename(tmp));
+        free(tmp);
+        ASSERT(b);
+    }
+}
+
+TEST_MAIN();


### PR DESCRIPTION
Replaces #2016

Changelog:
 - Don't use base64 for file names. Use file name scaping.
 - Save and load certificates in an user context config dir, inside an app specific directory.
 - Remove already merged commits
 - Other minor fixes