### PR TITLE
build: avoid files moved to build_dir on installing phase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ include $(top_srcdir)tools/build/Makefile.rules
 
 include $(top_srcdir)tools/build/Makefile.targets
 
-default_target: $(PRE_GEN) $(SOL_LIB_OUTPUT) $(bins-out) $(modules-out)
+default_target: $(PRE_GEN) $(SOL_LIB_OUTPUT) $(bins-out) $(modules-out) $(EXTRA_FILES)
 all: default_target
 endif # HAVE_KCONFIG_CONFIG
 endif # NOT_FOUND

--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -120,7 +120,7 @@ samples: samples-check $(SOL_LIB_OUTPUT) $(samples-out) $(PRE_GEN)
 PHONY += samples samples-check
 
 PRE_INSTALL := default_target $(all-mod-descs)
-PRE_INSTALL += $(NODE_TYPE_SCHEMA_DEST) $(BOARD_DETECT_DEST) $(GDB_AUTOLOAD_PY_DEST)
+EXTRA_FILES := $(NODE_TYPE_SCHEMA_DEST) $(BOARD_DETECT_DEST) $(GDB_AUTOLOAD_PY_DEST)
 
 ifeq (y,$(RPATH))
 rpath-bins := $(subst $(build_sysroot)/,$(DESTDIR),$(bins-out))


### PR DESCRIPTION
Otherwise it may lead to situations where the users used
by make and make clean diverge from make install and
clean can't actually remove the whole build directory.

Close gh-1536

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>