### PR TITLE
API Changes: Sol-arena

### DIFF
--- a/src/lib/comms/sol-http-server-impl-microhttpd.c
+++ b/src/lib/comms/sol-http-server-impl-microhttpd.c
@@ -223,7 +223,7 @@ load_ext_map(void)
             continue;
 
         len = itr - last;
-        s = sol_arena_strndup(ext_map.arena, last, len);
+        s = sol_arena_str_dup_n(ext_map.arena, last, len);
         SOL_NULL_CHECK_GOTO(s, end);
         last = itr + 1;
 

--- a/src/lib/datatypes/include/sol-arena.h
+++ b/src/lib/datatypes/include/sol-arena.h
@@ -76,11 +76,11 @@ void sol_arena_del(struct sol_arena *arena);
  *
  * @param arena The arena
  * @param dst String slice of the recently added string
- * @param str String to copy and store
+ * @param src String to copy and store
  *
  * @return @c 0 on success, error code (always negative) otherwise
  */
-int sol_arena_slice_dup_str(struct sol_arena *arena, struct sol_str_slice *dst, const char *str);
+int sol_arena_slice_dup_str(struct sol_arena *arena, struct sol_str_slice *dst, const char *src);
 
 /**
  * @brief Store a copy of at most @c n characters of a given string in the arena.
@@ -89,25 +89,25 @@ int sol_arena_slice_dup_str(struct sol_arena *arena, struct sol_str_slice *dst, 
  *
  * @param arena The arena
  * @param dst String slice of the recently added string
- * @param str String to copy and store
+ * @param src String to copy and store
  * @param n Maximum number of characters to copy
  *
  * @return @c 0 on success, error code (always negative) otherwise
  */
-int sol_arena_slice_dup_str_n(struct sol_arena *arena, struct sol_str_slice *dst, const char *str, size_t n);
+int sol_arena_slice_dup_str_n(struct sol_arena *arena, struct sol_str_slice *dst, const char *src, size_t n);
 
 /**
  * @brief Store a copy of a given string slice in the arena.
  *
- * Also, outputs the recently stored string slice in @c dst.
+ * Also, outputs the recently stored string src in @c dst.
  *
  * @param arena The arena
  * @param dst String slice of the recently added string slice
- * @param slice String slice to copy and store
+ * @param src String slice to copy and store
  *
  * @return @c 0 on success, error code (always negative) otherwise
  */
-int sol_arena_slice_dup(struct sol_arena *arena, struct sol_str_slice *dst, struct sol_str_slice slice);
+int sol_arena_slice_dup(struct sol_arena *arena, struct sol_str_slice *dst, struct sol_str_slice src);
 
 /**
  * @brief Store the output of 'sprintf()' in the arena.

--- a/src/lib/datatypes/sol-arena.c
+++ b/src/lib/datatypes/sol-arena.c
@@ -58,16 +58,16 @@ sol_arena_del(struct sol_arena *arena)
 }
 
 SOL_API int
-sol_arena_slice_dup_str_n(struct sol_arena *arena, struct sol_str_slice *dst, const char *str, size_t n)
+sol_arena_slice_dup_str_n(struct sol_arena *arena, struct sol_str_slice *dst, const char *src, size_t n)
 {
     struct sol_str_slice slice;
     int r;
 
     SOL_NULL_CHECK(arena, -EINVAL);
-    SOL_NULL_CHECK(str, -EINVAL);
+    SOL_NULL_CHECK(src, -EINVAL);
     SOL_INT_CHECK(n, <= 0, -EINVAL);
 
-    slice.data = strndup(str, n);
+    slice.data = strndup(src, n);
     SOL_NULL_CHECK(slice.data, -errno);
 
     slice.len = n;
@@ -83,16 +83,16 @@ sol_arena_slice_dup_str_n(struct sol_arena *arena, struct sol_str_slice *dst, co
 }
 
 SOL_API int
-sol_arena_slice_dup_str(struct sol_arena *arena, struct sol_str_slice *dst, const char *str)
+sol_arena_slice_dup_str(struct sol_arena *arena, struct sol_str_slice *dst, const char *src)
 {
-    SOL_NULL_CHECK(str, -EINVAL);
-    return sol_arena_slice_dup_str_n(arena, dst, str, strlen(str));
+    SOL_NULL_CHECK(src, -EINVAL);
+    return sol_arena_slice_dup_str_n(arena, dst, src, strlen(src));
 }
 
 SOL_API int
-sol_arena_slice_dup(struct sol_arena *arena, struct sol_str_slice *dst, struct sol_str_slice slice)
+sol_arena_slice_dup(struct sol_arena *arena, struct sol_str_slice *dst, struct sol_str_slice src)
 {
-    return sol_arena_slice_dup_str_n(arena, dst, slice.data, slice.len);
+    return sol_arena_slice_dup_str_n(arena, dst, src.data, src.len);
 }
 
 SOL_API int
@@ -123,11 +123,11 @@ SOL_API char *
 sol_arena_strdup(struct sol_arena *arena, const char *str)
 {
     SOL_NULL_CHECK(str, NULL);
-    return sol_arena_strndup(arena, str, strlen(str));
+    return sol_arena_str_dup_n(arena, str, strlen(str));
 }
 
 SOL_API char *
-sol_arena_strndup(struct sol_arena *arena, const char *str, size_t n)
+sol_arena_str_dup_n(struct sol_arena *arena, const char *str, size_t n)
 {
     char *result;
     int r;
@@ -151,5 +151,5 @@ sol_arena_strndup(struct sol_arena *arena, const char *str, size_t n)
 SOL_API char *
 sol_arena_strdup_slice(struct sol_arena *arena, const struct sol_str_slice slice)
 {
-    return sol_arena_strndup(arena, slice.data, slice.len);
+    return sol_arena_str_dup_n(arena, slice.data, slice.len);
 }

--- a/src/lib/flow/sol-flow-parser.c
+++ b/src/lib/flow/sol-flow-parser.c
@@ -423,7 +423,7 @@ build_node(
         return NULL;
     }
 
-    name = sol_arena_strndup(state->arena, node->name.data, node->name.len);
+    name = sol_arena_str_dup_n(state->arena, node->name.data, node->name.len);
     if (!name) {
         err = -errno;
         goto end;

--- a/src/test/test-arena.c
+++ b/src/test/test-arena.c
@@ -60,7 +60,7 @@ test_simple(void)
         ASSERT(dst_str);
         ASSERT(streq(gladiators[i], dst_str));
 
-        dst_str = sol_arena_strndup(arena, gladiators[i], strlen(gladiators[i]));
+        dst_str = sol_arena_str_dup_n(arena, gladiators[i], strlen(gladiators[i]));
         ASSERT(dst_str);
         ASSERT(streq(gladiators[i], dst_str));
     }
@@ -83,7 +83,7 @@ test_null(void)
     ASSERT(sol_arena_slice_dup_str_n(arena, &dst, NULL, 0));
     ASSERT(sol_arena_slice_dup(arena, &dst, SOL_STR_SLICE_STR(NULL, 0)));
     ASSERT(!sol_arena_strdup(arena, NULL));
-    ASSERT(!sol_arena_strndup(arena, NULL, 0));
+    ASSERT(!sol_arena_str_dup_n(arena, NULL, 0));
 
     sol_arena_del(arena);
 }


### PR DESCRIPTION
Rename function

In sol_arena_slice_dup_str_n() and sol_arena_slice_dup_str() rename
the str argument to src

In sol_arena_slice_dup() rename the slice argument to src

issue #1659

Signed-off-by: Amanda Coelho <amanda.winder.ribeiro.coelho@intel.com>