### PR TITLE
API Changes: IIO

### DIFF
--- a/src/lib/io/include/sol-iio.h
+++ b/src/lib/io/include/sol-iio.h
@@ -44,7 +44,7 @@ extern "C" {
  * @brief An IIO device handle
  * @see sol_iio_open()
  * @see sol_iio_close()
- * @see sol_iio_device_trigger_now()
+ * @see sol_iio_device_trigger()
  * @see sol_iio_device_start_buffer()
  */
 struct sol_iio_device;
@@ -141,9 +141,9 @@ struct sol_iio_channel *sol_iio_add_channel(struct sol_iio_device *device, const
  * @param channel IIO channel handle to be read
  * @param value Where read value will be stored
  *
- * @return true if reading was performed correctly
+ * @return 0 if reading was performed correctly, if fail return error code always negative.
  */
-bool sol_iio_read_channel_value(struct sol_iio_channel *channel, double *value);
+int sol_iio_read_channel_value(struct sol_iio_channel *channel, double *value);
 
 /**
  * @brief Manually 'pull' device current trigger.
@@ -153,9 +153,9 @@ bool sol_iio_read_channel_value(struct sol_iio_channel *channel, double *value);
  *
  * @param device IIO handler of device to have its trigger manually 'pulled'.
  *
- * @return true if writing to file is successful
+ * @return 0 if writing to file is successful, if fail return error code always negative.
  */
-bool sol_iio_device_trigger_now(struct sol_iio_device *device);
+int sol_iio_device_trigger(struct sol_iio_device *device);
 
 /**
  * @brief Start reading device buffer.
@@ -168,9 +168,9 @@ bool sol_iio_device_trigger_now(struct sol_iio_device *device);
  *
  * @param device IIO handler of device on which reading will be performed
  *
- * @return true if reading started successfully
+ * @return 0 if reading started successfully, if fail return error code always negative.
  */
-bool sol_iio_device_start_buffer(struct sol_iio_device *device);
+int sol_iio_device_start_buffer(struct sol_iio_device *device);
 
 /**
  * @brief Address an IIO device from a list of commands to find them.

--- a/src/lib/io/sol-iio.c
+++ b/src/lib/io/sol-iio.c
@@ -971,7 +971,7 @@ error:
     return NULL;
 }
 
-static bool
+static int
 iio_read_buffer_channel_value(struct sol_iio_channel *channel, double *value)
 {
     uint64_t data = 0;
@@ -982,18 +982,18 @@ iio_read_buffer_channel_value(struct sol_iio_channel *channel, double *value)
     struct sol_iio_device *device = channel->device;
     uint8_t *buffer = device->buffer.data;
 
-    SOL_NULL_CHECK(buffer, false);
+    SOL_NULL_CHECK(buffer, -EINVAL);
 
     if (channel->storagebits > 64) {
         SOL_WRN("Could not read channel [%s] value - more than 64 bits of"
             " storage - found %d. Use sol_iio_read_channel_raw_buffer() instead",
             channel->name, channel->storagebits);
-        return false;
+        return -EBADMSG;
     }
 
     if (channel->offset_in_buffer + channel->storagebits > device->buffer_size * 8) {
         SOL_WRN("Invalid read on buffer.");
-        return false;
+        return -EBADMSG;
     }
 
     offset_bytes = channel->offset_in_buffer / 8;
@@ -1027,10 +1027,10 @@ iio_read_buffer_channel_value(struct sol_iio_channel *channel, double *value)
     if (!channel->processed)
         *value = (*value + channel->offset) * channel->scale;
 
-    return true;
+    return 0;
 }
 
-SOL_API bool
+SOL_API int
 sol_iio_read_channel_value(struct sol_iio_channel *channel, double *value)
 {
     int len;
@@ -1039,8 +1039,8 @@ sol_iio_read_channel_value(struct sol_iio_channel *channel, double *value)
     struct sol_iio_device *device;
     bool r;
 
-    SOL_NULL_CHECK(channel, false);
-    SOL_NULL_CHECK(value, false);
+    SOL_NULL_CHECK(channel, -EINVAL);
+    SOL_NULL_CHECK(value, -EINVAL);
 
     device = channel->device;
 
@@ -1054,21 +1054,21 @@ sol_iio_read_channel_value(struct sol_iio_channel *channel, double *value)
     if (!r) {
         SOL_WRN("Could not read channel [%s] in device%d", channel->name,
             device->device_id);
-        return false;
+        return -EBADMSG;
     }
 
     len = sol_util_read_file(path, "%" SCNd64, &raw_value);
     if (len < 0) {
         SOL_WRN("Could not read channel [%s] in device%d", channel->name,
             device->device_id);
-        return false;
+        return -EBADMSG;
     }
 
     if (channel->processed)
         *value = raw_value;
     else
         *value = (raw_value + channel->offset) * channel->scale;
-    return true;
+    return 0;
 }
 
 static int
@@ -1085,18 +1085,18 @@ calc_channel_offset_in_buffer(const struct sol_iio_channel *channel)
     return offset;
 }
 
-SOL_API bool
-sol_iio_device_trigger_now(struct sol_iio_device *device)
+SOL_API int
+sol_iio_device_trigger(struct sol_iio_device *device)
 {
     char path[PATH_MAX];
     bool r;
     int i;
 
-    SOL_NULL_CHECK(device, false);
+    SOL_NULL_CHECK(device, -EINVAL);
 
     if (!device->manual_triggering) {
         SOL_WRN("No manual triggering available for device%d", device->device_id);
-        return false;
+        return -EBADF;
     }
 
     r = craft_filename_path(path, sizeof(path), SYSFS_TRIGGER_NOW_BY_ID_PATH,
@@ -1104,37 +1104,37 @@ sol_iio_device_trigger_now(struct sol_iio_device *device)
     if (!r) {
         SOL_WRN("No valid trigger_now file available for trigger [%s]",
             device->trigger_name);
-        return false;
+        return -EBADF;
     }
 
     if ((i = sol_util_write_file(path, "%d", 1)) < 0) {
         SOL_WRN("Could not write to trigger_now file for trigger [%s]: %s",
             device->trigger_name, sol_util_strerrora(i));
-        return false;
+        return -EBADF;
     }
 
-    return true;
+    return 0;
 }
 
-SOL_API bool
+SOL_API int
 sol_iio_device_start_buffer(struct sol_iio_device *device)
 {
     struct sol_iio_channel *channel;
     int i;
 
-    SOL_NULL_CHECK(device, false);
+    SOL_NULL_CHECK(device, -EINVAL);
 
     /* Enable device after added all channels */
     if (device->buffer_enabled && !set_buffer_enabled(device, true)) {
         SOL_WRN("Could not enable buffer for device. No readings will be performed");
-        return false;
+        return -EBADMSG;
     }
 
     device->buffer_size = calc_buffer_size(device);
     i = sol_buffer_ensure(&device->buffer, device->buffer_size);
     if (i < 0) {
         SOL_WRN("Could not alloc buffer for device. No readings will be performed");
-        return false;
+        return -EBADMSG;
     }
 
     /* Now that all channels have been added, calc their offset in buffer */
@@ -1142,7 +1142,7 @@ sol_iio_device_start_buffer(struct sol_iio_device *device)
         channel->offset_in_buffer = calc_channel_offset_in_buffer(channel);
     }
 
-    return true;
+    return 0;
 }
 
 static enum sol_util_iterate_dir_reason

--- a/src/modules/flow/iio/nodes.c
+++ b/src/modules/flow/iio/nodes.c
@@ -49,16 +49,16 @@ reader_cb(void *data, struct sol_iio_device *device)
         .min = mdata->out_range.min,
         .max = mdata->out_range.max
     };
-    bool b;
+    int b;
 
     b = sol_iio_read_channel_value(mdata->channel_x, &out.x);
-    if (!b) goto error;
+    if (b < 0) goto error;
 
     b = sol_iio_read_channel_value(mdata->channel_y, &out.y);
-    if (!b) goto error;
+    if (b < 0) goto error;
 
     b = sol_iio_read_channel_value(mdata->channel_z, &out.z);
-    if (!b) goto error;
+    if (b < 0) goto error;
 
     sol_flow_send_direction_vector_packet(node,
         SOL_FLOW_NODE_TYPE_IIO_GYROSCOPE__OUT__OUT, &out);
@@ -170,7 +170,7 @@ gyroscope_tick(struct sol_flow_node *node, void *data, uint16_t port, uint16_t c
     struct gyroscope_data *mdata = data;
 
     if (mdata->buffer_enabled) {
-        if (!sol_iio_device_trigger_now(mdata->device))
+        if (sol_iio_device_trigger(mdata->device) < 0)
             goto error;
     } else {
         reader_cb(node, mdata->device);
@@ -209,16 +209,16 @@ magnet_reader_cb(void *data, struct sol_iio_device *device)
         .min = mdata->out_range.min,
         .max = mdata->out_range.max
     };
-    bool b;
+    int b;
 
     b = sol_iio_read_channel_value(mdata->channel_x, &out.x);
-    if (!b) goto error;
+    if (b < 0) goto error;
 
     b = sol_iio_read_channel_value(mdata->channel_y, &out.y);
-    if (!b) goto error;
+    if (b < 0) goto error;
 
     b = sol_iio_read_channel_value(mdata->channel_z, &out.z);
-    if (!b) goto error;
+    if (b < 0) goto error;
 
     sol_flow_send_direction_vector_packet(node,
         SOL_FLOW_NODE_TYPE_IIO_MAGNETOMETER__OUT__OUT, &out);
@@ -329,7 +329,7 @@ magnet_tick(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn
     struct magnet_data *mdata = data;
 
     if (mdata->buffer_enabled) {
-        if (!sol_iio_device_trigger_now(mdata->device))
+        if (sol_iio_device_trigger(mdata->device) < 0)
             goto error;
     } else {
         magnet_reader_cb(node, mdata->device);
@@ -367,10 +367,10 @@ temp_reader_cb(void *data, struct sol_iio_device *device)
         .max = mdata->out_range.max,
         .step = mdata->out_range.step
     };
-    bool b;
+    int b;
 
     b = sol_iio_read_channel_value(mdata->channel_val, &out.val);
-    if (!b) goto error;
+    if (b < 0) goto error;
 
     sol_flow_send_drange_value_packet(node,
         SOL_FLOW_NODE_TYPE_IIO_THERMOMETER__OUT__OUT, out.val);
@@ -481,7 +481,7 @@ temperature_tick(struct sol_flow_node *node, void *data, uint16_t port, uint16_t
     struct temperature_data *mdata = data;
 
     if (mdata->buffer_enabled) {
-        if (!sol_iio_device_trigger_now(mdata->device))
+        if (sol_iio_device_trigger(mdata->device) < 0)
             goto error;
     } else {
         temp_reader_cb(node, mdata->device);
@@ -519,10 +519,10 @@ pressure_reader_cb(void *data, struct sol_iio_device *device)
         .max = mdata->out_range.max,
         .step = mdata->out_range.step
     };
-    bool b;
+    int b;
 
     b = sol_iio_read_channel_value(mdata->channel_val, &out.val);
-    if (!b) goto error;
+    if (b < 0) goto error;
 
     sol_flow_send_drange_value_packet(node,
         SOL_FLOW_NODE_TYPE_IIO_PRESSURE_SENSOR__OUT__OUT, out.val);
@@ -633,7 +633,7 @@ pressure_tick(struct sol_flow_node *node, void *data, uint16_t port, uint16_t co
     struct pressure_data *mdata = data;
 
     if (mdata->buffer_enabled) {
-        if (!sol_iio_device_trigger_now(mdata->device))
+        if (sol_iio_device_trigger(mdata->device) < 0)
             goto error;
     } else {
         pressure_reader_cb(node, mdata->device);
@@ -674,18 +674,18 @@ color_reader_cb(void *data, struct sol_iio_device *device)
         .blue_max = mdata->out_range.max
     };
     double tmp;
-    bool b;
+    int b;
 
     b = sol_iio_read_channel_value(mdata->channel_red, &tmp);
-    if (!b || tmp < 0 || tmp > UINT32_MAX) goto error;
+    if (b < 0|| tmp < 0 || tmp > UINT32_MAX) goto error;
     out.red = tmp;
 
     b = sol_iio_read_channel_value(mdata->channel_green, &tmp);
-    if (!b || tmp < 0 || tmp > UINT32_MAX) goto error;
+    if (b < 0 || tmp < 0 || tmp > UINT32_MAX) goto error;
     out.green = tmp;
 
     b = sol_iio_read_channel_value(mdata->channel_blue, &tmp);
-    if (!b || tmp < 0 || tmp > UINT32_MAX) goto error;
+    if (b < 0 || tmp < 0 || tmp > UINT32_MAX) goto error;
     out.blue = tmp;
 
     sol_flow_send_rgb_packet(node,
@@ -797,7 +797,7 @@ color_tick(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_
     struct color_data *mdata = data;
 
     if (mdata->buffer_enabled) {
-        if (!sol_iio_device_trigger_now(mdata->device))
+        if (sol_iio_device_trigger(mdata->device) < 0)
             goto error;
     } else {
         color_reader_cb(node, mdata->device);
@@ -836,16 +836,16 @@ accelerate_reader_cb(void *data, struct sol_iio_device *device)
         .min = mdata->out_range.min,
         .max = mdata->out_range.max
     };
-    bool b;
+    int b;
 
     b = sol_iio_read_channel_value(mdata->channel_x, &out.x);
-    if (!b) goto error;
+    if (b < 0) goto error;
 
     b = sol_iio_read_channel_value(mdata->channel_y, &out.y);
-    if (!b) goto error;
+    if (b < 0) goto error;
 
     b = sol_iio_read_channel_value(mdata->channel_z, &out.z);
-    if (!b) goto error;
+    if (b < 0) goto error;
 
     sol_flow_send_direction_vector_packet(node,
         SOL_FLOW_NODE_TYPE_IIO_ACCELEROMETER__OUT__OUT, &out);
@@ -956,7 +956,7 @@ accelerate_tick(struct sol_flow_node *node, void *data, uint16_t port, uint16_t 
     struct accelerate_data *mdata = data;
 
     if (mdata->buffer_enabled) {
-        if (!sol_iio_device_trigger_now(mdata->device))
+        if (sol_iio_device_trigger(mdata->device) < 0)
             goto error;
     } else {
         accelerate_reader_cb(node, mdata->device);
@@ -994,10 +994,10 @@ humidity_reader_cb(void *data, struct sol_iio_device *device)
         .max = mdata->out_range.max,
         .step = mdata->out_range.step
     };
-    bool b;
+    int b;
 
     b = sol_iio_read_channel_value(mdata->channel_val, &out.val);
-    if (!b) goto error;
+    if (b < 0) goto error;
 
     sol_flow_send_drange_value_packet(node,
         SOL_FLOW_NODE_TYPE_IIO_HUMIDITY_SENSOR__OUT__OUT, out.val);
@@ -1108,7 +1108,7 @@ humidity_tick(struct sol_flow_node *node, void *data, uint16_t port, uint16_t co
     struct humidity_data *mdata = data;
 
     if (mdata->buffer_enabled) {
-        if (!sol_iio_device_trigger_now(mdata->device))
+        if (sol_iio_device_trigger(mdata->device) < 0)
             goto error;
     } else {
         humidity_reader_cb(node, mdata->device);
@@ -1146,10 +1146,10 @@ adc_reader_cb(void *data, struct sol_iio_device *device)
         .max = mdata->out_range.max,
         .step = mdata->out_range.step
     };
-    bool b;
+    int b;
 
     b = sol_iio_read_channel_value(mdata->channel_val, &out.val);
-    if (!b) goto error;
+    if (b < 0) goto error;
 
     sol_flow_send_drange_value_packet(node,
         SOL_FLOW_NODE_TYPE_IIO_ADC__OUT__OUT, out.val);
@@ -1260,7 +1260,7 @@ adc_tick(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id
     struct adc_data *mdata = data;
 
     if (mdata->buffer_enabled) {
-        if (!sol_iio_device_trigger_now(mdata->device))
+        if (sol_iio_device_trigger(mdata->device) < 0)
             goto error;
     } else {
         adc_reader_cb(node, mdata->device);
@@ -1298,10 +1298,10 @@ light_reader_cb(void *data, struct sol_iio_device *device)
         .max = mdata->out_range.max,
         .step = mdata->out_range.step
     };
-    bool b;
+    int b;
 
     b = sol_iio_read_channel_value(mdata->channel_val, &out.val);
-    if (!b) goto error;
+    if (b < 0) goto error;
 
     sol_flow_send_drange_value_packet(node,
         SOL_FLOW_NODE_TYPE_IIO_LIGHT_SENSOR__OUT__OUT, out.val);
@@ -1414,7 +1414,7 @@ light_tick(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_
     struct light_data *mdata = data;
 
     if (mdata->buffer_enabled) {
-        if (!sol_iio_device_trigger_now(mdata->device))
+        if (sol_iio_device_trigger(mdata->device) < 0)
             goto error;
     } else {
         light_reader_cb(node, mdata->device);
@@ -1452,10 +1452,10 @@ proximity_reader_cb(void *data, struct sol_iio_device *device)
         .max = mdata->out_range.max,
         .step = mdata->out_range.step
     };
-    bool b;
+    int b;
 
     b = sol_iio_read_channel_value(mdata->channel_val, &out.val);
-    if (!b) goto error;
+    if (b < 0) goto error;
 
     sol_flow_send_drange_value_packet(node,
         SOL_FLOW_NODE_TYPE_IIO_PROXIMITY_SENSOR__OUT__OUT, out.val);
@@ -1568,7 +1568,7 @@ proximity_tick(struct sol_flow_node *node, void *data, uint16_t port, uint16_t c
     struct proximity_data *mdata = data;
 
     if (mdata->buffer_enabled) {
-        if (!sol_iio_device_trigger_now(mdata->device))
+        if (sol_iio_device_trigger(mdata->device) < 0)
             goto error;
     } else {
         proximity_reader_cb(node, mdata->device);


### PR DESCRIPTION
Rename sol_iio_device_trigger_now() to sol_iio_device_trigger()

Change the type of iio_read_buffer_channel_value(), sol_iio_read_channel_value()
sol_iio_device_trigger() and sol_iio_device_start_buffer. Now they return an int,
in case of fail, they return a negative error code.

issue #1742

Signed-off-by: Amanda Coelho <amanda.winder.ribeiro.coelho@intel.com>