### PR TITLE
sol-coap: sol_coap_packet_add_uri_path_option fails for "/" path

### DIFF
--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -1156,6 +1156,9 @@ sol_coap_packet_add_uri_path_option(struct sol_coap_packet *pkt, const char *uri
         return -EINVAL;
     }
 
+    if (strlen(uri) == 1)
+        return 0;
+
     for (uri++; *uri; uri = slash + 1) {
         int r;
 


### PR DESCRIPTION
The API currently fails if the URI parameter is only "/".

Although the user of the API should better check the parameter when
setting up a packet, not even calling it if this is the case [1],
I think the API should not fail/return an error in this case either.

Maybe we can add a warning [as well]?

[1] https://tools.ietf.org/html/rfc7252#page-62 step 7 and
https://tools.ietf.org/html/rfc7252#page-61 step 8 shows
that one Uri-Path option with "/" is the same as no Uri-Path option at all .

Signed-off-by: Bruno Melo <bsilva.melo@gmail.com>