### PR TITLE
i2c & aio: set errno to a positive error value

### DIFF
--- a/src/bin/sol-aio/sol-aio.c
+++ b/src/bin/sol-aio/sol-aio.c
@@ -45,7 +45,7 @@ static bool
 on_timeout(void *data)
 {
     pending = sol_aio_get_value(aio, read_cb, NULL);
-    if (!pending && errno != -EBUSY)
+    if (!pending && errno != EBUSY)
         fprintf(stderr, "ERROR: Failed to request read operation to <%d, %d>.\n", device, pin);
 
     return true;

--- a/src/lib/io/include/sol-aio.h
+++ b/src/lib/io/include/sol-aio.h
@@ -136,8 +136,8 @@ void sol_aio_close(struct sol_aio *aio);
  * @return pending An AIO pending operation handle on success and errno is set to @c 0,
  * otherwise @c NULL. It's only valid before @a read_cb is called. It
  * may be used before that to cancel the read operation.
- * If @c NULL is returned, the errno variable will be set with the correct error value. The error value is always negative.
- * In case that the AIO device is in use, the errno variale is set to -EBUSY.
+ * If @c NULL is returned, the errno variable will be set with the correct error value.
+ * In case that the AIO device is in use, the errno variable is set to EBUSY.
  */
 struct sol_aio_pending *sol_aio_get_value(struct sol_aio *aio, void (*read_cb)(void *cb_data, struct sol_aio *aio, int32_t ret), const void *cb_data);
 

--- a/src/lib/io/include/sol-i2c.h
+++ b/src/lib/io/include/sol-i2c.h
@@ -196,8 +196,8 @@ uint8_t sol_i2c_get_slave_address(struct sol_i2c *i2c);
  * @return pending An I2C pending operation handle on success,
  * otherwise @c NULL. It's only valid before @a write_quick_cb is
  * called. It may be used before that to cancel the read operation.
- * If @c NULL is returned, the errno variable will be set with the correct error value. The error value is always negative.
- * In case that the AIO device is in use, the errno variale is set to -EBUSY.
+ * If @c NULL is returned, the errno variable will be set with the correct error value.
+ * In case that the I2C device is in use, the errno variable is set to EBUSY.
  */
 struct sol_i2c_pending *sol_i2c_write_quick(struct sol_i2c *i2c, bool rw, void (*write_quick_cb)(void *cb_data, struct sol_i2c *i2c, ssize_t status), const void *cb_data);
 
@@ -227,8 +227,8 @@ struct sol_i2c_pending *sol_i2c_write_quick(struct sol_i2c *i2c, bool rw, void (
  * @return pending An I2C pending operation handle on success,
  * otherwise @c NULL. It's only valid before @a read_cb is called. It
  * may be used before that to cancel the read operation.
- * If @c NULL is returned, the errno variable will be set with the correct error value. The error value is always negative.
- * In case that the AIO device is in use, the errno variale is set to -EBUSY.
+ * If @c NULL is returned, the errno variable will be set with the correct error value.
+ * In case that the I2C device is in use, the errno variable is set to EBUSY.
  */
 struct sol_i2c_pending *sol_i2c_read(struct sol_i2c *i2c, uint8_t *data, size_t count, void (*read_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t *data, ssize_t status), const void *cb_data);
 
@@ -258,8 +258,8 @@ struct sol_i2c_pending *sol_i2c_read(struct sol_i2c *i2c, uint8_t *data, size_t 
  * @return pending An I2C pending operation handle on success,
  * otherwise @c NULL. It's only valid before @a write_cb is called. It
  * may be used before that to cancel the read operation.
- * If @c NULL is returned, the errno variable will be set with the correct error value. The error value is always negative.
- * In case that the AIO device is in use, the errno variale is set to -EBUSY.
+ * If @c NULL is returned, the errno variable will be set with the correct error value.
+ * In case that the I2C device is in use, the errno variable is set to EBUSY.
  */
 struct sol_i2c_pending *sol_i2c_write(struct sol_i2c *i2c, uint8_t *data, size_t count, void (*write_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t *data, ssize_t status), const void *cb_data);
 
@@ -284,8 +284,8 @@ struct sol_i2c_pending *sol_i2c_write(struct sol_i2c *i2c, uint8_t *data, size_t
  * @return pending An I2C pending operation handle on success,
  * otherwise @c NULL. It's only valid before @a read_reg_cb is called.
  * It may be used before that to cancel the read operation.
- * If @c NULL is returned, the errno variable will be set with the correct error value. The error value is always negative.
- * In case that the AIO device is in use, the errno variale is set to -EBUSY.
+ * If @c NULL is returned, the errno variable will be set with the correct error value.
+ * In case that the I2C device is in use, the errno variable is set to EBUSY.
  */
 struct sol_i2c_pending *sol_i2c_read_register(struct sol_i2c *i2c, uint8_t reg, uint8_t *data, size_t count, void (*read_reg_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status), const void *cb_data);
 
@@ -310,8 +310,8 @@ struct sol_i2c_pending *sol_i2c_read_register(struct sol_i2c *i2c, uint8_t reg, 
  * @return pending An I2C pending operation handle on success,
  * otherwise @c NULL. It's only valid before @a write_reg_cb is
  * called. It may be used before that to cancel the read operation.
- * If @c NULL is returned, the errno variable will be set with the correct error value. The error value is always negative.
- * In case that the AIO device is in use, the errno variale is set to -EBUSY.
+ * If @c NULL is returned, the errno variable will be set with the correct error value.
+ * In case that the I2C device is in use, the errno variable is set to EBUSY.
  */
 struct sol_i2c_pending *sol_i2c_write_register(struct sol_i2c *i2c, uint8_t reg, const uint8_t *data, size_t count, void (*write_reg_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status), const void *cb_data);
 
@@ -350,8 +350,8 @@ struct sol_i2c_pending *sol_i2c_write_register(struct sol_i2c *i2c, uint8_t reg,
  * @return pending An I2C pending operation handle on success,
  * otherwise @c NULL. It's only valid before @a read_reg_multiple_cb
  * is called. It may be used before that to cancel the read operation.
- * If @c NULL is returned, the errno variable will be set with the correct error value. The error value is always negative.
- * In case that the AIO device is in use, the errno variale is set to -EBUSY.
+ * If @c NULL is returned, the errno variable will be set with the correct error value.
+ * In case that the I2C device is in use, the errno variable is set to EBUSY.
  */
 struct sol_i2c_pending *sol_i2c_read_register_multiple(struct sol_i2c *i2c, uint8_t reg, uint8_t *values, size_t count, uint8_t times, void (*read_reg_multiple_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status), const void *cb_data);
 

--- a/src/lib/io/sol-aio-impl-linux.c
+++ b/src/lib/io/sol-aio-impl-linux.c
@@ -221,11 +221,11 @@ sol_aio_get_value(struct sol_aio *aio,
     };
 #endif
 
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(aio, NULL);
     SOL_NULL_CHECK(aio->fp, NULL);
 
-    errno = -EBUSY;
+    errno = EBUSY;
     BUSY_CHECK(aio, NULL);
 
     aio->async.value = 0;
@@ -249,7 +249,7 @@ sol_aio_get_value(struct sol_aio *aio,
     return pending;
 
 err_no_mem:
-    errno = -ENOMEM;
+    errno = ENOMEM;
     return NULL;
 }
 

--- a/src/lib/io/sol-aio-impl-riot.c
+++ b/src/lib/io/sol-aio-impl-riot.c
@@ -192,10 +192,10 @@ sol_aio_get_value(struct sol_aio *aio,
     int32_t ret),
     const void *cb_data)
 {
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(aio, NULL);
 
-    errno = -EBUSY;
+    errno = EBUSY;
     SOL_EXP_CHECK(aio->async.timeout, NULL);
 
     aio->async.value = 0;
@@ -203,7 +203,7 @@ sol_aio_get_value(struct sol_aio *aio,
     aio->async.cb_data = cb_data;
 
     aio->async.timeout = sol_timeout_add(0, aio_read_timeout_cb, aio);
-    errno = -ENOMEM;
+    errno = ENOMEM;
     SOL_NULL_CHECK(aio->async.timeout, NULL);
 
     errno = 0;

--- a/src/lib/io/sol-aio-impl-zephyr.c
+++ b/src/lib/io/sol-aio-impl-zephyr.c
@@ -157,10 +157,10 @@ sol_aio_get_value(struct sol_aio *aio,
     int32_t ret),
     const void *cb_data)
 {
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(aio, NULL);
 
-    errno = -EBUSY;
+    errno = EBUSY;
     SOL_EXP_CHECK(aio->async.timeout, NULL);
 
     aio->async.cb_data = cb_data;
@@ -168,7 +168,7 @@ sol_aio_get_value(struct sol_aio *aio,
     aio->async.value = 0;
 
     aio->async.timeout = sol_timeout_add(0, aio_read_timeout_cb, aio);
-    errno = -ENOMEM;
+    errno = ENOMEM;
     SOL_NULL_CHECK(aio->async.timeout, NULL);
 
     errno = 0;

--- a/src/lib/io/sol-i2c-impl-contiki-qmsi.c
+++ b/src/lib/io/sol-i2c-impl-contiki-qmsi.c
@@ -313,13 +313,13 @@ sol_i2c_read(struct sol_i2c *i2c, uint8_t *data, size_t count,
 {
     qm_rc_t ret;
 
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(data, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
 
     if (qm_i2c_get_status(i2c->bus) != QM_I2C_IDLE) {
-        errno = -EBUSY;
+        errno = EBUSY;
         return NULL;
     }
 
@@ -332,7 +332,7 @@ sol_i2c_read(struct sol_i2c *i2c, uint8_t *data, size_t count,
 
     ret = begin_transfer(i2c->bus, i2c->slave_addr, i2c->bus, NULL, 0,
         data, i2c->xfer.length, true);
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_EXP_CHECK(ret != QM_RC_OK, NULL);
 
     errno = 0;
@@ -346,13 +346,13 @@ sol_i2c_write(struct sol_i2c *i2c, uint8_t *data, size_t count,
 {
     qm_rc_t ret;
 
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(data, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
 
     if (qm_i2c_get_status(i2c->bus) != QM_I2C_IDLE) {
-        errno = -EBUSY;
+        errno = EBUSY;
         return NULL;
     }
 
@@ -367,7 +367,7 @@ sol_i2c_write(struct sol_i2c *i2c, uint8_t *data, size_t count,
 
     ret = begin_transfer(i2c->bus, i2c->slave_addr, i2c->bus, i2c->xfer.data,
         i2c->xfer.length, NULL, 0, true);
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_EXP_CHECK(ret != QM_RC_OK, NULL);
 
     errno = 0;
@@ -381,13 +381,13 @@ sol_i2c_read_register(struct sol_i2c *i2c, uint8_t reg, uint8_t *data,
 {
     qm_rc_t ret;
 
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(data, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
 
     if (qm_i2c_get_status(i2c->bus) != QM_I2C_IDLE) {
-        errno = -EBUSY;
+        errno = EBUSY;
         return NULL;
     }
 
@@ -401,7 +401,7 @@ sol_i2c_read_register(struct sol_i2c *i2c, uint8_t reg, uint8_t *data,
 
     ret = begin_transfer(i2c->bus, i2c->slave_addr, i2c->bus, &i2c->xfer.reg, 1,
         data, i2c->xfer.length, true);
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_EXP_CHECK(ret != QM_RC_OK, NULL);
 
     errno = 0;
@@ -416,13 +416,13 @@ sol_i2c_read_register_multiple(struct sol_i2c *i2c, uint8_t reg, uint8_t *data,
 {
     qm_rc_t ret;
 
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(data, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
 
     if (qm_i2c_get_status(i2c->bus) != QM_I2C_IDLE) {
-        errno = -EBUSY;
+        errno = EBUSY;
         return NULL;
     }
 
@@ -438,7 +438,7 @@ sol_i2c_read_register_multiple(struct sol_i2c *i2c, uint8_t reg, uint8_t *data,
 
     ret = begin_transfer(i2c->bus, i2c->slave_addr, i2c->bus, &i2c->xfer.reg, 1,
         data, i2c->xfer.length, false);
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_EXP_CHECK(ret != QM_RC_OK, NULL);
 
     errno = 0;
@@ -452,13 +452,13 @@ sol_i2c_write_register(struct sol_i2c *i2c, uint8_t reg, const uint8_t *data,
 {
     qm_rc_t ret;
 
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(data, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
 
     if (qm_i2c_get_status(i2c->bus) != QM_I2C_IDLE) {
-        errno = -EBUSY;
+        errno = EBUSY;
         return NULL;
     }
 
@@ -474,7 +474,7 @@ sol_i2c_write_register(struct sol_i2c *i2c, uint8_t reg, const uint8_t *data,
 
     ret = begin_transfer(i2c->bus, i2c->slave_addr, i2c->bus, &i2c->xfer.reg, 1,
         NULL, 0, false);
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_EXP_CHECK(ret != QM_RC_OK, NULL);
 
     errno = 0;

--- a/src/lib/io/sol-i2c-impl-linux.c
+++ b/src/lib/io/sol-i2c-impl-linux.c
@@ -274,10 +274,10 @@ sol_i2c_write_quick(struct sol_i2c *i2c, bool rw, void (*write_quick_cb)(void *c
     };
 #endif
 
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_INT_CHECK(i2c->dev, == 0, NULL);
-    errno = -EBUSY;
+    errno = EBUSY;
     BUSY_CHECK(i2c, NULL);
 
     i2c->async.data = (uint8_t *)(long)rw;
@@ -300,7 +300,7 @@ sol_i2c_write_quick(struct sol_i2c *i2c, bool rw, void (*write_quick_cb)(void *c
     return pending;
 
 err_no_mem:
-    errno = -ENOMEM;
+    errno = ENOMEM;
     return NULL;
 }
 
@@ -408,12 +408,12 @@ sol_i2c_read(struct sol_i2c *i2c, uint8_t *values, size_t count, void (*read_cb)
     };
 #endif
 
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(values, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
     SOL_INT_CHECK(i2c->dev, == 0, NULL);
-    errno = -EBUSY;
+    errno = EBUSY;
     BUSY_CHECK(i2c, NULL);
 
     i2c->async.data = values;
@@ -437,7 +437,7 @@ sol_i2c_read(struct sol_i2c *i2c, uint8_t *values, size_t count, void (*read_cb)
     return pending;
 
 err_no_mem:
-    errno = -ENOMEM;
+    errno = ENOMEM;
     return NULL;
 }
 
@@ -493,12 +493,12 @@ sol_i2c_write(struct sol_i2c *i2c, uint8_t *values, size_t count, void (*write_c
     };
 #endif
 
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(values, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
     SOL_INT_CHECK(i2c->dev, == 0, NULL);
-    errno = -EBUSY;
+    errno = EBUSY;
     BUSY_CHECK(i2c, NULL);
 
     i2c->async.data = values;
@@ -522,7 +522,7 @@ sol_i2c_write(struct sol_i2c *i2c, uint8_t *values, size_t count, void (*write_c
     return pending;
 
 err_no_mem:
-    errno = -ENOMEM;
+    errno = ENOMEM;
     return NULL;
 }
 
@@ -656,12 +656,12 @@ sol_i2c_read_register(struct sol_i2c *i2c, uint8_t reg, uint8_t *values, size_t 
     };
 #endif
 
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(values, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
     SOL_INT_CHECK(i2c->dev, == 0, NULL);
-    errno = -EBUSY;
+    errno = EBUSY;
     BUSY_CHECK(i2c, NULL);
 
     i2c->async.data = values;
@@ -686,7 +686,7 @@ sol_i2c_read_register(struct sol_i2c *i2c, uint8_t reg, uint8_t *values, size_t 
     return pending;
 
 err_no_mem:
-    errno = -ENOMEM;
+    errno = ENOMEM;
     return NULL;
 }
 
@@ -781,13 +781,13 @@ sol_i2c_read_register_multiple(struct sol_i2c *i2c, uint8_t reg, uint8_t *values
     };
 #endif
 
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(values, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
     SOL_INT_CHECK(times, == 0, NULL);
     SOL_INT_CHECK(i2c->dev, == 0, NULL);
-    errno = -EBUSY;
+    errno = EBUSY;
     BUSY_CHECK(i2c, NULL);
 
     i2c->async.data = values;
@@ -813,7 +813,7 @@ sol_i2c_read_register_multiple(struct sol_i2c *i2c, uint8_t reg, uint8_t *values
     return pending;
 
 err_no_mem:
-    errno = -ENOMEM;
+    errno = ENOMEM;
     return NULL;
 }
 
@@ -932,12 +932,12 @@ sol_i2c_write_register(struct sol_i2c *i2c, uint8_t reg, const uint8_t *values, 
     };
 #endif
 
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(values, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
     SOL_INT_CHECK(i2c->dev, == 0, NULL);
-    errno = -EBUSY;
+    errno = EBUSY;
     BUSY_CHECK(i2c, NULL);
 
     i2c->async.data = (uint8_t *)values;
@@ -962,7 +962,7 @@ sol_i2c_write_register(struct sol_i2c *i2c, uint8_t reg, const uint8_t *values, 
     return pending;
 
 err_no_mem:
-    errno = -ENOMEM;
+    errno = ENOMEM;
     return NULL;
 }
 

--- a/src/lib/io/sol-i2c-impl-riot.c
+++ b/src/lib/io/sol-i2c-impl-riot.c
@@ -109,7 +109,7 @@ SOL_API struct sol_i2c_pending *
 sol_i2c_write_quick(struct sol_i2c *i2c, bool rw, void (*write_quick_cb)(void *cb_data, struct sol_i2c *i2c, ssize_t status), const void *cb_data)
 {
     SOL_CRI("Unsupported");
-    errno = -ENOSYS;
+    errno = ENOSYS;
     return NULL;
 }
 
@@ -139,11 +139,11 @@ i2c_read_timeout_cb(void *data)
 SOL_API struct sol_i2c_pending *
 sol_i2c_read(struct sol_i2c *i2c, uint8_t *data, size_t count, void (*read_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t *data, ssize_t status), const void *cb_data)
 {
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(data, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
-    errno = -EBUSY;
+    errno = EBUSY;
     SOL_EXP_CHECK(i2c->async.timeout, NULL);
 
     i2c->async.data = data;
@@ -154,7 +154,7 @@ sol_i2c_read(struct sol_i2c *i2c, uint8_t *data, size_t count, void (*read_cb)(v
     i2c->async.cb_data = cb_data;
 
     i2c->async.timeout = sol_timeout_add(0, i2c_read_timeout_cb, i2c);
-    errno = -ENOMEM;
+    errno = ENOMEM;
     SOL_NULL_CHECK(i2c->async.timeout, NULL);
 
     errno = 0;
@@ -179,11 +179,11 @@ i2c_write_timeout_cb(void *data)
 SOL_API struct sol_i2c_pending *
 sol_i2c_write(struct sol_i2c *i2c, uint8_t *data, size_t count, void (*write_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t *data, ssize_t status), const void *cb_data)
 {
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(data, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
-    errno = -EBUSY;
+    errno = EBUSY;
     SOL_EXP_CHECK(i2c->async.timeout, NULL);
 
     i2c->async.data = data;
@@ -194,7 +194,7 @@ sol_i2c_write(struct sol_i2c *i2c, uint8_t *data, size_t count, void (*write_cb)
     i2c->async.cb_data = cb_data;
 
     i2c->async.timeout = sol_timeout_add(0, i2c_write_timeout_cb, i2c);
-    errno = -ENOMEM;
+    errno = ENOMEM;
     SOL_NULL_CHECK(i2c->async.timeout, NULL);
 
     errno = 0;
@@ -227,11 +227,11 @@ i2c_read_reg_timeout_cb(void *data)
 SOL_API struct sol_i2c_pending *
 sol_i2c_read_register(struct sol_i2c *i2c, uint8_t command, uint8_t *values, size_t count, void (*read_reg_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status), const void *cb_data)
 {
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(values, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
-    errno = -EBUSY;
+    errno = EBUSY;
     SOL_EXP_CHECK(i2c->async.timeout, NULL);
 
     i2c->async.data = values;
@@ -243,7 +243,7 @@ sol_i2c_read_register(struct sol_i2c *i2c, uint8_t command, uint8_t *values, siz
     i2c->async.cb_data = cb_data;
 
     i2c->async.timeout = sol_timeout_add(0, i2c_read_reg_timeout_cb, i2c);
-    errno = -ENOMEM;
+    errno = ENOMEM;
     SOL_NULL_CHECK(i2c->async.timeout, NULL);
 
     errno = 0;
@@ -278,11 +278,11 @@ i2c_read_reg_multiple_timeout_cb(void *data)
 SOL_API struct sol_i2c_pending *
 sol_i2c_read_register_multiple(struct sol_i2c *i2c, uint8_t reg, uint8_t *data, size_t count, uint8_t times, void (*read_reg_multiple_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status), const void *cb_data)
 {
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(data, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
-    errno = -EBUSY;
+    errno = EBUSY;
     SOL_EXP_CHECK(i2c->async.timeout, NULL);
 
     i2c->async.data = data;
@@ -295,7 +295,7 @@ sol_i2c_read_register_multiple(struct sol_i2c *i2c, uint8_t reg, uint8_t *data, 
     i2c->async.times = times;
 
     i2c->async.timeout = sol_timeout_add(0, i2c_read_reg_multiple_timeout_cb, i2c);
-    errno = -ENOMEM;
+    errno = ENOMEM;
     SOL_NULL_CHECK(i2c->async.timeout, NULL);
 
     errno = 0;
@@ -320,11 +320,11 @@ i2c_write_reg_timeout_cb(void *data)
 SOL_API struct sol_i2c_pending *
 sol_i2c_write_register(struct sol_i2c *i2c, uint8_t reg, const uint8_t *data, size_t count, void (*write_reg_cb)(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssize_t status), const void *cb_data)
 {
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(data, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
-    errno = -EBUSY;
+    errno = EBUSY;
     SOL_EXP_CHECK(i2c->async.timeout, NULL);
 
     i2c->async.data = (uint8_t *)data;
@@ -336,7 +336,7 @@ sol_i2c_write_register(struct sol_i2c *i2c, uint8_t reg, const uint8_t *data, si
     i2c->async.cb_data = cb_data;
 
     i2c->async.timeout = sol_timeout_add(0, i2c_write_reg_timeout_cb, i2c);
-    errno = -ENOMEM;
+    errno = ENOMEM;
     SOL_NULL_CHECK(i2c->async.timeout, false);
 
     errno = 0;

--- a/src/lib/io/sol-i2c-impl-zephyr.c
+++ b/src/lib/io/sol-i2c-impl-zephyr.c
@@ -170,7 +170,7 @@ sol_i2c_write_quick(struct sol_i2c *i2c,
     const void *cb_data)
 {
     SOL_WRN("Unsupported");
-    errno = -ENOSYS;
+    errno = ENOSYS;
     return NULL;
 }
 
@@ -212,14 +212,14 @@ sol_i2c_read(struct sol_i2c *i2c,
     ssize_t status),
     const void *cb_data)
 {
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(data, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
     if (i2c->async.timeout) {
         SOL_WRN("There's an ongoing operation for the given I2C handle (%p), "
             "wait for it to finish or cancel it to make this call", i2c);
-        errno = -EBUSY;
+        errno = EBUSY;
         return NULL;
     }
 
@@ -231,7 +231,7 @@ sol_i2c_read(struct sol_i2c *i2c,
     i2c->async.cb_data = cb_data;
 
     i2c->async.timeout = sol_timeout_add(0, i2c_read_timeout_cb, i2c);
-    errno = -ENOMEM;
+    errno = ENOMEM;
     SOL_NULL_CHECK(i2c->async.timeout, NULL);
 
     errno = 0;
@@ -266,14 +266,14 @@ sol_i2c_write(struct sol_i2c *i2c,
     ssize_t status),
     const void *cb_data)
 {
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(data, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
     if (i2c->async.timeout) {
         SOL_WRN("There's an ongoing operation for the given I2C handle (%p), "
             "wait for it to finish or cancel it to make this call", i2c);
-        errno = -EBUSY;
+        errno = EBUSY;
         return NULL;
     }
 
@@ -285,7 +285,7 @@ sol_i2c_write(struct sol_i2c *i2c,
     i2c->async.cb_data = cb_data;
 
     i2c->async.timeout = sol_timeout_add(0, i2c_write_timeout_cb, i2c);
-    errno = -ENOMEM;
+    errno = ENOMEM;
     SOL_NULL_CHECK(i2c->async.timeout, NULL);
 
     errno = 0;
@@ -340,14 +340,14 @@ sol_i2c_read_register(struct sol_i2c *i2c,
     ssize_t status),
     const void *cb_data)
 {
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(values, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
     if (i2c->async.timeout) {
         SOL_WRN("There's an ongoing operation for the given I2C handle (%p), "
             "wait for it to finish or cancel it to make this call", i2c);
-        errno = -EBUSY;
+        errno = EBUSY;
         return NULL;
     }
 
@@ -360,7 +360,7 @@ sol_i2c_read_register(struct sol_i2c *i2c,
     i2c->async.cb_data = cb_data;
 
     i2c->async.timeout = sol_timeout_add(0, i2c_read_reg_timeout_cb, i2c);
-    errno = -ENOMEM;
+    errno = ENOMEM;
     SOL_NULL_CHECK(i2c->async.timeout, NULL);
 
     errno = 0;
@@ -420,14 +420,14 @@ sol_i2c_read_register_multiple(struct sol_i2c *i2c,
     ssize_t status),
     const void *cb_data)
 {
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c, NULL);
     SOL_NULL_CHECK(data, NULL);
     SOL_INT_CHECK(count, == 0, NULL);
     if (i2c->async.timeout) {
         SOL_WRN("There's an ongoing operation for the given I2C handle (%p), "
             "wait for it to finish or cancel it to make this call", i2c);
-        errno = -EBUSY;
+        errno = EBUSY;
         return NULL;
     }
 
@@ -442,7 +442,7 @@ sol_i2c_read_register_multiple(struct sol_i2c *i2c,
 
     i2c->async.timeout = sol_timeout_add
             (0, i2c_read_reg_multiple_timeout_cb, i2c);
-    errno = -EINVAL;
+    errno = EINVAL;
     SOL_NULL_CHECK(i2c->async.timeout, NULL);
 
     errno = 0;
@@ -494,7 +494,7 @@ sol_i2c_write_register(struct sol_i2c *i2c,
     if (i2c->async.timeout) {
         SOL_WRN("There's an ongoing operation for the given I2C handle (%p), "
             "wait for it to finish or cancel it to make this call", i2c);
-        errno = -EBUSY;
+        errno = EBUSY;
         return NULL;
     }
 
@@ -507,7 +507,7 @@ sol_i2c_write_register(struct sol_i2c *i2c,
     i2c->async.cb_data = cb_data;
 
     i2c->async.timeout = sol_timeout_add(0, i2c_write_reg_timeout_cb, i2c);
-    errno = -ENOMEM;
+    errno = ENOMEM;
     SOL_NULL_CHECK(i2c->async.timeout, NULL);
     errno = 0;
     return (struct sol_i2c_pending *)i2c->async.timeout;

--- a/src/modules/flow/aio/aio.c
+++ b/src/modules/flow/aio/aio.c
@@ -93,7 +93,7 @@ _on_reader_timeout(void *data)
     struct aio_data *mdata = data;
 
     mdata->pending = sol_aio_get_value(mdata->aio, read_cb, mdata);
-    if (!mdata->pending && errno != -EBUSY) {
+    if (!mdata->pending && errno != EBUSY) {
         sol_flow_send_error_packet(mdata->node, errno,
             "AIO (%s): Failed to issue read operation.", mdata->pin);
         return false;

--- a/src/modules/flow/si114x/si114x.c
+++ b/src/modules/flow/si114x/si114x.c
@@ -242,7 +242,7 @@ setup_device(void *cb_data, struct sol_i2c *i2c, uint8_t reg, uint8_t *data, ssi
         setup_device, cb_data);
 
     if (!mdata->i2c_pending) {
-        if (errno == -EBUSY)
+        if (errno == EBUSY)
             mdata->timer = sol_timeout_add(0, busy_bus_callback, mdata);
         else
             sol_flow_send_error_packet(mdata->node, errno,
@@ -318,7 +318,7 @@ do_processing(void *data)
         &read_callback, mdata);
 
     if (!mdata->i2c_pending) {
-        if (errno == -EBUSY)
+        if (errno == EBUSY)
             mdata->timer = sol_timeout_add(0, &do_processing, mdata);
         else
             sol_flow_send_error_packet(mdata->node, errno,


### PR DESCRIPTION
As mentioned here https://github.com/solettaproject/soletta/pull/2129#discussion_r65670041 global `errno` should always be positive, so this patch sets `errno` to a positive error value.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>