### PR TITLE
sol-platform: Ignore comments in locale.conf

### DIFF
--- a/src/lib/common/sol-platform-linux-common.c
+++ b/src/lib/common/sol-platform-linux-common.c
@@ -957,6 +957,10 @@ sol_platform_impl_load_locales(char **locale_cache)
 
     line = NULL;
     while (fscanf(f, "%m[^\n]\n", &line) != EOF) {
+        /* It is possible to have comments in locale.conf, ignore them */
+        if (line[0] == '#')
+            goto ignore;
+
         sep = strchr(line, '=');
         if (!sep) {
             SOL_WRN("The locale entry: %s does not have the separator '='",


### PR DESCRIPTION
Some systems may include lines starting with '#' indicating that they
are comments in their locale.conf files.

Signed-off-by: Vinicius Costa Gomes <vinicius.gomes@intel.com>