### PR TITLE
check if sol_i2c_set_slave_address returns -ERRNO

### DIFF
--- a/src/modules/flow/accelerometer/lsm303.c
+++ b/src/modules/flow/accelerometer/lsm303.c
@@ -104,7 +104,11 @@ set_slave(struct accelerometer_lsm303_data *mdata, bool (*cb)(void *data))
 static void
 lsm303_scale_bit_set(struct accelerometer_lsm303_data *mdata)
 {
-    if (!sol_i2c_set_slave_address(mdata->i2c, mdata->slave)) {
+    int r;
+
+    r = sol_i2c_set_slave_address(mdata->i2c, mdata->slave);
+
+    if (r < 0) {
         SOL_WRN("Failed to set slave at address 0x%02x\n", mdata->slave);
         return;
     }

--- a/src/modules/flow/jhd1313m1/jhd1313m1.c
+++ b/src/modules/flow/jhd1313m1/jhd1313m1.c
@@ -357,7 +357,11 @@ i2c_write_cb(void *cb_data,
 static int
 command_send(struct lcd_data *mdata, struct command *cmd)
 {
-    if (!sol_i2c_set_slave_address(mdata->i2c, cmd->chip_addr)) {
+    int r;
+
+    r = sol_i2c_set_slave_address(mdata->i2c, cmd->chip_addr);
+
+    if (r < 0) {
         SOL_WRN("Failed to set slave at address 0x%02x\n", cmd->chip_addr);
         return -EIO;
     }


### PR DESCRIPTION
Since last change from patch 026c6f6945998ee1b365e8bb7f20e556f42efba4 the
function sol_i2c_set_slave_address does not return bool and yet it returns
a -ERRNO informing the probable cause of the error.

Thus the module should use in the same way instead of checking if false.

Signed-off-by: Bruno Bottazzini <bruno.bottazzini@intel.com>