### PR TITLE
API Changes: Sol-str-slice #2143

### DIFF
--- a/src/bin/sol-fbp-generator/main.c
+++ b/src/bin/sol-fbp-generator/main.c
@@ -478,9 +478,9 @@ check_suboption(const struct sol_str_slice option,
 static struct sol_str_slice
 get_irange_drange_option_value(const struct sol_str_slice option)
 {
-    if (sol_str_slice_str_caseeq(option, "nan"))
+    if (sol_str_slice_str_case_eq(option, "nan"))
         return sol_str_slice_from_str("NAN");
-    if (sol_str_slice_str_caseeq(option, "inf"))
+    if (sol_str_slice_str_case_eq(option, "inf"))
         return sol_str_slice_from_str("INFINITY");
     return option;
 }

--- a/src/lib/comms/sol-http-client-impl-curl.c
+++ b/src/lib/comms/sol-http-client-impl-curl.c
@@ -697,7 +697,7 @@ set_headers_from_params(CURL *curl, const struct sol_http_params *params,
         if (iter->type != SOL_HTTP_PARAM_HEADER)
             continue;
 
-        if (sol_str_slice_str_caseeq(key, "Content-Length")) {
+        if (sol_str_slice_str_case_eq(key, "Content-Length")) {
             curl_off_t len;
             len = sol_util_strtol_n(iter->value.key_value.value.data, NULL,
                 iter->value.key_value.value.len, 0);

--- a/src/lib/comms/sol-mavlink.c
+++ b/src/lib/comms/sol-mavlink.c
@@ -628,7 +628,7 @@ static const struct sol_str_table_ptr protocol_table[] = {
 };
 
 static inline const void *
-sol_mavlink_parse_addr_protocol(const char *str, struct sol_str_slice *addr, int *port)
+sol_mavlink_parse_addr_protocol(const char *str, struct sol_str_slice *addr, long int *port)
 {
     struct sol_vector tokens;
     struct sol_str_slice slice = sol_str_slice_from_str(str);
@@ -679,7 +679,7 @@ sol_mavlink_connect(const char *addr, const struct sol_mavlink_config *config, c
 {
     struct sol_mavlink *mavlink;
     struct sol_str_slice address;
-    int port;
+    long int port;
 
     int (*init) (struct sol_mavlink *mavlink);
 

--- a/src/lib/datatypes/include/sol-str-slice.h
+++ b/src/lib/datatypes/include/sol-str-slice.h
@@ -96,7 +96,7 @@ struct sol_str_slice {
  *
  * @return @c true if the contents are equal, @c false otherwise
  *
- * @see sol_str_slice_str_caseeq
+ * @see sol_str_slice_str_case_eq
  */
 static inline bool
 sol_str_slice_str_eq(const struct sol_str_slice a, const char *b)
@@ -112,7 +112,7 @@ sol_str_slice_str_eq(const struct sol_str_slice a, const char *b)
  *
  * @return @c true if the contents are equal, @c false otherwise
  *
- * @see sol_str_slice_caseeq
+ * @see sol_str_slice_case_eq
  */
 static inline bool
 sol_str_slice_eq(const struct sol_str_slice a, const struct sol_str_slice b)
@@ -133,7 +133,7 @@ sol_str_slice_eq(const struct sol_str_slice a, const struct sol_str_slice b)
  * @see sol_str_slice_str_eq
  */
 static inline bool
-sol_str_slice_str_caseeq(const struct sol_str_slice a, const char *b)
+sol_str_slice_str_case_eq(const struct sol_str_slice a, const char *b)
 {
     return b && a.len == strlen(b) && (strncasecmp(a.data, b, a.len) == 0);
 }
@@ -141,7 +141,7 @@ sol_str_slice_str_caseeq(const struct sol_str_slice a, const char *b)
 /**
  * @brief Checks if the content of both slices are equal.
  *
- * Similar to @ref sol_str_slice_caseeq, but ignoring the case of the characters.
+ * Similar to @ref sol_str_slice_case_eq, but ignoring the case of the characters.
  *
  * @param a First slice
  * @param b Second slice
@@ -151,7 +151,7 @@ sol_str_slice_str_caseeq(const struct sol_str_slice a, const char *b)
  * @see sol_str_slice_eq
  */
 static inline bool
-sol_str_slice_caseeq(const struct sol_str_slice a, const struct sol_str_slice b)
+sol_str_slice_case_eq(const struct sol_str_slice a, const struct sol_str_slice b)
 {
     return a.len == b.len && (strncasecmp(a.data, b.data, a.len) == 0);
 }
@@ -293,7 +293,7 @@ sol_str_slice_to_blob(const struct sol_str_slice slice)
  *
  * @return @c 0 on success, error code (always negative) otherwise
  */
-int sol_str_slice_to_int(const struct sol_str_slice s, int *value);
+int sol_str_slice_to_int(const struct sol_str_slice s, long int *value);
 
 /**
  * @brief Creates a string from a string slice.

--- a/src/lib/datatypes/sol-str-slice.c
+++ b/src/lib/datatypes/sol-str-slice.c
@@ -25,7 +25,7 @@
 #include "sol-util-internal.h"
 
 SOL_API int
-sol_str_slice_to_int(const struct sol_str_slice s, int *value)
+sol_str_slice_to_int(const struct sol_str_slice s, long int *value)
 {
     char *endptr = NULL;
     long int v;

--- a/src/lib/parsers/sol-json.c
+++ b/src/lib/parsers/sol-json.c
@@ -1542,7 +1542,7 @@ error:
 SOL_API int32_t
 sol_json_path_array_get_segment_index(struct sol_str_slice key)
 {
-    int index_val;
+    long int index_val;
     int r;
 
     SOL_NULL_CHECK(key.data, -EINVAL);
@@ -1555,7 +1555,7 @@ sol_json_path_array_get_segment_index(struct sol_str_slice key)
         &index_val);
     SOL_INT_CHECK(r, < 0, r);
 
-    if ((int)(uint16_t)index_val != index_val)
+    if ((long int)(uint16_t)index_val != index_val)
         return -ERANGE;
 
     return index_val;

--- a/src/modules/flow/http-client/http-client.c
+++ b/src/modules/flow/http-client/http-client.c
@@ -803,7 +803,8 @@ int_process_json(struct sol_flow_node *node, const struct sol_str_slice slice)
 static int
 int_process_data(struct sol_flow_node *node, struct sol_buffer *buf)
 {
-    int value, r;
+    int r;
+    long int value;
 
     r = sol_str_slice_to_int(sol_buffer_get_slice(buf), &value);
     SOL_INT_CHECK(r, < 0, r);

--- a/src/test/test-str-slice.c
+++ b/src/test/test-str-slice.c
@@ -89,7 +89,8 @@ test_str_slice_to_int(void)
     };
 
     for (i = 0; i < sol_util_array_size(table); i++) {
-        int error, value = 0;
+        int error;
+        long int value = 0;
         error = sol_str_slice_to_int(table[i].input, &value);
         ASSERT_INT_EQ(error, table[i].output_error);
         ASSERT_INT_EQ(value, table[i].output_value);


### PR DESCRIPTION
Replace the caseeq keyword with case_eq

sol_str_slice_to_int() now receive a pointer to long int.

issue #1663

Signed-off-by: Amanda Coelho <amanda.winder.ribeiro.coelho@intel.com>