### PR TITLE
build: Avoid warning about BOARD_NAME redefined

### DIFF
--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -241,10 +241,6 @@ endif
 
 endif #LOG
 
-ifneq (,$(BOARD_NAME))
-COMMON_CFLAGS += -DBOARD_NAME=\"$(BOARD_NAME)\"
-endif
-
 COMMON_CFLAGS += \
 	-DVERSION="\"$(VERSION)\"" \
 	-DSYSCONF="\"$(SYSCONF)\"" \


### PR DESCRIPTION
BOARD_NAME is now always available in the config, even as an empty
string, so it comes as a #define through the generated sol_config.h.
Having it also in the command line, in some cases, generates a
redefinition warning.

Signed-off-by: Iván Briano <ivan.briano@intel.com>