### PR TITLE
comms: Add so-netctl API

### DIFF
--- a/src/lib/comms/Kconfig
+++ b/src/lib/comms/Kconfig
@@ -43,6 +43,18 @@ config BLUETOOTH_NONE
 
 endchoice
 
+config NETCTL
+        bool "connection manager interfaces"
+        default y
+        depends on FEATURE_NETCTL && NETWORK
+        help
+           This provides the connection manager interfaces API.
+           The user can use the connection manager APIs to control
+           network and get the network info from connection manager.
+           It includes to get the network state, get the name of services
+           (wireless AP/Bluetooth Devices/...), get the ip address of
+           services, connect/disconnect services and so on.
+
 config COAP
 	bool "CoAP"
 	default y

--- a/src/lib/comms/Makefile
+++ b/src/lib/comms/Makefile
@@ -8,6 +8,11 @@ obj-networking-$(NETWORK) := \
     sol-comms.o \
     sol-socket.o
 
+obj-networking-$(NETCTL) += \
+    sol-netctl-impl-connman.o
+obj-networking-$(NETCTL)-extra-cflags += $(SYSTEMD_CFLAGS)
+obj-networking-$(NETCTL)-extra-ldflags += $(SYSTEMD_LDFLAGS)
+
 obj-dtls-$(DTLS) += \
     sol-socket-dtls-impl-tinydtls.o \
     $(TINYDTLS_SRC_PATH)/aes/rijndael.o \
@@ -158,6 +163,9 @@ headers-$(COAP) += \
 headers-$(BLUETOOTH) += \
     include/sol-bluetooth.h \
     include/sol-gatt.h
+
+headers-$(NETCTL) += \
+    include/sol-netctl.h
 
 headers-$(OIC) += \
     include/sol-oic.h \

--- a/src/lib/comms/include/sol-netctl.h
+++ b/src/lib/comms/include/sol-netctl.h
@@ -1,0 +1,476 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <sol-network.h>
+#include <sol-buffer.h>
+#include <sol-vector.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @struct sol_netctl_service
+ *
+ * @brief service struct
+ */
+struct sol_netctl_service;
+
+/**
+ * @struct sol_netctl_network_params
+ *
+ * @brief network params
+ *
+ * This struct contains the information of a network.
+ * it has the addr of network link addr, the network of
+ * netmask and its gateway of network.
+ */
+struct sol_netctl_network_params {
+    /**
+     * @brief The network devices address
+     */
+    struct sol_network_link_addr addr;
+    /**
+     * @brief The network devices netmask
+     */
+    struct sol_network_link_addr netmask;
+    /**
+     * @brief The network gateway
+     */
+    struct sol_network_link_addr gateway;
+};
+
+/**
+ * @enum sol_netctl_service_state
+ *
+ * @brief service state
+ *
+ * One of these must be chosen to set the state of service,
+ * with sol_netctl_service_get_state()
+ *
+ * @note SOL_NETCTL_SERVICE_STATE_REMOVE is used to show
+ * the service has been removed. When it is notified,
+ * the service has been removed in the system.
+ */
+enum sol_netctl_service_state {
+    /*
+     * @brief the service is unknow
+     *
+     * a service is unknow when the service is init
+     * and the service state can't be given.
+     */
+    SOL_NETCTL_SERVICE_STATE_UNKNOWN = 0,
+    /*
+     * @brief the service is idle
+     *
+     * a service is idle when the service is not in use
+     * at all at the moment and it is not attempting to
+     * connect or do anything.
+     */
+    SOL_NETCTL_SERVICE_STATE_IDLE,
+    /*
+     * @brief the service is association
+     *
+     * a service is association when the service tries to
+     * establish a low-level connection to the network.
+     */
+    SOL_NETCTL_SERVICE_STATE_ASSOCIATION,
+    /*
+     * @brief the service is configuration
+     *
+     * a service is configuration when the service is trying to
+     * retrieve/configure IP settings.
+     */
+    SOL_NETCTL_SERVICE_STATE_CONFIGURATION,
+    /*
+     * @brief the service is ready
+     *
+     * a service is ready when a successfully connected device.
+     */
+    SOL_NETCTL_SERVICE_STATE_READY,
+    /*
+     * @brief the service is online
+     *
+     * a service is online when an internet connection is available
+     * and has been verified.
+     */
+    SOL_NETCTL_SERVICE_STATE_ONLINE,
+    /*
+     * @brief the service is disconnect
+     *
+     * a service is disconnect when the service is going to terminate
+     * the current connection and will return to "idle".
+     */
+    SOL_NETCTL_SERVICE_STATE_DISCONNECT,
+    /*
+     * @brief the service is failure
+     *
+     * a service is failure when the service indicates a wrong behavior.
+     */
+    SOL_NETCTL_SERVICE_STATE_FAILURE,
+    /*
+     * @brief the service is remove
+     *
+     * a service is remove when the service is not available and removed
+     * from the network system. At the same time, the service handle(pointer)
+     * will become invalid.
+     */
+    SOL_NETCTL_SERVICE_STATE_REMOVE,
+};
+
+#define SOL_NETCTL_SERVICE_TYPE_ETHERNET   "ethernet"  /**< @brief ethernet service type string */
+#define SOL_NETCTL_SERVICE_TYPE_WIFI       "wifi"      /**< @brief wifi service type string */
+#define SOL_NETCTL_SERVICE_TYPE_BLUETOOTH  "bluetooth" /**< @brief bluetooth service type string */
+#define SOL_NETCTL_SERVICE_TYPE_CELLULAR   "cellular"   /**< @brief bluetooth service type string */
+#define SOL_NETCTL_SERVICE_TYPE_GPS        "gps"       /**< @brief gps service type string */
+#define SOL_NETCTL_SERVICE_TYPE_VPN        "vpn"       /**< @brief vpn service type string */
+#define SOL_NETCTL_SERVICE_TYPE_GADGET     "gadget"    /**< @brief gadget service type string */
+#define SOL_NETCTL_SERVICE_TYPE_P2P        "p2p"       /**< @brief p2p service type string */
+
+/**
+ * @enum sol_netctl_state
+ *
+ * @brief the global connection state of system
+ *
+ * One of these must be chosen for the global connection state,
+ * with sol_netctl_get_state()
+ *
+ */
+enum sol_netctl_state {
+    /*
+     * @brief the state is unknow
+     *
+     * a state is unknow when the state is init
+     * and the state can't be given.
+     */
+    SOL_NETCTL_STATE_UNKNOWN = 0,
+    /*
+     * @brief the state is idle
+     *
+     * a state is idle when no serives is in either "ready" or "online" state.
+     */
+    SOL_NETCTL_STATE_IDLE,
+    /*
+     * @brief the state is ready
+     *
+     * a state is ready when at least one service is in "ready"
+     * state and no service is in "online" state.
+     */
+    SOL_NETCTL_STATE_READY,
+    /*
+     * @brief the state is online
+     *
+     * a state is online when at least one service is in "online".
+     */
+    SOL_NETCTL_STATE_ONLINE,
+    /*
+     * @brief the state is offline
+     *
+     * a state is offline when the device is in offline mode and
+     * the user doesn't re-enable individual technologies like
+     * WiFi and Bluetooth while in offline mode.
+     */
+    SOL_NETCTL_STATE_OFFLINE,
+};
+
+/**
+ * @brief Service monitor callback used to inform a service changed
+ *
+ * @param data the user data
+ * @param service the monitor service
+ */
+typedef void (*sol_netctl_service_monitor_cb)
+    (void *data,
+    const struct sol_netctl_service *service);
+
+/**
+ * @brief Manager monitor callback used to inform a manager updated
+ *
+ * @param data the user data
+ */
+typedef void (*sol_netctl_manager_monitor_cb)(void *data);
+
+/**
+ * @brief error monitor callback used to inform a call result
+ *
+ * @param data the user data
+ * @param service the activity service
+ * @param error the call result
+ */
+typedef void (*sol_netctl_error_monitor_cb)
+    (void *data, const struct sol_netctl_service *service,
+    unsigned int error);
+
+/**
+ * @brief Gets the service name
+ *
+ * This function gets the name for the netctl service,
+ * after the service is to give by service monitor.
+ *
+ * @param service The service structure which the name is desired
+ *
+ * @return The name of the services on success, NULL on failure.
+ */
+const char *sol_netctl_service_get_name(
+    const struct sol_netctl_service *service);
+
+/**
+ * @brief Gets the service state
+ *
+ * This function gets the state for the netctl service,
+ * after the service is to give by service monitor.
+ *
+ * @note SOL_NETCTL_SERVICE_STATE_REMOVE is used to show
+ * the service has been removed. When it is notified,
+ * the service has been removed in the system.
+ *
+ * @param service The service structure which the state is desired
+ *
+ * @return The state of the services on success,
+ * SOL_NETCTL_SERVICE_STATE_UNKNOWN on failure.
+ */
+enum sol_netctl_service_state sol_netctl_service_get_state(
+    const struct sol_netctl_service *service);
+
+/**
+ * @brief Gets the service type
+ *
+ * This function gets the type for the netctl service,
+ * after the service is to give by service monitor.
+ *
+ * @param service The service structure which the type is desired
+ *
+ * @return The type of the services on success, NULL on failure.
+ */
+const char *sol_netctl_service_get_type(
+    const struct sol_netctl_service *service);
+
+/**
+ * @brief Gets the service network address
+ *
+ * This function gets the network address for the netctl service,
+ * after the service is to give by service monitor.
+ *
+ * @param service The service structure which the network address is desired
+ * @param link The retrieved content
+ *
+ * @return 0 on success, -errno on failure.
+ */
+int sol_netctl_service_get_network_address(
+    const struct sol_netctl_service *service, struct sol_network_link **link);
+
+/**
+ * @brief Gets the service strength
+ *
+ * This function gets the service strength for the netctl service,
+ * after the service is to give by service monitor.
+ *
+ * @param service The service structure which the service strength is
+ * desired
+ *
+ * @return 0-100 on success, -errno on failure.
+ */
+int32_t sol_netctl_service_get_strength(
+    const struct sol_netctl_service *service);
+
+/**
+ * @brief Gets the global connection state of system
+ *
+ * This function gets the global connection state for system,
+ * after the state is to give by manager monitor.
+ * This callback of sol_netctl_add_manager_monitor must be
+ * added BEFORE sol_netctl_get_state() is called
+ * to ensure no messages are lost.
+ *
+ * @return The state of the global connection state on success,
+ * SOL_NETCTL_STATE_UNKNOWN on failure
+ */
+enum sol_netctl_state sol_netctl_get_state(void);
+
+/**
+ * @brief Sets the global connection state to offline
+ *
+ * This function sets the global connection state to offline,
+ * enter offline Mode too.
+ *
+ * @param enabled The value is set for offline on/off
+ *
+ * @return 0 on success, -errno on failure.
+ */
+int sol_netctl_set_radios_offline(bool enabled);
+
+/**
+ * @brief Gets the global connection state of offline
+ *
+ * This function gets the global connection state of offline,
+ * after the state is to give by manager monitor.
+ * This callback of sol_netctl_add_manager_monitor must be
+ * added BEFORE sol_netctl_get_radios_offline() is called
+ * to ensure no messages are lost.
+ *
+ * @return True if the offline is enabled, false otherwise.
+ */
+bool sol_netctl_get_radios_offline(void);
+
+/**
+ * @brief Connect the service
+ *
+ * This function connects the service, after the service is to give by service monitor.
+ * Since the netctl function is asynchronous, the return is not connection error,
+ * but just some dispatching/immediate error. The actual state change will be notified
+ * via sol_netctl_add_service_monitor() callbacks. The service connect error info will be
+ * notified by error monitor. This callbacks of sol_netctl_add_service_monitor and
+ * sol_netctl_add_error_monitor must be added BEFORE the sol_netctl_service_connect()
+ * is called to ensure no messages are lost.
+ *
+ * @param service The service structure which the connection is desired
+ *
+ * @return 0 on success, -errno on failure.
+ */
+int sol_netctl_service_connect(struct sol_netctl_service *service);
+
+/**
+ * @brief Disconnect the service
+ *
+ * This function disconnects the service.
+ * Since the netctl function is asynchronous, the return is not disconnection error,
+ * but just some dispatching/immediate error. The actual state change will be notified
+ * via sol_netctl_add_service_monitor() callbacks.The service disconnect error info
+ * will be notified by error monitor. This callbacks of sol_netctl_add_service_monitor and
+ * sol_netctl_add_error_monitor must be added BEFORE the sol_netctl_service_disconnect()
+ * is called to ensure no messages are lost.
+ *
+ * @param service The service structure which the disconnection is desired
+ *
+ * @return 0 on success, -errno on failure.
+ */
+int sol_netctl_service_disconnect(struct sol_netctl_service *service);
+
+/**
+ * @brief Adds a monitor for the updated netctl services
+ *
+ * To monitor the property of services, it gives information
+ * about the services. The callback is used to provide the information.
+ * sol_netctl_add_service_monitor will trigger all required activations.
+ * This callback must be added BEFORE the all functions are called to
+ * ensure connection manager has been initialized.
+ *
+ * @param cb monitor Callback to be called when the services are updated
+ * @param data Add a user data per callback
+ *
+ * @return 1 on the first time success, 0 on success, -errno on failure.
+ */
+int sol_netctl_add_service_monitor(sol_netctl_service_monitor_cb cb,
+    const void *data);
+
+/**
+ * @brief Dels a monitor for the updated netctl services
+ *
+ * Removes the monitor for updated netctl services.
+ * sol_netctl_del_service_monitor will trigger all required activations.
+ * This callback must be added AFTER the all functions are called to
+ * ensure connection manager has been shutdown.
+ *
+ * @param cb monitor Callback to be called when the services are updated
+ * @param data Add a user data per callback
+ *
+ * @return 0 on success, -errno on failure.
+ */
+int sol_netctl_del_service_monitor(sol_netctl_service_monitor_cb cb,
+    const void *data);
+
+/**
+ * @brief Adds a monitor for the updated netctl manager properties
+ *
+ * To monitor (State, Offline...), a single monitor can be done for
+ * "something changed", and then the new value can be get.
+ * sol_netctl_add_manager_monitor will trigger all required activations.
+ * This callback must be added BEFORE sol_netctl_get_state and
+ * sol_netctl_get_radios_offline.
+ *
+ * @param cb monitor Callback to be called when the manager are updated
+ * @param data Add a user data per callback
+ *
+ * @return 1 on the first time success, 0 on success, -errno on failure.
+ */
+int sol_netctl_add_manager_monitor(sol_netctl_manager_monitor_cb cb,
+    const void *data);
+
+/**
+ * @brief Dels a monitor for the updated netctl manager properties
+ *
+ * Removes the monitor for updated netctl manager properties.
+ * sol_netctl_del_manager_monitor will trigger all required activations.
+ *
+ * @param cb monitor Callback to be called when the manager are updated
+ * @param data Add a user data per callback
+ *
+ * @return 0 on success, -errno on failure.
+ */
+int sol_netctl_del_manager_monitor(sol_netctl_manager_monitor_cb cb,
+    const void *data);
+
+/**
+ * @brief Adds a monitor for the call error happens
+ *
+ * To monitor the call error happens, a single monitor can be done for
+ * error happens, and then the call result can be get.
+ * sol_netctl_add_error_monitor will call trigger all required activations.
+ * This callback must be added BEFORE sol_netctl_service_connect and
+ * sol_netctl_service_disconnect.
+ *
+ * @param cb monitor Callback to be called when the call result are updated
+ * @param data Add a user data per callback
+ *
+ * @return 0 on success, -errno on failure.
+ */
+int sol_netctl_add_error_monitor(sol_netctl_error_monitor_cb cb,
+    const void *data);
+
+/**
+ * @brief Dels a monitor for the call error happens
+ *
+ * Removes the monitor for updated the call error happens.
+ * sol_netctl_del_error_monitor will trigger all required activations.
+ *
+ * @param cb monitor Callback to be called when the call result are updated
+ * @param data Add a user data per callback
+ *
+ * @return 0 on success, -errno on failure.
+ */
+int sol_netctl_del_error_monitor(sol_netctl_error_monitor_cb cb,
+    const void *data);
+/**
+ * @brief Gets the netctl services
+ *
+ * The netctl services vector can be given via sol_netctl_get_services.
+ * The vector is the last-known and more may be added/removed dynamically,
+ * then the pattern is to add a service monitor BEFORE calling the function.
+ *
+ * @return The retrieved content on success, NULL on failure.
+ */
+const struct sol_ptr_vector *sol_netctl_get_services(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/lib/comms/sol-comms.c
+++ b/src/lib/comms/sol-comms.c
@@ -54,6 +54,22 @@ extern void sol_network_shutdown(void);
 extern void sol_oic_server_shutdown(void);
 #endif
 
+#ifdef NETCTL
+extern int sol_netctl_init(void);
+extern void sol_netctl_shutdown(void);
+#else
+static int
+sol_netctl_init(void)
+{
+    return 0;
+}
+
+static void
+sol_netctl_shutdown(void)
+{
+}
+#endif
+
 int sol_comms_init(void);
 void sol_comms_shutdown(void);
 
@@ -74,8 +90,13 @@ sol_comms_init(void)
     if (ret != 0)
         goto http_server_error;
 
+    ret = sol_netctl_init();
+    if (ret != 0)
+        goto netctl_error;
+
     return 0;
 
+netctl_error:
 http_server_error:
     sol_http_client_init();
 http_client_error:
@@ -93,4 +114,5 @@ sol_comms_shutdown(void)
     sol_http_client_shutdown();
     sol_http_server_shutdown();
     sol_network_shutdown();
+    sol_netctl_shutdown();
 }

--- a/src/lib/comms/sol-netctl-impl-connman.c
+++ b/src/lib/comms/sol-netctl-impl-connman.c
@@ -65,6 +65,38 @@ struct ctx {
 static struct ctx _ctx;
 
 static void
+call_service_monitor_callback(struct sol_netctl_service *service)
+{
+    struct sol_monitors_entry *m;
+    uint16_t i;
+
+    SOL_MONITORS_WALK (&_ctx.service_ms, m, i)
+        ((sol_netctl_service_monitor_cb)m->cb)((void *)m->data, service);
+}
+
+static void
+call_manager_monitor_callback(void)
+{
+    struct sol_monitors_entry *m;
+    uint16_t i;
+
+    SOL_MONITORS_WALK (&_ctx.manager_ms, m, i)
+        ((sol_netctl_manager_monitor_cb)m->cb)((void *)m->data);
+}
+
+static void
+call_error_monitor_callback(struct sol_netctl_service *service,
+    unsigned int error)
+{
+    struct sol_monitors_entry *m;
+    uint16_t i;
+
+    SOL_MONITORS_WALK (&_ctx.error_ms, m, i)
+        ((sol_netctl_error_monitor_cb)m->cb)((void *)m->data,
+            service, error);
+}
+
+static void
 _init_connman_service(struct sol_netctl_service *service)
 {
     SOL_SET_API_VERSION(service->link.api_version = SOL_NETWORK_LINK_API_VERSION; )
@@ -270,6 +302,7 @@ remove_services(const char *path)
     SOL_PTR_VECTOR_FOREACH_IDX (&_ctx.service_vector, service, i) {
         if (streq(service->path, path)) {
             service->state = SOL_NETCTL_SERVICE_STATE_REMOVE;
+            call_service_monitor_callback(service);
             sol_ptr_vector_del(&_ctx.service_vector, i);
             _free_connman_service(service);
             break;
@@ -439,6 +472,8 @@ end:
     } else
         return r;
 
+    call_service_monitor_callback(service);
+
     return 0;
 }
 
@@ -568,6 +603,8 @@ end:
     else
         return r;
 
+    call_manager_monitor_callback();
+
     return r;
 }
 
@@ -682,6 +719,9 @@ sol_netctl_shutdown(void)
         _free_connman_service(service);
 
     sol_ptr_vector_clear(&_ctx.service_vector);
+    sol_monitors_clear(&_ctx.service_ms);
+    sol_monitors_clear(&_ctx.manager_ms);
+    sol_monitors_clear(&_ctx.error_ms);
 
     _ctx.connman_state = SOL_NETCTL_STATE_UNKNOWN;
 }
@@ -710,6 +750,9 @@ sol_netctl_init_lazy(void)
     }
 
     sol_ptr_vector_init(&_ctx.service_vector);
+    sol_monitors_init(&_ctx.service_ms, NULL);
+    sol_monitors_init(&_ctx.manager_ms, NULL);
+    sol_monitors_init(&_ctx.error_ms, NULL);
 
     return 0;
 }
@@ -741,6 +784,9 @@ sol_netctl_shutdown_lazy(void)
         _free_connman_service(service);
 
     sol_ptr_vector_clear(&_ctx.service_vector);
+    sol_monitors_clear(&_ctx.service_ms);
+    sol_monitors_clear(&_ctx.manager_ms);
+    sol_monitors_clear(&_ctx.error_ms);
 
     _ctx.connman_state = SOL_NETCTL_STATE_UNKNOWN;
 }
@@ -778,6 +824,7 @@ _match_properties_changed(sd_bus_message *m, void *userdata,
         if (streq(str, "State")) {
             r = get_manager_properties(m);
             SOL_INT_CHECK(r, < 0, r);
+            call_manager_monitor_callback();
         } else {
             SOL_DBG("Ignored changed property: %s", str);
             r = sd_bus_message_skip(m, "v");

--- a/src/lib/comms/sol-netctl-impl-connman.c
+++ b/src/lib/comms/sol-netctl-impl-connman.c
@@ -46,7 +46,9 @@ struct sol_netctl_service {
 
 struct ctx {
     struct sol_bus_client *connman;
+    sd_bus_slot *manager_slot;
     sd_bus_slot *state_slot;
+    enum sol_netctl_state connman_state;
     int32_t refcount;
 };
 
@@ -114,10 +116,101 @@ sol_netctl_service_get_strength(const struct sol_netctl_service *service)
     return service->strength;
 }
 
+static int
+get_manager_properties(sd_bus_message *m)
+{
+    char *state;
+    int r;
+    static const struct sol_str_table table[] = {
+        SOL_STR_TABLE_ITEM("online",
+            SOL_NETCTL_STATE_ONLINE),
+        SOL_STR_TABLE_ITEM("ready",
+            SOL_NETCTL_STATE_READY),
+        SOL_STR_TABLE_ITEM("idle",
+            SOL_NETCTL_STATE_IDLE),
+        SOL_STR_TABLE_ITEM("offline",
+            SOL_NETCTL_STATE_OFFLINE),
+        { }
+    };
+
+    r = sd_bus_message_enter_container(m, SD_BUS_TYPE_VARIANT, "s");
+    SOL_INT_CHECK(r, < 0, r);
+
+    r = sd_bus_message_read_basic(m, SD_BUS_TYPE_STRING, &state);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (state)
+        _ctx.connman_state = sol_str_table_lookup_fallback(table,
+            sol_str_slice_from_str(state),
+            SOL_NETCTL_STATE_UNKNOWN);
+
+    r = sd_bus_message_exit_container(m);
+    SOL_INT_CHECK(r, < 0, r);
+
+    return 0;
+}
+
+static int
+_manager_properties_changed(sd_bus_message *m, void *userdata,
+    sd_bus_error *ret_error)
+{
+    struct ctx *pending = userdata;
+    char *str;
+    int r;
+
+    pending->manager_slot = sd_bus_slot_unref(pending->manager_slot);
+
+    if (sol_bus_log_callback(m, userdata, ret_error) < 0)
+        return -EINVAL;
+
+    r = sd_bus_message_enter_container(m, SD_BUS_TYPE_ARRAY, "{sv}");
+    SOL_INT_CHECK(r, < 0, r);
+
+    do {
+        r = sd_bus_message_enter_container(m, SD_BUS_TYPE_DICT_ENTRY, "sv");
+        SOL_INT_CHECK_GOTO(r, < 1, end);
+
+        r = sd_bus_message_read_basic(m, SD_BUS_TYPE_STRING, &str);
+        SOL_INT_CHECK(r, < 0, r);
+
+        if (streq(str, "State")) {
+            r = get_manager_properties(m);
+            SOL_INT_CHECK(r, < 0, r);
+        } else {
+            SOL_DBG("Ignored global manager property: %s", str);
+            r = sd_bus_message_skip(m, "v");
+            SOL_INT_CHECK(r, < 0, r);
+        }
+
+        r = sd_bus_message_exit_container(m);
+        SOL_INT_CHECK(r, < 0, r);
+    } while (1);
+
+end:
+    if (r == 0)
+        r = sd_bus_message_exit_container(m);
+    else
+        return r;
+
+    return r;
+}
+
+static int
+dbus_connection_get_manager_properties(void)
+{
+    sd_bus *bus = sol_bus_client_get_bus(_ctx.connman);
+
+    SOL_NULL_CHECK(bus, -EINVAL);
+
+    return sd_bus_call_method_async(bus, &_ctx.manager_slot,
+        "net.connman", "/", "net.connman.Manager", "GetProperties",
+        _manager_properties_changed, &_ctx, NULL);
+}
+
 SOL_API enum sol_netctl_state
 sol_netctl_get_state(void)
 {
-    return SOL_NETCTL_STATE_UNKNOWN;
+    return _ctx.connman_state;
 }
 
 static int
@@ -153,6 +246,9 @@ sol_netctl_set_radios_offline(bool enabled)
 SOL_API bool
 sol_netctl_get_radios_offline(void)
 {
+    if (_ctx.connman_state != SOL_CONNMAN_STATE_OFFLINE)
+        return false;
+
     return true;
 }
 
@@ -186,6 +282,10 @@ sol_netctl_shutdown(void)
 
     _ctx.state_slot =
         sd_bus_slot_unref(_ctx.state_slot);
+    _ctx.manager_slot =
+        sd_bus_slot_unref(_ctx.manager_slot);
+
+    _ctx.connman_state = SOL_NETCTL_STATE_UNKNOWN;
 }
 
 static int
@@ -229,6 +329,10 @@ sol_netctl_shutdown_lazy(void)
 
     _ctx.state_slot =
         sd_bus_slot_unref(_ctx.state_slot);
+    _ctx.manager_slot =
+        sd_bus_slot_unref(_ctx.manager_slot);
+
+    _ctx.connman_state = SOL_NETCTL_STATE_UNKNOWN;
 }
 
 SOL_API int

--- a/src/lib/comms/sol-netctl-impl-connman.c
+++ b/src/lib/comms/sol-netctl-impl-connman.c
@@ -26,6 +26,9 @@
 #define SOL_LOG_DOMAIN &_sol_netctl_log_domain
 #include <sol-log-internal.h>
 
+#include "sol-str-table.h"
+#include "sol-str-slice.h"
+#include "sol-util-internal.h"
 #include "sol-bus.h"
 #include "sol-netctl.h"
 
@@ -45,8 +48,10 @@ struct sol_netctl_service {
 };
 
 struct ctx {
+    struct sol_ptr_vector service_vector;
     struct sol_bus_client *connman;
     sd_bus_slot *manager_slot;
+    sd_bus_slot *service_slot;
     sd_bus_slot *state_slot;
     enum sol_netctl_state connman_state;
     int32_t refcount;
@@ -116,6 +121,322 @@ sol_netctl_service_get_strength(const struct sol_netctl_service *service)
     return service->strength;
 }
 
+static struct sol_netctl_network_params *
+get_network_link(
+    struct sol_network_link *link, enum sol_network_family family)
+{
+    struct sol_netctl_network_params *network_addr;
+    uint16_t idx;
+
+    SOL_VECTOR_FOREACH_IDX (&link->addrs, network_addr, idx) {
+        if (network_addr->addr.family == family)
+            return network_addr;
+    }
+
+    network_addr = sol_vector_append(&link->addrs);
+    SOL_NULL_CHECK(network_addr, NULL);
+
+    return network_addr;
+}
+
+static void
+get_address_ip(struct sol_network_link *link,
+    char *address, enum sol_network_family family)
+{
+    struct sol_netctl_network_params *params;
+
+    params = get_network_link(link, family);
+    SOL_NULL_CHECK(params);
+
+    params->addr.family = family;
+    sol_network_link_addr_from_str(&params->addr, address);
+    link->flags = SOL_NETWORK_LINK_UP;
+}
+
+static void
+get_netmask(struct sol_network_link *link,
+    char *netmask, enum sol_network_family family)
+{
+    struct sol_netctl_network_params *params;
+
+    params = get_network_link(link, family);
+    SOL_NULL_CHECK(params);
+
+    params->netmask.family = family;
+    sol_network_link_addr_from_str(&params->netmask, netmask);
+}
+
+static void
+get_gateway(struct sol_network_link *link,
+    char *gateway, enum sol_network_family family)
+{
+    struct sol_netctl_network_params *params;
+
+    params = get_network_link(link, family);
+    SOL_NULL_CHECK(params);
+
+    params->gateway.family = family;
+    sol_network_link_addr_from_str(&params->gateway, gateway);
+}
+
+static int
+get_service_ip(sd_bus_message *m,
+    struct sol_network_link *link, enum sol_network_family family)
+{
+    char *str;
+    int r;
+
+    SOL_NULL_CHECK(link, -EINVAL);
+
+    r = sd_bus_message_enter_container(m, SD_BUS_TYPE_ARRAY, "{sv}");
+    SOL_INT_CHECK(r, < 0, r);
+
+    do {
+        r = sd_bus_message_enter_container(m, SD_BUS_TYPE_DICT_ENTRY, "sv");
+        SOL_INT_CHECK_GOTO(r, < 1, end);
+
+        r = sd_bus_message_read_basic(m, SD_BUS_TYPE_STRING, &str);
+        SOL_INT_CHECK(r, < 0, r);
+        if (streq(str, "Address")) {
+            char *address;
+
+            r = sd_bus_message_enter_container(m, SD_BUS_TYPE_VARIANT, "s");
+            SOL_INT_CHECK(r, < 0, r);
+
+            r = sd_bus_message_read_basic(m, SD_BUS_TYPE_STRING, &address);
+            SOL_INT_CHECK(r, < 0, r);
+
+            get_address_ip(link, address, family);
+
+            r = sd_bus_message_exit_container(m);
+            SOL_INT_CHECK(r, < 0, r);
+        } else if (streq(str, "Netmask")) {
+            char *netmask;
+
+            r = sd_bus_message_enter_container(m, SD_BUS_TYPE_VARIANT, "s");
+            SOL_INT_CHECK(r, < 0, r);
+
+            r = sd_bus_message_read_basic(m, SD_BUS_TYPE_STRING, &netmask);
+            SOL_INT_CHECK(r, < 0, r);
+
+            get_netmask(link, netmask, family);
+
+            r = sd_bus_message_exit_container(m);
+            SOL_INT_CHECK(r, < 0, r);
+        } else if (streq(str, "Gateway")) {
+            char *gateway;
+
+            r = sd_bus_message_enter_container(m, SD_BUS_TYPE_VARIANT, "s");
+            SOL_INT_CHECK(r, < 0, r);
+
+            r = sd_bus_message_read_basic(m, SD_BUS_TYPE_STRING, &gateway);
+            SOL_INT_CHECK(r, < 0, r);
+
+            get_gateway(link, gateway, family);
+
+            r = sd_bus_message_exit_container(m);
+            SOL_INT_CHECK(r, < 0, r);
+        } else {
+            SOL_DBG("Ignored service ip property: %s", str);
+            r = sd_bus_message_skip(m, "v");
+            SOL_INT_CHECK(r, < 0, r);
+        }
+
+        r = sd_bus_message_exit_container(m);
+        SOL_INT_CHECK(r, < 0, r);
+    } while (1);
+
+end:
+    if (r == 0)
+        r = sd_bus_message_exit_container(m);
+
+    return r;
+}
+
+static void
+remove_services(const char *path)
+{
+    struct sol_netctl_service *service;
+    uint16_t i;
+
+    if (!path)
+        return;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&_ctx.service_vector, service, i) {
+        if (streq(service->path, path)) {
+            service->state = SOL_NETCTL_SERVICE_STATE_REMOVE;
+            sol_ptr_vector_del(&_ctx.service_vector, i);
+            _free_connman_service(service);
+            break;
+        }
+    }
+}
+
+static struct sol_netctl_service *
+find_service_by_path(const char *path)
+{
+    struct sol_netctl_service *service;
+    uint16_t i;
+    bool is_exist = false;
+    int r;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&_ctx.service_vector, service, i) {
+        if (streq(service->path, path)) {
+            is_exist = true;
+            break;
+        }
+    }
+
+    if (is_exist == false) {
+        service = calloc(1, sizeof(struct sol_netctl_service));
+        SOL_NULL_CHECK(service, NULL);
+        _init_connman_service(service);
+
+        r = sol_ptr_vector_append(&_ctx.service_vector, service);
+        SOL_INT_CHECK_GOTO(r, < 0, fail_append);
+
+        service->path = strdup(path);
+        SOL_NULL_CHECK_GOTO(service->path, fail);
+    }
+
+    return service;
+
+fail:
+    sol_ptr_vector_del_last(&_ctx.service_vector);
+fail_append:
+    _free_connman_service(service);
+    return NULL;
+}
+
+static int
+get_services_properties(sd_bus_message *m, const char *path)
+{
+    int r;
+    struct sol_netctl_service *service;
+
+    service = find_service_by_path(path);
+    SOL_NULL_CHECK(service, -ENOMEM);
+
+    r = sd_bus_message_enter_container(m, SD_BUS_TYPE_ARRAY, "{sv}");
+    SOL_INT_CHECK(r, < 0, r);
+
+    do {
+        char *str;
+
+        r = sd_bus_message_enter_container(m, SD_BUS_TYPE_DICT_ENTRY, "sv");
+        SOL_INT_CHECK_GOTO(r, < 1, end);
+
+        r = sd_bus_message_read_basic(m, SD_BUS_TYPE_STRING, &str);
+        SOL_INT_CHECK(r, < 0, r);
+        if (streq(str, "Name")) {
+            char *name;
+
+            r = sd_bus_message_enter_container(m, SD_BUS_TYPE_VARIANT, "s");
+            SOL_INT_CHECK(r, < 0, r);
+
+            r = sd_bus_message_read_basic(m, SD_BUS_TYPE_STRING, &name);
+            SOL_INT_CHECK(r, < 0, r);
+
+            r = sol_util_replace_str_if_changed(&service->name, name);
+            SOL_INT_CHECK(r, < 0, r);
+
+            r = sd_bus_message_exit_container(m);
+            SOL_INT_CHECK(r, < 0, r);
+        } else if (streq(str, "State")) {
+            char *state;
+            static const struct sol_str_table table[] = {
+                SOL_STR_TABLE_ITEM("online",
+                    SOL_NETCTL_SERVICE_STATE_ONLINE),
+                SOL_STR_TABLE_ITEM("ready",
+                    SOL_NETCTL_SERVICE_STATE_READY),
+                SOL_STR_TABLE_ITEM("association",
+                    SOL_NETCTL_SERVICE_STATE_ASSOCIATION),
+                SOL_STR_TABLE_ITEM("configuration",
+                    SOL_NETCTL_SERVICE_STATE_CONFIGURATION),
+                SOL_STR_TABLE_ITEM("disconnect",
+                    SOL_NETCTL_SERVICE_STATE_DISCONNECT),
+                SOL_STR_TABLE_ITEM("idle",
+                    SOL_NETCTL_SERVICE_STATE_IDLE),
+                SOL_STR_TABLE_ITEM("failure",
+                    SOL_NETCTL_SERVICE_STATE_FAILURE),
+                { }
+            };
+
+            r = sd_bus_message_enter_container(m, SD_BUS_TYPE_VARIANT, "s");
+            SOL_INT_CHECK(r, < 0, r);
+
+            r = sd_bus_message_read_basic(m, SD_BUS_TYPE_STRING, &state);
+            SOL_INT_CHECK(r, < 0, r);
+
+            if (state)
+                service->state = sol_str_table_lookup_fallback(table,
+                    sol_str_slice_from_str(state),
+                    SOL_NETCTL_SERVICE_STATE_UNKNOWN);
+
+            r = sd_bus_message_exit_container(m);
+            SOL_INT_CHECK(r, < 0, r);
+        } else if (streq(str, "Strength")) {
+            uint8_t strength = 0;
+
+            r = sd_bus_message_enter_container(m, SD_BUS_TYPE_VARIANT, "y");
+            SOL_INT_CHECK(r, < 0, r);
+
+            r = sd_bus_message_read_basic(m, SD_BUS_TYPE_BYTE, &strength);
+            SOL_INT_CHECK(r, < 0, r);
+
+            service->strength = strength;
+
+            r = sd_bus_message_exit_container(m);
+            SOL_INT_CHECK(r, < 0, r);
+        } else if (streq(str, "Type")) {
+            char *type;
+
+            r = sd_bus_message_enter_container(m, SD_BUS_TYPE_VARIANT, "s");
+            SOL_INT_CHECK(r, < 0, r);
+
+            r = sd_bus_message_read_basic(m, SD_BUS_TYPE_STRING, &type);
+            SOL_INT_CHECK(r, < 0, r);
+
+            r = sol_util_replace_str_if_changed(&service->type, type);
+            SOL_INT_CHECK(r, < 0, r);
+
+            r = sd_bus_message_exit_container(m);
+            SOL_INT_CHECK(r, < 0, r);
+        } else if (streq(str, "IPv4")) {
+            r = sd_bus_message_enter_container(m, SD_BUS_TYPE_VARIANT, "a{sv}");
+            SOL_INT_CHECK(r, < 0, r);
+
+            get_service_ip(m, &service->link, SOL_NETWORK_FAMILY_INET);
+
+            r = sd_bus_message_exit_container(m);
+            SOL_INT_CHECK(r, < 0, r);
+        } else if (streq(str, "IPv6")) {
+            r = sd_bus_message_enter_container(m, SD_BUS_TYPE_VARIANT, "a{sv}");
+            SOL_INT_CHECK(r, < 0, r);
+
+            get_service_ip(m, &service->link, SOL_NETWORK_FAMILY_INET6);
+
+            r = sd_bus_message_exit_container(m);
+            SOL_INT_CHECK(r, < 0, r);
+        }  else {
+            SOL_DBG("Ignored service property: %s", str);
+            r = sd_bus_message_skip(m, NULL);
+            SOL_INT_CHECK(r, < 0, r);
+        }
+        r = sd_bus_message_exit_container(m);
+        SOL_INT_CHECK(r, < 0, r);
+    } while (1);
+
+end:
+    if (r == 0) {
+        r = sd_bus_message_exit_container(m);
+        SOL_INT_CHECK(r, < 0, r);
+    } else
+        return r;
+
+    return 0;
+}
+
 static int
 get_manager_properties(sd_bus_message *m)
 {
@@ -148,6 +469,56 @@ get_manager_properties(sd_bus_message *m)
     SOL_INT_CHECK(r, < 0, r);
 
     return 0;
+}
+
+static int
+services_list_changed(sd_bus_message *m)
+{
+    int r = 0;
+    char *path = NULL;
+
+    r = sd_bus_message_enter_container(m, SD_BUS_TYPE_ARRAY, "(oa{sv})");
+    SOL_INT_CHECK(r, < 0, r);
+
+    while (sd_bus_message_enter_container(m, SD_BUS_TYPE_STRUCT, "oa{sv}") > 0) {
+        r = sd_bus_message_read(m, "o", &path);
+        SOL_INT_CHECK(r, < 0, r);
+
+        r = get_services_properties(m, path);
+        SOL_INT_CHECK(r, < 0, r);
+
+        r = sd_bus_message_exit_container(m);
+        SOL_INT_CHECK(r, < 0, r);
+    }
+
+    r = sd_bus_message_exit_container(m);
+    SOL_INT_CHECK(r, < 0, r);
+
+    r = sd_bus_message_enter_container(m, SD_BUS_TYPE_ARRAY, "o");
+    SOL_INT_CHECK(r, < 0, r);
+
+    while (sd_bus_message_read(m, "o", &path) > 0) {
+        remove_services(path);
+    }
+
+    r = sd_bus_message_exit_container(m);
+    SOL_INT_CHECK(r, < 0, r);
+
+    return 0;
+}
+
+static int
+_services_properties_changed(sd_bus_message *m, void *userdata,
+    sd_bus_error *ret_error)
+{
+    struct ctx *pending = userdata;
+
+    pending->service_slot = sd_bus_slot_unref(pending->service_slot);
+
+    if (sol_bus_log_callback(m, userdata, ret_error) < 0)
+        return -EINVAL;
+
+    return services_list_changed(m);
 }
 
 static int
@@ -207,6 +578,18 @@ dbus_connection_get_manager_properties(void)
         _manager_properties_changed, &_ctx, NULL);
 }
 
+static int
+dbus_connection_get_service_properties(void)
+{
+    sd_bus *bus = sol_bus_client_get_bus(_ctx.connman);
+
+    SOL_NULL_CHECK(bus, -EINVAL);
+
+    return sd_bus_call_method_async(bus, &_ctx.service_slot,
+        "net.connman", "/", "net.connman.Manager", "GetServices",
+        _services_properties_changed, &_ctx, NULL);
+}
+
 SOL_API enum sol_netctl_state
 sol_netctl_get_state(void)
 {
@@ -246,7 +629,7 @@ sol_netctl_set_radios_offline(bool enabled)
 SOL_API bool
 sol_netctl_get_radios_offline(void)
 {
-    if (_ctx.connman_state != SOL_CONNMAN_STATE_OFFLINE)
+    if (_ctx.connman_state != SOL_NETCTL_STATE_OFFLINE)
         return false;
 
     return true;
@@ -273,6 +656,9 @@ sol_netctl_init(void)
 void
 sol_netctl_shutdown(void)
 {
+    struct sol_netctl_service *service;
+    uint16_t id;
+
     _ctx.refcount = 0;
 
     if (_ctx.connman) {
@@ -284,6 +670,13 @@ sol_netctl_shutdown(void)
         sd_bus_slot_unref(_ctx.state_slot);
     _ctx.manager_slot =
         sd_bus_slot_unref(_ctx.manager_slot);
+    _ctx.service_slot =
+        sd_bus_slot_unref(_ctx.service_slot);
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&_ctx.service_vector, service, id)
+        _free_connman_service(service);
+
+    sol_ptr_vector_clear(&_ctx.service_vector);
 
     _ctx.connman_state = SOL_NETCTL_STATE_UNKNOWN;
 }
@@ -311,12 +704,17 @@ sol_netctl_init_lazy(void)
         return -EINVAL;
     }
 
+    sol_ptr_vector_init(&_ctx.service_vector);
+
     return 0;
 }
 
 static void
 sol_netctl_shutdown_lazy(void)
 {
+    struct sol_netctl_service *service;
+    uint16_t id;
+
     _ctx.refcount--;
 
     if (_ctx.refcount)
@@ -331,6 +729,13 @@ sol_netctl_shutdown_lazy(void)
         sd_bus_slot_unref(_ctx.state_slot);
     _ctx.manager_slot =
         sd_bus_slot_unref(_ctx.manager_slot);
+    _ctx.service_slot =
+        sd_bus_slot_unref(_ctx.service_slot);
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&_ctx.service_vector, service, id)
+        _free_connman_service(service);
+
+    sol_ptr_vector_clear(&_ctx.service_vector);
 
     _ctx.connman_state = SOL_NETCTL_STATE_UNKNOWN;
 }

--- a/src/lib/comms/sol-netctl-impl-connman.c
+++ b/src/lib/comms/sol-netctl-impl-connman.c
@@ -46,6 +46,7 @@ struct sol_netctl_service {
 
 struct ctx {
     struct sol_bus_client *connman;
+    sd_bus_slot *state_slot;
     int32_t refcount;
 };
 
@@ -119,9 +120,33 @@ sol_netctl_get_state(void)
     return SOL_NETCTL_STATE_UNKNOWN;
 }
 
+static int
+_set_state_property_changed(sd_bus_message *reply, void *userdata,
+    sd_bus_error *ret_error)
+{
+    struct ctx *pending = userdata;
+
+    pending->state_slot = sd_bus_slot_unref(pending->state_slot);
+
+    return sol_bus_log_callback(reply, userdata, ret_error);
+}
+
 SOL_API int
 sol_netctl_set_radios_offline(bool enabled)
 {
+    int r;
+    sd_bus *bus = sol_bus_client_get_bus(_ctx.connman);
+
+    SOL_NULL_CHECK(bus, -EINVAL);
+
+    if (_ctx.state_slot)
+        return -EBUSY;
+
+    r = sd_bus_call_method_async(bus, &_ctx.state_slot, "net.connman", "/",
+        "net.connman.Manager", "SetProperty", _set_state_property_changed,
+        &_ctx, "sv", "OfflineMode", "b", enabled);
+    SOL_INT_CHECK(r, < 0, r);
+
     return 0;
 }
 
@@ -159,7 +184,8 @@ sol_netctl_shutdown(void)
         _ctx.connman = NULL;
     }
 
-    return;
+    _ctx.state_slot =
+        sd_bus_slot_unref(_ctx.state_slot);
 }
 
 static int
@@ -200,6 +226,9 @@ sol_netctl_shutdown_lazy(void)
         sol_bus_client_free(_ctx.connman);
         _ctx.connman = NULL;
     }
+
+    _ctx.state_slot =
+        sd_bus_slot_unref(_ctx.state_slot);
 }
 
 SOL_API int

--- a/src/lib/comms/sol-netctl-impl-connman.c
+++ b/src/lib/comms/sol-netctl-impl-connman.c
@@ -44,6 +44,13 @@ struct sol_netctl_service {
     struct sol_network_link link;
 };
 
+struct ctx {
+    struct sol_bus_client *connman;
+    int32_t refcount;
+};
+
+static struct ctx _ctx;
+
 static void
 _init_connman_service(struct sol_netctl_service *service)
 {
@@ -145,7 +152,54 @@ sol_netctl_init(void)
 void
 sol_netctl_shutdown(void)
 {
+    _ctx.refcount = 0;
+
+    if (_ctx.connman) {
+        sol_bus_client_free(_ctx.connman);
+        _ctx.connman = NULL;
+    }
+
     return;
+}
+
+static int
+sol_netctl_init_lazy(void)
+{
+    sd_bus *bus;
+
+    _ctx.refcount++;
+
+    if (_ctx.connman)
+        return 0;
+
+    bus = sol_bus_get(NULL);
+    if (!bus) {
+        SOL_WRN("Unable to get sd bus");
+        return -EINVAL;
+    }
+
+    _ctx.connman = sol_bus_client_new(bus, "org.connman");
+    if (!_ctx.connman) {
+        sd_bus_unref(bus);
+        SOL_WRN("Unable to new a bus client");
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+static void
+sol_netctl_shutdown_lazy(void)
+{
+    _ctx.refcount--;
+
+    if (_ctx.refcount)
+        return;
+
+    if (_ctx.connman) {
+        sol_bus_client_free(_ctx.connman);
+        _ctx.connman = NULL;
+    }
 }
 
 SOL_API int

--- a/src/lib/comms/sol-netctl-impl-connman.c
+++ b/src/lib/comms/sol-netctl-impl-connman.c
@@ -1,0 +1,197 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <systemd/sd-bus.h>
+#include <systemd/sd-event.h>
+
+#define SOL_LOG_DOMAIN &_sol_netctl_log_domain
+#include <sol-log-internal.h>
+
+#include "sol-bus.h"
+#include "sol-netctl.h"
+
+SOL_LOG_INTERNAL_DECLARE_STATIC(_sol_netctl_log_domain, "netctl");
+
+int sol_netctl_init(void);
+void sol_netctl_shutdown(void);
+
+struct sol_netctl_service {
+    sd_bus_slot *slot;
+    char *path;
+    char *name;
+    char *type;
+    int32_t strength;
+    enum sol_netctl_service_state state;
+    struct sol_network_link link;
+};
+
+static void
+_init_connman_service(struct sol_netctl_service *service)
+{
+    SOL_SET_API_VERSION(service->link.api_version = SOL_NETWORK_LINK_API_VERSION; )
+    sol_vector_init(&service->link.addrs, sizeof(struct sol_netctl_network_params));
+}
+
+static void
+_free_connman_service(struct sol_netctl_service *service)
+{
+    service->slot = sd_bus_slot_unref(service->slot);
+
+    free(service->path);
+    free(service->type);
+    sol_vector_clear(&service->link.addrs);
+    free(service);
+}
+
+SOL_API const char *
+sol_netctl_service_get_name(const struct sol_netctl_service *service)
+{
+    SOL_NULL_CHECK(service, NULL);
+
+    return service->name;
+}
+
+SOL_API const char *
+sol_netctl_service_get_type(const struct sol_netctl_service *service)
+{
+    SOL_NULL_CHECK(service, NULL);
+
+    return service->type;
+}
+
+SOL_API enum sol_netctl_service_state
+sol_netctl_service_get_state(const struct sol_netctl_service *service)
+{
+    SOL_NULL_CHECK(service, SOL_NETCTL_SERVICE_STATE_UNKNOWN);
+
+    return service->state;
+}
+
+SOL_API int
+sol_netctl_service_get_network_address(const struct sol_netctl_service *service,
+    struct sol_network_link **link)
+{
+    SOL_NULL_CHECK(service, -EINVAL);
+    SOL_NULL_CHECK(link, -EINVAL);
+
+    *link = (struct sol_network_link *)&service->link;
+
+    return 0;
+}
+
+SOL_API int32_t
+sol_netctl_service_get_strength(const struct sol_netctl_service *service)
+{
+    SOL_NULL_CHECK(service, -EINVAL);
+
+    return service->strength;
+}
+
+SOL_API enum sol_netctl_state
+sol_netctl_get_state(void)
+{
+    return SOL_NETCTL_STATE_UNKNOWN;
+}
+
+SOL_API int
+sol_netctl_set_radios_offline(bool enabled)
+{
+    return 0;
+}
+
+SOL_API bool
+sol_netctl_get_radios_offline(void)
+{
+    return true;
+}
+
+SOL_API int
+sol_netctl_service_connect(struct sol_netctl_service *service)
+{
+    return 0;
+}
+
+SOL_API int
+sol_netctl_service_disconnect(struct sol_netctl_service *service)
+{
+    return 0;
+}
+
+int
+sol_netctl_init(void)
+{
+    return 0;
+}
+
+void
+sol_netctl_shutdown(void)
+{
+    return;
+}
+
+SOL_API int
+sol_netctl_add_service_monitor(
+    sol_netctl_service_monitor_cb cb, const void *data)
+{
+    return 0;
+}
+
+SOL_API int
+sol_netctl_del_service_monitor(
+    sol_netctl_service_monitor_cb cb, const void *data)
+{
+    return 0;
+}
+
+SOL_API int
+sol_netctl_add_manager_monitor(
+    sol_netctl_manager_monitor_cb cb, const void *data)
+{
+    return 0;
+}
+
+SOL_API int
+sol_netctl_del_manager_monitor(
+    sol_netctl_manager_monitor_cb cb, const void *data)
+{
+    return 0;
+}
+
+SOL_API int
+sol_netctl_add_error_monitor(
+    sol_netctl_error_monitor_cb cb, const void *data)
+{
+    return 0;
+}
+
+SOL_API int
+sol_netctl_del_error_monitor(
+    sol_netctl_error_monitor_cb cb, const void *data)
+{
+    return 0;
+}
+
+SOL_API const struct sol_ptr_vector *
+sol_netctl_get_services(void)
+{
+    return NULL;
+}

--- a/src/lib/comms/sol-netctl-impl-connman.c
+++ b/src/lib/comms/sol-netctl-impl-connman.c
@@ -97,6 +97,50 @@ call_error_monitor_callback(struct sol_netctl_service *service,
 }
 
 static void
+_set_error_to_callback(struct sol_netctl_service *service,
+    const sd_bus_error *ret_error)
+{
+    unsigned int error;
+    static const struct sol_str_table err_table[] = {
+        SOL_STR_TABLE_ITEM("org.freedesktop.DBus.Error.NoMemory",
+            ENOMEM),
+        SOL_STR_TABLE_ITEM("org.freedesktop.DBus.Error.AccessDenied",
+            EPERM),
+        SOL_STR_TABLE_ITEM("org.freedesktop.DBus.Error.InvalidArgs",
+            EINVAL),
+        SOL_STR_TABLE_ITEM("org.freedesktop.DBus.Error.UnixProcessIdUnknown",
+            ESRCH),
+        SOL_STR_TABLE_ITEM("org.freedesktop.DBus.Error.FileNotFound",
+            ENOENT),
+        SOL_STR_TABLE_ITEM("org.freedesktop.DBus.Error.FileExists",
+            EEXIST),
+        SOL_STR_TABLE_ITEM("org.freedesktop.DBus.Error.Timeout",
+            ETIMEDOUT),
+        SOL_STR_TABLE_ITEM("org.freedesktop.DBus.Error.IOError",
+            EIO),
+        SOL_STR_TABLE_ITEM("org.freedesktop.DBus.Error.Disconnected",
+            ECONNRESET),
+        SOL_STR_TABLE_ITEM("org.freedesktop.DBus.Error.NotSupported",
+            ENOTSUP),
+        SOL_STR_TABLE_ITEM("org.freedesktop.DBus.Error.BadAddress",
+            EFAULT),
+        SOL_STR_TABLE_ITEM("org.freedesktop.DBus.Error.LimitsExceeded",
+            ENOBUFS),
+        SOL_STR_TABLE_ITEM("org.freedesktop.DBus.Error.AddressInUse",
+            EADDRINUSE),
+        SOL_STR_TABLE_ITEM("org.freedesktop.DBus.Error.InconsistentMessage",
+            EBADMSG),
+        { }
+    };
+
+    if (ret_error) {
+        error = sol_str_table_lookup_fallback(err_table,
+            sol_str_slice_from_str(ret_error->name), EINVAL);
+        call_error_monitor_callback(service, error);
+    }
+}
+
+static void
 _init_connman_service(struct sol_netctl_service *service)
 {
     SOL_SET_API_VERSION(service->link.api_version = SOL_NETWORK_LINK_API_VERSION; )
@@ -643,10 +687,16 @@ _set_state_property_changed(sd_bus_message *reply, void *userdata,
     sd_bus_error *ret_error)
 {
     struct ctx *pending = userdata;
+    const sd_bus_error *error;
 
     pending->state_slot = sd_bus_slot_unref(pending->state_slot);
 
-    return sol_bus_log_callback(reply, userdata, ret_error);
+    if (sol_bus_log_callback(reply, userdata, ret_error) < 0) {
+        error = sd_bus_message_get_error(reply);
+        _set_error_to_callback(NULL, error);
+    }
+
+    return 0;
 }
 
 SOL_API int
@@ -677,16 +727,74 @@ sol_netctl_get_radios_offline(void)
     return true;
 }
 
+static int
+_service_connect(sd_bus_message *reply, void *userdata,
+    sd_bus_error *ret_error)
+{
+    struct sol_netctl_service *service = userdata;
+    const sd_bus_error *error;
+
+    SOL_NULL_CHECK(service, -EINVAL);
+
+    service->slot = sd_bus_slot_unref(service->slot);
+
+    if (sol_bus_log_callback(reply, userdata, ret_error) < 0) {
+        error = sd_bus_message_get_error(reply);
+        _set_error_to_callback(service, error);
+    }
+
+    return 0;
+}
+
 SOL_API int
 sol_netctl_service_connect(struct sol_netctl_service *service)
 {
+    sd_bus *bus = sol_bus_client_get_bus(_ctx.connman);
+
+    SOL_NULL_CHECK(bus, -EINVAL);
+    SOL_NULL_CHECK(service, -EINVAL);
+    SOL_NULL_CHECK(service->path, -EINVAL);
+
+    if (service->slot)
+        return -EBUSY;
+
+    return sd_bus_call_method_async(bus, &service->slot, "net.connman", service->path,
+        "net.connman.Service", "Connect", _service_connect, service, NULL);
+}
+
+static int
+_service_disconnect(sd_bus_message *reply, void *userdata,
+    sd_bus_error *ret_error)
+{
+    struct sol_netctl_service *service = userdata;
+    const sd_bus_error *error;
+
+    SOL_NULL_CHECK(service, -EINVAL);
+
+    service->slot = sd_bus_slot_unref(service->slot);
+
+    if (sol_bus_log_callback(reply, userdata, ret_error) < 0) {
+        error = sd_bus_message_get_error(reply);
+        _set_error_to_callback(service, error);
+    }
+
     return 0;
 }
 
 SOL_API int
 sol_netctl_service_disconnect(struct sol_netctl_service *service)
 {
-    return 0;
+    sd_bus *bus = sol_bus_client_get_bus(_ctx.connman);
+
+    SOL_NULL_CHECK(bus, -EINVAL);
+    SOL_NULL_CHECK(service, -EINVAL);
+    SOL_NULL_CHECK(service->path, -EINVAL);
+
+    if (service->slot)
+        service->slot = sd_bus_slot_unref(service->slot);
+
+    return sd_bus_call_method_async(bus, &service->slot, "net.connman", service->path,
+        "net.connman.Service", "Disconnect", _service_disconnect, service, NULL);
 }
 
 int

--- a/src/lib/comms/sol-netctl-impl-connman.c
+++ b/src/lib/comms/sol-netctl-impl-connman.c
@@ -1167,5 +1167,5 @@ sol_netctl_del_error_monitor(
 SOL_API const struct sol_ptr_vector *
 sol_netctl_get_services(void)
 {
-    return NULL;
+    return &_ctx.service_vector;
 }

--- a/src/test/Kconfig
+++ b/src/test/Kconfig
@@ -15,6 +15,11 @@ config TEST_COAP
 	depends on COAP
 	default y
 
+config TEST_NETCTL
+        bool "netctl"
+        depends on NETCTL
+        default y
+
 config TEST_FBP
 	bool "fbp"
 	depends on USE_FLOW

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -8,6 +8,10 @@ test-internal-$(TEST_COAP) += test-coap
 test-internal-test-coap-$(TEST_COAP) := test.c test-coap.c
 test-internal-test-coap-$(TEST_COAP)-deps := lib/comms/coap.o
 
+test-internal-$(TEST_NETCTL) += test-netctl
+test-internal-test-netctl-$(TEST_NETCTL) := test-netctl.c
+test-internal-test-netctl-$(TEST_NETCTL)-deps := lib/comms/sol-netctl-impl-connman.o
+
 test-$(TEST_FBP) += test-fbp
 test-test-fbp-$(TEST_FBP) := test.c test-fbp.c
 

--- a/src/test/test-netctl.c
+++ b/src/test/test-netctl.c
@@ -1,0 +1,114 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdbool.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <errno.h>
+
+#include "soletta.h"
+#include "sol-netctl.h"
+
+#include "sol-util.h"
+#include "sol-log.h"
+
+#include "test.h"
+
+#define CONN_AP "Guest"
+
+static void
+manager_cb(void *data)
+{
+    enum sol_netctl_state g_state;
+    bool offline;
+
+    g_state = sol_netctl_get_state();
+    printf("manager_cb system state = %d\n", g_state);
+
+    offline = sol_netctl_get_radios_offline();
+    printf("manager_cb system offline = %d\n", offline);
+}
+
+static void
+service_cb(void *data, const struct sol_netctl_service *service)
+{
+    const char *str;
+    int r;
+    enum sol_netctl_service_state state;
+
+    state = sol_netctl_service_get_state(service);
+    printf("service_cb service state = %d\n", state);
+
+    str = sol_netctl_service_get_type(service);
+    if (str)
+        printf("service_cb service type = %s\n", str);
+    else
+        printf("service_cb service type = NULL\n");
+
+    r = sol_netctl_service_get_strength(service);
+    printf("service_cb strength = %d\n", r);
+
+    str = sol_netctl_service_get_name(service);
+    if (str)
+        printf("service_cb service name = %s\n", str);
+    else
+        printf("service_cb service name = NULL\n");
+
+    if (str && strcmp(str, CONN_AP) == 0) {
+        if (state == SOL_NETCTL_SERVICE_STATE_IDLE) {
+            printf("connect AP\n");
+            sol_netctl_service_connect((struct sol_netctl_service *)service);
+        } else if (state == SOL_NETCTL_SERVICE_STATE_READY) {
+            printf("Disconnect AP\n");
+            sol_netctl_service_disconnect((struct sol_netctl_service *)service);
+        }
+    }
+}
+
+static void
+error_cb(void *data, const struct sol_netctl_service *service,
+    unsigned int error)
+{
+    const char *str;
+
+    str = sol_netctl_service_get_name(service);
+    if (str)
+        printf("error_cb service name = %s\n", str);
+    else
+        printf("error_cb service name = NULL\n");
+
+    printf("error_cb error is %d\n", error);
+}
+
+static void
+shutdown(void)
+{
+    sol_netctl_del_manager_monitor(manager_cb, NULL);
+    sol_netctl_del_service_monitor(service_cb, NULL);
+    sol_netctl_del_error_monitor(error_cb, NULL);
+}
+
+static void
+startup(void)
+{
+    sol_netctl_add_service_monitor(service_cb, NULL);
+    sol_netctl_add_manager_monitor(manager_cb, NULL);
+    sol_netctl_add_error_monitor(error_cb, NULL);
+}
+
+SOL_MAIN_DEFAULT(startup, shutdown);

--- a/tools/build/Kconfig.features
+++ b/tools/build/Kconfig.features
@@ -1,6 +1,9 @@
 config FEATURE_BLUETOOTH
     bool
 
+config FEATURE_NETCTL
+    bool
+
 config FEATURE_CC_SANITIZE
     bool
 

--- a/tools/build/Kconfig.linux
+++ b/tools/build/Kconfig.linux
@@ -1,6 +1,7 @@
 config LINUX
     def_bool y
     select FEATURE_BLUETOOTH if HAVE_SYSTEMD
+    select FEATURE_NETCTL if HAVE_SYSTEMD
     select FEATURE_CC_SANITIZE
     select FEATURE_COAP
     select FEATURE_CRYPTO_MESSAGE_DIGEST


### PR DESCRIPTION
so-netctl is for implementing connection manager features.
The APIs should be implemented in Zephyr, connman and so on.
To connman, the connman D-Bus APIs are wrapped in the so-netctl
APIs. The user can use the so-netctl APIs to control connman.

To invoke the D-Bus method of connman, the async call is used,
the callback function is set to get the results of async call.

The basic so-netctl APIs are in the patch.
It provides the APis of getting the name, ip address... of services.
The service connect/disconnect APIs and set/get offline
are implemented too.

The further sol-netctl APIs are being planned.

Signed-off-by: Wu Zheng wu.zheng@intel.com