### PR TITLE
Node.js bindings: Adapt JS bindings to the latest API changes

### DIFF
--- a/bindings/nodejs/lib/gpio.js
+++ b/bindings/nodejs/lib/gpio.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
- var soletta = require( 'bindings' )( 'soletta' ),
+var soletta = require( './lowlevel'),
     _ = require( 'lodash' );
 
 exports.open = function( init ) {

--- a/bindings/nodejs/lib/pwm.js
+++ b/bindings/nodejs/lib/pwm.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-var soletta = require( 'bindings' )( 'soletta' ),
+var soletta = require( './lowlevel'),
     _ = require( 'lodash' );
 
 exports.open = function( init ) {

--- a/bindings/nodejs/lib/spi.js
+++ b/bindings/nodejs/lib/spi.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-var soletta = require( 'bindings' )( 'soletta' ),
+var soletta = require( './lowlevel'),
     _ = require( 'lodash' );
 
 exports.open = function( init ) {
@@ -64,10 +64,12 @@ _.extend( SPIBus.prototype, {
                function( txData, rxData, count ) {
                    if ( rxData !== null ) {
                        fulfill( rxData );
+                   } else {
+                       reject( new Error( "SPI transmission failed" ) );
                    }
            });
 
-           if ( ( typeof returnStatus === 'undefined' ) || !returnStatus ) {
+           if ( returnStatus < 0 ) {
                reject( new Error( "SPI transmission failed" ) );
            }
        }, this ) );

--- a/bindings/nodejs/lib/uart.js
+++ b/bindings/nodejs/lib/uart.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-var soletta = require( 'bindings' )( 'soletta' ),
+var soletta = require( './lowlevel'),
     _ = require( 'lodash' );
 
 exports.open = function( init ) {

--- a/bindings/nodejs/src/functions/aio.cc
+++ b/bindings/nodejs/src/functions/aio.cc
@@ -98,6 +98,8 @@ NAN_METHOD(bind_sol_aio_close) {
     VALIDATE_ARGUMENT_TYPE(info, 0, IsObject);
     Local<Object> jsAio = Nan::To<Object>(info[0]).ToLocalChecked();
     sol_aio *aio = (sol_aio *)SolAio::Resolve(jsAio);
+    if (!aio)
+        return;
 
     sol_aio_close(aio);
     Nan::SetInternalFieldPointer(jsAio, 0, 0);
@@ -124,6 +126,8 @@ NAN_METHOD(bind_sol_aio_get_value) {
     VALIDATE_ARGUMENT_TYPE(info, 1, IsFunction);
     Local<Object> jsAio = Nan::To<Object>(info[0]).ToLocalChecked();
     sol_aio *aio = (sol_aio *)SolAio::Resolve(jsAio);
+    if (!aio)
+        return;
 
     Nan::Callback *callback =
         new Nan::Callback(Local<Function>::Cast(info[1]));
@@ -150,10 +154,13 @@ NAN_METHOD(bind_sol_aio_pending_cancel)
     VALIDATE_ARGUMENT_TYPE(info, 1, IsObject);
     Local<Object> jsAio = Nan::To<Object>(info[0]).ToLocalChecked();
     sol_aio *aio = (sol_aio *)SolAio::Resolve(jsAio);
+    if (!aio)
+        return;
 
     Local<Object> jsAioPending = Nan::To<Object>(info[1]).ToLocalChecked();
     sol_aio_pending *aio_pending = (sol_aio_pending *)SolAio::Resolve(jsAioPending);
+    if (!aio_pending)
+        return;
 
     sol_aio_pending_cancel(aio, aio_pending);
-    hijack_unref();
 }

--- a/bindings/nodejs/src/functions/i2c.cc
+++ b/bindings/nodejs/src/functions/i2c.cc
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include <errno.h>
 #include <v8.h>
 #include <node.h>
 #include <nan.h>
@@ -26,6 +27,7 @@
 #include "../data.h"
 #include "../hijack.h"
 #include "../structures/js-handle.h"
+#include "../sys-constants.h"
 
 using namespace v8;
 
@@ -75,7 +77,11 @@ NAN_METHOD(bind_sol_i2c_set_slave_address)
     sol_i2c *i2c = (sol_i2c *)SolI2c::Resolve(jsI2c);
 
     int returnValue = sol_i2c_set_slave_address(i2c, info[1]->Uint32Value());
-    info.GetReturnValue().Set(Nan::New(returnValue));
+    if (returnValue < 0) {
+        info.GetReturnValue().Set(ReverseLookupConstant("E", abs(returnValue)));
+    } else {
+        info.GetReturnValue().Set(Nan::New(returnValue));
+    }
 }
 
 NAN_METHOD(bind_sol_i2c_close)
@@ -104,7 +110,6 @@ NAN_METHOD(bind_sol_i2c_pending_cancel)
 
     sol_i2c_pending_cancel(i2c, i2c_pending);
     Nan::SetInternalFieldPointer(jsI2cPending, 0, 0);
-    hijack_unref();
 }
 
 static void sol_i2c_write_cb(void *cb_data, struct sol_i2c *i2c,
@@ -174,6 +179,7 @@ NAN_METHOD(bind_sol_i2c_write)
         free(inputBuffer);
         delete callback;
         hijack_unref();
+        info.GetReturnValue().Set(ReverseLookupConstant("E", errno));
         return;
     }
 
@@ -252,6 +258,7 @@ NAN_METHOD(bind_sol_i2c_write_register)
         free(inputBuffer);
         delete callback;
         hijack_unref();
+        info.GetReturnValue().Set(ReverseLookupConstant("E", errno));
         return;
     }
 
@@ -297,6 +304,7 @@ NAN_METHOD(bind_sol_i2c_write_quick)
     if (!i2c_pending) {
         delete callback;
         hijack_unref();
+        info.GetReturnValue().Set(ReverseLookupConstant("E", errno));
         return;
     }
 
@@ -361,6 +369,7 @@ NAN_METHOD(bind_sol_i2c_read)
         free(outputBuffer);
         delete callback;
         hijack_unref();
+        info.GetReturnValue().Set(ReverseLookupConstant("E", errno));
         return;
     }
 
@@ -429,6 +438,7 @@ NAN_METHOD(bind_sol_i2c_read_register)
         free(outputBuffer);
         delete callback;
         hijack_unref();
+        info.GetReturnValue().Set(ReverseLookupConstant("E", errno));
         return;
     }
 
@@ -475,6 +485,7 @@ NAN_METHOD(bind_sol_i2c_read_register_multiple)
         free(outputBuffer);
         delete callback;
         hijack_unref();
+        info.GetReturnValue().Set(ReverseLookupConstant("E", errno));
         return;
     }
 


### PR DESCRIPTION
Adapt AIO,SPI and I2C JS bindings to the latest API changes. Also, to make the bindings consistent, always require the low-level bindings.

Replaces #2153

Signed-off-by: Sudarsana Nagineni sudarsana.nagineni@intel.com