### PR TITLE
sol-platform: allow spaces before '#' on conf comments

### DIFF
--- a/src/lib/common/sol-platform-linux-common.c
+++ b/src/lib/common/sol-platform-linux-common.c
@@ -957,9 +957,15 @@ sol_platform_impl_load_locales(char **locale_cache)
 
     line = NULL;
     while (fscanf(f, "%m[^\n]\n", &line) != EOF) {
+        unsigned int i, len = strlen(line);
+
         /* It is possible to have comments in locale.conf, ignore them */
-        if (line[0] == '#')
-            goto ignore;
+        for (i = 0; i < len; i++) {
+            if (line[i] == '#')
+                goto ignore;
+            if (line[i] != ' ')
+                break;
+        }
 
         sep = strchr(line, '=');
         if (!sep) {
@@ -972,7 +978,7 @@ sol_platform_impl_load_locales(char **locale_cache)
         key.data = line;
         value.data = sep + 1;
         key.len = sep - key.data;
-        value.len = strlen(line) - key.len - 1;
+        value.len = len - key.len - 1;
         if (!value.len)
             goto ignore;
 

--- a/src/lib/common/sol-platform-linux-common.c
+++ b/src/lib/common/sol-platform-linux-common.c
@@ -957,6 +957,10 @@ sol_platform_impl_load_locales(char **locale_cache)
 
     line = NULL;
     while (fscanf(f, "%m[^\n]\n", &line) != EOF) {
+        /* It is possible to have comments in locale.conf, ignore them */
+        if (line[0] == '#')
+            goto ignore;
+
         sep = strchr(line, '=');
         if (!sep) {
             SOL_WRN("The locale entry: %s does not have the separator '='",


### PR DESCRIPTION
Requested on PR #2144

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>