### PR TITLE
platform: Remove unreachable code

### DIFF
--- a/src/lib/common/sol-platform.c
+++ b/src/lib/common/sol-platform.c
@@ -840,9 +840,9 @@ sol_platform_get_appname(void)
 
 #undef SUFIX_LEN
 #undef SUFIX
-#endif //SOL_FEATURE_FILESYSTEM
-
+#else
     return default_name;
+#endif //SOL_FEATURE_FILESYSTEM
 }
 
 int


### PR DESCRIPTION
When SOL_FEATURE_FILESYSTEM is set, we don't need to use the default
app name, so move this code to #else section.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>