### PR TITLE
WIP: lwm2m: adding the Bootstrap Interface [v2]

### DIFF
--- a/src/lib/comms/include/sol-lwm2m.h
+++ b/src/lib/comms/include/sol-lwm2m.h
@@ -353,7 +353,7 @@ struct sol_lwm2m_resource {
  * @param ret_value_ The return value of sol_lwm2m_resource_init()
  * @param resource_ The resource to be initialized.
  * @param id_ The resource id.
- * @param data_type_ The resource type.
+ * @param data_type_ The resource data type.
  * @param resource_len_ The resource data size.
  * @param ... The LWM2M resource data, respecting the table according to the resource type.
  * @see sol_lwm2m_resource_init()
@@ -398,7 +398,7 @@ struct sol_lwm2m_resource {
  *
  * Every LWM2M client must implement a set of LWM2M objects,
  * This struct is used by the sol-lwm2m to know which objects a
- * LWM2M implements.
+ * LWM2M Client implements.
  *
  * All the functions in this struct will be called by the sol-lwm2m infra,
  * when the LWM2M server request an operation.
@@ -499,11 +499,11 @@ struct sol_lwm2m_object {
      * @param user_data The data provided during sol_lwm2m_client_new().
      * @param client The LWM2M client.
      * @param instance_id The instance id.
-     * @param tlvs a vector of #sol_lwm2m_tlv
+     * @param tlvs A vector of #sol_lwm2m_tlv
      * @return 0 on success or -errno on error.
      * @note Since TLV does not contains a field to express the
-     * data type. It's the user responsibility to know which
-     * function it should be used to get the content value.
+     * data type, it's the user's responsibility to know which
+     * function should be used to get the content value.
      */
     int (*write_tlv)(void *instance_data, void *user_data,
         struct sol_lwm2m_client *client, uint16_t instance_id,
@@ -514,8 +514,8 @@ struct sol_lwm2m_object {
      * A LWM2M Object resource may be executable. An executable resource
      * means that the LWM2M object instance will initiate some action
      * that was requested by the LWM2M server.
-     * As an example, if the LWM2M server wants that the client
-     * sends an update request, the LWM2M server will send
+     * As an example, if the LWM2M server wants the client
+     * to send an update request, the LWM2M server will send
      * an execute command on the path "/1/AnServerInstanceId/8", this will
      * trigger the LWM2M client, which will send the update
      * request.
@@ -639,9 +639,9 @@ int sol_lwm2m_client_send_update(struct sol_lwm2m_client *client);
  * @param client The LWM2M client.
  * @param paths The resource paths that were changed, must be @c NULL terminated.
  * @return 0 on success, -errno on error.
- * @note If a LWM2M server creates an object instance, write on an object instance or
- * write in an object resource, the LWM2M client infrastruct will automatically notify all
- * observing servers.
+ * @note If a LWM2M server creates an object instance, writes on an object instance or
+ * writes in an object resource, the LWM2M client infrastructure will automatically
+ * notify all observing servers.
  */
 int sol_lwm2m_client_notify(struct sol_lwm2m_client *client, const char **paths);
 
@@ -674,9 +674,9 @@ void sol_lwm2m_resource_clear(struct sol_lwm2m_resource *resource);
  *
  * @param resource The resource to be initialized.
  * @param id The resource id.
- * @param data_type The resource type.
+ * @param data_type The resource data type.
  * @param resource_len The resource data size.
- * @param ... The LWM2M resource data, respecting the table according to the resource type.
+ * @param ... The LWM2M resource data, respecting the table according to the resource data type.
  * @return 0 on success, negative errno on error.
  * @see sol_lwm2m_resource_clear()
  * @see SOL_LWM2M_RESOURCE_INIT()
@@ -949,7 +949,7 @@ int sol_lwm2m_server_create_object_instance(struct sol_lwm2m_server *server,
     const void *data);
 
 /**
- * @brief Reads an object, instance or object from a client.
+ * @brief Reads an object, instance or resource from a client.
  *
  * @param server The LWM2M server.
  * @param client The LWM2M client info to be read.
@@ -976,7 +976,7 @@ int sol_lwm2m_server_read(struct sol_lwm2m_server *server,
  * Use this function to stop the LWM2M server and release its resources.
  *
  * @param server The LWM2M server to be deleted.
- * @see sol_lwm2m_server_del()
+ * @see sol_lwm2m_server_new()
  */
 void sol_lwm2m_server_del(struct sol_lwm2m_server *server);
 

--- a/src/lib/comms/include/sol-lwm2m.h
+++ b/src/lib/comms/include/sol-lwm2m.h
@@ -877,6 +877,78 @@ int sol_lwm2m_client_del_bootstrap_finish_monitor(struct sol_lwm2m_client *clien
     enum sol_lwm2m_bootstrap_event event),
     const void *data);
 
+/**
+ * @brief Writes a full object through the Bootstrap Interface.
+ *
+ * @param server The LWM2M bootstrap server.
+ * @param client The LWM2M bootstrap client info to write.
+ * @param path The object path to be written (Example /2).
+ * @param instances An array of #sol_lwm2m_resource arrays
+ * @param instances_len An array with the length of each element from @c instances
+ * @param instances_ids An array with the desired instance_id of each element from @c instances
+ * @param len The length of @c instances
+ * @param sol_lwm2m_bootstrap_server_status_response_cb A callback to be called when the write operation is completed. - @c server The LW2M bootstrap server; @c client The LWM2M client; @c path The client's path; @c response_code The operation's @c response_code; @c data User data.
+ * @param data User data to @c sol_lwm2m_bootstrap_server_status_response_cb
+ * @return 0 on success, -errno on error.
+ *
+ * @note All data is sent using TLV.
+ * @note Only in Bootstrap Interface, the Write operation can be made using a TLV consisting of various Object Instances.
+ */
+int sol_lwm2m_bootstrap_server_write_object(struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *client, const char *path,
+    struct sol_lwm2m_resource **instances, size_t *instances_len,
+    uint16_t *instances_ids, size_t len,
+    void (*sol_lwm2m_bootstrap_server_status_response_cb)(void *data,
+    struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *client, const char *path,
+    enum sol_coap_response_code response_code),
+    const void *data);
+
+/**
+ * @brief Writes an object instance or resource through the Bootstrap Interface.
+ *
+ * @param server The LWM2M bootstrap server.
+ * @param client The LWM2M bootstrap client info to write.
+ * @param path The object path to be written (Example /2/1).
+ * @param resources An array of #sol_lwm2m_resource
+ * @param len The length of @c resources
+ * @param sol_lwm2m_bootstrap_server_status_response_cb A callback to be called when the write operation is completed. - @c server The LW2M bootstrap server; @c client The LWM2M client; @c path The client's path; @c response_code The operation's @c response_code; @c data User data.
+ * @param data User data to @c sol_lwm2m_bootstrap_server_status_response_cb
+ * @return 0 on success, -errno on error.
+ *
+ * @note All data is sent using TLV.
+ * @note Only in Bootstrap Interface, the Write operation can be made using a TLV consisting of various Object Instances.
+ */
+int sol_lwm2m_bootstrap_server_write(struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *client, const char *path,
+    struct sol_lwm2m_resource *resources, size_t len,
+    void (*sol_lwm2m_bootstrap_server_status_response_cb)(void *data,
+    struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *client, const char *path,
+    enum sol_coap_response_code response_code),
+    const void *data);
+
+/**
+ * @brief Deletes an object instance on a client through the Bootstrap Interface.
+ *
+ * @param server The LWM2M bootstrap server.
+ * @param client The LWM2M bootstrap client info to delete an object
+ * @param path The object path to be deleted (Example /1/1).
+ * @param sol_lwm2m_bootstrap_server_status_response_cb A callback to be called when the delete operation is completed. - @c server The LW2M bootstrap server; @c client The LWM2M client; @c path The client's path; @c response_code The operation's @c response_code; @c data User data.
+ * @param data User data to @c sol_lwm2m_bootstrap_server_status_response_cb
+ * @return 0 on success, -errno on error.
+ *
+ * @note Only in Bootstrap Interface, Delete operation MAY target to '/' URI to delete all the existing Object Instances - except LWM2M Bootstrap Server Account - in the LWM2M Client, for initialization purpose before LWM2M Bootstrap Server sends Write operation(s) to the LWM2M Client.
+ */
+int sol_lwm2m_bootstrap_server_delete_object_instance(struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *client, const char *path,
+    void (*sol_lwm2m_bootstrap_server_status_response_cb)(void *data,
+    struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *client, const char *path,
+    enum sol_coap_response_code response_code),
+    const void *data);
+
+/**
  * @brief Adds a registration monitor.
  *
  * This function registers a monitor, making it easier to observe a

--- a/src/lib/comms/sol-lwm2m.c
+++ b/src/lib/comms/sol-lwm2m.c
@@ -39,9 +39,11 @@
 
 SOL_LOG_INTERNAL_DECLARE_STATIC(_lwm2m_domain, "lwm2m");
 
+#define LWM2M_BOOTSTRAP_QUERY_PARAMS (1)
 #define LWM2M_UPDATE_QUERY_PARAMS (4)
 #define LWM2M_REGISTER_QUERY_PARAMS (5)
 #define NUMBER_OF_PATH_SEGMENTS (3)
+#define DEFAULT_SHORT_SERVER_ID (0)
 #define DEFAULT_CLIENT_LIFETIME (86400)
 #define DEFAULT_BINDING_MODE (SOL_LWM2M_BINDING_MODE_U)
 #define DEFAULT_LOCATION_PATH_SIZE (10)
@@ -57,11 +59,14 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_lwm2m_domain, "lwm2m");
 #define LEN_IS_16BITS_MASK (16)
 #define LEN_IS_24BITS_MASK (24)
 #define UINT24_MAX (16777215)
+#define ONE_SECOND (1000)
 
 #define SECURITY_SERVER_OBJECT_ID (0)
 #define SECURITY_SERVER_URI (0)
 #define SECURITY_SERVER_IS_BOOTSTRAP (1)
 #define SECURITY_SERVER_ID (10)
+#define SECURITY_SERVER_CLIENT_HOLD_OFF_TIME (11)
+#define SECURITY_SERVER_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT (12)
 
 #define SERVER_OBJECT_ID (1)
 #define SERVER_OBJECT_SERVER_ID (0)
@@ -127,6 +132,16 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_lwm2m_domain, "lwm2m");
 #define LWM2M_OBJECT_CHECK_API_GOTO(_obj, _label)
 #endif
 
+#define ADD_QUERY(_key, _format, _value) \
+    do { \
+        query.used = 0; \
+        r = sol_buffer_append_printf(&query, "%s=" _format "", _key, _value); \
+        SOL_INT_CHECK_GOTO(r, < 0, err_coap); \
+        r = sol_coap_add_option(pkt, SOL_COAP_OPTION_URI_QUERY, \
+            query.data, query.used); \
+        SOL_INT_CHECK_GOTO(r, < 0, err_coap); \
+    } while (0);
+
 enum tlv_length_size_type {
     LENGTH_SIZE_CHECK_NEXT_TWO_BITS = 0,
     LENGTH_SIZE_8_BITS = 8,
@@ -156,6 +171,13 @@ struct sol_lwm2m_server {
     struct lifetime_ctx lifetime_ctx;
 };
 
+struct sol_lwm2m_bootstrap_server {
+    struct sol_coap_server *coap;
+    struct sol_ptr_vector clients;
+    struct sol_monitors bootstrap;
+    const char **known_clients;
+};
+
 struct sol_lwm2m_client_object {
     struct sol_ptr_vector instances;
     uint16_t id;
@@ -173,6 +195,11 @@ struct sol_lwm2m_client_info {
     struct sol_network_link_addr cliaddr;
     enum sol_lwm2m_binding_mode binding;
     struct sol_coap_resource resource;
+};
+
+struct sol_lwm2m_bootstrap_client_info {
+    char *name;
+    struct sol_network_link_addr cliaddr;
 };
 
 struct observer_entry {
@@ -229,6 +256,11 @@ struct sol_lwm2m_client {
     struct lifetime_ctx lifetime_ctx;
     struct sol_vector connections;
     struct sol_vector objects;
+    struct sol_monitors bootstrap;
+    struct {
+        struct sol_timeout *timeout;
+        struct sol_blob *server_uri;
+    } bootstrap_ctx;
     const void *user_data;
     uint16_t splitted_path_len;
     char *name;
@@ -236,13 +268,14 @@ struct sol_lwm2m_client {
     char *sms;
     bool running;
     bool removed;
+    bool is_bootstrapping;
 };
 
 struct server_conn_ctx {
     struct sol_network_hostname_pending *hostname_handle;
     struct sol_lwm2m_client *client;
     struct sol_vector server_addr_list;
-    struct sol_coap_packet *pending_pkt; //Pending registration reply
+    struct sol_coap_packet *pending_pkt; //Pending registration or bootstrap reply
     int64_t server_id;
     int64_t lifetime;
     uint16_t port;
@@ -255,6 +288,8 @@ static bool lifetime_server_timeout(void *data);
 static bool lifetime_client_timeout(void *data);
 static int register_with_server(struct sol_lwm2m_client *client,
     struct server_conn_ctx *conn_ctx, bool is_update);
+static int bootstrap_with_server(struct sol_lwm2m_client *client,
+    struct server_conn_ctx *conn_ctx);
 static int handle_resource(void *data, struct sol_coap_server *server,
     const struct sol_coap_resource *resource, struct sol_coap_packet *req,
     const struct sol_network_link_addr *cliaddr);
@@ -292,6 +327,31 @@ dispatch_registration_event(struct sol_lwm2m_server *server,
 }
 
 static void
+dispatch_bootstrap_event_to_client(struct sol_lwm2m_client *client,
+    enum sol_lwm2m_bootstrap_event event)
+{
+    uint16_t i;
+    struct sol_monitors_entry *m;
+
+    SOL_MONITORS_WALK (&client->bootstrap, m, i)
+        ((void (*)(void *, struct sol_lwm2m_client *,
+        enum sol_lwm2m_bootstrap_event))m->cb)((void *)m->data, client, event);
+}
+
+static void
+dispatch_bootstrap_event_to_server(struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *bs_cinfo)
+{
+    uint16_t i;
+    struct sol_monitors_entry *m;
+
+    SOL_MONITORS_WALK (&server->bootstrap, m, i)
+        ((void (*)(void *, struct sol_lwm2m_bootstrap_server *,
+        struct sol_lwm2m_bootstrap_client_info *))m->cb)((void *)m->data, server,
+            bs_cinfo);
+}
+
+static void
 client_objects_clear(struct sol_ptr_vector *objects)
 {
     uint16_t i, j, *id;
@@ -305,6 +365,13 @@ client_objects_clear(struct sol_ptr_vector *objects)
     }
 
     sol_ptr_vector_clear(objects);
+}
+
+static void
+bootstrap_client_info_del(struct sol_lwm2m_bootstrap_client_info *bs_cinfo)
+{
+    free(bs_cinfo->name);
+    free(bs_cinfo);
 }
 
 static void
@@ -629,6 +696,45 @@ err_cinfo_prop:
 }
 
 static int
+extract_bootstrap_client_info(struct sol_coap_packet *req,
+    struct sol_str_slice *client_name)
+{
+    struct sol_str_slice query;
+    int r;
+
+    r = sol_coap_find_options(req, SOL_COAP_OPTION_URI_QUERY, &query,
+        LWM2M_BOOTSTRAP_QUERY_PARAMS);
+    SOL_INT_CHECK(r, < 0, r);
+
+    struct sol_str_slice key, value;
+    const char *sep;
+
+    SOL_DBG("Query:%.*s", SOL_STR_SLICE_PRINT(query));
+    sep = memchr(query.data, '=', query.len);
+
+    if (!sep) {
+        SOL_WRN("Could not find the separator '=' at: %.*s",
+            SOL_STR_SLICE_PRINT(query));
+        return -EINVAL;
+    }
+
+    key.data = query.data;
+    key.len = sep - query.data;
+    value.data = sep + 1;
+    value.len = query.len - key.len - 1;
+
+    if (sol_str_slice_str_eq(key, "ep")) {
+        //Required info
+        *client_name = value;
+    } else {
+        SOL_WRN("The client did not provide its name!");
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+static int
 reschedule_timeout(struct sol_lwm2m_server *server)
 {
     struct sol_lwm2m_client_info *cinfo;
@@ -835,6 +941,24 @@ err_exit:
     return r;
 }
 
+static int
+new_bootstrap_client_info(struct sol_lwm2m_bootstrap_client_info **bs_cinfo,
+    const struct sol_network_link_addr *cliaddr, const struct sol_str_slice client_name)
+{
+    *bs_cinfo = calloc(1, sizeof(struct sol_lwm2m_bootstrap_client_info));
+    SOL_NULL_CHECK(bs_cinfo, -ENOMEM);
+
+    memcpy(&(*bs_cinfo)->cliaddr, cliaddr, sizeof(struct sol_network_link_addr));
+
+    (*bs_cinfo)->name = sol_str_slice_to_str(client_name);
+    SOL_NULL_CHECK_GOTO((*bs_cinfo)->name, err_no_name);
+    return 0;
+
+err_no_name:
+    free(bs_cinfo);
+    return -ENOMEM;
+}
+
 static struct sol_lwm2m_client_info *
 get_client_info_by_name(struct sol_ptr_vector *clients,
     const char *name)
@@ -930,6 +1054,78 @@ static const struct sol_coap_resource registration_interface = {
     }
 };
 
+static int
+bootstrap_request(void *data, struct sol_coap_server *coap,
+    const struct sol_coap_resource *resource,
+    struct sol_coap_packet *req,
+    const struct sol_network_link_addr *cliaddr)
+{
+    struct sol_lwm2m_bootstrap_client_info *bs_cinfo;
+    struct sol_lwm2m_bootstrap_server *server = data;
+    struct sol_coap_packet *response;
+    struct sol_str_slice client_name = SOL_STR_SLICE_EMPTY;
+    int r;
+    size_t i;
+    bool know_client = false;
+
+    SOL_DBG("Client Bootstrap Request received");
+
+    response = sol_coap_packet_new(req);
+    SOL_NULL_CHECK(response, -ENOMEM);
+
+    r = extract_bootstrap_client_info(req, &client_name);
+    SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+
+    for (i = 0; server->known_clients[i]; i++) {
+        if (sol_str_slice_str_eq(client_name, server->known_clients[i]))
+            know_client = true;
+    }
+
+    if (!know_client) {
+        SOL_WRN("Client %.*s bootstrap request received, but this Bootstrap Server"
+            " doesn't have Bootstrap Information for this client.",
+            SOL_STR_SLICE_PRINT(client_name));
+        goto err_exit;
+    }
+
+    r = new_bootstrap_client_info(&bs_cinfo, cliaddr, client_name);
+    SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+
+    r = sol_ptr_vector_append(&server->clients, bs_cinfo);
+    SOL_INT_CHECK_GOTO(r, < 0, err_exit_del_client);
+
+
+    r = sol_coap_header_set_code(response, SOL_COAP_RESPONSE_CODE_CHANGED);
+    SOL_INT_CHECK_GOTO(r, < 0, err_exit_del_client_list);
+
+    SOL_DBG("Client %s bootstrap request received."
+        " Bootstrap Process will start now.", bs_cinfo->name);
+
+    r = sol_coap_send_packet(coap, response, cliaddr);
+    dispatch_bootstrap_event_to_server(server, bs_cinfo);
+
+    return r;
+
+err_exit_del_client_list:
+    (void)sol_ptr_vector_remove(&server->clients, bs_cinfo);
+err_exit_del_client:
+    bootstrap_client_info_del(bs_cinfo);
+err_exit:
+    sol_coap_header_set_code(response, SOL_COAP_RESPONSE_CODE_BAD_REQUEST);
+    (void)sol_coap_send_packet(coap, response, cliaddr);
+    return r;
+}
+
+static const struct sol_coap_resource bootstrap_request_interface = {
+    SOL_SET_API_VERSION(.api_version = SOL_COAP_RESOURCE_API_VERSION, )
+    .post = bootstrap_request,
+    .flags = SOL_COAP_FLAGS_NONE,
+    .path = {
+        SOL_STR_SLICE_LITERAL("bs"),
+        SOL_STR_SLICE_EMPTY
+    }
+};
+
 static void
 observer_entry_free(struct observer_entry *entry)
 {
@@ -992,6 +1188,32 @@ err_exit:
 }
 
 static int
+add_to_monitors(struct sol_monitors *monitors, sol_monitors_cb_t cb, const void *data)
+{
+    struct sol_monitors_entry *m;
+
+    SOL_NULL_CHECK(cb, -EINVAL);
+
+    m = sol_monitors_append(monitors, cb, data);
+    SOL_NULL_CHECK(m, -ENOMEM);
+
+    return 0;
+}
+
+static int
+remove_from_monitors(struct sol_monitors *monitors, sol_monitors_cb_t cb, const void *data)
+{
+    int i;
+
+    SOL_NULL_CHECK(cb, -EINVAL);
+
+    i = sol_monitors_find(monitors, cb, data);
+    SOL_INT_CHECK(i, < 0, i);
+
+    return sol_monitors_del(monitors, i);
+}
+
+static int
 observer_entry_add_monitor(struct observer_entry *entry,
     void (*cb)(void *data,
     struct sol_lwm2m_server *server,
@@ -1002,11 +1224,9 @@ observer_entry_add_monitor(struct observer_entry *entry,
     struct sol_str_slice content),
     const void *data)
 {
-    struct sol_monitors_entry *e;
+    SOL_NULL_CHECK(entry, -EINVAL);
 
-    e = sol_monitors_append(&entry->monitors, (sol_monitors_cb_t)cb, data);
-    SOL_NULL_CHECK(e, -ENOMEM);
-    return 0;
+    return add_to_monitors(&entry->monitors, (sol_monitors_cb_t)cb, data);
 }
 
 static int
@@ -1020,12 +1240,9 @@ observer_entry_del_monitor(struct observer_entry *entry,
     struct sol_str_slice content),
     const void *data)
 {
-    int r;
+    SOL_NULL_CHECK(entry, -EINVAL);
 
-    r = sol_monitors_find(&entry->monitors, (sol_monitors_cb_t)cb, data);
-    SOL_INT_CHECK(r, < 0, r);
-
-    return sol_monitors_del(&entry->monitors, r);
+    return remove_from_monitors(&entry->monitors, (sol_monitors_cb_t)cb, data);
 }
 
 SOL_API struct sol_lwm2m_server *
@@ -1096,15 +1313,9 @@ sol_lwm2m_server_add_registration_monitor(struct sol_lwm2m_server *server,
     enum sol_lwm2m_registration_event event),
     const void *data)
 {
-    struct sol_monitors_entry *m;
-
-    SOL_NULL_CHECK(cb, -EINVAL);
     SOL_NULL_CHECK(server, -EINVAL);
 
-    m = sol_monitors_append(&server->registration,
-        (sol_monitors_cb_t)cb, data);
-    SOL_NULL_CHECK(m, -ENOMEM);
-    return 0;
+    return add_to_monitors(&server->registration, (sol_monitors_cb_t)cb, data);
 }
 
 SOL_API int
@@ -1115,16 +1326,112 @@ sol_lwm2m_server_del_registration_monitor(struct sol_lwm2m_server *server,
     enum sol_lwm2m_registration_event event),
     const void *data)
 {
-    int i;
-
     SOL_NULL_CHECK(server, -EINVAL);
-    SOL_NULL_CHECK(cb, -EINVAL);
 
-    i = sol_monitors_find(&server->registration, (sol_monitors_cb_t)cb, data);
-    if (i < 0)
-        return i;
+    return remove_from_monitors(&server->registration, (sol_monitors_cb_t)cb, data);
+}
 
-    return sol_monitors_del(&server->registration, i);
+SOL_API struct sol_lwm2m_bootstrap_server *
+sol_lwm2m_bootstrap_server_new(uint16_t port, const char **known_clients)
+{
+    struct sol_lwm2m_bootstrap_server *server;
+    struct sol_network_link_addr servaddr = { .family = SOL_NETWORK_FAMILY_INET6,
+                                              .port = port };
+    int r;
+
+    SOL_LOG_INTERNAL_INIT_ONCE;
+
+    SOL_NULL_CHECK(known_clients, NULL);
+
+    server = calloc(1, sizeof(struct sol_lwm2m_bootstrap_server));
+    SOL_NULL_CHECK(server, NULL);
+
+    server->coap = sol_coap_server_new(&servaddr, false);
+    SOL_NULL_CHECK_GOTO(server->coap, err_coap);
+
+    server->known_clients = known_clients;
+
+    sol_ptr_vector_init(&server->clients);
+
+    sol_monitors_init(&server->bootstrap, NULL);
+
+    r = sol_coap_server_register_resource(server->coap,
+        &bootstrap_request_interface, server);
+    SOL_INT_CHECK_GOTO(r, < 0, err_register);
+
+    return server;
+
+err_register:
+    sol_coap_server_unref(server->coap);
+err_coap:
+    free(server);
+    return NULL;
+}
+
+SOL_API void
+sol_lwm2m_bootstrap_server_del(struct sol_lwm2m_bootstrap_server *server)
+{
+    uint16_t i;
+    struct sol_lwm2m_bootstrap_client_info *bs_cinfo;
+
+    SOL_NULL_CHECK(server);
+
+    sol_coap_server_unref(server->coap);
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&server->clients, bs_cinfo, i)
+        bootstrap_client_info_del(bs_cinfo);
+
+    sol_monitors_clear(&server->bootstrap);
+    sol_ptr_vector_clear(&server->clients);
+    free(server);
+}
+
+SOL_API int
+sol_lwm2m_bootstrap_server_add_request_monitor(struct sol_lwm2m_bootstrap_server *server,
+    void (*cb)(void *data,
+    struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *bs_cinfo),
+    const void *data)
+{
+    SOL_NULL_CHECK(server, -EINVAL);
+
+    return add_to_monitors(&server->bootstrap, (sol_monitors_cb_t)cb, data);
+}
+
+SOL_API int
+sol_lwm2m_bootstrap_server_del_request_monitor(struct sol_lwm2m_bootstrap_server *server,
+    void (*cb)(void *data,
+    struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *bs_cinfo),
+    const void *data)
+{
+    SOL_NULL_CHECK(server, -EINVAL);
+
+    return remove_from_monitors(&server->bootstrap, (sol_monitors_cb_t)cb, data);
+}
+
+SOL_API int
+sol_lwm2m_client_add_bootstrap_finish_monitor(struct sol_lwm2m_client *client,
+    void (*cb)(void *data,
+    struct sol_lwm2m_client *client,
+    enum sol_lwm2m_bootstrap_event event),
+    const void *data)
+{
+    SOL_NULL_CHECK(client, -EINVAL);
+
+    return add_to_monitors(&client->bootstrap, (sol_monitors_cb_t)cb, data);
+}
+
+SOL_API int
+sol_lwm2m_client_del_bootstrap_finish_monitor(struct sol_lwm2m_client *client,
+    void (*cb)(void *data,
+    struct sol_lwm2m_client *client,
+    enum sol_lwm2m_bootstrap_event event),
+    const void *data)
+{
+    SOL_NULL_CHECK(client, -EINVAL);
+
+    return remove_from_monitors(&client->bootstrap, (sol_monitors_cb_t)cb, data);
 }
 
 SOL_API const struct sol_ptr_vector *
@@ -1133,6 +1440,14 @@ sol_lwm2m_server_get_clients(const struct sol_lwm2m_server *server)
     SOL_NULL_CHECK(server, NULL);
 
     return &server->clients;
+}
+
+SOL_API const char *
+sol_lwm2m_bootstrap_client_info_get_name(const struct sol_lwm2m_bootstrap_client_info *client)
+{
+    SOL_NULL_CHECK(client, NULL);
+
+    return client->name;
 }
 
 SOL_API const char *
@@ -1190,6 +1505,14 @@ sol_lwm2m_client_info_get_binding_mode(
 
 SOL_API const struct sol_network_link_addr *
 sol_lwm2m_client_info_get_address(const struct sol_lwm2m_client_info *client)
+{
+    SOL_NULL_CHECK(client, NULL);
+
+    return &client->cliaddr;
+}
+
+SOL_API const struct sol_network_link_addr *
+sol_lwm2m_bootstrap_client_info_get_address(const struct sol_lwm2m_bootstrap_client_info *client)
 {
     SOL_NULL_CHECK(client, NULL);
 
@@ -2515,6 +2838,17 @@ err_exit:
     return -ENOMEM;
 }
 
+static void
+clear_bootstrap_ctx(struct sol_lwm2m_client *client)
+{
+    if (client->bootstrap_ctx.timeout) {
+        sol_timeout_del(client->bootstrap_ctx.timeout);
+        sol_blob_unref(client->bootstrap_ctx.server_uri);
+        client->bootstrap_ctx.timeout = NULL;
+        client->bootstrap_ctx.server_uri = NULL;
+    }
+}
+
 static uint8_t
 handle_delete(struct sol_lwm2m_client *client,
     struct obj_ctx *obj_ctx, struct obj_instance *obj_instance)
@@ -3195,6 +3529,8 @@ sol_lwm2m_client_new(const char *name, const char *path, const char *sms,
     client->coap_server = sol_coap_server_new(&servaddr, false);
     SOL_NULL_CHECK_GOTO(client->coap_server, err_coap);
 
+    sol_monitors_init(&client->bootstrap, NULL);
+
     client->user_data = data;
 
     return client;
@@ -3275,6 +3611,8 @@ sol_lwm2m_client_del(struct sol_lwm2m_client *client)
     SOL_NULL_CHECK(client);
     client->removed = true;
 
+    clear_bootstrap_ctx(client);
+
     sol_coap_server_unref(client->coap_server);
 
     SOL_VECTOR_FOREACH_IDX (&client->objects, ctx, i)
@@ -3282,6 +3620,7 @@ sol_lwm2m_client_del(struct sol_lwm2m_client *client)
 
     server_connection_ctx_list_clear(&client->connections);
     sol_vector_clear(&client->objects);
+    sol_monitors_clear(&client->bootstrap);
     free(client->name);
     if (client->splitted_path) {
         for (i = 0; i < client->splitted_path_len; i++)
@@ -3587,16 +3926,6 @@ register_with_server(struct sol_lwm2m_client *client,
     struct sol_buffer *buf;
     int r;
 
-#define ADD_QUERY(_key, _format, _value) \
-    do { \
-        query.used = 0; \
-        r = sol_buffer_append_printf(&query, "%s=" _format "", _key, _value); \
-        SOL_INT_CHECK_GOTO(r, < 0, err_coap); \
-        r = sol_coap_add_option(pkt, SOL_COAP_OPTION_URI_QUERY, \
-            query.data, query.used); \
-        SOL_INT_CHECK_GOTO(r, < 0, err_coap); \
-    } while (0);
-
     r = setup_objects_payload(client, &objs_payload);
     SOL_INT_CHECK(r, < 0, r);
 
@@ -3658,8 +3987,82 @@ err_exit:
     if (binding)
         sol_blob_unref(binding);
     return r;
+}
 
-#undef ADD_QUERY
+static bool
+bootstrap_request_reply(void *data, struct sol_coap_server *server,
+    struct sol_coap_packet *pkt,
+    const struct sol_network_link_addr *server_addr)
+{
+    struct server_conn_ctx *conn_ctx = data;
+    uint8_t code;
+    int r;
+
+    SOL_BUFFER_DECLARE_STATIC(addr, SOL_NETWORK_INET_ADDR_STR_LEN);
+
+    sol_coap_packet_unref(conn_ctx->pending_pkt);
+    conn_ctx->pending_pkt = NULL;
+
+    if (!pkt && !server_addr) {
+        SOL_WRN("Bootstrap request timeout");
+        SOL_INT_CHECK_GOTO(++conn_ctx->addr_list_idx,
+            == conn_ctx->server_addr_list.len, err_exit);
+        r = bootstrap_with_server(conn_ctx->client, conn_ctx);
+        SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+        SOL_WRN("Trying another address");
+        return false;
+    }
+    if (!sol_network_link_addr_to_str(server_addr, &addr))
+        SOL_WRN("Could not convert the server address to string");
+
+    sol_coap_header_get_code(pkt, &code);
+    SOL_INT_CHECK_GOTO(code, != SOL_COAP_RESPONSE_CODE_CHANGED, err_exit);
+
+    SOL_DBG("Bootstrap process with server %.*s can start",
+        SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr)));
+    sol_vector_clear(&conn_ctx->server_addr_list);
+
+    return false;
+
+err_exit:
+    SOL_WRN("Bootstrap process with server %.*s failed!",
+        SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr)));
+    server_connection_ctx_remove(&conn_ctx->client->connections, conn_ctx);
+    return false;
+}
+
+static int
+bootstrap_with_server(struct sol_lwm2m_client *client,
+    struct server_conn_ctx *conn_ctx)
+{
+    struct sol_buffer query = SOL_BUFFER_INIT_EMPTY;
+    struct sol_coap_packet *pkt;
+    int r;
+
+    pkt = sol_coap_packet_new_request(SOL_COAP_METHOD_POST, SOL_COAP_MESSAGE_TYPE_CON);
+    r = -ENOMEM;
+    SOL_NULL_CHECK_GOTO(pkt, err_exit);
+
+    r = sol_coap_add_option(pkt, SOL_COAP_OPTION_URI_PATH, "bs", strlen("bs"));
+    SOL_INT_CHECK_GOTO(r, < 0, err_coap);
+
+    conn_ctx->pending_pkt = sol_coap_packet_ref(pkt);
+
+    ADD_QUERY("ep", "%s", client->name);
+
+    SOL_DBG("Sending Bootstrap Request to LWM2M Bootstrap Server");
+    r = sol_coap_send_packet_with_reply(client->coap_server,
+        pkt,
+        sol_vector_get_no_check(&conn_ctx->server_addr_list,
+        conn_ctx->addr_list_idx), bootstrap_request_reply, conn_ctx);
+    sol_buffer_fini(&query);
+    return r;
+
+err_coap:
+    sol_coap_packet_unref(pkt);
+    sol_buffer_fini(&query);
+err_exit:
+    return r;
 }
 
 static void
@@ -3681,8 +4084,13 @@ hostname_ready(void *data,
         cpy->port = conn_ctx->port;
     }
 
-    r = register_with_server(conn_ctx->client, conn_ctx, false);
-    SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+    if (conn_ctx->server_id != DEFAULT_SHORT_SERVER_ID) {
+        r = register_with_server(conn_ctx->client, conn_ctx, false);
+        SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+    } else {
+        r = bootstrap_with_server(conn_ctx->client, conn_ctx);
+        SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+    }
 
     return;
 
@@ -3719,7 +4127,7 @@ server_connection_ctx_new(struct sol_lwm2m_client *client,
         SOL_NETWORK_FAMILY_UNSPEC, hostname_ready, conn_ctx);
     SOL_NULL_CHECK_GOTO(conn_ctx->hostname_handle, err_exit);
 
-    //Location will be filled in register_reply()
+    //For Registration Interface, location will be filled in register_reply()
 
     return conn_ctx;
 
@@ -3759,9 +4167,119 @@ lifetime_client_timeout(void *data)
 }
 
 SOL_API int
+sol_lwm2m_bootstrap_server_send_finish(struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *client)
+{
+    struct sol_coap_packet *pkt;
+    int r;
+
+    SOL_NULL_CHECK(server, -EINVAL);
+    SOL_NULL_CHECK(client, -EINVAL);
+
+    pkt = sol_coap_packet_new_request(SOL_COAP_METHOD_POST, SOL_COAP_MESSAGE_TYPE_CON);
+    r = -ENOMEM;
+    SOL_NULL_CHECK_GOTO(pkt, err_exit);
+
+    r = sol_coap_add_option(pkt, SOL_COAP_OPTION_URI_PATH, "bs", strlen("bs"));
+    SOL_INT_CHECK_GOTO(r, < 0, err_coap);
+
+    SOL_DBG("Sending Bootstrap Finish to LWM2M Client %s", client->name);
+    r = sol_coap_send_packet(server->coap, pkt, &client->cliaddr);
+
+    r = sol_ptr_vector_remove(&server->clients, client);
+    if (r < 0)
+        SOL_WRN("Could not remove the client %s from the clients list",
+            client->name);
+    bootstrap_client_info_del(client);
+
+    return r;
+
+err_coap:
+    sol_coap_packet_unref(pkt);
+err_exit:
+    return r;
+}
+
+static int
+bootstrap_finish(void *data, struct sol_coap_server *coap,
+    const struct sol_coap_resource *resource,
+    struct sol_coap_packet *req,
+    const struct sol_network_link_addr *cliaddr)
+{
+    struct sol_lwm2m_client *client = data;
+    struct sol_coap_packet *response;
+    int r;
+
+    SOL_DBG("Bootstrap Finish received");
+
+    response = sol_coap_packet_new(req);
+    SOL_NULL_CHECK(response, -ENOMEM);
+
+    r = sol_coap_header_set_code(response, SOL_COAP_RESPONSE_CODE_CHANGED);
+    SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+
+    //The '/bs' endpoint can be removed from the Client now
+    r = sol_coap_server_unregister_resource(coap, resource);
+    SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+
+    client->is_bootstrapping = false;
+
+    r = sol_coap_send_packet(coap, response, cliaddr);
+    dispatch_bootstrap_event_to_client(client, SOL_LWM2M_BOOTSTRAP_EVENT_FINISHED);
+    return r;
+
+err_exit:
+    sol_coap_header_set_code(response, SOL_COAP_RESPONSE_CODE_BAD_REQUEST);
+    (void)sol_coap_send_packet(coap, response, cliaddr);
+    dispatch_bootstrap_event_to_client(client, SOL_LWM2M_BOOTSTRAP_EVENT_ERROR);
+    return r;
+}
+
+static const struct sol_coap_resource bootstrap_finish_interface = {
+    SOL_SET_API_VERSION(.api_version = SOL_COAP_RESOURCE_API_VERSION, )
+    .post = bootstrap_finish,
+    .flags = SOL_COAP_FLAGS_NONE,
+    .path = {
+        SOL_STR_SLICE_LITERAL("bs"),
+        SOL_STR_SLICE_EMPTY
+    }
+};
+
+static bool
+client_bootstrap(void *data)
+{
+    struct sol_lwm2m_client *client = data;
+    struct server_conn_ctx *conn_ctx;
+
+    client->bootstrap_ctx.timeout = NULL;
+
+    //Try client-initiated bootstrap:
+    conn_ctx = server_connection_ctx_new(client,
+        sol_str_slice_from_blob(client->bootstrap_ctx.server_uri),
+        DEFAULT_SHORT_SERVER_ID);
+    sol_blob_unref(client->bootstrap_ctx.server_uri);
+    client->bootstrap_ctx.server_uri = NULL;
+
+    if (!conn_ctx) {
+        SOL_WRN("Could not perform Client-initiated Bootstrap with server %.*s",
+            SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(client->bootstrap_ctx.server_uri)));
+
+        if (sol_coap_server_set_unknown_resource_handler(client->coap_server,
+            NULL, client) < 0)
+            SOL_WRN("Could not unregister Bootstrap Unknown resource for client.");
+        if (sol_coap_server_unregister_resource(client->coap_server,
+            &bootstrap_finish_interface) < 0)
+            SOL_WRN("Could not unregister Bootstrap Finish resource for client.");
+    }
+
+    return false;
+}
+
+SOL_API int
 sol_lwm2m_client_start(struct sol_lwm2m_client *client)
 {
     uint16_t i, j, k;
+    uint16_t bootstrap_account_idx;
     struct obj_ctx *ctx;
     bool has_server = false;
     struct obj_instance *instance;
@@ -3778,27 +4296,62 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
         return -ENOENT;
     }
 
+    //Try to register with all available [non-bootstrap] servers
     SOL_VECTOR_FOREACH_IDX (&ctx->instances, instance, i) {
-        r = read_resources(client, ctx, instance, res, sol_util_array_size(res),
-            SECURITY_SERVER_URI, SECURITY_SERVER_IS_BOOTSTRAP,
-            SECURITY_SERVER_ID);
+        r = read_resources(client, ctx, instance, res, 1,
+            SECURITY_SERVER_IS_BOOTSTRAP);
         SOL_INT_CHECK_GOTO(r, < 0, err_exit);
 
         //Is it a bootstap?
-        if (!res[1].data[0].b) {
+        if (!res[0].data[0].b) {
+            sol_lwm2m_resource_clear(&res[0]);
+            r = read_resources(client, ctx, instance, res, 2,
+                SECURITY_SERVER_URI, SECURITY_SERVER_ID);
+            SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+
             conn_ctx = server_connection_ctx_new(client, sol_str_slice_from_blob(res[0].data[0].blob),
-                res[2].data[0].integer);
+                res[1].data[0].integer);
             r = -ENOMEM;
-            SOL_NULL_CHECK_GOTO(conn_ctx, err_clear);
+            SOL_NULL_CHECK_GOTO(conn_ctx, err_clear_2);
             has_server = true;
+
+            clear_resource_array(res, 2);
+        } else {
+            sol_lwm2m_resource_clear(&res[0]);
+            bootstrap_account_idx = i;
         }
-        clear_resource_array(res, sol_util_array_size(res));
     }
 
+    //If all attempts to register failed, try to bootstrap
     if (!has_server) {
-        SOL_WRN("The client did not specify a LWM2M server to connect");
-        r = -ENOENT;
-        goto err_exit;
+        SOL_DBG("The client did not specify a LWM2M server to connect."
+            " Trying to bootstrap now.");
+
+        client->is_bootstrapping = true;
+
+        r = read_resources(client, ctx,
+            sol_vector_get_no_check(&ctx->instances, bootstrap_account_idx), res, 3,
+            SECURITY_SERVER_URI, SECURITY_SERVER_CLIENT_HOLD_OFF_TIME,
+            SECURITY_SERVER_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT);
+
+        //Create '/bs' CoAP resource to receive Bootstrap Finish notification
+        r = sol_coap_server_register_resource(client->coap_server,
+            &bootstrap_finish_interface, client);
+        SOL_INT_CHECK_GOTO(r, < 0, err_clear_3);
+
+        SOL_DBG("Expecting server-initiated Bootstrap for"
+            " %" PRId64 " seconds", res[1].data[0].integer);
+
+        //Expect server-initiated bootstrap with sol_timeout before client-initiated bootstrap
+        client->bootstrap_ctx.server_uri = sol_blob_ref(res[0].data[0].blob);
+        SOL_NULL_CHECK_GOTO(client->bootstrap_ctx.server_uri, err_unregister_unknown);
+
+        client->bootstrap_ctx.timeout = sol_timeout_add(res[1].data[0].integer * ONE_SECOND, client_bootstrap, client);
+        SOL_NULL_CHECK_GOTO(client->bootstrap_ctx.timeout, err_unregister_unknown);
+
+        clear_resource_array(res, sol_util_array_size(res));
+
+        return 0;
     }
 
     SOL_VECTOR_FOREACH_IDX (&client->objects, ctx, i) {
@@ -3822,8 +4375,14 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
 
     return 0;
 
-err_clear:
-    clear_resource_array(res, sol_util_array_size(res));
+err_unregister_bs:
+    if (sol_coap_server_unregister_resource(client->coap_server, &bootstrap_finish_interface) < 0)
+        SOL_WRN("Could not unregister Bootstrap Finish resource for client.");
+err_clear_3:
+    sol_lwm2m_resource_clear(&res[2]);
+err_clear_2:
+    sol_lwm2m_resource_clear(&res[1]);
+    sol_lwm2m_resource_clear(&res[0]);
 err_exit:
     return r;
 }
@@ -3879,29 +4438,46 @@ sol_lwm2m_client_stop(struct sol_lwm2m_client *client)
     SOL_NULL_CHECK(client, -EINVAL);
 
     SOL_VECTOR_FOREACH_IDX (&client->connections, conn_ctx, i) {
-        r = send_client_delete_request(client, conn_ctx);
-        SOL_INT_CHECK(r, < 0, r);
-    }
-
-    SOL_VECTOR_FOREACH_IDX (&client->objects, ctx, i) {
-        r = sol_coap_server_unregister_resource(client->coap_server,
-            ctx->obj_res);
-        SOL_INT_CHECK(r, < 0, r);
-        SOL_VECTOR_FOREACH_IDX (&ctx->instances, instance, j) {
-            r = sol_coap_server_unregister_resource(client->coap_server,
-                instance->instance_res);
+        //Send unregister only to non-bootstrap servers
+        if (conn_ctx->registration_time) {
+            r = send_client_delete_request(client, conn_ctx);
             SOL_INT_CHECK(r, < 0, r);
+        }
 
-            SOL_VECTOR_FOREACH_IDX (&instance->resources_ctx, res_ctx, k) {
-                r = sol_coap_server_unregister_resource(client->coap_server,
-                    res_ctx->res);
-                SOL_INT_CHECK(r, < 0, r);
-            }
+        if (conn_ctx->pending_pkt) {
+            r = sol_coap_cancel_send_packet(client->coap_server,
+                conn_ctx->pending_pkt,
+                sol_vector_get_no_check(&conn_ctx->server_addr_list,
+                conn_ctx->addr_list_idx));
+            sol_coap_packet_unref(conn_ctx->pending_pkt);
+            conn_ctx->pending_pkt = NULL;
+            SOL_INT_CHECK(r, < 0, r);
         }
     }
 
-    client->running = false;
+    if (client->running) {
+        SOL_VECTOR_FOREACH_IDX (&client->objects, ctx, i) {
+            r = sol_coap_server_unregister_resource(client->coap_server,
+                ctx->obj_res);
+            SOL_INT_CHECK(r, < 0, r);
+            SOL_VECTOR_FOREACH_IDX (&ctx->instances, instance, j) {
+                r = sol_coap_server_unregister_resource(client->coap_server,
+                    instance->instance_res);
+                SOL_INT_CHECK(r, < 0, r);
+
+                SOL_VECTOR_FOREACH_IDX (&instance->resources_ctx, res_ctx, k) {
+                    r = sol_coap_server_unregister_resource(client->coap_server,
+                        res_ctx->res);
+                    SOL_INT_CHECK(r, < 0, r);
+                }
+            }
+        }
+
+        client->running = false;
+    }
+
     server_connection_ctx_list_clear(&client->connections);
+
     return 0;
 }
 

--- a/src/lib/comms/sol-lwm2m.c
+++ b/src/lib/comms/sol-lwm2m.c
@@ -2656,7 +2656,7 @@ handle_write(struct sol_lwm2m_client *client,
 {
     int r;
 
-    //If write_resource is not NULL then write_tlv is guaramteed to ve valid as well.
+    //If write_resource is not NULL then write_tlv is guaranteed to be valid as well.
     if (!obj_ctx->obj->write_resource) {
         SOL_WRN("Object %" PRIu16 " does not support the write method",
             obj_ctx->obj->id);

--- a/src/lib/comms/sol-lwm2m.c
+++ b/src/lib/comms/sol-lwm2m.c
@@ -228,6 +228,20 @@ struct management_ctx {
     const void *data;
 };
 
+enum bootstrap_type {
+    BOOTSTRAP_DELETE,
+    BOOTSTRAP_WRITE
+};
+
+struct bootstrap_ctx {
+    enum bootstrap_type type;
+    struct sol_lwm2m_bootstrap_server *server;
+    struct sol_lwm2m_bootstrap_client_info *cinfo;
+    char *path;
+    void *cb;
+    const void *data;
+};
+
 struct resource_ctx {
     char *str_id;
     struct sol_coap_resource *res;
@@ -1786,6 +1800,35 @@ exit:
 }
 
 static int
+instances_to_tlv(struct sol_lwm2m_resource **instances,
+    size_t *instances_len, uint16_t *instances_ids, size_t len, struct sol_buffer *tlvs)
+{
+    int r;
+    size_t i, res_id, instance_data_len, data_len;
+
+    for (i = 0; i < len; i++) {
+        for (res_id = 0, instance_data_len = 0; res_id < instances_len[i]; res_id++) {
+            r = get_resource_len(&instances[i][res_id], res_id, &data_len);
+            SOL_INT_CHECK(r, < 0, r);
+
+            instance_data_len += data_len;
+        }
+
+        r = setup_tlv_header(SOL_LWM2M_TLV_TYPE_OBJECT_INSTANCE,
+            instances_ids[i], tlvs, instance_data_len);
+        SOL_INT_CHECK(r, < 0, r);
+
+        r = resources_to_tlv(instances[i], instances_len[i], tlvs);
+        SOL_INT_CHECK_GOTO(r, < 0, exit);
+    }
+
+    return 0;
+
+exit:
+    return r;
+}
+
+static int
 add_coap_int_option(struct sol_coap_packet *pkt,
     enum sol_coap_option opt, const void *data, uint16_t len)
 {
@@ -1817,7 +1860,8 @@ static int
 setup_coap_packet(enum sol_coap_method method,
     enum sol_coap_message_type type, const char *objects_path, const char *path,
     uint8_t *obs, int64_t *token, struct sol_lwm2m_resource *resources,
-    size_t len,
+    struct sol_lwm2m_resource **instances, size_t *instances_len,
+    uint16_t *instances_ids, size_t len,
     const char *execute_args,
     struct sol_coap_packet **pkt)
 {
@@ -1869,8 +1913,10 @@ setup_coap_packet(enum sol_coap_method method,
     r = sol_buffer_append_slice(&buf, sol_str_slice_from_str(path));
     SOL_INT_CHECK_GOTO(r, < 0, exit);
 
-    r = sol_coap_packet_add_uri_path_option(*pkt, buf.data);
-    SOL_INT_CHECK_GOTO(r, < 0, exit);
+    if (strcmp(path, "/") != 0) {
+        r = sol_coap_packet_add_uri_path_option(*pkt, buf.data);
+        SOL_INT_CHECK_GOTO(r, < 0, exit);
+    }
 
     if (execute_args) {
         size_t str_len;
@@ -1883,6 +1929,14 @@ setup_coap_packet(enum sol_coap_method method,
     } else if (resources) {
         content_type = SOL_LWM2M_CONTENT_TYPE_TLV;
         r = resources_to_tlv(resources, len, &tlvs);
+        SOL_INT_CHECK_GOTO(r, < 0, exit);
+        r = -ENOMEM;
+        SOL_INT_CHECK_GOTO(tlvs.used, >= UINT16_MAX, exit);
+        content_data = tlvs.data;
+        content_len = tlvs.used;
+    } else if (instances) {
+        content_type = SOL_LWM2M_CONTENT_TYPE_TLV;
+        r = instances_to_tlv(instances, instances_len, instances_ids, len, &tlvs);
         SOL_INT_CHECK_GOTO(r, < 0, exit);
         r = -ENOMEM;
         SOL_INT_CHECK_GOTO(tlvs.used, >= UINT16_MAX, exit);
@@ -2010,7 +2064,7 @@ sol_lwm2m_server_add_observer(struct sol_lwm2m_server *server,
         return 0;
 
     r = setup_coap_packet(SOL_COAP_METHOD_GET, SOL_COAP_MESSAGE_TYPE_CON,
-        client->objects_path, path, &obs, &entry->token, NULL, 0, NULL, &pkt);
+        client->objects_path, path, &obs, &entry->token, NULL, NULL, NULL, NULL, 0, NULL, &pkt);
     SOL_INT_CHECK(r, < 0, r);
 
     return sol_coap_send_packet_with_reply(server->coap, pkt, &client->cliaddr,
@@ -2187,8 +2241,8 @@ send_management_packet(struct sol_lwm2m_server *server,
     struct management_ctx *ctx;
 
     r = setup_coap_packet(method, SOL_COAP_MESSAGE_TYPE_CON,
-        client->objects_path, path, NULL, NULL, resources, len,
-        execute_args, &pkt);
+        client->objects_path, path, NULL, NULL, resources, NULL, NULL, NULL,
+        len, execute_args, &pkt);
     SOL_INT_CHECK(r, < 0, r);
 
     if (!cb)
@@ -2595,17 +2649,14 @@ extract_path(struct sol_lwm2m_client *client, struct sol_coap_packet *req,
     uint16_t *path_id, uint16_t *path_size)
 {
     struct sol_str_slice path[16] = { };
-    int i, j, r, count;
+    int i, j, r;
 
     r = sol_coap_find_options(req, SOL_COAP_OPTION_URI_PATH, path,
         sol_util_array_size(path));
-    count = r;
-    SOL_INT_CHECK_GOTO(r, < 0, err_exit);
-    r = -ENOENT;
-    SOL_INT_CHECK_GOTO(count, == 0, err_exit);
+    SOL_INT_CHECK(r, < 0, r);
 
     for (i = client->splitted_path_len ? client->splitted_path_len : 0, j = 0;
-        i < count; i++, j++) {
+        i < r; i++, j++) {
         char *end;
         //Only numbers are allowed.
         path_id[j] = sol_util_strtoul_n(path[i].data, &end, path[i].len, 10);
@@ -2613,17 +2664,13 @@ extract_path(struct sol_lwm2m_client *client, struct sol_coap_packet *req,
             errno != 0) {
             SOL_WRN("Could not convert %.*s to integer",
                 SOL_STR_SLICE_PRINT(path[i]));
-            r = -EINVAL;
-            goto err_exit;
+            return -EINVAL;
         }
         SOL_DBG("Path ID at request: %" PRIu16 "", path_id[j]);
     }
 
     *path_size = j;
     return 0;
-
-err_exit:
-    return r;
 }
 
 static struct obj_ctx *
@@ -2853,31 +2900,62 @@ static uint8_t
 handle_delete(struct sol_lwm2m_client *client,
     struct obj_ctx *obj_ctx, struct obj_instance *obj_instance)
 {
-    int r;
+    int r, ret;
+    uint16_t i, j;
 
-    if (!obj_instance) {
-        SOL_WRN("Object instance was not provided to delete! (object id: %"
-            PRIu16 "", obj_ctx->obj->id);
-        return SOL_COAP_RESPONSE_CODE_BAD_REQUEST;
+    if (client->is_bootstrapping) {
+        clear_bootstrap_ctx(client);
+        ret = SOL_COAP_RESPONSE_CODE_BAD_REQUEST;
     }
 
-    if (!obj_ctx->obj->del) {
-        SOL_WRN("The object %" PRIu16 " does not implement the delete method",
-            obj_ctx->obj->id);
-        return SOL_COAP_RESPONSE_CODE_NOT_ALLOWED;
+    //Specific Instance?
+    if (obj_ctx && obj_instance) {
+        if (!obj_ctx->obj->del) {
+            SOL_WRN("The object %" PRIu16 " does not implement the delete method",
+                obj_ctx->obj->id);
+            return client->is_bootstrapping ? SOL_COAP_RESPONSE_CODE_BAD_REQUEST :
+                   SOL_COAP_RESPONSE_CODE_NOT_ALLOWED;
+        }
+
+        r = obj_ctx->obj->del((void *)obj_instance->data,
+            (void *)client->user_data, client, obj_instance->id);
+        if (r < 0) {
+            SOL_WRN("Could not properly delete object id %"
+                PRIu16 " instance id: %" PRIu16 " reason:%d",
+                obj_ctx->obj->id, obj_instance->id, r);
+            return client->is_bootstrapping ? SOL_COAP_RESPONSE_CODE_BAD_REQUEST :
+                   SOL_COAP_RESPONSE_CODE_NOT_ALLOWED;
+        }
+
+        obj_instance->should_delete = true;
+        ret = SOL_COAP_RESPONSE_CODE_DELETED;
+    } else {
+        SOL_VECTOR_FOREACH_IDX (&client->objects, obj_ctx, i) {
+            if (!obj_ctx->obj->del) {
+                SOL_WRN("The object %" PRIu16 " does not implement the delete method."
+                    " Skipping this Object.",
+                    obj_ctx->obj->id);
+                continue;
+            }
+
+            SOL_VECTOR_FOREACH_IDX (&obj_ctx->instances, obj_instance, j) {
+                r = obj_ctx->obj->del((void *)obj_instance->data,
+                    (void *)client->user_data, client, obj_instance->id);
+
+                if (r < 0) {
+                    SOL_WRN("Could not properly delete object id %"
+                        PRIu16 " instance id: %" PRIu16 " reason:%d",
+                        obj_ctx->obj->id, obj_instance->id, r);
+                } else {
+                    obj_instance_clear(client, obj_ctx, obj_instance);
+                    (void)sol_vector_del_element(&obj_ctx->instances, obj_instance);
+                    ret = SOL_COAP_RESPONSE_CODE_DELETED;
+                }
+            }
+        }
     }
 
-    r = obj_ctx->obj->del((void *)obj_instance->data,
-        (void *)client->user_data, client, obj_instance->id);
-    if (r < 0) {
-        SOL_WRN("Could not properly delete object id %"
-            PRIu16 " instance id: %" PRIu16 " reason:%d",
-            obj_ctx->obj->id, obj_instance->id, r);
-        return SOL_COAP_RESPONSE_CODE_NOT_ALLOWED;
-    }
-
-    obj_instance->should_delete = true;
-    return SOL_COAP_RESPONSE_CODE_DELETED;
+    return ret;
 }
 
 static bool
@@ -2982,8 +3060,22 @@ handle_execute(struct sol_lwm2m_client *client,
     return SOL_COAP_RESPONSE_CODE_CHANGED;
 }
 
+//TODO: dummy. implement this function
 static uint8_t
-handle_write(struct sol_lwm2m_client *client,
+create_resource(struct sol_lwm2m_client *client,
+    struct obj_ctx *obj_ctx, struct obj_instance *obj_instance,
+    int32_t resource, uint16_t content_format,
+    const struct sol_str_slice payload)
+{
+    int r;
+
+    r = SOL_COAP_RESPONSE_CODE_BAD_REQUEST;
+
+    return r;
+}
+
+static uint8_t
+write_instance_tlv_or_resource(struct sol_lwm2m_client *client,
     struct obj_ctx *obj_ctx, struct obj_instance *obj_instance,
     int32_t resource, uint16_t content_format,
     const struct sol_str_slice payload)
@@ -2995,12 +3087,6 @@ handle_write(struct sol_lwm2m_client *client,
         SOL_WRN("Object %" PRIu16 " does not support the write method",
             obj_ctx->obj->id);
         return SOL_COAP_RESPONSE_CODE_NOT_ALLOWED;
-    }
-
-    if (!content_format) {
-        SOL_WRN("Content format was not set."
-            " Impossible to create object instance");
-        return SOL_COAP_RESPONSE_CODE_BAD_REQUEST;
     }
 
     if (!payload.len) {
@@ -3085,7 +3171,7 @@ handle_create(struct sol_lwm2m_client *client,
         obj_instance->id, (void *)&obj_instance->data, content_format, payload);
     SOL_INT_CHECK_GOTO(r, < 0, err_exit);
 
-    r = setup_instance_resource(client, obj_ctx, obj_instance, true);
+    r = setup_instance_resource(client, obj_ctx, obj_instance, !client->is_bootstrapping);
     SOL_INT_CHECK_GOTO(r, < 0, err_exit);
 
     return SOL_COAP_RESPONSE_CODE_CREATED;
@@ -3093,6 +3179,153 @@ handle_create(struct sol_lwm2m_client *client,
 err_exit:
     obj_instance_clear(client, obj_ctx, obj_instance);
     return SOL_COAP_RESPONSE_CODE_BAD_REQUEST;
+}
+
+static uint8_t
+handle_write(struct sol_lwm2m_client *client,
+    struct obj_ctx *obj_ctx, struct obj_instance *obj_instance,
+    uint16_t *path, uint16_t path_size, uint16_t content_format,
+    const struct sol_str_slice payload)
+{
+    int r;
+
+    if (client->is_bootstrapping) {
+        clear_bootstrap_ctx(client);
+    }
+
+    if (!content_format) {
+        SOL_WRN("Content format was not set. Impossible to create object instance");
+        return SOL_COAP_RESPONSE_CODE_BAD_REQUEST;
+    }
+
+    if (path_size < 2 && client->is_bootstrapping) {
+        //Bootstrap Write on Object (e.g.: PUT /1)
+        //In this case the payload is composed of <multiple TLVs> of type OBJECT_INSTANCE,
+        // <each one containing multiple TLVs> of type MULTIPLE_RESOURCES or RESOURCE_WITH_VALUE
+        // and each TLV of type MULTIPLE_RESOURCES can contain multiple TLVs of type
+        // RESOURCE_INSTANCE
+        struct sol_vector object_tlvs;
+        struct sol_lwm2m_tlv *instance_tlvs;
+        uint16_t i;
+
+        if (!payload.len) {
+            SOL_WRN("Payload to write on Object /%" PRIu16 " is empty", obj_ctx->obj->id);
+            return SOL_COAP_RESPONSE_CODE_BAD_REQUEST;
+        }
+
+        if (content_format == SOL_LWM2M_CONTENT_TYPE_TLV) {
+            r = sol_lwm2m_parse_tlv(payload, &object_tlvs);
+            SOL_INT_CHECK(r, < 0, SOL_COAP_RESPONSE_CODE_BAD_REQUEST);
+
+            SOL_VECTOR_FOREACH_IDX (&object_tlvs, instance_tlvs, i) {
+                if (instance_tlvs->type != SOL_LWM2M_TLV_TYPE_OBJECT_INSTANCE) {
+                    SOL_WRN("Only TLV is supported for writing an individual Object Instance."
+                        " Received: %" PRIu16 ". Skipping this instance.", instance_tlvs->type);
+                    continue;
+                }
+
+                obj_instance = find_object_instance_by_instance_id(obj_ctx, instance_tlvs->id);
+
+                //Instance already exists?
+                if (obj_instance) {
+                    //TODO: How to pass only the payload "slice" which contains this individual
+                    // instance's TLV? Can I use instance_tlvs->content?
+                    r = write_instance_tlv_or_resource(client, obj_ctx, obj_instance, -1,
+                        content_format, payload);
+                } else {
+                    //TODO: How to pass only the payload "slice" which contains this individual
+                    // instance's TLV? Can I use instance_tlvs->content?
+                    r = handle_create(client, obj_ctx, instance_tlvs->id, content_format, payload);
+                }
+
+                if (r == SOL_COAP_RESPONSE_CODE_CHANGED || r == SOL_COAP_RESPONSE_CODE_CREATED) {
+                    SOL_DBG("Bootstrap Write on Object Instance /%"
+                        PRIu16 "/%" PRIu16 " succeeded!", obj_ctx->obj->id, instance_tlvs->id);
+                } else {
+                    SOL_WRN("Bootstrap Write on Object Instance /%"
+                        PRIu16 "/%" PRIu16 " failed!", obj_ctx->obj->id, instance_tlvs->id);
+                }
+            }
+
+            sol_lwm2m_tlv_list_clear(&object_tlvs);
+            SOL_INT_CHECK(r, < 0, SOL_COAP_RESPONSE_CODE_BAD_REQUEST);
+
+            SOL_DBG("Bootstrap Write on Object /%" PRIu16 " succeeded!", obj_ctx->obj->id);
+
+            return SOL_COAP_RESPONSE_CODE_CHANGED;
+        } else {
+            SOL_WRN("Only TLV is supported for writing multiple Object Instances."
+                " Received: %" PRIu16 "", content_format);
+            return SOL_COAP_RESPONSE_CODE_UNSUPPORTED_CONTENT_FORMAT;
+        }
+
+    } else if (path_size < 3 && client->is_bootstrapping) {
+        //Bootstrap Write on Object Instance (e.g.: PUT /1/5)
+        //In this case the payload is composed of <multiple TLVs> of type MULTIPLE_RESOURCES
+        // or RESOURCE_WITH_VALUE and each TLV of type MULTIPLE_RESOURCES can contain
+        // multiple TLVs of type RESOURCE_INSTANCE
+        if (!payload.len) {
+            SOL_WRN("Payload to write on Object Instance /%"
+                PRIu16 "/%" PRIu16 " is empty", obj_ctx->obj->id, path[1]);
+            return SOL_COAP_RESPONSE_CODE_BAD_REQUEST;
+        }
+
+        if (content_format == SOL_LWM2M_CONTENT_TYPE_TLV) {
+            //Instance already exists?
+            if (obj_instance) {
+                r = write_instance_tlv_or_resource(client, obj_ctx, obj_instance, -1,
+                    content_format, payload);
+            } else {
+                r = handle_create(client, obj_ctx, path[1], content_format, payload);
+            }
+
+            if (r == SOL_COAP_RESPONSE_CODE_CHANGED || r == SOL_COAP_RESPONSE_CODE_CREATED) {
+                SOL_DBG("Bootstrap Write on Object Instance /%"
+                    PRIu16 "/%" PRIu16 " succeeded!", obj_ctx->obj->id, path[1]);
+                return SOL_COAP_RESPONSE_CODE_CHANGED;
+            } else {
+                return r;
+            }
+        } else {
+            SOL_WRN("Only TLV is supported for writing Object Instance."
+                " Received: %" PRIu16 "", content_format);
+            return SOL_COAP_RESPONSE_CODE_UNSUPPORTED_CONTENT_FORMAT;
+        }
+
+    } else if (client->is_bootstrapping) {
+        //Bootstrap Write on Resource (e.g.: PUT /1/5/1)
+        //In this case the payload is composed of a <single TLV> of type MULTIPLE_RESOURCES
+        // or RESOURCE_WITH_VALUE and in case of TLV of type MULTIPLE_RESOURCES this TLV can contain
+        // multiple TLVs of type RESOURCE_INSTANCE
+        if (!payload.len) {
+            SOL_WRN("Payload to write on Resource /%" PRIu16 "/%"
+                PRIu16 "/%" PRIu16 " is empty", obj_ctx->obj->id, obj_instance->id, path[2]);
+            return SOL_COAP_RESPONSE_CODE_BAD_REQUEST;
+        }
+
+        //TODO: How to find out if Resource already exists?
+        if (path[2]) {
+            r = write_instance_tlv_or_resource(client, obj_ctx, obj_instance, path[2],
+                content_format, payload);
+        } else {
+            r = create_resource(client, obj_ctx, obj_instance, path[2],
+                content_format, payload);
+        }
+
+        if (r == SOL_COAP_RESPONSE_CODE_CHANGED || r == SOL_COAP_RESPONSE_CODE_CREATED) {
+            SOL_DBG("Bootstrap Write on Resource /%" PRIu16 "/%" PRIu16 "/%" PRIu16 " succeeded!",
+                obj_ctx->obj->id, obj_instance->id, path[2]);
+            return SOL_COAP_RESPONSE_CODE_CHANGED;
+        } else {
+            return r;
+        }
+
+    } else {
+        //Management Write as [Replace] on Object Instance (e.g.: PUT /1/5) or Resource (e.g.: PUT /1/5/1)
+        // or as [Partial Update] on Object Instance (e.g.: POST /1/5)
+        return write_instance_tlv_or_resource(client, obj_ctx, obj_instance, path[2],
+            content_format, payload);
+    }
 }
 
 static int
@@ -3353,10 +3586,12 @@ handle_resource(void *data, struct sol_coap_server *server,
     header_code = SOL_COAP_RESPONSE_CODE_BAD_REQUEST;
     SOL_INT_CHECK_GOTO(r, < 0, exit);
 
-    obj_ctx = find_object_ctx_by_id(client, path[0]);
-    header_code = SOL_COAP_RESPONSE_CODE_NOT_FOUND;
-    SOL_NULL_CHECK_GOTO(obj_ctx, exit);
-
+    if (path_size >= 1) {
+        obj_ctx = find_object_ctx_by_id(client, path[0]);
+        header_code = client->is_bootstrapping ? SOL_COAP_RESPONSE_CODE_NOT_FOUND :
+            SOL_COAP_RESPONSE_CODE_BAD_REQUEST;
+        SOL_NULL_CHECK_GOTO(obj_ctx, exit);
+    }
     if (path_size >= 2)
         obj_instance = find_object_instance_by_instance_id(obj_ctx, path[1]);
 
@@ -3372,6 +3607,12 @@ handle_resource(void *data, struct sol_coap_server *server,
     }
 
     sol_coap_header_get_code(req, &method);
+
+    if (client->is_bootstrapping &&
+        (method == SOL_COAP_METHOD_GET || method == SOL_COAP_METHOD_POST)) {
+        header_code = SOL_COAP_RESPONSE_CODE_BAD_REQUEST;
+        goto exit;
+    }
 
     switch (method) {
     case SOL_COAP_METHOD_GET:
@@ -3394,8 +3635,8 @@ handle_resource(void *data, struct sol_coap_server *server,
             header_code = handle_create(client, obj_ctx, path[1],
                 content_format, payload);
         else if (path_size == 2)
-            //Write on object instance
-            header_code = handle_write(client, obj_ctx, obj_instance, -1,
+            //Management Write on object instance
+            header_code = handle_write(client, obj_ctx, obj_instance, path, path_size,
                 content_format, payload);
         else {
             //Execute.
@@ -3405,11 +3646,12 @@ handle_resource(void *data, struct sol_coap_server *server,
         }
         break;
     case SOL_COAP_METHOD_PUT:
-        if (path_size == 3) {
-            //Write op on a resource.
-            header_code = handle_write(client, obj_ctx, obj_instance,
-                path[2], content_format, payload);
-        } else {
+        if ((path_size == 3 && !client->is_bootstrapping) ||
+            client->is_bootstrapping)
+            //Bootstrap Write on Obj, ObjInst or Res; or Management Write on a resource.
+            header_code = handle_write(client, obj_ctx, obj_instance, path, path_size,
+                content_format, payload);
+        else {
             header_code = SOL_COAP_RESPONSE_CODE_BAD_REQUEST;
             SOL_WRN("Write request without full path specified!");
         }
@@ -3427,17 +3669,27 @@ exit:
     r = sol_coap_send_packet(server, resp, cliaddr);
 
     if (should_dispatch_notifications(header_code, is_execute) &&
+        resource &&
         !dispatch_notifications(client, resource,
         header_code == SOL_COAP_RESPONSE_CODE_DELETED)) {
         SOL_WRN("Could not dispatch the observe notifications");
     }
 
-    if (header_code == SOL_COAP_RESPONSE_CODE_DELETED) {
+    if (header_code == SOL_COAP_RESPONSE_CODE_DELETED &&
+        !client->is_bootstrapping) {
         obj_instance_clear(client, obj_ctx, obj_instance);
         (void)sol_vector_del_element(&obj_ctx->instances, obj_instance);
     }
 
     return r;
+}
+
+static int
+handle_unknown_bootstrap_resource(void *data, struct sol_coap_server *server,
+    struct sol_coap_packet *req,
+    const struct sol_network_link_addr *cliaddr)
+{
+    return handle_resource(data, server, NULL, req, cliaddr);
 }
 
 static char **
@@ -4166,6 +4418,127 @@ lifetime_client_timeout(void *data)
     return false;
 }
 
+static bool
+bootstrap_reply(void *data, struct sol_coap_server *server,
+    struct sol_coap_packet *req, const struct sol_network_link_addr *cliaddr)
+{
+    struct bootstrap_ctx *ctx = data;
+    uint8_t code = 0;
+
+    if (!cliaddr && !req)
+        code = SOL_COAP_RESPONSE_CODE_GATEWAY_TIMEOUT;
+
+    if (!code)
+        sol_coap_header_get_code(req, &code);
+    ((void (*)(void *,
+    struct sol_lwm2m_bootstrap_server *,
+    struct sol_lwm2m_bootstrap_client_info *, const char *,
+    enum sol_coap_response_code))ctx->cb)
+        ((void *)ctx->data, ctx->server, ctx->cinfo, ctx->path, code);
+
+    if (code != SOL_COAP_RESPONSE_CODE_GATEWAY_TIMEOUT)
+        send_ack_if_needed(server, req, cliaddr);
+    free(ctx->path);
+    free(ctx);
+    return false;
+}
+
+static int
+send_bootstrap_packet(struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *client, const char *path,
+    enum bootstrap_type type, void *cb, const void *data,
+    enum sol_coap_method method,
+    struct sol_lwm2m_resource *resources,
+    struct sol_lwm2m_resource **instances, size_t *instances_len,
+    uint16_t *instances_ids, size_t len)
+{
+    int r;
+    struct sol_coap_packet *pkt;
+    struct bootstrap_ctx *ctx;
+
+    r = setup_coap_packet(method, SOL_COAP_MESSAGE_TYPE_CON,
+        NULL, path, NULL, NULL, resources, instances, instances_len,
+        instances_ids, len, NULL, &pkt);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (!cb)
+        return sol_coap_send_packet(server->coap, pkt, &client->cliaddr);
+
+    ctx = malloc(sizeof(struct bootstrap_ctx));
+    SOL_NULL_CHECK_GOTO(ctx, err_exit);
+
+    ctx->path = strdup(path);
+    SOL_NULL_CHECK_GOTO(ctx->path, err_exit);
+    ctx->type = type;
+    ctx->server = server;
+    ctx->cinfo = client;
+    ctx->data = data;
+    ctx->cb = cb;
+
+    return sol_coap_send_packet_with_reply(server->coap, pkt, &client->cliaddr,
+        bootstrap_reply, ctx);
+
+err_exit:
+    free(ctx);
+    sol_coap_packet_unref(pkt);
+    return -ENOMEM;
+}
+
+SOL_API int
+sol_lwm2m_bootstrap_server_write_object(struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *client, const char *path,
+    struct sol_lwm2m_resource **instances, size_t *instances_len,
+    uint16_t *instances_ids, size_t len,
+    void (*cb)(void *data,
+    struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *client, const char *path,
+    enum sol_coap_response_code response_code),
+    const void *data)
+{
+    SOL_NULL_CHECK(server, -EINVAL);
+    SOL_NULL_CHECK(client, -EINVAL);
+    SOL_NULL_CHECK(path, -EINVAL);
+
+    return send_bootstrap_packet(server, client, path,
+        BOOTSTRAP_WRITE, cb, data, SOL_COAP_METHOD_PUT, NULL, instances,
+        instances_len, instances_ids, len);
+}
+
+SOL_API int
+sol_lwm2m_bootstrap_server_write(struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *client, const char *path,
+    struct sol_lwm2m_resource *resources, size_t len,
+    void (*cb)(void *data,
+    struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *client, const char *path,
+    enum sol_coap_response_code response_code),
+    const void *data)
+{
+    SOL_NULL_CHECK(server, -EINVAL);
+    SOL_NULL_CHECK(client, -EINVAL);
+    SOL_NULL_CHECK(path, -EINVAL);
+
+    return send_bootstrap_packet(server, client, path,
+        BOOTSTRAP_WRITE, cb, data, SOL_COAP_METHOD_PUT, resources, NULL, NULL, NULL, len);
+}
+
+SOL_API int
+sol_lwm2m_bootstrap_server_delete_object_instance(struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *client, const char *path,
+    void (*cb)(void *data,
+    struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *client, const char *path,
+    enum sol_coap_response_code response_code),
+    const void *data)
+{
+    SOL_NULL_CHECK(server, -EINVAL);
+    SOL_NULL_CHECK(client, -EINVAL);
+    SOL_NULL_CHECK(path, -EINVAL);
+
+    return send_bootstrap_packet(server, client, path,
+        BOOTSTRAP_DELETE, cb, data, SOL_COAP_METHOD_DELETE, NULL, NULL, NULL, NULL, 0);
+}
+
 SOL_API int
 sol_lwm2m_bootstrap_server_send_finish(struct sol_lwm2m_bootstrap_server *server,
     struct sol_lwm2m_bootstrap_client_info *client)
@@ -4339,6 +4712,11 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
             &bootstrap_finish_interface, client);
         SOL_INT_CHECK_GOTO(r, < 0, err_clear_3);
 
+        //Create unknown CoAP resource to handle Bootstrap Write and Bootstrap Delete
+        r = sol_coap_server_set_unknown_resource_handler(client->coap_server,
+            &handle_unknown_bootstrap_resource, client);
+        SOL_INT_CHECK_GOTO(r, < 0, err_unregister_bs);
+
         SOL_DBG("Expecting server-initiated Bootstrap for"
             " %" PRId64 " seconds", res[1].data[0].integer);
 
@@ -4375,6 +4753,9 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
 
     return 0;
 
+err_unregister_unknown:
+    if (sol_coap_server_set_unknown_resource_handler(client->coap_server, NULL, client) < 0)
+        SOL_WRN("Could not unregister Bootstrap Unknown resource for client.");
 err_unregister_bs:
     if (sol_coap_server_unregister_resource(client->coap_server, &bootstrap_finish_interface) < 0)
         SOL_WRN("Could not unregister Bootstrap Finish resource for client.");

--- a/src/samples/coap/Makefile
+++ b/src/samples/coap/Makefile
@@ -7,6 +7,7 @@ sample-oic-client-$(OIC_SAMPLES) := oic-client.c
 sample-oic-server-$(OIC_SAMPLES) := oic-server.c
 sample-iotivity-test-client-$(OIC_SAMPLES) := iotivity-test-client.c
 
-sample-$(LWM2M_SAMPLES) += lwm2m-sample-server lwm2m-sample-client
+sample-$(LWM2M_SAMPLES) += lwm2m-sample-server lwm2m-sample-client lwm2m-sample-bs-server
 sample-lwm2m-sample-server-$(LWM2M_SAMPLES) := lwm2m-server.c
 sample-lwm2m-sample-client-$(LWM2M_SAMPLES) := lwm2m-client.c
+sample-lwm2m-sample-bs-server-$(LWM2M_SAMPLES) := lwm2m-bs-server.c

--- a/src/samples/coap/lwm2m-bs-server.c
+++ b/src/samples/coap/lwm2m-bs-server.c
@@ -1,0 +1,202 @@
+/*
+ * This file is part of the Soletta Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+   To run: ./lwm2m-sample-bs-server
+   For every LWM2M client that connects with the bootstrap server, the bootstrap
+   server will send bootstrap information in order for that client to connect
+   with the lwm2m-sample-server.
+ */
+
+#include "sol-lwm2m.h"
+#include "sol-mainloop.h"
+#include "sol-vector.h"
+#include "sol-util.h"
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <errno.h>
+
+#define LIFETIME (60)
+
+#define SERVER_OBJ_ID (1)
+#define SERVER_OBJ_SHORT_RES_ID (0)
+#define SERVER_OBJ_LIFETIME_RES_ID (1)
+#define SERVER_OBJ_BINDING_RES_ID (7)
+#define SERVER_OBJ_REGISTRATION_UPDATE_RES_ID (8)
+
+#define SECURITY_SERVER_OBJ_ID (0)
+#define SECURITY_SERVER_SERVER_URI_RES_ID (0)
+#define SECURITY_SERVER_IS_BOOTSTRAP_RES_ID (1)
+#define SECURITY_SERVER_SERVER_ID_RES_ID (10)
+#define SECURITY_SERVER_CLIENT_HOLD_OFF_TIME_RES_ID (11)
+#define SECURITY_SERVER_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT_RES_ID (12)
+
+const char *known_clients[] = { "cli1", "cli2", NULL };
+
+static struct sol_blob server_one_addr = {
+    .type = &SOL_BLOB_TYPE_NO_FREE,
+    .parent = NULL,
+    .mem = (void *)"coap://localhost:5683",
+    .size = sizeof("coap://localhost:5683") - 1,
+    .refcnt = 1
+};
+
+static struct sol_blob binding = {
+    .type = &SOL_BLOB_TYPE_NO_FREE,
+    .parent = NULL,
+    .mem = (void *)"U",
+    .size = sizeof("U") - 1,
+    .refcnt = 1
+};
+
+static void
+write_cb(void *data,
+    struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *bs_cinfo, const char *path,
+    enum sol_coap_response_code response_code)
+{
+    const char *name = sol_lwm2m_bootstrap_client_info_get_name(bs_cinfo);
+
+    if (response_code != SOL_COAP_RESPONSE_CODE_CHANGED) {
+        fprintf(stderr, "The client %s could not write the object/resource at %s.\n",
+            name, path);
+        return;
+    }
+
+    printf("The client %s wrote the object/resource at %s.\n", name, path);
+
+    sol_lwm2m_bootstrap_server_send_finish(server, bs_cinfo);
+}
+
+static void
+delete_all_cb(void *data,
+    struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *bs_cinfo, const char *path,
+    enum sol_coap_response_code response_code)
+{
+    const char *name = sol_lwm2m_bootstrap_client_info_get_name(bs_cinfo);
+    int r;
+    uint16_t i;
+    struct sol_lwm2m_resource sec_server_one[3];
+    struct sol_lwm2m_resource server_one[3];
+
+    if (response_code != SOL_COAP_RESPONSE_CODE_DELETED) {
+        fprintf(stderr, "The client %s could not delete the object at %s.\n",
+            name, path);
+        return;
+    }
+
+    printf("The client %s deleted the object at %s.\n", name, path);
+
+    // Server One's Security Object
+    SOL_LWM2M_RESOURCE_INIT(r, &sec_server_one[0], SECURITY_SERVER_SERVER_URI_RES_ID, 1,
+        SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, &server_one_addr);
+    if (r < 0) {
+        fprintf(stderr, "Could not init Security Object's [Server URI] resource\n");
+        return;
+    }
+    SOL_LWM2M_RESOURCE_INIT(r, &sec_server_one[1], SECURITY_SERVER_IS_BOOTSTRAP_RES_ID, 1,
+        SOL_LWM2M_RESOURCE_DATA_TYPE_BOOL, false);
+    if (r < 0) {
+        fprintf(stderr, "Could not init Security Object's [Bootstrap Server] resource\n");
+        return;
+    }
+    SOL_LWM2M_RESOURCE_INT_INIT(r, &sec_server_one[2], SECURITY_SERVER_SERVER_ID_RES_ID, 101);
+    if (r < 0) {
+        fprintf(stderr, "Could not init Security Object's [Short Server ID] resource\n");
+        return;
+    }
+
+    sol_lwm2m_bootstrap_server_write(server, bs_cinfo, "/0/0",
+        sec_server_one, sol_util_array_size(sec_server_one), NULL, NULL);
+
+    // Server One's Server Object
+    SOL_LWM2M_RESOURCE_INT_INIT(r, &server_one[0], SERVER_OBJ_SHORT_RES_ID, 101);
+    if (r < 0) {
+        fprintf(stderr, "Could not init Server Object's [Short Server ID] resource\n");
+        return;
+    }
+    SOL_LWM2M_RESOURCE_INT_INIT(r, &server_one[1], SERVER_OBJ_LIFETIME_RES_ID, LIFETIME);
+    if (r < 0) {
+        fprintf(stderr, "Could not init Server Object's [Lifetime] resource\n");
+        return;
+    }
+    SOL_LWM2M_RESOURCE_INIT(r, &server_one[2], SERVER_OBJ_BINDING_RES_ID, 1,
+        SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, &binding);
+    if (r < 0) {
+        fprintf(stderr, "Could not init Server Object's [Binding] resource\n");
+        return;
+    }
+
+    sol_lwm2m_bootstrap_server_write(server, bs_cinfo, "/1/0",
+        server_one, sol_util_array_size(server_one), write_cb, NULL);
+
+    for (i = 0; i < sol_util_array_size(sec_server_one); i++)
+        sol_lwm2m_resource_clear(&sec_server_one[i]);
+
+    for (i = 0; i < sol_util_array_size(server_one); i++)
+        sol_lwm2m_resource_clear(&server_one[i]);
+}
+
+static void
+bootstrap_cb(void *data,
+    struct sol_lwm2m_bootstrap_server *server,
+    struct sol_lwm2m_bootstrap_client_info *bs_cinfo)
+{
+    const char *name = sol_lwm2m_bootstrap_client_info_get_name(bs_cinfo);
+
+    printf("Client-initiated Bootstrap from %s starting!\n", name);
+
+    sol_lwm2m_bootstrap_server_delete_object_instance(server, bs_cinfo, "/",
+        delete_all_cb, NULL);
+}
+
+int
+main(int argc, char *argv[])
+{
+    struct sol_lwm2m_bootstrap_server *server;
+    uint16_t port = 5783;
+    int r;
+
+    printf("Using port %" PRIu16 "\n", port);
+    sol_init();
+
+    server = sol_lwm2m_bootstrap_server_new(port, known_clients);
+    if (!server) {
+        r = -1;
+        fprintf(stderr, "Could not create the LWM2M bootstrap server\n");
+        goto exit;
+    }
+
+    r = sol_lwm2m_bootstrap_server_add_request_monitor(server, bootstrap_cb,
+        NULL);
+    if (r < 0) {
+        fprintf(stderr, "Could not add a bootstrap monitor\n");
+        goto exit_del;
+    }
+
+    sol_run();
+
+    r = 0;
+exit_del:
+    sol_lwm2m_bootstrap_server_del(server);
+exit:
+    sol_shutdown();
+    return r;
+}

--- a/src/samples/coap/lwm2m-client.c
+++ b/src/samples/coap/lwm2m-client.c
@@ -17,11 +17,21 @@
  */
 
 /*
-   To run: ./lwm2m-sample-client [client name]
+   To run: ./lwm2m-sample-client <client name> [bootstrap]
+   If [bootstrap] argument is not given:
    This LWM2M client sample will try to connect to a LWM2M server @ locahost:5683.
    If a location object is created by the LWM2M server, it will report its location
    every one second.
+
+   If [bootstrap] argument is given:
+   This LWM2M client sample will try to connect to a LWM2M server @ locahost:5683.
+   It should fail and thus will expect a server-initiated bootstrap.
+   If it doesn't happen in 30s, it will try to connect to a LWM2M bootstrap server
+   @ localhost:5783 and perform client-initiated bootstrap.
+   If the bootstrap is successfull, it will try to connect and register with the
+   server received in the bootstrap information.
  */
+
 
 #include "sol-lwm2m.h"
 #include "sol-mainloop.h"
@@ -51,6 +61,29 @@
 #define SECURITY_SERVER_SERVER_URI_RES_ID (0)
 #define SECURITY_SERVER_IS_BOOTSTRAP_RES_ID (1)
 #define SECURITY_SERVER_SERVER_ID_RES_ID (10)
+#define SECURITY_SERVER_CLIENT_HOLD_OFF_TIME_RES_ID (11)
+#define SECURITY_SERVER_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT_RES_ID (12)
+
+struct client_data_ctx {
+    bool has_location_instance;
+    bool is_bootstrap;
+};
+
+struct security_obj_instance_ctx {
+    struct sol_lwm2m_client *client;
+    struct sol_blob *server_uri;
+    bool is_bootstrap;
+    int64_t server_id;
+    int64_t client_hold_off_time;
+    int64_t bootstrap_server_account_timeout;
+};
+
+struct server_obj_instance_ctx {
+    struct sol_lwm2m_client *client;
+    struct sol_blob *binding;
+    int64_t server_id;
+    int64_t lifetime;
+};
 
 struct location_obj_instance_ctx {
     struct sol_timeout *timeout;
@@ -60,7 +93,15 @@ struct location_obj_instance_ctx {
     int64_t timestamp;
 };
 
-static struct sol_blob addr = {
+static struct sol_blob bootstrap_server_addr = {
+    .type = &SOL_BLOB_TYPE_NO_FREE,
+    .parent = NULL,
+    .mem = (void *)"coap://localhost:5783",
+    .size = sizeof("coap://localhost:5783") - 1,
+    .refcnt = 1
+};
+
+static struct sol_blob server_addr = {
     .type = &SOL_BLOB_TYPE_NO_FREE,
     .parent = NULL,
     .mem = (void *)"coap://localhost:5683",
@@ -132,14 +173,14 @@ create_location_obj(void *user_data, struct sol_lwm2m_client *client,
     const struct sol_str_slice content)
 {
     struct location_obj_instance_ctx *instance_ctx;
-    bool *has_location_instance = user_data;
+    struct client_data_ctx *data_ctx = user_data;
     struct sol_vector tlvs;
     int r;
     uint16_t i;
     struct sol_lwm2m_tlv *tlv;
 
     //Only one location object is allowed
-    if (*has_location_instance) {
+    if (data_ctx->has_location_instance) {
         fprintf(stderr, "Only one location object instance is allowed\n");
         return -EINVAL;
     }
@@ -211,7 +252,7 @@ create_location_obj(void *user_data, struct sol_lwm2m_client *client,
 
     instance_ctx->client = client;
     *instance_data = instance_ctx;
-    *has_location_instance = true;
+    data_ctx->has_location_instance = true;
     sol_lwm2m_tlv_list_clear(&tlvs);
     printf("Location object created\n");
 
@@ -263,27 +304,35 @@ read_location_obj(void *instance_data, void *user_data,
 }
 
 static int
-read_security_server_obj(void *instance_data, void *user_data,
+read_security_obj(void *instance_data, void *user_data,
     struct sol_lwm2m_client *client,
     uint16_t instance_id, uint16_t res_id, struct sol_lwm2m_resource *res)
 {
+    struct security_obj_instance_ctx *ctx = instance_data;
     int r;
 
-    //It implements only the necassary info to connect to a LWM2M server Without encryption.
+    //It implements only the necassary info to connect to a LWM2M server
+    // or bootstrap server without encryption.
     switch (res_id) {
     case SECURITY_SERVER_SERVER_URI_RES_ID:
-        SOL_LWM2M_RESOURCE_INIT(r, res, 0, 1,
-            SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, &addr);
+        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
+            SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, ctx->server_uri);
         break;
     case SECURITY_SERVER_IS_BOOTSTRAP_RES_ID:
-        SOL_LWM2M_RESOURCE_INIT(r, res, 1, 1,
-            SOL_LWM2M_RESOURCE_DATA_TYPE_BOOL, false);
+        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
+            SOL_LWM2M_RESOURCE_DATA_TYPE_BOOL, ctx->is_bootstrap);
         break;
     case SECURITY_SERVER_SERVER_ID_RES_ID:
-        SOL_LWM2M_RESOURCE_INT_INIT(r, res, 10, 101);
+        SOL_LWM2M_RESOURCE_INT_INIT(r, res, res_id, ctx->server_id);
+        break;
+    case SECURITY_SERVER_CLIENT_HOLD_OFF_TIME_RES_ID:
+        SOL_LWM2M_RESOURCE_INT_INIT(r, res, res_id, ctx->client_hold_off_time);
+        break;
+    case SECURITY_SERVER_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT_RES_ID:
+        SOL_LWM2M_RESOURCE_INT_INIT(r, res, res_id, ctx->bootstrap_server_account_timeout);
         break;
     default:
-        if (res_id >= 2 && res_id <= 11)
+        if (res_id >= 2 && res_id <= 9)
             r = -ENOENT;
         else
             r = -EINVAL;
@@ -293,23 +342,181 @@ read_security_server_obj(void *instance_data, void *user_data,
 }
 
 static int
+write_security_res(void *instance_data, void *user_data,
+    struct sol_lwm2m_client *client,
+    uint16_t instance_id, uint16_t res_id, const struct sol_lwm2m_resource *res)
+{
+    struct security_obj_instance_ctx *instance_ctx = instance_data;
+    int r;
+
+    // res_id?
+    switch (res->id) {
+    case SECURITY_SERVER_SERVER_URI_RES_ID:
+        // TODO: Should I check if exists and unref(instance_ctx->server_uri) first?
+        instance_ctx->server_uri = sol_blob_ref(res->data->blob);
+        break;
+    case SECURITY_SERVER_IS_BOOTSTRAP_RES_ID:
+        instance_ctx->is_bootstrap = res->data->b;
+        break;
+    case SECURITY_SERVER_SERVER_ID_RES_ID:
+        instance_ctx->server_id = res->data->integer;
+        break;
+    case SECURITY_SERVER_CLIENT_HOLD_OFF_TIME_RES_ID:
+        instance_ctx->client_hold_off_time = res->data->integer;
+        break;
+    case SECURITY_SERVER_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT_RES_ID:
+        instance_ctx->bootstrap_server_account_timeout = res->data->integer;
+        break;
+    default:
+        if (res_id >= 2 && res_id <= 9)
+            r = -ENOENT;
+        else
+            r = -EINVAL;
+    }
+
+    return r;
+}
+
+static int
+write_security_tlv(void *instance_data, void *user_data,
+    struct sol_lwm2m_client *client,
+    uint16_t instance_id, struct sol_vector *tlvs)
+{
+    int r;
+    uint16_t i;
+    struct sol_lwm2m_tlv *tlv;
+    struct security_obj_instance_ctx *instance_ctx = instance_data;
+
+    SOL_VECTOR_FOREACH_IDX (tlvs, tlv, i) {
+        SOL_BUFFER_DECLARE_STATIC(buf, 64);
+
+        switch (tlv->id) {
+        case SECURITY_SERVER_SERVER_URI_RES_ID:
+            r = sol_lwm2m_tlv_get_bytes(tlv, &buf);
+            // TODO: Should I check if exists and unref(instance_ctx->server_uri) first?
+            instance_ctx->server_uri = sol_buffer_to_blob(&buf);
+            break;
+        case SECURITY_SERVER_IS_BOOTSTRAP_RES_ID:
+            r = sol_lwm2m_tlv_get_bool(tlv, &instance_ctx->is_bootstrap);
+            break;
+        case SECURITY_SERVER_SERVER_ID_RES_ID:
+            r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->server_id);
+            break;
+        case SECURITY_SERVER_CLIENT_HOLD_OFF_TIME_RES_ID:
+            r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->client_hold_off_time);
+            break;
+        case SECURITY_SERVER_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT_RES_ID:
+            r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->bootstrap_server_account_timeout);
+            break;
+        default:
+            // TODO: How to inform the infra of each failed resource id (tlv->id)?
+            fprintf(stderr, "tlv type: %u, ID: %" PRIu16 ", Size: %zu, Content: %.*s"
+                " could not be written to Security Server Object at /0/%" PRIu16,
+                tlv->type, tlv->id, tlv->content.used,
+                SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&tlv->content)), instance_id);
+            break;
+        }
+    }
+
+    return r;
+}
+
+static int
+create_security_obj(void *user_data, struct sol_lwm2m_client *client,
+    uint16_t instance_id, void **instance_data,
+    enum sol_lwm2m_content_type content_type,
+    const struct sol_str_slice content)
+{
+    struct security_obj_instance_ctx *instance_ctx;
+    struct sol_vector tlvs;
+    int r;
+    uint16_t i;
+    struct sol_lwm2m_tlv *tlv;
+
+    if (content_type != SOL_LWM2M_CONTENT_TYPE_TLV) {
+        fprintf(stderr, "Content type is not in TLV format\n");
+        return -EINVAL;
+    }
+
+    instance_ctx = calloc(1, sizeof(struct security_obj_instance_ctx));
+    if (!instance_ctx) {
+        fprintf(stderr, "Could not alloc memory for security object context\n");
+        return -ENOMEM;
+    }
+
+    r = sol_lwm2m_parse_tlv(content, &tlvs);
+    if (r < 0) {
+        fprintf(stderr, "Could not parse the TLV content\n");
+        goto err_free_tlvs;
+    }
+
+    SOL_VECTOR_FOREACH_IDX (&tlvs, tlv, i) {
+        SOL_BUFFER_DECLARE_STATIC(buf, 64);
+
+        if (tlv->id == SECURITY_SERVER_SERVER_URI_RES_ID) {
+            r = sol_lwm2m_tlv_get_bytes(tlv, &buf);
+            instance_ctx->server_uri = sol_buffer_to_blob(&buf);
+        } else if (tlv->id == SECURITY_SERVER_IS_BOOTSTRAP_RES_ID) {
+            r = sol_lwm2m_tlv_get_bool(tlv, &instance_ctx->is_bootstrap);
+        } else if (tlv->id == SECURITY_SERVER_SERVER_ID_RES_ID) {
+            r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->server_id);
+        } else if (tlv->id == SECURITY_SERVER_CLIENT_HOLD_OFF_TIME_RES_ID) {
+            r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->client_hold_off_time);
+        } else if (tlv->id == SECURITY_SERVER_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT_RES_ID) {
+            r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->bootstrap_server_account_timeout);
+        }
+
+        if (r < 0) {
+            fprintf(stderr, "Could not get the tlv value for resource %"
+                PRIu16 "\n", tlv->id);
+            goto err_free_tlvs;
+        }
+    }
+
+    instance_ctx->client = client;
+    *instance_data = instance_ctx;
+    sol_lwm2m_tlv_list_clear(&tlvs);
+    printf("Security object created\n");
+
+    return 0;
+
+err_free_tlvs:
+    sol_lwm2m_tlv_list_clear(&tlvs);
+    free(instance_ctx);
+    return r;
+}
+
+static int
+del_security_obj(void *instance_data, void *user_data,
+    struct sol_lwm2m_client *client, uint16_t instance_id)
+{
+    struct security_obj_instance_ctx *instance_ctx = instance_data;
+
+    sol_blob_unref(instance_ctx->server_uri);
+    free(instance_ctx);
+    return 0;
+}
+
+static int
 read_server_obj(void *instance_data, void *user_data,
     struct sol_lwm2m_client *client,
     uint16_t instance_id, uint16_t res_id, struct sol_lwm2m_resource *res)
 {
+    struct server_obj_instance_ctx *ctx = instance_data;
     int r;
 
-    //It implements only the necassary info to connect to a LWM2M server Without encryption.
+    //It implements only the necassary info to connect to a LWM2M server
+    // without encryption.
     switch (res_id) {
     case SERVER_OBJ_SHORT_RES_ID:
-        SOL_LWM2M_RESOURCE_INT_INIT(r, res, res_id, 101);
+        SOL_LWM2M_RESOURCE_INT_INIT(r, res, res_id, ctx->server_id);
         break;
     case SERVER_OBJ_LIFETIME_RES_ID:
-        SOL_LWM2M_RESOURCE_INT_INIT(r, res, res_id, LIFETIME);
+        SOL_LWM2M_RESOURCE_INT_INIT(r, res, res_id, ctx->lifetime);
         break;
     case SERVER_OBJ_BINDING_RES_ID:
         SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
-            SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, &binding);
+            SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, ctx->binding);
         break;
     default:
         if (res_id >= 2 && res_id <= 6)
@@ -322,10 +529,140 @@ read_server_obj(void *instance_data, void *user_data,
 }
 
 static int
+write_server_res(void *instance_data, void *user_data,
+    struct sol_lwm2m_client *client,
+    uint16_t instance_id, uint16_t res_id, const struct sol_lwm2m_resource *res)
+{
+    struct server_obj_instance_ctx *instance_ctx = instance_data;
+    int r;
+
+    // res_id?
+    switch (res->id) {
+    case SERVER_OBJ_SHORT_RES_ID:
+        instance_ctx->server_id = res->data->integer;
+        break;
+    case SERVER_OBJ_LIFETIME_RES_ID:
+        instance_ctx->lifetime = res->data->integer;
+        break;
+    case SERVER_OBJ_BINDING_RES_ID:
+        // TODO: Should I check if exists and unref(instance_ctx->binding) first?
+        instance_ctx->binding = sol_blob_ref(res->data->blob);
+        break;
+    default:
+        if (res_id >= 2 && res_id <= 6)
+            r = -ENOENT;
+        else
+            r = -EINVAL;
+    }
+
+    return r;
+}
+
+static int
+write_server_tlv(void *instance_data, void *user_data,
+    struct sol_lwm2m_client *client,
+    uint16_t instance_id, struct sol_vector *tlvs)
+{
+    int r;
+    uint16_t i;
+    struct sol_lwm2m_tlv *tlv;
+    struct server_obj_instance_ctx *instance_ctx = instance_data;
+
+    SOL_VECTOR_FOREACH_IDX (tlvs, tlv, i) {
+        SOL_BUFFER_DECLARE_STATIC(buf, 64);
+
+        switch (tlv->id) {
+        case SERVER_OBJ_SHORT_RES_ID:
+            r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->server_id);
+            break;
+        case SERVER_OBJ_LIFETIME_RES_ID:
+            r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->lifetime);
+            break;
+        case SERVER_OBJ_BINDING_RES_ID:
+            r = sol_lwm2m_tlv_get_bytes(tlv, &buf);
+            // TODO: Should I check if exists and unref(instance_ctx->binding) first?
+            instance_ctx->binding = sol_buffer_to_blob(&buf);
+            break;
+        default:
+            // TODO: How to inform the infra of each failed resource id (tlv->id)?
+            fprintf(stderr, "tlv type: %u, ID: %" PRIu16 ", Size: %zu, Content: %.*s"
+                " could not be written to Server Object at /1/%" PRIu16,
+                tlv->type, tlv->id, tlv->content.used,
+                SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&tlv->content)), instance_id);
+            break;
+        }
+    }
+
+    return r;
+}
+
+static int
+create_server_obj(void *user_data, struct sol_lwm2m_client *client,
+    uint16_t instance_id, void **instance_data,
+    enum sol_lwm2m_content_type content_type,
+    const struct sol_str_slice content)
+{
+    struct server_obj_instance_ctx *instance_ctx;
+    struct sol_vector tlvs;
+    int r;
+    uint16_t i;
+    struct sol_lwm2m_tlv *tlv;
+
+    if (content_type != SOL_LWM2M_CONTENT_TYPE_TLV) {
+        fprintf(stderr, "Content type is not in TLV format\n");
+        return -EINVAL;
+    }
+
+    instance_ctx = calloc(1, sizeof(struct server_obj_instance_ctx));
+    if (!instance_ctx) {
+        fprintf(stderr, "Could not alloc memory for server object context\n");
+        return -ENOMEM;
+    }
+
+    r = sol_lwm2m_parse_tlv(content, &tlvs);
+    if (r < 0) {
+        fprintf(stderr, "Could not parse the TLV content\n");
+        goto err_free_tlvs;
+    }
+
+    SOL_VECTOR_FOREACH_IDX (&tlvs, tlv, i) {
+        SOL_BUFFER_DECLARE_STATIC(buf, 64);
+
+        if (tlv->id == SERVER_OBJ_SHORT_RES_ID) {
+            r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->server_id);
+        } else if (tlv->id == SERVER_OBJ_LIFETIME_RES_ID) {
+            r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->lifetime);
+        } else if (tlv->id == SERVER_OBJ_BINDING_RES_ID) {
+            r = sol_lwm2m_tlv_get_bytes(tlv, &buf);
+            instance_ctx->binding = sol_buffer_to_blob(&buf);
+        }
+
+        if (r < 0) {
+            fprintf(stderr, "Could not get the tlv value for resource %"
+                PRIu16 "\n", tlv->id);
+            goto err_free_tlvs;
+        }
+    }
+
+    instance_ctx->client = client;
+    *instance_data = instance_ctx;
+    sol_lwm2m_tlv_list_clear(&tlvs);
+    printf("Server object created\n");
+
+    return 0;
+
+err_free_tlvs:
+    sol_lwm2m_tlv_list_clear(&tlvs);
+    free(instance_ctx);
+    return r;
+}
+
+static int
 execute_server_obj(void *instance_data, void *user_data,
     struct sol_lwm2m_client *client, uint16_t instance_id,
     uint16_t res_id, const struct sol_str_slice args)
 {
+    // TODO: should I add this resource to server_obj_instance_ctx?
     if (res_id != SERVER_OBJ_REGISTRATION_UPDATE_RES_ID)
         return -EINVAL;
 
@@ -333,17 +670,42 @@ execute_server_obj(void *instance_data, void *user_data,
 }
 
 static int
+del_server_obj(void *instance_data, void *user_data,
+    struct sol_lwm2m_client *client, uint16_t instance_id)
+{
+    struct server_obj_instance_ctx *instance_ctx = instance_data;
+
+    sol_blob_unref(instance_ctx->binding);
+    free(instance_ctx);
+    return 0;
+}
+
+static int
 del_location_obj(void *instance_data, void *user_data,
     struct sol_lwm2m_client *client, uint16_t instance_id)
 {
     struct location_obj_instance_ctx *instance_ctx = instance_data;
-    bool *has_location_instance = user_data;
+    struct client_data_ctx *data_ctx = user_data;
 
     if (instance_ctx->timeout)
         sol_timeout_del(instance_ctx->timeout);
     free(instance_ctx);
-    *has_location_instance = false;
+    data_ctx->has_location_instance = false;
     return 0;
+}
+
+static void
+bootstrap_cb(void *data,
+    struct sol_lwm2m_client *client,
+    enum sol_lwm2m_bootstrap_event event)
+{
+    if (event == SOL_LWM2M_BOOTSTRAP_EVENT_FINISHED) {
+        printf("...<Call local Bootstrap clean-up operations>...\n"
+            "...<Now that it should have a Server, try to register again>\n");
+        sol_lwm2m_client_start(client);
+    } else if (event == SOL_LWM2M_BOOTSTRAP_EVENT_ERROR) {
+        fprintf(stderr, "Bootstrap Request or Bootstrap Finish Failed!\n");
+    }
 }
 
 static const struct sol_lwm2m_object location_object = {
@@ -359,7 +721,11 @@ static const struct sol_lwm2m_object security_object = {
     SOL_SET_API_VERSION(.api_version = SOL_LWM2M_OBJECT_API_VERSION, )
     .id = SECURITY_SERVER_OBJ_ID,
     .resources_count = 12,
-    .read = read_security_server_obj
+    .read = read_security_obj,
+    .create = create_security_obj,
+    .del = del_security_obj,
+    .write_resource = write_security_res,
+    .write_tlv = write_security_tlv
 };
 
 static const struct sol_lwm2m_object server_object = {
@@ -367,6 +733,10 @@ static const struct sol_lwm2m_object server_object = {
     .id = SERVER_OBJ_ID,
     .resources_count = 9,
     .read = read_server_obj,
+    .create = create_server_obj,
+    .del = del_server_obj,
+    .write_resource = write_server_res,
+    .write_tlv = write_server_tlv,
     .execute = execute_server_obj
 };
 
@@ -376,19 +746,24 @@ main(int argc, char *argv[])
     struct sol_lwm2m_client *client;
     static const struct sol_lwm2m_object *objects[] =
     { &security_object, &server_object, &location_object, NULL };
-    bool has_location_instance = false;
+    struct client_data_ctx data_ctx = { 0 };
+    struct security_obj_instance_ctx *security_data;
+    struct server_obj_instance_ctx *server_data;
     int r;
 
     srand(time(NULL));
     if (argc < 2) {
-        fprintf(stderr, "Usage: ./lwm2m-sample-client [client-name]\n");
+        fprintf(stderr, "Usage: ./lwm2m-sample-client <client-name> [bootstrap]\n");
         return -1;
     }
 
     sol_init();
 
+    if (argv[2])
+        data_ctx.is_bootstrap = true;
+
     client = sol_lwm2m_client_new(argv[1], NULL, NULL, objects,
-        &has_location_instance);
+        &data_ctx);
 
     if (!client) {
         r = -1;
@@ -396,13 +771,52 @@ main(int argc, char *argv[])
         goto exit;
     }
 
-    r = sol_lwm2m_add_object_instance(client, &server_object, NULL);
-    if (r < 0) {
-        fprintf(stderr, "Could not add a server object instance\n");
-        goto exit_del;
+    security_data = calloc(1, sizeof(struct security_obj_instance_ctx));
+    if (!security_data) {
+        fprintf(stderr, "Could not alloc memory for security object context\n");
+        return -ENOMEM;
     }
 
-    r = sol_lwm2m_add_object_instance(client, &security_object, NULL);
+    security_data->client = client;
+
+    if (!data_ctx.is_bootstrap) {
+        server_data = calloc(1, sizeof(struct server_obj_instance_ctx));
+        if (!server_data) {
+            fprintf(stderr, "Could not alloc memory for server object context\n");
+            return -ENOMEM;
+        }
+
+        server_data->client = client;
+        server_data->binding = &binding;
+        server_data->server_id = 101;
+        server_data->lifetime = LIFETIME;
+
+        r = sol_lwm2m_add_object_instance(client, &server_object, server_data);
+
+        if (r < 0) {
+            fprintf(stderr, "Could not add a server object instance\n");
+            goto exit_del;
+        }
+
+        security_data->server_uri = &server_addr;
+        security_data->is_bootstrap = false;
+        security_data->server_id = 101;
+    } else {
+        r = sol_lwm2m_client_add_bootstrap_finish_monitor(client, bootstrap_cb,
+            NULL);
+
+        if (r < 0) {
+            fprintf(stderr, "Could not add a bootstrap monitor\n");
+            goto exit_del;
+        }
+
+        security_data->server_uri = &bootstrap_server_addr;
+        security_data->is_bootstrap = true;
+        security_data->client_hold_off_time = 5;
+        security_data->bootstrap_server_account_timeout = 0;
+    }
+
+    r = sol_lwm2m_add_object_instance(client, &security_object, security_data);
 
     if (r < 0) {
         fprintf(stderr, "Could not add a security object instance\n");


### PR DESCRIPTION
Main changes from v1 (#2178):
- Infra
 - Added list of clients to `sol_lwm2m_bootstrap_server`.
 - Refactored all `*_{add, del}_monitor*` functions.
 - Removed is_bootstrap flag from server_connection_ctx_* functions.
 - Removing the deleted instances after calling the del callback from the client.
 - Setting up the CoAP resources for the instances after Bootstrap Write.

- Samples
 - bs-server: Chaining the Write/Delete callbacks in order to perform Bootstrap Finish correctly.
 - bs-server: Writing a Server Object as well, in addition to the Security Object.
 - client: Changed `security_obj_instance_ctx.server_uri` from `char *` to `struct sol_blob *`.
 - client: Added `server_obj_instance_ctx` and related management functions.
 - client: Client now successfully receives all Bootstrap Information (Security Object + Server Object) and is able to register at the received server. :-)

- TODO
 - [x] Use `sol_timeout` to wait for server-initiated bootstrap before the client-initiated one.
 - [ ] Refactor `handle_unknown_bootstrap_resource`, `handle_bootstrap_write_object` and friends.
 - [x] Refactor the `sol_lwm2m_bootstrap_client_info` memory allocation.

- Future Improvements
 - Use the `SOL_MAIN_DEFAULT()`
 - Add an API to add and remove known clients on the fly

Signed-off-by: Bruno Melo bsilva.melo@gmail.com