### PR TITLE
cheat-sheet: fix broken links that was not pointing to the nodelist - V2

### DIFF
--- a/doc/node-types-html/css/main.css
+++ b/doc/node-types-html/css/main.css
@@ -183,6 +183,13 @@ body{
     background-color: rgba(255,255,255,0.05);
     overflow: hidden;
 }
+#example-image-container p{
+    clear: both;
+    color: white;
+    width: auto;
+    height: auto;
+    text-align: center;
+}
 .example-thumb{
     float: left;
     margin-bottom: 8px;

--- a/doc/node-types-html/index.html.in
+++ b/doc/node-types-html/index.html.in
@@ -38,6 +38,32 @@
             /* getting the DOM element */
             var el = $('#example');
 
+            backCompleted = function() {
+                if (window.hashControl) {
+                    $(document).off('scroll');
+
+                    /* removing all active elements */
+                    $('#navigation a').each(function() {
+                        $(this).removeClass('active');
+                    });
+
+                    /* adding the active class to the selected object */
+                    $(this).addClass('active');
+                    var target = $(window.hashString);
+
+                    /* animating the page scroll to the target category */
+                    $('html, body').stop().animate(
+                        {'scrollTop':target.offset().top - 101 - 91},
+                        1200,
+                        'swing',
+                        function() {
+                            window.location.hash = hashString;
+                        }
+                    )
+                    window.hashControl = "";
+                }
+            };
+
             /* setting up the back button */
             $('.button-back').on('click',onBackClick);
             function onBackClick(event){
@@ -209,6 +235,7 @@
                 $('#example-info-code').remove();
                 $('#example').hide();
                 el.trigger('examples:closed');
+                backCompleted();
             }
 
             ExamplesView.prototype.show = function(_data){
@@ -318,28 +345,9 @@
             $('a[href^="#"]').on('click',onMenuItemClick);
 
             function onMenuItemClick(event){
-                event.preventDefault;
-                $(document).off('scroll');
-
-                /* removing all active elements */
-                $('#navigation a').each(function(){
-                    $(this).removeClass('active');
-                });
-
-                /* adding the active class to the selected object */
-                $(this).addClass('active');
-                var hashString = String(this.hash);
-                var target = $(hashString);
-
-                /* animating the page scroll to the target category */
-                $('html, body').stop().animate(
-                    {'scrollTop':target.offset().top - 101 - 91},
-                    1200,
-                    'swing',
-                    function(){
-                        window.location.hash = hashString;
-                    }
-                )
+                window.hashString = String(this.hash);
+                window.hashControl = window.hashString;
+                $('.button-back').click();
             }
         });
     </script>

--- a/doc/node-types-html/index.html.in
+++ b/doc/node-types-html/index.html.in
@@ -90,29 +90,37 @@
                 var info = $('#example-info');
                 var title = $('<h1></h1>');
                 var description = $('<p></p>');
+                var getCodeButton = $('<img></img>');
                 title.text(_data['name']);
                 description.text(_data['description']);
                 info.append(title);
                 info.append(description);
-                /* loading all thumbnails */
-                for(var i=0; i<_data['exampleList'].length; i++){
-                    var thumb = $('<img></img>');
-                    thumb.addClass('example-thumb');
-                    /* thumbnail main attributes */
-                    thumb.attr('src',_data['exampleList'][i]['thumb']);
-                    thumb.attr('id','thumb_' + i);
 
-                    /* thumbnail data */
-                    thumb.data('large',_data['exampleList'][i]['large']);
-                    thumb.data('code',_data['exampleList'][i]['code']);
+                if (_data['exampleList'].length === 0) {
+                    var thumb = $('<p>There is no example for this Nodetype</p>');
+                    $("#example-image-container").append(thumb);
+                    getCodeButton.css('visibility', 'hidden');
+                } else {
+                    /* loading all thumbnails */
+                    for(var i=0; i<_data['exampleList'].length; i++){
+                        var thumb = $('<img></img>');
+                        thumb.addClass('example-thumb');
+                        /* thumbnail main attributes */
+                        thumb.attr('src',_data['exampleList'][i]['thumb']);
+                        thumb.attr('id','thumb_' + i);
 
-                    /* thumbnail events */
-                    thumb.on('click',onThumbExampleClick);
-                    info.append(thumb);
+                        /* thumbnail data */
+                        thumb.data('large',_data['exampleList'][i]['large']);
+                        thumb.data('code',_data['exampleList'][i]['code']);
 
-                    if(i==0){
-                        /* load the first example */
-                        loadExampleImage(thumb);
+                        /* thumbnail events */
+                        thumb.on('click',onThumbExampleClick);
+                        info.append(thumb);
+
+                        if(i==0){
+                            /* load the first example */
+                            loadExampleImage(thumb);
+                        }
                     }
                 }
                 // Added hidden textarea element to store code
@@ -121,7 +129,6 @@
                 hidden_code.attr('id','example-info-code');
                 hidden_code.disabled=true;
                 /* adding the get-code button */
-                var getCodeButton = $('<img></img>');
                 getCodeButton.attr('src','images/button_get_code.png');
                 getCodeButton.attr('id','example-get-code');
                 info.append(getCodeButton);


### PR DESCRIPTION
After opening a nodetype and clicking in the nodetypes list, the navigation was
invalid.

In this patch, the back action is executed before selecting the nodetype in the
list thus the nodetype will be valid to be selected.

Difference from V1:

- Fix Firefox compability as pointed by @bdilly (Thanks!)
- Add commit that warns when the selected node has no examples to be shown. Also, the Get Code Button will get hidden.

Signed-off-by: Bruno Bottazzini <bruno.bottazzini@intel.com>