### PR TITLE
build: simplify versioning

### DIFF
--- a/HOW_TO_RELEASE
+++ b/HOW_TO_RELEASE
@@ -1,0 +1,16 @@
+To properly versioning the Soletta (TM) Project the
+following variables are used and should be updated
+before each new release (all of them on Makefiles.vars)
+
+The shared object versioning follows libtool approach.
+
+    * SOL_VERSION -> project version, not related to soname
+    * SOL_CURRENT
+    * SOL_AGE
+    * SOL_REVISION
+
+1) At every release you should increment SOL_VERSION
+2) If the library source code has changed at all since the last update, then increment SOL_REVISION
+3) If any interfaces have been added, removed, or changed since the last update, increment SOL_CURRENT, and set SOL_REVISION to 0.
+4) If any interfaces have been added since the last public release, then increment SOL_AGE.
+5) If any interfaces have been removed or changed since the last public release, then set SOL_AGE to 0.

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -82,10 +82,15 @@ LIB_ASAN_PATH =
 PREFIX := $(patsubst "%",%,$(PREFIX))
 EXTRA_BINS :=
 
+SOL_VERSION := 0
+SOL_CURRENT := 0
+SOL_REVISION := 0
+SOL_AGE := 0
+
 export PKGNAME := soletta
-export VERSION_MAJOR := 0
-export VERSION_MINOR := 0
-export VERSION_RELEASE := 1
+export VERSION_MAJOR := $(shell echo $$(($(SOL_CURRENT) - $(SOL_AGE))))
+export VERSION_MINOR := $(SOL_AGE)
+export VERSION_RELEASE := $(SOL_REVISION)
 export VERSION := $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_RELEASE)
 export DESTDIR ?= /
 export SYSCONF ?= /etc/


### PR DESCRIPTION
Use current:age:revision semantic to make it easier to update
the project at each release and separate Soletta Project
revision from soname.

So now we may have something like Soletta Project version 7
and soname would be 2.1.1.

@barbieri please see if that's what you were expecting

v2 for pr #2192