### PR TITLE
Build: Avoid race condition when generation OIC node types. [WIP]

### DIFF
--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -404,7 +404,7 @@ $(SOL_LIB_SO): $(SOL_SHARED_AR)
 
 # generators
 define make-oic-gen
-$(addprefix $(addprefix $(1), $(notdir $(abspath $(1)))), .json) $(addprefix $(addprefix $(1), $(notdir $(abspath $(1)))), .c) $(addprefix $(addprefix $(1), $(notdir $(abspath $(1)))), -gen.c) $(addprefix $(addprefix $(1), $(notdir $(abspath $(1)))), .h): $(FLOW_OIC_GEN_SCRIPT)
+$(addprefix $(addprefix $(1), $(notdir $(abspath $(1)))), .c): $(FLOW_OIC_GEN_SCRIPT)
 	$(Q)echo "     "GEN"   "$$@
 	$(Q)$(PYTHON) $(FLOW_OIC_GEN_SCRIPT) \
 		--quiet \


### PR DESCRIPTION
Only the C source is needed for the build target.

Signed-off-by: Guilherme Iscaro <guilherme.iscaro@intel.com>