### PR TITLE
Build: Avoid race condition when generation OIC node types. v2

### DIFF
--- a/tools/build/Makefile.rules
+++ b/tools/build/Makefile.rules
@@ -404,7 +404,7 @@ $(SOL_LIB_SO): $(SOL_SHARED_AR)
 
 # generators
 define make-oic-gen
-$(addprefix $(addprefix $(1), $(notdir $(abspath $(1)))), .json) $(addprefix $(addprefix $(1), $(notdir $(abspath $(1)))), .c) $(addprefix $(addprefix $(1), $(notdir $(abspath $(1)))), -gen.c) $(addprefix $(addprefix $(1), $(notdir $(abspath $(1)))), .h): $(FLOW_OIC_GEN_SCRIPT)
+$(addprefix $(addprefix $(1), $(notdir $(abspath $(1)))), .json): $(FLOW_OIC_GEN_SCRIPT)
 	$(Q)echo "     "GEN"   "$$@
 	$(Q)$(PYTHON) $(FLOW_OIC_GEN_SCRIPT) \
 		--quiet \
@@ -414,6 +414,8 @@ $(addprefix $(addprefix $(1), $(notdir $(abspath $(1)))), .json) $(addprefix $(a
 		--node-type-gen-h=$(addprefix sol-flow/, $(addprefix $(notdir $(abspath $(1))), .h)) \
 		$(2)
 	$(eval cleanup-files += $(addprefix $(addprefix $(1), $(notdir $(abspath $(1)))), .json) $(addprefix $(addprefix $(1), $(notdir $(abspath $(1)))), .c))
+$(addprefix $(addprefix $(1), $(notdir $(abspath $(1)))), .c): $(addprefix $(addprefix $(1), $(notdir $(abspath $(1)))), .json)
+$(addprefix $(addprefix $(1), $(notdir $(abspath $(1)))), .h): $(addprefix $(addprefix $(1), $(notdir $(abspath $(1)))), .json)
 endef
 $(foreach gen,$(sort $(oic-gens)),$(eval $(call make-oic-gen,$(gen),$(oic-gens-$(gen)))))
 


### PR DESCRIPTION
Node's header and source code should depend on the JSON file.

Signed-off-by: Guilherme Iscaro <guilherme.iscaro@intel.com>