### PR TITLE
I2C: Use lowercase chars for I2C device numbers.

### DIFF
--- a/src/lib/io/sol-i2c-impl-linux.c
+++ b/src/lib/io/sol-i2c-impl-linux.c
@@ -1060,7 +1060,7 @@ create_device_iter_cb(void *data, const char *dir_path, struct dirent *ent)
                 sol_util_strerrora(errno));
         }
 
-        r = snprintf(path, PATH_MAX, "%s/%s/%s-00%X",
+        r = snprintf(path, PATH_MAX, "%s/%s/%s-00%x",
             dir_path, ent->d_name, ent->d_name + strlen("i2c-"),
             result->dev_number);
         if (r < 0 || r >= PATH_MAX) {


### PR DESCRIPTION
Soletta should match the Linux I2C name style. This will prevent
some problems that can occur when trying to use the I2C device via IIO.

Signed-off-by: Guilherme Iscaro <guilherme.iscaro@intel.com>