### PR TITLE
WIP: LWM2M: Access Control

### DIFF
--- a/data/scripts/libsoletta.sym
+++ b/data/scripts/libsoletta.sym
@@ -517,6 +517,7 @@ global:
         sol_lwm2m_parse_tlv;
         sol_lwm2m_resource_clear;
         sol_lwm2m_resource_init;
+        sol_lwm2m_resource_init_vector;
         sol_lwm2m_server_add_observer;
         sol_lwm2m_server_add_registration_monitor;
         sol_lwm2m_server_create_object_instance;

--- a/src/lib/comms/include/sol-lwm2m.h
+++ b/src/lib/comms/include/sol-lwm2m.h
@@ -52,11 +52,9 @@ extern "C" {
  * - TLV format.
  *
  * Unsupported features for now:
- * - Bootstrap.
  * - LWM2M JSON.
  * - Queue Mode operation (only 'U' is supported for now).
  * - Data encryption.
- * - Access rights.
  *
  * @{
  */
@@ -374,6 +372,42 @@ struct sol_lwm2m_resource {
             bool b;
         } content;
     } *data;
+};
+
+/**
+ * @brief Enum that represents the Access Control Rights.
+ *
+ * Setting each bit means the LWM2M Server has the access right for that operation.
+ */
+enum sol_lwm2m_acl_rights {
+    /**
+     * No bit is set (No access rights for any operation)
+     */
+    SOL_LWM2M_ACL_NONE = (0),
+    /**
+     * 1st lsb: R (Read, Observe, Discover, Write Attributes)
+     */
+    SOL_LWM2M_ACL_READ = (1),
+    /**
+     * 2nd lsb: W (Write)
+     */
+    SOL_LWM2M_ACL_WRITE = (2),
+    /**
+     * 3rd lsb: E (Execute)
+     */
+    SOL_LWM2M_ACL_EXECUTE = (4),
+    /**
+     * 4th lsb: D (Delete)
+     */
+    SOL_LWM2M_ACL_DELETE = (8),
+    /**
+     * 5th lsb: C (Create)
+     */
+    SOL_LWM2M_ACL_CREATE = (16),
+    /**
+     * All 5 lsbs: Full Access Rights
+     */
+    SOL_LWM2M_ACL_ALL = (31)
 };
 
 /**

--- a/src/lib/comms/sol-lwm2m.c
+++ b/src/lib/comms/sol-lwm2m.c
@@ -2047,7 +2047,7 @@ observation_request_reply(void *data, struct sol_coap_server *coap_server,
             return false;
         }
         SOL_WRN("Could not complete the observation request on client:%s"
-            " path:%s", entry->path, entry->cinfo->name);
+            " path:%s", entry->cinfo->name, entry->path);
         keep_alive = false;
     } else {
         extract_content(req, &code, &type, &content);

--- a/src/lib/comms/sol-lwm2m.c
+++ b/src/lib/comms/sol-lwm2m.c
@@ -1600,11 +1600,11 @@ get_resource_len(const struct sol_lwm2m_resource *resource, uint16_t index,
     switch (resource->data_type) {
     case SOL_LWM2M_RESOURCE_DATA_TYPE_STRING:
     case SOL_LWM2M_RESOURCE_DATA_TYPE_OPAQUE:
-        *len = resource->data[index].blob->size;
+        *len = resource->data[index].content.blob->size;
         return 0;
     case SOL_LWM2M_RESOURCE_DATA_TYPE_INT:
     case SOL_LWM2M_RESOURCE_DATA_TYPE_TIME:
-        *len = get_int_size(resource->data[index].integer);
+        *len = get_int_size(resource->data[index].content.integer);
         return 0;
     case SOL_LWM2M_RESOURCE_DATA_TYPE_BOOL:
         *len = 1;
@@ -1682,16 +1682,16 @@ add_resource_bytes_to_buffer(const struct sol_lwm2m_resource *resource,
     switch (resource->data_type) {
     case SOL_LWM2M_RESOURCE_DATA_TYPE_STRING:
     case SOL_LWM2M_RESOURCE_DATA_TYPE_OPAQUE:
-        return sol_buffer_append_slice(buf, sol_str_slice_from_blob(resource->data[idx].blob));
+        return sol_buffer_append_slice(buf, sol_str_slice_from_blob(resource->data[idx].content.blob));
     case SOL_LWM2M_RESOURCE_DATA_TYPE_INT:
     case SOL_LWM2M_RESOURCE_DATA_TYPE_TIME:
     case SOL_LWM2M_RESOURCE_DATA_TYPE_OBJ_LINK:
-        return add_int_resource(buf, resource->data[idx].integer, len);
+        return add_int_resource(buf, resource->data[idx].content.integer, len);
     case SOL_LWM2M_RESOURCE_DATA_TYPE_BOOL:
-        b = resource->data[idx].integer != 0 ? 1 : 0;
+        b = resource->data[idx].content.integer != 0 ? 1 : 0;
         return sol_buffer_append_bytes(buf, (uint8_t *)&b, 1);
     case SOL_LWM2M_RESOURCE_DATA_TYPE_FLOAT:
-        return add_float_resource(buf, resource->data[idx].fp, len);
+        return add_float_resource(buf, resource->data[idx].content.fp, len);
     default:
         return -EINVAL;
     }
@@ -1791,7 +1791,7 @@ setup_tlv(struct sol_lwm2m_resource *resource, struct sol_buffer *buf)
     for (i = 0; i < resource->data_len; i++) {
         r = get_resource_len(resource, i, &data_len);
         SOL_INT_CHECK(r, < 0, r);
-        r = setup_tlv_header(SOL_LWM2M_TLV_TYPE_RESOURCE_INSTANCE, i,
+        r = setup_tlv_header(SOL_LWM2M_TLV_TYPE_RESOURCE_INSTANCE, resource->data[i].id,
             buf, data_len);
         SOL_INT_CHECK(r, < 0, r);
         r = add_resource_bytes_to_buffer(resource, buf, i);
@@ -2131,7 +2131,7 @@ sol_lwm2m_server_del_observer(struct sol_lwm2m_server *server,
 
 SOL_API int
 sol_lwm2m_resource_init(struct sol_lwm2m_resource *resource,
-    uint16_t id, uint16_t resource_len,
+    uint16_t id, enum sol_lwm2m_resource_type type, uint16_t resource_len,
     enum sol_lwm2m_resource_data_type data_type, ...)
 {
     uint16_t i;
@@ -2146,39 +2146,39 @@ sol_lwm2m_resource_init(struct sol_lwm2m_resource *resource,
     LWM2M_RESOURCE_CHECK_API(resource, -EINVAL);
 
     resource->id = id;
-    if (resource_len > 1)
-        resource->type = SOL_LWM2M_RESOURCE_TYPE_MULTIPLE;
-    else
-        resource->type = SOL_LWM2M_RESOURCE_TYPE_SINGLE;
+    resource->type = type;
     resource->data_type = data_type;
-    resource->data = calloc(resource_len, sizeof(union sol_lwm2m_resource_data));
+    resource->data = calloc(resource_len, sizeof(struct sol_lwm2m_resource_data));
     SOL_NULL_CHECK(resource->data, -ENOMEM);
     resource->data_len = resource_len;
 
     va_start(ap, data_type);
 
     for (i = 0; i < resource_len; i++) {
+        if (resource->type == SOL_LWM2M_RESOURCE_TYPE_MULTIPLE)
+            resource->data[i].id = va_arg(ap, int);
+
         switch (resource->data_type) {
         case SOL_LWM2M_RESOURCE_DATA_TYPE_OPAQUE:
         case SOL_LWM2M_RESOURCE_DATA_TYPE_STRING:
             blob = va_arg(ap, struct sol_blob *);
             SOL_NULL_CHECK_GOTO(blob, err_exit);
-            resource->data[i].blob = sol_blob_ref(blob);
-            SOL_NULL_CHECK_GOTO(resource->data[i].blob, err_ref);
+            resource->data[i].content.blob = sol_blob_ref(blob);
+            SOL_NULL_CHECK_GOTO(resource->data[i].content.blob, err_ref);
             break;
         case SOL_LWM2M_RESOURCE_DATA_TYPE_FLOAT:
-            resource->data[i].fp = va_arg(ap, double);
+            resource->data[i].content.fp = va_arg(ap, double);
             break;
         case SOL_LWM2M_RESOURCE_DATA_TYPE_INT:
         case SOL_LWM2M_RESOURCE_DATA_TYPE_TIME:
-            resource->data[i].integer = va_arg(ap, int64_t);
+            resource->data[i].content.integer = va_arg(ap, int64_t);
             break;
         case SOL_LWM2M_RESOURCE_DATA_TYPE_BOOL:
-            resource->data[i].integer = va_arg(ap, int);
+            resource->data[i].content.integer = va_arg(ap, int);
             break;
         case SOL_LWM2M_RESOURCE_DATA_TYPE_OBJ_LINK:
-            resource->data[i].integer = (uint16_t)va_arg(ap, int);
-            resource->data[i].integer = (resource->data[i].integer << 16) |
+            resource->data[i].content.integer = (uint16_t)va_arg(ap, int);
+            resource->data[i].content.integer = (resource->data[i].content.integer << 16) |
                 (uint16_t)va_arg(ap, int);
             break;
         default:
@@ -2198,10 +2198,88 @@ err_exit:
         uint16_t until = i;
 
         for (i = 0; i < until; i++)
-            sol_blob_unref(resource->data[i].blob);
+            sol_blob_unref(resource->data[i].content.blob);
     }
     free(resource->data);
     va_end(ap);
+    return r;
+}
+
+SOL_API int
+sol_lwm2m_resource_init_vector(struct sol_lwm2m_resource *resource,
+    uint16_t id, enum sol_lwm2m_resource_data_type data_type,
+    struct sol_vector *res_inst_ids, struct sol_vector *res_inst_values)
+{
+    uint16_t i;
+    int r = -EINVAL;
+    uint16_t resource_len = res_inst_ids->len;
+
+    if (!resource || data_type == SOL_LWM2M_RESOURCE_DATA_TYPE_NONE ||
+        !resource_len || sizeof(res_inst_ids->elem_size) != sizeof(uint16_t) ||
+        res_inst_ids->len != res_inst_values->len)
+        return -EINVAL;
+
+    LWM2M_RESOURCE_CHECK_API(resource, -EINVAL);
+
+    resource->id = id;
+    resource->type = SOL_LWM2M_RESOURCE_TYPE_MULTIPLE;
+    resource->data_type = data_type;
+    resource->data = calloc(resource_len, sizeof(struct sol_lwm2m_resource_data));
+    SOL_NULL_CHECK(resource->data, -ENOMEM);
+    resource->data_len = resource_len;
+
+    for (i = 0; i < resource_len; i++) {
+        void *v = sol_vector_get_no_check(res_inst_ids, i);
+        uint16_t *ui = v;
+        resource->data[i].id = *ui;
+
+        v = sol_vector_get_no_check(res_inst_values, i);
+
+        if (resource->data_type == SOL_LWM2M_RESOURCE_DATA_TYPE_OPAQUE ||
+            resource->data_type == SOL_LWM2M_RESOURCE_DATA_TYPE_STRING) {
+            struct sol_blob *blob = v;
+            SOL_NULL_CHECK_GOTO(blob, err_exit);
+            resource->data[i].content.blob = sol_blob_ref(blob);
+            SOL_NULL_CHECK_GOTO(resource->data[i].content.blob, err_ref);
+
+        } else if (resource->data_type == SOL_LWM2M_RESOURCE_DATA_TYPE_FLOAT) {
+            double *d = v;
+            resource->data[i].content.fp = *d;
+
+        } else if (resource->data_type == SOL_LWM2M_RESOURCE_DATA_TYPE_INT ||
+            resource->data_type == SOL_LWM2M_RESOURCE_DATA_TYPE_TIME) {
+            int64_t *isf = v;
+            resource->data[i].content.integer = *isf;
+
+        } else if (resource->data_type == SOL_LWM2M_RESOURCE_DATA_TYPE_BOOL) {
+            int *ic = v;
+            resource->data[i].content.integer = *ic;
+
+        } else if (resource->data_type == SOL_LWM2M_RESOURCE_DATA_TYPE_OBJ_LINK) {
+            int *ic = v;
+            resource->data[i].content.integer = (uint16_t)*ic;
+            resource->data[i].content.integer = (resource->data[i].content.integer << 16) |
+                (uint16_t)*ic;
+
+        } else {
+            SOL_WRN("Unknown resource data type");
+            goto err_exit;
+        }
+    }
+
+    return 0;
+
+err_ref:
+    r = -EOVERFLOW;
+err_exit:
+    if (data_type == SOL_LWM2M_RESOURCE_DATA_TYPE_OPAQUE ||
+        data_type == SOL_LWM2M_RESOURCE_DATA_TYPE_STRING) {
+        uint16_t until = i;
+
+        for (i = 0; i < until; i++)
+            sol_blob_unref(resource->data[i].content.blob);
+    }
+    free(resource->data);
     return r;
 }
 
@@ -2659,7 +2737,7 @@ sol_lwm2m_resource_clear(struct sol_lwm2m_resource *resource)
     if (resource->data_type == SOL_LWM2M_RESOURCE_DATA_TYPE_OPAQUE ||
         resource->data_type == SOL_LWM2M_RESOURCE_DATA_TYPE_STRING) {
         for (i = 0; i < resource->data_len; i++)
-            sol_blob_unref(resource->data[i].blob);
+            sol_blob_unref(resource->data[i].content.blob);
     }
     free(resource->data);
     resource->data = NULL;
@@ -3127,7 +3205,7 @@ write_instance_tlv_or_resource(struct sol_lwm2m_client *client,
         SOL_NULL_CHECK(blob, SOL_COAP_RESPONSE_CODE_BAD_REQUEST);
 
         SOL_SET_API_VERSION(res.api_version = SOL_LWM2M_RESOURCE_API_VERSION; )
-        r = sol_lwm2m_resource_init(&res, resource, 1,
+        r = sol_lwm2m_resource_init(&res, resource, 1, SOL_LWM2M_RESOURCE_TYPE_SINGLE,
             payload.type == SOL_LWM2M_CONTENT_TYPE_TEXT ?
             SOL_LWM2M_RESOURCE_DATA_TYPE_STRING :
             SOL_LWM2M_RESOURCE_DATA_TYPE_OPAQUE, blob);
@@ -3972,12 +4050,12 @@ get_binding_and_lifetime(struct sol_lwm2m_client *client, int64_t server_id,
             SERVER_OBJECT_BINDING);
         SOL_INT_CHECK(r, < 0, r);
 
-        if (res[0].data[0].integer == server_id) {
+        if (res[0].data[0].content.integer == server_id) {
             r = -EINVAL;
-            SOL_INT_CHECK_GOTO(get_binding_mode_from_str(sol_str_slice_from_blob(res[2].data[0].blob)),
+            SOL_INT_CHECK_GOTO(get_binding_mode_from_str(sol_str_slice_from_blob(res[2].data[0].content.blob)),
                 == SOL_LWM2M_BINDING_MODE_UNKNOWN, exit);
-            *lifetime = res[1].data[0].integer;
-            *binding = sol_blob_ref(res[2].data[0].blob);
+            *lifetime = res[1].data[0].content.integer;
+            *binding = sol_blob_ref(res[2].data[0].content.blob);
             r = 0;
             goto exit;
         }
@@ -4673,14 +4751,14 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
         SOL_INT_CHECK_GOTO(r, < 0, err_exit);
 
         //Is it a bootstap?
-        if (!res[0].data[0].b) {
+        if (!res[0].data[0].content.b) {
             sol_lwm2m_resource_clear(&res[0]);
             r = read_resources(client, ctx, instance, res, 2,
                 SECURITY_SERVER_URI, SECURITY_SERVER_ID);
             SOL_INT_CHECK_GOTO(r, < 0, err_exit);
 
-            conn_ctx = server_connection_ctx_new(client, sol_str_slice_from_blob(res[0].data[0].blob),
-                res[1].data[0].integer);
+            conn_ctx = server_connection_ctx_new(client, sol_str_slice_from_blob(res[0].data[0].content.blob),
+                res[1].data[0].content.integer);
             r = -ENOMEM;
             SOL_NULL_CHECK_GOTO(conn_ctx, err_clear_2);
             has_server = true;
@@ -4715,13 +4793,13 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
         SOL_INT_CHECK_GOTO(r, < 0, err_unregister_bs);
 
         SOL_DBG("Expecting server-initiated Bootstrap for"
-            " %" PRId64 " seconds", res[1].data[0].integer);
+            " %" PRId64 " seconds", res[1].data[0].content.integer);
 
         //Expect server-initiated bootstrap with sol_timeout before client-initiated bootstrap
-        client->bootstrap_ctx.server_uri = sol_blob_ref(res[0].data[0].blob);
+        client->bootstrap_ctx.server_uri = sol_blob_ref(res[0].data[0].content.blob);
         SOL_NULL_CHECK_GOTO(client->bootstrap_ctx.server_uri, err_unregister_unknown);
 
-        client->bootstrap_ctx.timeout = sol_timeout_add(res[1].data[0].integer * ONE_SECOND,
+        client->bootstrap_ctx.timeout = sol_timeout_add(res[1].data[0].content.integer * ONE_SECOND,
             client_bootstrap, client);
         SOL_NULL_CHECK_GOTO(client->bootstrap_ctx.timeout, err_unregister_unknown);
 

--- a/src/samples/coap/lwm2m-bs-server.c
+++ b/src/samples/coap/lwm2m-bs-server.c
@@ -160,7 +160,7 @@ write_server_one_cb(void *data,
         fprintf(stderr, "Could not init Server Object's [Lifetime] resource\n");
         return;
     }
-    SOL_LWM2M_RESOURCE_INIT(r, &server_two[2], SERVER_OBJ_BINDING_RES_ID, 1,
+    SOL_LWM2M_RESOURCE_SINGLE_INIT(r, &server_two[2], SERVER_OBJ_BINDING_RES_ID,
         SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, &binding);
     if (r < 0) {
         fprintf(stderr, "Could not init Server Object's [Binding] resource\n");
@@ -178,7 +178,7 @@ write_server_one_cb(void *data,
         fprintf(stderr, "Could not init Server Object's [Lifetime] resource\n");
         return;
     }
-    SOL_LWM2M_RESOURCE_INIT(r, &server_three[2], SERVER_OBJ_BINDING_RES_ID, 1,
+    SOL_LWM2M_RESOURCE_SINGLE_INIT(r, &server_three[2], SERVER_OBJ_BINDING_RES_ID,
         SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, &binding);
     if (r < 0) {
         fprintf(stderr, "Could not init Server Object's [Binding] resource\n");
@@ -226,7 +226,7 @@ write_sec_one_cb(void *data,
         fprintf(stderr, "Could not init Server Object's [Lifetime] resource\n");
         return;
     }
-    SOL_LWM2M_RESOURCE_INIT(r, &server_one[2], SERVER_OBJ_BINDING_RES_ID, 1,
+    SOL_LWM2M_RESOURCE_SINGLE_INIT(r, &server_one[2], SERVER_OBJ_BINDING_RES_ID,
         SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, &binding);
     if (r < 0) {
         fprintf(stderr, "Could not init Server Object's [Binding] resource\n");
@@ -263,13 +263,13 @@ delete_all_cb(void *data,
     printf("The client %s deleted the object at %s.\n", name, path);
 
     // Server One's Security Object
-    SOL_LWM2M_RESOURCE_INIT(r, &sec_server_one[0], SECURITY_SERVER_SERVER_URI_RES_ID, 1,
+    SOL_LWM2M_RESOURCE_SINGLE_INIT(r, &sec_server_one[0], SECURITY_SERVER_SERVER_URI_RES_ID,
         SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, &server_one_addr);
     if (r < 0) {
         fprintf(stderr, "Could not init Security Object's [Server URI] resource\n");
         return;
     }
-    SOL_LWM2M_RESOURCE_INIT(r, &sec_server_one[1], SECURITY_SERVER_IS_BOOTSTRAP_RES_ID, 1,
+    SOL_LWM2M_RESOURCE_SINGLE_INIT(r, &sec_server_one[1], SECURITY_SERVER_IS_BOOTSTRAP_RES_ID,
         SOL_LWM2M_RESOURCE_DATA_TYPE_BOOL, false);
     if (r < 0) {
         fprintf(stderr, "Could not init Security Object's [Bootstrap Server] resource\n");

--- a/src/samples/coap/lwm2m-client.c
+++ b/src/samples/coap/lwm2m-client.c
@@ -57,6 +57,12 @@
 #define SERVER_OBJ_BINDING_RES_ID (7)
 #define SERVER_OBJ_REGISTRATION_UPDATE_RES_ID (8)
 
+#define ACCESS_CONTROL_OBJ_ID (2)
+#define ACCESS_CONTROL_OBJ_OBJECT_RES_ID (0)
+#define ACCESS_CONTROL_OBJ_INSTANCE_RES_ID (1)
+#define ACCESS_CONTROL_OBJ_ACL_RES_ID (2)
+#define ACCESS_CONTROL_OBJ_OWNER_RES_ID (3)
+
 #define SECURITY_SERVER_OBJ_ID (0)
 #define SECURITY_SERVER_SERVER_URI_RES_ID (0)
 #define SECURITY_SERVER_IS_BOOTSTRAP_RES_ID (1)
@@ -83,6 +89,19 @@ struct server_obj_instance_ctx {
     struct sol_blob *binding;
     int64_t server_id;
     int64_t lifetime;
+};
+
+struct acl_instance {
+    uint16_t key;
+    int64_t value;
+};
+
+struct access_control_obj_instance_ctx {
+    struct sol_lwm2m_client *client;
+    int64_t owner_id;
+    int64_t object_id;
+    int64_t instance_id;
+    struct sol_vector acl;
 };
 
 struct location_obj_instance_ctx {
@@ -707,6 +726,276 @@ del_location_obj(void *instance_data, void *user_data,
     return 0;
 }
 
+static int
+read_access_control_obj(void *instance_data, void *user_data,
+    struct sol_lwm2m_client *client,
+    uint16_t instance_id, uint16_t res_id, struct sol_lwm2m_resource *res)
+{
+    struct access_control_obj_instance_ctx *ctx = instance_data;
+    int r;
+
+    if (res_id == ACCESS_CONTROL_OBJ_OBJECT_RES_ID) {
+        SOL_LWM2M_RESOURCE_INT_INIT(r, res, res_id, ctx->object_id);
+    } else if (res_id == ACCESS_CONTROL_OBJ_INSTANCE_RES_ID) {
+        SOL_LWM2M_RESOURCE_INT_INIT(r, res, res_id, ctx->instance_id);
+    } else if (res_id == ACCESS_CONTROL_OBJ_ACL_RES_ID) {
+        struct acl_instance *acl_item;
+        uint16_t i;
+        struct sol_vector server_ids, acl_values;
+        uint16_t *server_id;
+        int64_t *acl_value;
+
+        if (ctx->acl.len == 0)
+            return -ENOENT;
+
+        sol_vector_init(&server_ids, sizeof(uint16_t));
+        sol_vector_init(&acl_values, sizeof(int64_t));
+
+        SOL_VECTOR_FOREACH_IDX (&ctx->acl, acl_item, i) {
+            server_id = sol_vector_append(&server_ids);
+            *server_id = acl_item->key;
+
+            acl_value = sol_vector_append(&acl_values);
+            *acl_value = acl_item->value;
+        }
+
+        SOL_SET_API_VERSION(res->api_version = SOL_LWM2M_RESOURCE_API_VERSION; )
+        r = sol_lwm2m_resource_init_vector(res, ACCESS_CONTROL_OBJ_ACL_RES_ID,
+            SOL_LWM2M_RESOURCE_DATA_TYPE_INT, &server_ids, &acl_values);
+
+        sol_vector_clear(&server_ids);
+        sol_vector_clear(&acl_values);
+    } else if (res_id == ACCESS_CONTROL_OBJ_OWNER_RES_ID) {
+        SOL_LWM2M_RESOURCE_INT_INIT(r, res, res_id, ctx->owner_id);
+    } else {
+        r = -EINVAL;
+    }
+
+    return r;
+}
+
+static int
+write_access_control_res(void *instance_data, void *user_data,
+    struct sol_lwm2m_client *client,
+    uint16_t instance_id, uint16_t res_id, const struct sol_lwm2m_resource *res)
+{
+    struct access_control_obj_instance_ctx *instance_ctx = instance_data;
+    int r = 0;
+    struct acl_instance *acl_item;
+    uint16_t i;
+
+    switch (res->id) {
+    case ACCESS_CONTROL_OBJ_OBJECT_RES_ID:
+        instance_ctx->object_id = res->data->content.integer;
+        break;
+    case ACCESS_CONTROL_OBJ_INSTANCE_RES_ID:
+        instance_ctx->instance_id = res->data->content.integer;
+        break;
+    case ACCESS_CONTROL_OBJ_ACL_RES_ID:
+        if (res->type == SOL_LWM2M_RESOURCE_TYPE_MULTIPLE) {
+            sol_vector_clear(&instance_ctx->acl);
+
+            for (i = 0; i < res->data_len; i++) {
+                acl_item = sol_vector_append(&instance_ctx->acl);
+                if (!acl_item) {
+                    fprintf(stderr, "Could not alloc memory for access control list Resource Instance\n");
+                    r = -ENOMEM;
+                    goto err_free_acl;
+                }
+
+                acl_item->key = res->data[i].id;
+                acl_item->value = res->data[i].content.integer;
+                fprintf(stderr, "<<[WRITE_RES]<< acl[%" PRIu16 "]=%" PRId64 ">>>>\n", acl_item->key, acl_item->value);
+            }
+        } else {
+            r = -EINVAL;
+        }
+        break;
+    case ACCESS_CONTROL_OBJ_OWNER_RES_ID:
+        instance_ctx->owner_id = res->data->content.integer;
+        break;
+    default:
+        r = -EINVAL;
+    }
+
+    if (r >= 0)
+        printf("Resource written to Access Control object at /2/%" PRIu16 "/%" PRIu16 "\n",
+            instance_id, res->id);
+
+    return r;
+
+err_free_acl:
+    sol_vector_clear(&instance_ctx->acl);
+    return r;
+}
+
+static int
+write_access_control_tlv(void *instance_data, void *user_data,
+    struct sol_lwm2m_client *client,
+    uint16_t instance_id, struct sol_vector *tlvs)
+{
+    int r;
+    uint16_t i;
+    struct sol_lwm2m_tlv *tlv;
+    struct access_control_obj_instance_ctx *instance_ctx = instance_data;
+    struct acl_instance *acl_item;
+
+    SOL_VECTOR_FOREACH_IDX (tlvs, tlv, i) {
+        if (tlv->id == ACCESS_CONTROL_OBJ_OBJECT_RES_ID &&
+            tlv->type == SOL_LWM2M_TLV_TYPE_RESOURCE_WITH_VALUE) {
+            r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->object_id);
+            if (r < 0)
+                return r;
+        } else if (tlv->id == ACCESS_CONTROL_OBJ_INSTANCE_RES_ID &&
+            tlv->type == SOL_LWM2M_TLV_TYPE_RESOURCE_WITH_VALUE) {
+            r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->instance_id);
+            if (r < 0)
+                return r;
+        } else if (tlv->id == ACCESS_CONTROL_OBJ_ACL_RES_ID &&
+            tlv->type == SOL_LWM2M_TLV_TYPE_MULTIPLE_RESOURCES) {
+                uint16_t j = i + 1;
+                struct sol_lwm2m_tlv *res_tlv;
+                int64_t res_val;
+
+                sol_vector_clear(&instance_ctx->acl);
+
+                while ((res_tlv = sol_vector_get(tlvs, j)) &&
+                    res_tlv->type == SOL_LWM2M_TLV_TYPE_RESOURCE_INSTANCE) {
+                    r = sol_lwm2m_tlv_get_int(res_tlv, &res_val);
+                    if (r < 0)
+                        goto err_free_acl;
+
+                    acl_item = sol_vector_append(&instance_ctx->acl);
+                    if (!acl_item) {
+                        fprintf(stderr, "Could not alloc memory for access control list Resource Instance\n");
+                        r = -ENOMEM;
+                        goto err_free_acl;
+                    }
+
+                    acl_item->key = res_tlv->id;
+                    acl_item->value = res_val;
+                    fprintf(stderr, "<<[WRITE_TLV]<< acl[%" PRIu16 "]=%" PRId64 ">>>>\n", acl_item->key, acl_item->value);
+                    j++;
+                }
+                i = j - 1;
+        } else if (tlv->id == ACCESS_CONTROL_OBJ_OWNER_RES_ID &&
+            tlv->type == SOL_LWM2M_TLV_TYPE_RESOURCE_WITH_VALUE) {
+            r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->owner_id);
+            if (r < 0)
+                return r;
+        } else {
+            fprintf(stderr, "tlv type: %u, ID: %" PRIu16 ", Size: %zu, Content: %.*s"
+                " could not be written to Access Control Object at /2/%" PRIu16,
+                tlv->type, tlv->id, tlv->content.used,
+                SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&tlv->content)), instance_id);
+            return -EINVAL;
+        }
+    }
+
+    if (tlvs->len == 1 && r >= 0)
+        printf("TLV written to Access Control object at /2/%" PRIu16 "/%" PRIu16 "\n",
+            instance_id, tlv->id);
+    else
+        printf("TLV written to Access Control object at /2/%" PRIu16 "\n", instance_id);
+
+    return r;
+
+err_free_acl:
+    sol_vector_clear(&instance_ctx->acl);
+    return r;
+}
+
+static int
+create_access_control_obj(void *user_data, struct sol_lwm2m_client *client,
+    uint16_t instance_id, void **instance_data,
+    struct sol_lwm2m_payload payload)
+{
+    struct access_control_obj_instance_ctx *instance_ctx;
+    int r;
+    uint16_t i;
+    struct sol_lwm2m_tlv *tlv;
+    struct acl_instance *acl_item;
+
+    if (payload.type != SOL_LWM2M_CONTENT_TYPE_TLV) {
+        fprintf(stderr, "Content type is not in TLV format\n");
+        return -EINVAL;
+    }
+
+    instance_ctx = calloc(1, sizeof(struct access_control_obj_instance_ctx));
+    if (!instance_ctx) {
+        fprintf(stderr, "Could not alloc memory for access control object context\n");
+        return -ENOMEM;
+    }
+
+    sol_vector_init(&instance_ctx->acl, sizeof(struct acl_instance));
+
+    SOL_VECTOR_FOREACH_IDX (&payload.payload.tlv_content, tlv, i) {
+        if (tlv->id == ACCESS_CONTROL_OBJ_OBJECT_RES_ID &&
+            tlv->type == SOL_LWM2M_TLV_TYPE_RESOURCE_WITH_VALUE) {
+            r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->object_id);
+        } else if (tlv->id == ACCESS_CONTROL_OBJ_INSTANCE_RES_ID &&
+            tlv->type == SOL_LWM2M_TLV_TYPE_RESOURCE_WITH_VALUE) {
+            r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->instance_id);
+        } else if (tlv->id == ACCESS_CONTROL_OBJ_ACL_RES_ID &&
+            tlv->type == SOL_LWM2M_TLV_TYPE_MULTIPLE_RESOURCES) {
+                uint16_t j = i + 1;
+                struct sol_lwm2m_tlv *res_tlv;
+                int64_t res_val;
+
+                while ((res_tlv = sol_vector_get(&payload.payload.tlv_content, j)) &&
+                    res_tlv->type == SOL_LWM2M_TLV_TYPE_RESOURCE_INSTANCE) {
+                    r = sol_lwm2m_tlv_get_int(res_tlv, &res_val);
+                    if (r < 0)
+                        goto err_free_acl;
+
+                    acl_item = sol_vector_append(&instance_ctx->acl);
+                    if (!acl_item) {
+                        fprintf(stderr, "Could not alloc memory for access control list Resource Instance\n");
+                        r = -ENOMEM;
+                        goto err_free_acl;
+                    }
+
+                    acl_item->key = res_tlv->id;
+                    acl_item->value = res_val;
+                    fprintf(stderr, "<<[CREATE]<< acl[%" PRIu16 "]=%" PRId64 ">>>>\n", acl_item->key, acl_item->value);
+                    j++;
+                }
+                i = j - 1;
+        } else if (tlv->id == ACCESS_CONTROL_OBJ_OWNER_RES_ID &&
+            tlv->type == SOL_LWM2M_TLV_TYPE_RESOURCE_WITH_VALUE) {
+            r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->owner_id);
+        }
+
+        if (r < 0) {
+            fprintf(stderr, "Could not get the tlv value for resource %"
+                PRIu16 "\n", tlv->id);
+            goto err_free_acl;
+        }
+    }
+
+    instance_ctx->client = client;
+    *instance_data = instance_ctx;
+    printf("Access Control object created at /2/%" PRIu16 "\n\n", instance_id);
+
+    return 0;
+
+err_free_acl:
+    sol_vector_clear(&instance_ctx->acl);
+    free(instance_ctx);
+    return r;
+}
+
+static int
+del_access_control_obj(void *instance_data, void *user_data,
+    struct sol_lwm2m_client *client, uint16_t instance_id)
+{
+    struct access_control_obj_instance_ctx *instance_ctx = instance_data;
+
+    sol_vector_clear(&instance_ctx->acl);
+    free(instance_ctx);
+    return 0;
+}
+
 static void
 bootstrap_cb(void *data,
     struct sol_lwm2m_client *client,
@@ -753,12 +1042,23 @@ static const struct sol_lwm2m_object server_object = {
     .execute = execute_server_obj
 };
 
+static const struct sol_lwm2m_object access_control_object = {
+    SOL_SET_API_VERSION(.api_version = SOL_LWM2M_OBJECT_API_VERSION, )
+    .id = ACCESS_CONTROL_OBJ_ID,
+    .resources_count = 4,
+    .read = read_access_control_obj,
+    .create = create_access_control_obj,
+    .del = del_access_control_obj,
+    .write_resource = write_access_control_res,
+    .write_tlv = write_access_control_tlv,
+};
+
 int
 main(int argc, char *argv[])
 {
     struct sol_lwm2m_client *client;
     static const struct sol_lwm2m_object *objects[] =
-    { &security_object, &server_object, &location_object, NULL };
+    { &security_object, &server_object, &access_control_object, &location_object, NULL };
     struct client_data_ctx data_ctx = { 0 };
     struct security_obj_instance_ctx *security_data;
     struct server_obj_instance_ctx *server_data;

--- a/src/samples/coap/lwm2m-client.c
+++ b/src/samples/coap/lwm2m-client.c
@@ -267,18 +267,18 @@ read_location_obj(void *instance_data, void *user_data,
     switch (res_id) {
     case LOCATION_OBJ_LATITUDE_RES_ID:
         blob = coord_to_str(ctx->latitude);
-        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
+        SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, res_id,
             SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, blob);
         sol_blob_unref(blob);
         break;
     case LOCATION_OBJ_LONGITUDE_RES_ID:
         blob = coord_to_str(ctx->longitude);
-        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
+        SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, res_id,
             SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, blob);
         sol_blob_unref(blob);
         break;
     case LOCATION_OBJ_TIMESTAMP_RES_ID:
-        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
+        SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, res_id,
             SOL_LWM2M_RESOURCE_DATA_TYPE_TIME, ctx->timestamp);
         break;
     default:
@@ -303,11 +303,11 @@ read_security_obj(void *instance_data, void *user_data,
     // or bootstrap server without encryption.
     switch (res_id) {
     case SECURITY_SERVER_SERVER_URI_RES_ID:
-        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
+        SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, res_id,
             SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, ctx->server_uri);
         break;
     case SECURITY_SERVER_IS_BOOTSTRAP_RES_ID:
-        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
+        SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, res_id,
             SOL_LWM2M_RESOURCE_DATA_TYPE_BOOL, ctx->is_bootstrap);
         break;
     case SECURITY_SERVER_SERVER_ID_RES_ID:
@@ -340,19 +340,19 @@ write_security_res(void *instance_data, void *user_data,
     switch (res->id) {
     case SECURITY_SERVER_SERVER_URI_RES_ID:
         sol_blob_unref(instance_ctx->server_uri);
-        instance_ctx->server_uri = sol_blob_ref(res->data->blob);
+        instance_ctx->server_uri = sol_blob_ref(res->data->content.blob);
         break;
     case SECURITY_SERVER_IS_BOOTSTRAP_RES_ID:
-        instance_ctx->is_bootstrap = res->data->b;
+        instance_ctx->is_bootstrap = res->data->content.b;
         break;
     case SECURITY_SERVER_SERVER_ID_RES_ID:
-        instance_ctx->server_id = res->data->integer;
+        instance_ctx->server_id = res->data->content.integer;
         break;
     case SECURITY_SERVER_CLIENT_HOLD_OFF_TIME_RES_ID:
-        instance_ctx->client_hold_off_time = res->data->integer;
+        instance_ctx->client_hold_off_time = res->data->content.integer;
         break;
     case SECURITY_SERVER_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT_RES_ID:
-        instance_ctx->bootstrap_server_account_timeout = res->data->integer;
+        instance_ctx->bootstrap_server_account_timeout = res->data->content.integer;
         break;
     default:
         if (res->id >= 2 && res->id <= 9)
@@ -518,7 +518,7 @@ read_server_obj(void *instance_data, void *user_data,
         SOL_LWM2M_RESOURCE_INT_INIT(r, res, res_id, ctx->lifetime);
         break;
     case SERVER_OBJ_BINDING_RES_ID:
-        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
+        SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, res_id,
             SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, ctx->binding);
         break;
     default:
@@ -541,14 +541,14 @@ write_server_res(void *instance_data, void *user_data,
 
     switch (res->id) {
     case SERVER_OBJ_SHORT_RES_ID:
-        instance_ctx->server_id = res->data->integer;
+        instance_ctx->server_id = res->data->content.integer;
         break;
     case SERVER_OBJ_LIFETIME_RES_ID:
-        instance_ctx->lifetime = res->data->integer;
+        instance_ctx->lifetime = res->data->content.integer;
         break;
     case SERVER_OBJ_BINDING_RES_ID:
         sol_blob_unref(instance_ctx->binding);
-        instance_ctx->binding = sol_blob_ref(res->data->blob);
+        instance_ctx->binding = sol_blob_ref(res->data->content.blob);
         break;
     default:
         if (res->id >= 2 && res->id <= 6)

--- a/src/samples/coap/lwm2m-server.c
+++ b/src/samples/coap/lwm2m-server.c
@@ -199,7 +199,7 @@ create_location_obj(struct sol_lwm2m_server *server,
        It sets only the mandatory fields.
        The coordinates are the position of the Eiffel tower.
      */
-    SOL_LWM2M_RESOURCE_INIT(r, &res[0], LATITUDE_ID, 1,
+    SOL_LWM2M_RESOURCE_SINGLE_INIT(r, &res[0], LATITUDE_ID,
         SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, &lat);
 
     if (r < 0) {
@@ -207,7 +207,7 @@ create_location_obj(struct sol_lwm2m_server *server,
         return;
     }
 
-    SOL_LWM2M_RESOURCE_INIT(r, &res[1], LONGITUDE_ID, 1,
+    SOL_LWM2M_RESOURCE_SINGLE_INIT(r, &res[1], LONGITUDE_ID,
         SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, &longi);
 
     if (r < 0) {
@@ -215,7 +215,7 @@ create_location_obj(struct sol_lwm2m_server *server,
         return;
     }
 
-    SOL_LWM2M_RESOURCE_INIT(r, &res[2], TIMESTAMP_ID, 1,
+    SOL_LWM2M_RESOURCE_SINGLE_INIT(r, &res[2], TIMESTAMP_ID,
         SOL_LWM2M_RESOURCE_DATA_TYPE_TIME,
         (int64_t)time(NULL));
 

--- a/src/test/test-lwm2m.c
+++ b/src/test/test-lwm2m.c
@@ -102,11 +102,11 @@ security_object_read(void *instance_data, void *user_data,
 
     switch (res_id) {
     case SECURITY_SERVER_URI:
-        SOL_LWM2M_RESOURCE_INIT(r, res, 0, 1,
+        SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, 0,
             SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, &addr);
         break;
     case SECURITY_SERVER_IS_BOOTSTRAP:
-        SOL_LWM2M_RESOURCE_INIT(r, res, 1, 1,
+        SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, 1,
             SOL_LWM2M_RESOURCE_DATA_TYPE_BOOL, false);
         break;
     case SECURITY_SERVER_ID:
@@ -134,7 +134,7 @@ server_object_read(void *instance_data, void *user_data,
         SOL_LWM2M_RESOURCE_INT_INIT(r, res, 1, LIFETIME);
         break;
     case SERVER_OBJECT_BINDING:
-        SOL_LWM2M_RESOURCE_INIT(r, res, 7, 1,
+        SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, 7,
             SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, &binding);
         break;
     default:
@@ -296,14 +296,14 @@ read_dummy_resource(void *instance_data, void *user_data,
     case DUMMY_OBJECT_STRING_ID:
         blob = sol_blob_new(&SOL_BLOB_TYPE_NO_FREE_DATA, NULL,
             ctx->str1, strlen(ctx->str1));
-        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
+        SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, res_id,
             SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, blob);
         sol_blob_unref(blob);
         break;
     case DUMMY_OBJECT_OPAQUE_ID:
         blob = sol_blob_new(&SOL_BLOB_TYPE_NO_FREE_DATA, NULL,
             ctx->opaque, strlen(ctx->opaque));
-        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
+        SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, res_id,
             SOL_LWM2M_RESOURCE_DATA_TYPE_OPAQUE, blob);
         sol_blob_unref(blob);
         break;
@@ -311,24 +311,24 @@ read_dummy_resource(void *instance_data, void *user_data,
         SOL_LWM2M_RESOURCE_INT_INIT(r, res, res_id, ctx->i);
         break;
     case DUMMY_OBJECT_BOOLEAN_FALSE_ID:
-        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
+        SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, res_id,
             SOL_LWM2M_RESOURCE_DATA_TYPE_BOOL, ctx->f);
         break;
     case DUMMY_OBJECT_BOOLEAN_TRUE_ID:
-        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
+        SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, res_id,
             SOL_LWM2M_RESOURCE_DATA_TYPE_BOOL, ctx->t);
         break;
     case DUMMY_OBJECT_FLOAT_ID:
-        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
+        SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, res_id,
             SOL_LWM2M_RESOURCE_DATA_TYPE_FLOAT, ctx->fp);
         break;
     case DUMMY_OBJECT_OBJ_LINK_ID:
-        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 1,
+        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, SOL_LWM2M_RESOURCE_TYPE_SINGLE, 1,
             SOL_LWM2M_RESOURCE_DATA_TYPE_OBJ_LINK, ctx->obj, ctx->instance);
         break;
     case DUMMY_OBJECT_ARRAY_ID:
-        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, 2,
-            SOL_LWM2M_RESOURCE_DATA_TYPE_INT, ctx->array[0], ctx->array[1]);
+        SOL_LWM2M_RESOURCE_INIT(r, res, res_id, SOL_LWM2M_RESOURCE_TYPE_MULTIPLE, 2,
+            SOL_LWM2M_RESOURCE_DATA_TYPE_INT, 0, ctx->array[0], 1, ctx->array[1]);
         break;
     default:
         r = -EINVAL;
@@ -512,33 +512,35 @@ create_obj(struct sol_lwm2m_server *server, struct sol_lwm2m_client_info *cinfo)
     blob = sol_blob_new(&SOL_BLOB_TYPE_NO_FREE_DATA, NULL,
         STR, strlen(STR));
 
-    SOL_LWM2M_RESOURCE_INIT(r, &res[0], DUMMY_OBJECT_STRING_ID, 1,
+    SOL_LWM2M_RESOURCE_SINGLE_INIT(r, &res[0], DUMMY_OBJECT_STRING_ID,
         SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, blob);
     sol_blob_unref(blob);
     ASSERT(r == 0);
 
     blob = sol_blob_new(&SOL_BLOB_TYPE_NO_FREE_DATA, NULL,
         OPAQUE_STR, strlen(OPAQUE_STR));
-    SOL_LWM2M_RESOURCE_INIT(r, &res[1], DUMMY_OBJECT_OPAQUE_ID, 1,
+    SOL_LWM2M_RESOURCE_SINGLE_INIT(r, &res[1], DUMMY_OBJECT_OPAQUE_ID,
         SOL_LWM2M_RESOURCE_DATA_TYPE_OPAQUE, blob);
     sol_blob_unref(blob);
     ASSERT(r == 0);
     SOL_LWM2M_RESOURCE_INT_INIT(r, &res[2], DUMMY_OBJECT_INT_ID, INT_VALUE);
     ASSERT(r == 0);
-    SOL_LWM2M_RESOURCE_INIT(r, &res[3], DUMMY_OBJECT_BOOLEAN_FALSE_ID, 1,
+    SOL_LWM2M_RESOURCE_SINGLE_INIT(r, &res[3], DUMMY_OBJECT_BOOLEAN_FALSE_ID,
         SOL_LWM2M_RESOURCE_DATA_TYPE_BOOL, false);
     ASSERT(r == 0);
-    SOL_LWM2M_RESOURCE_INIT(r, &res[4], DUMMY_OBJECT_BOOLEAN_TRUE_ID, 1,
+    SOL_LWM2M_RESOURCE_SINGLE_INIT(r, &res[4], DUMMY_OBJECT_BOOLEAN_TRUE_ID,
         SOL_LWM2M_RESOURCE_DATA_TYPE_BOOL, true);
     ASSERT(r == 0);
-    SOL_LWM2M_RESOURCE_INIT(r, &res[5], DUMMY_OBJECT_FLOAT_ID, 1,
+    SOL_LWM2M_RESOURCE_SINGLE_INIT(r, &res[5], DUMMY_OBJECT_FLOAT_ID,
         SOL_LWM2M_RESOURCE_DATA_TYPE_FLOAT, FLOAT_VALUE);
     ASSERT(r == 0);
-    SOL_LWM2M_RESOURCE_INIT(r, &res[6], DUMMY_OBJECT_OBJ_LINK_ID, 1,
+    SOL_LWM2M_RESOURCE_INIT(r, &res[6], DUMMY_OBJECT_OBJ_LINK_ID,
+        SOL_LWM2M_RESOURCE_TYPE_SINGLE, 1,
         SOL_LWM2M_RESOURCE_DATA_TYPE_OBJ_LINK, OBJ_VALUE, INSTANCE_VALUE);
     ASSERT(r == 0);
-    SOL_LWM2M_RESOURCE_INIT(r, &res[7], DUMMY_OBJECT_ARRAY_ID, 2,
-        SOL_LWM2M_RESOURCE_DATA_TYPE_INT, ARRAY_VALUE_ONE, ARRAY_VALUE_TWO);
+    SOL_LWM2M_RESOURCE_INIT(r, &res[7], DUMMY_OBJECT_ARRAY_ID,
+        SOL_LWM2M_RESOURCE_TYPE_MULTIPLE, 2,
+        SOL_LWM2M_RESOURCE_DATA_TYPE_INT, 0, ARRAY_VALUE_ONE, 1, ARRAY_VALUE_TWO);
     ASSERT(r == 0);
     r = sol_lwm2m_server_create_object_instance(server, cinfo, "/999", res,
         sol_util_array_size(res), create_cb, NULL);


### PR DESCRIPTION
This patch introduces:
- Access Control Object Management
 - Instantiation
   - Bootstrap case
    - 'Create' Operation case
 - Update
   - Write (modifying access rights)
    - Delete (removing associated Access Control Object)
- Authorization
 - `is_authorized()` is called everytime a 'C'reate, 'R'ead, 'W'rite, 'D'elete, or 'E'xecute operation takes place, to check for the required access right
 - Full Support: Create; Read; Write; Delete; Execute operations
 - Partial Support: Observe and Notify operations (both use the 'R'ead bit)

Also the `sol_lwm2m_resource` API had to be improved to add support to:
- Resource Instance IDs
- Init of a Resource of type `SOL_LWM2M_RESOURCE_TYPE_MULTIPLE` with a single Resource Instance
- A way to init a Resource when we don't know beforehand the amount of Resource Instances desired: `sol_lwm2m_resource_init_vector()`.

TODO:
- [x] Fixing a SEGFAULT when adding the code to delete the connection with the Bootstrap Server after Bootstrap Finish is received (https://github.com/bsmelo/soletta/commit/1bf776c964dbb936c924dbaf867a04a35c4900e9#diff-e4058dc14a343a8aceb7210b323358a2R4816)
- [ ] Figuring out how to deal with Notify operation triggered by the client API (https://github.com/bsmelo/soletta/commit/f94f22ca0f59f25f048ba38ee77669b84fee3a83#diff-e4058dc14a343a8aceb7210b323358a2R5495)
- [ ] Observe operation may be related to the issue above, and may require a fix in `sol-coap`.