### PR TITLE
all: add typedefs for public facing structs

### DIFF
--- a/src/lib/common/include/sol-certificate.h
+++ b/src/lib/common/include/sol-certificate.h
@@ -45,6 +45,7 @@ extern "C" {
  * This object is the abstraction of certificate.
  */
 struct sol_cert;
+typedef struct sol_cert sol_cert;
 
 /**
  * @brief Load a certificate from an id

--- a/src/lib/common/include/sol-file-reader.h
+++ b/src/lib/common/include/sol-file-reader.h
@@ -35,6 +35,7 @@ extern "C" {
  * @brief Opaque handler for a file reader.
  */
 struct sol_file_reader;
+typedef struct sol_file_reader sol_file_reader;
 
 /**
  * @brief Open a file using its filename.

--- a/src/lib/common/include/sol-log.h
+++ b/src/lib/common/include/sol-log.h
@@ -416,6 +416,7 @@ struct sol_log_domain {
     const char *name; /**< @brief Domain name */
     uint8_t level; /**< @brief Maximum level to log for this domain */
 };
+typedef struct sol_log_domain sol_log_domain;
 
 /**
  * @brief Global logging domain.

--- a/src/lib/common/include/sol-mainloop.h
+++ b/src/lib/common/include/sol-mainloop.h
@@ -348,6 +348,7 @@ void sol_shutdown(void);
  * @brief Handle for timers tracking the timeouts.
  */
 struct sol_timeout;
+typedef struct sol_timeout sol_timeout;
 
 /**
  * @brief Adds a function to be called periodically by the main loop.
@@ -388,6 +389,7 @@ bool sol_timeout_del(struct sol_timeout *handle);
  * This structure is used to help setup and control Idlers.
  */
 struct sol_idle;
+typedef struct sol_idle sol_idle;
 
 /**
  * @brief Adds a function to be called when the application goes idle.
@@ -481,6 +483,7 @@ enum sol_fd_flags {
  * @brief A handle to a fd watcher
  */
 struct sol_fd;
+typedef struct sol_fd sol_fd;
 
 /**
  * @brief Adds a function to be called when the requested events are triggered by the
@@ -581,6 +584,7 @@ uint32_t sol_fd_get_flags(const struct sol_fd *handle);
  * This structure is used to setup and control children process.
  */
 struct sol_child_watch;
+typedef struct sol_child_watch sol_child_watch;
 
 /**
  * @brief Watch for a child process' termination.
@@ -749,12 +753,14 @@ struct sol_mainloop_source_type {
      */
     void (*dispose)(void *data);
 };
+typedef struct sol_mainloop_source_type sol_mainloop_source_type;
 
 /**
  * @struct sol_mainloop_source
  * @brief Structure of a Source of mainloop events.
  */
 struct sol_mainloop_source;
+typedef struct sol_mainloop_source sol_mainloop_source;
 
 /**
  * @brief Create a new source of events to the main loop.
@@ -1143,6 +1149,7 @@ struct sol_mainloop_implementation {
      */
     void *(*source_get_data)(const void *handle);
 };
+typedef struct sol_mainloop_implementation sol_mainloop_implementation;
 
 /**
  * Pointer to Soletta's internal mainloop implementation, that is the
@@ -1246,6 +1253,7 @@ struct sol_main_callbacks {
     void (*startup)(void); /**< @brief Application @c startup function */
     void (*shutdown)(void); /**< @brief Application @c shutdown function */
 };
+typedef struct sol_main_callbacks sol_main_callbacks;
 
 /**
  * @brief Helper function called by @ref SOL_MAIN. Shouldn't be called directly.

--- a/src/lib/common/include/sol-pin-mux-modules.h
+++ b/src/lib/common/include/sol-pin-mux-modules.h
@@ -134,6 +134,7 @@ struct sol_pin_mux {
     int (*pwm)(int device, int channel);
 
 };
+typedef struct sol_pin_mux sol_pin_mux;
 
 /**
  * @def SOL_PIN_MUX_DECLARE(_NAME, decl ...)

--- a/src/lib/common/include/sol-platform-linux-micro.h
+++ b/src/lib/common/include/sol-platform-linux-micro.h
@@ -105,6 +105,7 @@ struct sol_platform_linux_micro_module {
      */
     int (*stop_monitor)(const struct sol_platform_linux_micro_module *module, const char *service);
 };
+typedef struct sol_platform_linux_micro_module sol_platform_linux_micro_module;
 
 /**
  * @brief Inform the service observers the current state of the @c service

--- a/src/lib/common/include/sol-platform-linux.h
+++ b/src/lib/common/include/sol-platform-linux.h
@@ -178,6 +178,7 @@ struct sol_uevent {
     struct sol_str_slice devtype; /**< The device type */
     struct sol_str_slice devname; /**< The device name */
 };
+typedef struct sol_uevent sol_uevent;
 
 /**
  * @brief Subscribe to monitor linux's uevent events

--- a/src/lib/common/include/sol-reentrant.h
+++ b/src/lib/common/include/sol-reentrant.h
@@ -52,6 +52,7 @@ struct sol_reentrant {
      */
     bool delete_me;
 };
+typedef struct sol_reentrant sol_reentrant;
 
 /**
  * @brief Wraps a function call to an external callback

--- a/src/lib/common/include/sol-types.h
+++ b/src/lib/common/include/sol-types.h
@@ -129,6 +129,7 @@ struct sol_direction_vector {
     double min; /**< @brief Minimum value of a coordinate for all axis */
     double max; /**< @brief Maximum value of a coordinate for all axis */
 };
+typedef struct sol_direction_vector sol_direction_vector;
 
 /**
  * @brief Checks the ranges of @c var0 and @c var1 for equality.
@@ -148,6 +149,7 @@ struct sol_location {
     double lon; /**< @brief Longitude */
     double alt; /**< @brief Altitude */
 };
+typedef struct sol_location sol_location;
 
 /**
  * @brief Data type to describe a RGB color.
@@ -160,6 +162,7 @@ struct sol_rgb {
     uint32_t green_max; /**< @brief Green component maximum value */
     uint32_t blue_max; /**< @brief Blue component maximum value */
 };
+typedef struct sol_rgb sol_rgb;
 
 /**
  * @brief Checks the ranges of @c var0 and @c var1 for equality.
@@ -190,6 +193,7 @@ struct sol_drange {
     double max; /**< @brief Range maximum value */
     double step; /**< @brief Range step */
 };
+typedef struct sol_drange sol_drange;
 
 /**
  * @brief Data type describing a spec for Double ranges.
@@ -201,6 +205,7 @@ struct sol_drange_spec {
     double max; /**< @brief Range maximum value */
     double step; /**< @brief Range step */
 };
+typedef struct sol_drange_spec sol_drange_spec;
 
 /**
  * @brief Helper macro to initialize a double range with default values.
@@ -330,6 +335,7 @@ struct sol_irange {
     int32_t max; /**< @brief Range maximum value */
     int32_t step; /**< @brief Range step */
 };
+typedef struct sol_irange sol_irange;
 
 /**
  * @brief Data type describing a spec for Integer ranges.
@@ -341,6 +347,7 @@ struct sol_irange_spec {
     int32_t max; /**< @brief Range maximum value */
     int32_t step; /**< @brief Range step */
 };
+typedef struct sol_irange_spec sol_irange_spec;
 
 /**
  * @brief Helper macro to initialize an integer range with default values.
@@ -461,6 +468,7 @@ bool sol_irange_eq(const struct sol_irange *var0, const struct sol_irange *var1)
 int sol_irange_compose(const struct sol_irange_spec *spec, int32_t value, struct sol_irange *result);
 
 struct sol_blob_type;
+typedef struct sol_blob_type sol_blob_type;
 
 /**
  * @brief Data type describing the default blob implementation.
@@ -472,6 +480,7 @@ struct sol_blob {
     size_t size; /**< @brief Blob size */
     uint16_t refcnt; /**< @brief Blob reference counter */
 };
+typedef struct sol_blob sol_blob;
 
 /**
  * @brief Data type describing a blob type.
@@ -487,6 +496,7 @@ struct sol_blob_type {
 #endif
     void (*free)(struct sol_blob *blob); /**< @brief Callback to free an instance */
 };
+typedef struct sol_blob_type sol_blob_type;
 
 /**
  * @brief Blob type object for the default implementation.
@@ -630,6 +640,7 @@ struct sol_key_value {
     const char *key; /**< @brief Pair's key */
     const char *value; /**< @brief Pair's value */
 };
+typedef struct sol_key_value sol_key_value;
 
 /**
  * @}

--- a/src/lib/common/include/sol-update-modules.h
+++ b/src/lib/common/include/sol-update-modules.h
@@ -107,6 +107,7 @@ struct sol_update {
      */
     void (*shutdown)(void);
 };
+typedef struct sol_update sol_update;
 
 /**
  * @def SOL_UPDATE_DECLARE(_NAME, decl ...)

--- a/src/lib/common/include/sol-update.h
+++ b/src/lib/common/include/sol-update.h
@@ -60,6 +60,7 @@ extern "C" {
  * appropriately.
  */
 struct sol_update_handle;
+typedef struct sol_update_handle sol_update_handle;
 
 /**
  * @brief Contains update info got via @c sol_update_check call.
@@ -75,6 +76,7 @@ struct sol_update_info {
     uint64_t size; /**< @brief Size of update file. Useful to warn user about big downloads. */
     bool need_update; /**< @brief If version of update is newer than current, so the update is necessary. */
 };
+typedef struct sol_update_info sol_update_info;
 
 /**
  * @brief Check if there's an update to get.

--- a/src/lib/common/include/sol-worker-thread.h
+++ b/src/lib/common/include/sol-worker-thread.h
@@ -46,6 +46,7 @@ extern "C" {
  */
 // TODO abstract locks? see eina_lock.h
 struct sol_worker_thread;
+typedef struct sol_worker_thread sol_worker_thread;
 
 /**
  * @struct sol_worker_thread_config
@@ -107,6 +108,7 @@ struct sol_worker_thread_config {
      */
     void (*feedback)(void *data);
 };
+typedef struct sol_worker_thread_config sol_worker_thread_config;
 
 /**
  * Create and run a worker thread.

--- a/src/lib/common/sol-bus.h
+++ b/src/lib/common/sol-bus.h
@@ -108,6 +108,7 @@ struct sol_bus_interfaces {
  * Represents an remote service on a bus.
  */
 struct sol_bus_client;
+typedef struct sol_bus_client sol_bus_client;
 
 /**
  * Opens and returns an connection to the system bus.

--- a/src/lib/comms/include/sol-bluetooth.h
+++ b/src/lib/comms/include/sol-bluetooth.h
@@ -82,6 +82,7 @@ struct sol_bt_uuid {
         uint8_t val[0];
     };
 };
+typedef struct sol_bt_uuid sol_bt_uuid;
 
 /**
  * @brief Convert a string to a UUID.
@@ -124,6 +125,7 @@ bool sol_bt_uuid_eq(const struct sol_bt_uuid *u1, const struct sol_bt_uuid *u2);
  * managed by sol_bt_conn_ref()/sol_bt_conn_unref().
  */
 struct sol_bt_conn;
+typedef struct sol_bt_conn sol_bt_conn;
 
 /**
  * @brief Increases the reference count of a connection.
@@ -200,6 +202,7 @@ int sol_bt_disconnect(struct sol_bt_conn *conn);
  * keep Bluetooth turned off if it's not used.
  */
 struct sol_bt_session;
+typedef struct sol_bt_session sol_bt_session;
 
 /**
  * @brief Enables the local Bluetooth controller.
@@ -267,6 +270,7 @@ struct sol_bt_device_info {
      */
     bool in_range;
 };
+typedef struct sol_bt_device_info sol_bt_device_info;
 
 /**
  * @brief Over which transport should a scan be performed.
@@ -307,6 +311,7 @@ enum sol_bt_transport sol_bt_transport_from_str(const char *str);
  * Represents a pending scan session, @see sol_bt_start_scan().
  */
 struct sol_bt_scan_pending;
+typedef struct sol_bt_scan_pending sol_bt_scan_pending;
 
 /**
  * @brief Start scanning for devices.

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -246,6 +246,7 @@ enum sol_coap_flags {
  * @brief Opaque handler for a CoAP packet.
  */
 struct sol_coap_packet;
+typedef struct sol_coap_packet sol_coap_packet;
 
 /**
  * @struct sol_coap_server
@@ -253,6 +254,7 @@ struct sol_coap_packet;
  * @brief Opaque handler for a CoAP server.
  */
 struct sol_coap_server;
+typedef struct sol_coap_server sol_coap_server;
 
 /**
  * @brief Description for a CoAP resource.
@@ -344,6 +346,7 @@ struct sol_coap_resource {
      */
     struct sol_str_slice path[];
 };
+typedef struct sol_coap_resource sol_coap_resource;
 
 /**
  * @brief Gets the CoAP protocol version of the packet.

--- a/src/lib/comms/include/sol-gatt.h
+++ b/src/lib/comms/include/sol-gatt.h
@@ -131,6 +131,7 @@ enum sol_gatt_desc_flags {
  * is complete.
  */
 struct sol_gatt_pending;
+typedef struct sol_gatt_pending sol_gatt_pending;
 
 /**
  * @brief Returns the attribute referenced by a pending operation
@@ -175,6 +176,7 @@ struct sol_gatt_attr {
 
     void *_priv;
 };
+typedef struct sol_gatt_attr sol_gatt_attr;
 
 /**
  * @brief Returns a response to an asynchronous operation

--- a/src/lib/comms/include/sol-http-client.h
+++ b/src/lib/comms/include/sol-http-client.h
@@ -57,6 +57,7 @@ extern "C" {
  * A connection may be canceled with sol_http_client_connection_cancel().
  */
 struct sol_http_client_connection;
+typedef struct sol_http_client_connection sol_http_client_connection;
 
 /**
  * @brief The HTTP request interface to use when creating a new request.
@@ -137,6 +138,7 @@ struct sol_http_request_interface {
      */
     size_t data_buffer_size;
 };
+typedef struct sol_http_request_interface sol_http_request_interface;
 
 /**
  * @brief Create a request for the specified URL using the given method. The result of

--- a/src/lib/comms/include/sol-http-server.h
+++ b/src/lib/comms/include/sol-http-server.h
@@ -54,6 +54,7 @@ extern "C" {
  * deleted with sol_http_server_del()
  */
 struct sol_http_server;
+typedef struct sol_http_server sol_http_server;
 
 /**
  * @struct sol_http_server_config
@@ -77,6 +78,7 @@ struct sol_http_server_config {
         const struct sol_cert *key;
     } security;
 };
+typedef struct sol_http_server_config sol_http_server_config;
 
 /**
  * @struct sol_http_request
@@ -91,6 +93,7 @@ struct sol_http_server_config {
  * A response to a request can be send with sol_http_server_send_response()
  */
 struct sol_http_request;
+typedef struct sol_http_request sol_http_request;
 
 /**
  * @struct sol_http_progressive_response
@@ -103,6 +106,7 @@ struct sol_http_request;
  * To delete it use sol_http_progressive_response_del().
  */
 struct sol_http_progressive_response;
+typedef struct sol_http_progressive_response sol_http_progressive_response;
 
 /**
  * @brief Creates an HTTP server, binding on all interfaces
@@ -328,6 +332,7 @@ struct sol_http_server_progressive_config {
      */
     size_t feed_size;
 };
+typedef struct sol_http_server_progressive_config sol_http_server_progressive_config;
 
 /**
  * @brief Send the response and keep connection alive to request given in the

--- a/src/lib/comms/include/sol-http.h
+++ b/src/lib/comms/include/sol-http.h
@@ -184,6 +184,7 @@ struct sol_http_params {
     struct sol_vector params; /**< vector of parameters, struct @ref sol_http_param_value */
     struct sol_arena *arena; /**< arena with copied parameter slices */
 };
+typedef struct sol_http_params sol_http_params;
 
 /**
  * @brief Used to rank content type priorities.
@@ -236,6 +237,7 @@ struct sol_http_param_value {
         } data;
     } value;
 };
+typedef struct sol_http_param_value sol_http_param_value;
 
 /**
  * @brief Handle for an HTTP response
@@ -257,6 +259,7 @@ struct sol_http_response {
     struct sol_http_params param;
     int response_code;
 };
+typedef struct sol_http_response sol_http_response;
 
 /**
  * @brief Handle for an HTTP URL
@@ -275,6 +278,7 @@ struct sol_http_url {
     struct sol_str_slice fragment;
     uint32_t port; /**< If set to 0 it'll be ignored */
 };
+typedef struct sol_http_url sol_http_url;
 
 #ifndef SOL_NO_API_VERSION
 /**

--- a/src/lib/comms/include/sol-mavlink.h
+++ b/src/lib/comms/include/sol-mavlink.h
@@ -52,6 +52,7 @@ extern "C" {
  * sol_mavlink_connect() API.
  */
 struct sol_mavlink;
+typedef struct sol_mavlink sol_mavlink;
 
 /**
  * @enum sol_mavlink_mode
@@ -186,6 +187,7 @@ struct sol_mavlink_position {
     /** Local Z position of this position in the local coordinate frame */
     float z;
 };
+typedef struct sol_mavlink_position sol_mavlink_position;
 
 /**
  * @struct sol_mavlink_handlers
@@ -281,6 +283,7 @@ struct sol_mavlink_handlers {
      */
     void (*mission_reached) (void *data, struct sol_mavlink *mavlink);
 };
+typedef struct sol_mavlink_handlers sol_mavlink_handlers;
 
 /**
  * @struct sol_mavlink_config
@@ -306,6 +309,7 @@ struct sol_mavlink_config {
      */
     int baud_rate;
 };
+typedef struct sol_mavlink_config sol_mavlink_config;
 
 /**
  * @brief Connect to a mavlink server

--- a/src/lib/comms/include/sol-mqtt.h
+++ b/src/lib/comms/include/sol-mqtt.h
@@ -130,6 +130,7 @@ enum sol_mqtt_conn_status {
  * sol_mqtt_connect() API.
  */
 struct sol_mqtt;
+typedef struct sol_mqtt sol_mqtt;
 
 /**
  * @struct sol_mqtt_message
@@ -173,6 +174,7 @@ struct sol_mqtt_message {
      */
     bool retain;
 };
+typedef struct sol_mqtt_message sol_mqtt_message;
 
 /**
  * @struct sol_mqtt_handlers
@@ -267,6 +269,7 @@ struct sol_mqtt_handlers {
      */
     void (*unsubscribe) (void *data, struct sol_mqtt *mqtt);
 };
+typedef struct sol_mqtt_handlers sol_mqtt_handlers;
 
 /**
  * @struct sol_mqtt_config
@@ -350,6 +353,7 @@ struct sol_mqtt_config {
      */
     const struct sol_mqtt_handlers handlers;
 };
+typedef struct sol_mqtt_config sol_mqtt_config;
 
 /**
  * @brief Connect to a MQTT broker

--- a/src/lib/comms/include/sol-netctl.h
+++ b/src/lib/comms/include/sol-netctl.h
@@ -35,6 +35,7 @@ extern "C" {
  * @brief service struct
  */
 struct sol_netctl_service;
+typedef struct sol_netctl_service sol_netctl_service;
 
 /**
  * @struct sol_netctl_network_params
@@ -59,6 +60,7 @@ struct sol_netctl_network_params {
      */
     struct sol_network_link_addr gateway;
 };
+typedef struct sol_netctl_network_params sol_netctl_network_params;
 
 /**
  * @enum sol_netctl_service_state

--- a/src/lib/comms/include/sol-network.h
+++ b/src/lib/comms/include/sol-network.h
@@ -78,6 +78,7 @@ extern "C" {
  * @see sol_network_hostname_pending_cancel()
  */
 struct sol_network_hostname_pending;
+typedef struct sol_network_hostname_pending sol_network_hostname_pending;
 
 /**
  * @brief Type of events generated for a network link.
@@ -152,6 +153,7 @@ struct sol_network_link_addr {
     } addr; /**< @brief The address itself */
     uint16_t port; /**< @brief The port associed with the IP address */
 };
+typedef struct sol_network_link_addr sol_network_link_addr;
 
 /**
  * @brief Structure to represent a network link.
@@ -174,6 +176,7 @@ struct sol_network_link {
      **/
     struct sol_vector addrs;
 };
+typedef struct sol_network_link sol_network_link;
 
 #ifndef SOL_NO_API_VERSION
 /**

--- a/src/lib/comms/include/sol-oic-client.h
+++ b/src/lib/comms/include/sol-oic-client.h
@@ -53,6 +53,7 @@ extern "C" {
  * deleted with sol_oic_client_del()
  */
 struct sol_oic_client;
+typedef struct sol_oic_client sol_oic_client;
 
 /**
  * @struct sol_oic_pending
@@ -65,6 +66,7 @@ struct sol_oic_client;
  *
  */
 struct sol_oic_pending;
+typedef struct sol_oic_pending sol_oic_pending;
 
 /**
  * @brief Structure defining an OIC resource. It's open to the API
@@ -108,6 +110,7 @@ struct sol_oic_resource {
      */
     const bool secure;
 };
+typedef struct sol_oic_resource sol_oic_resource;
 
 /**
  * @brief Creates a new OIC client intance.

--- a/src/lib/comms/include/sol-oic-server.h
+++ b/src/lib/comms/include/sol-oic-server.h
@@ -47,6 +47,7 @@ extern "C" {
  * @brief Opaque handler for a server resource
  */
 struct sol_oic_server_resource;
+typedef struct sol_oic_server_resource sol_oic_server_resource;
 
 /**
  * @struct sol_oic_resource_type
@@ -152,6 +153,7 @@ struct sol_oic_resource_type {
      */
         del;
 };
+typedef struct sol_oic_resource_type sol_oic_resource_type;
 
 /**
  * @brief Add resource to OIC server.

--- a/src/lib/comms/include/sol-oic.h
+++ b/src/lib/comms/include/sol-oic.h
@@ -111,6 +111,7 @@ struct sol_oic_platform_info {
      */
     struct sol_str_slice system_time;
 };
+typedef struct sol_oic_platform_info sol_oic_platform_info;
 
 /**
  * @brief Flags to set when adding a new resource to a server.
@@ -195,6 +196,7 @@ struct sol_oic_device_info {
      */
     struct sol_str_slice data_model_version;
 };
+typedef struct sol_oic_device_info sol_oic_device_info;
 
 /**
  * @brief field type of sol_oic_repr_field structure.
@@ -271,6 +273,7 @@ struct sol_oic_repr_field {
         bool v_boolean;
     };
 };
+typedef struct sol_oic_repr_field sol_oic_repr_field;
 
 /**
  * @brief Helper macro to create a #sol_oic_repr_field.
@@ -381,6 +384,7 @@ struct sol_oic_repr_field {
  * @see sol_oic_client_resource_request()
  */
 struct sol_oic_map_writer;
+typedef struct sol_oic_map_writer sol_oic_map_writer;
 
 /**
  * @brief Used in @ref sol_oic_map_writer to state if the map has a content or not
@@ -435,6 +439,7 @@ struct sol_oic_map_reader {
     const uint8_t type;
     const uint8_t flags;
 };
+typedef struct sol_oic_map_reader sol_oic_map_reader;
 
 /**
  * @struct sol_oic_request
@@ -444,6 +449,7 @@ struct sol_oic_map_reader {
  * @see sol_oic_server_send_response
  */
 struct sol_oic_request;
+typedef struct sol_oic_request sol_oic_request;
 
 /**
  * @struct sol_oic_response
@@ -453,6 +459,7 @@ struct sol_oic_request;
  * @see sol_oic_server_send_response
  */
 struct sol_oic_response;
+typedef struct sol_oic_response sol_oic_response;
 
 /**
  * @brief Possible reasons a @ref SOL_OIC_MAP_LOOP was terminated.

--- a/src/lib/comms/include/sol-socket.h
+++ b/src/lib/comms/include/sol-socket.h
@@ -39,6 +39,7 @@ extern "C" {
  * @brief Opaque handler for a socket
  */
 struct sol_socket;
+typedef struct sol_socket sol_socket;
 
 /**
  * @struct sol_socket_options
@@ -84,6 +85,7 @@ struct sol_socket_options {
      */
     const void *data;
 };
+typedef struct sol_socket_options sol_socket_options;
 
 /**
  * @struct sol_socket_options
@@ -120,6 +122,7 @@ struct sol_socket_ip_options {
      */
     bool reuse_addr;
 };
+typedef struct sol_socket_ip_options sol_socket_ip_options;
 
 /**
  * @brief Structure to represent a socket class.
@@ -219,6 +222,7 @@ struct sol_socket_type {
      */
     int (*bind)(struct sol_socket *s, const struct sol_network_link_addr *addr);
 };
+typedef struct sol_socket_type sol_socket_type;
 
 /**
  * @brief Structure to represent a socket.
@@ -228,6 +232,7 @@ struct sol_socket_type {
 struct sol_socket {
     const struct sol_socket_type *type;
 };
+typedef struct sol_socket sol_socket;
 
 /**
  * @brief Creates an endpoint for communication.

--- a/src/lib/comms/sol-oic-security.h
+++ b/src/lib/comms/sol-oic-security.h
@@ -27,6 +27,7 @@
 #define MACHINE_ID_LEN 16
 
 struct sol_oic_security;
+typedef struct sol_oic_security sol_oic_security;
 
 struct sol_oic_security *sol_oic_server_security_add(
     struct sol_coap_server *server, struct sol_coap_server *server_dtls);

--- a/src/lib/crypto/include/sol-message-digest.h
+++ b/src/lib/crypto/include/sol-message-digest.h
@@ -84,6 +84,7 @@ extern "C" {
  * @brief A handle for a message digest
  */
 struct sol_message_digest;
+typedef struct sol_message_digest sol_message_digest;
 
 /**
  * The message digest configuration to use when creating a new handle.
@@ -178,6 +179,7 @@ struct sol_message_digest_config {
      */
     size_t feed_size;
 };
+typedef struct sol_message_digest_config sol_message_digest_config;
 
 /**
  * Create a new handle to feed the message to digest.

--- a/src/lib/datatypes/include/sol-arena.h
+++ b/src/lib/datatypes/include/sol-arena.h
@@ -51,6 +51,7 @@ extern "C" {
  * See also @ref sol_buffer if you just need a single re-sizable buffer.
  */
 struct sol_arena;
+typedef struct sol_arena sol_arena;
 
 /**
  * @brief Creates an Arena.

--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -135,6 +135,7 @@ struct sol_buffer {
     size_t used;  /**< @brief Used size in bytes */
     enum sol_buffer_flags flags; /**< @brief Buffer flags */
 };
+typedef struct sol_buffer sol_buffer;
 
 /**
  * @brief Case of a string to be decoded.

--- a/src/lib/datatypes/include/sol-list.h
+++ b/src/lib/datatypes/include/sol-list.h
@@ -63,6 +63,7 @@ struct sol_list {
     struct sol_list *next; /**< @brief Link to the next node in the list */
     struct sol_list *prev; /**< @brief Link to the previous node in the list */
 };
+typedef struct sol_list sol_list;
 
 /**
  * @def SOL_LIST_INIT

--- a/src/lib/datatypes/include/sol-memdesc.h
+++ b/src/lib/datatypes/include/sol-memdesc.h
@@ -56,6 +56,7 @@ extern "C" {
  * @struct sol_memdesc
  */
 struct sol_memdesc;
+typedef struct sol_memdesc sol_memdesc;
 
 /**
  * @brief Designates the type of the memory description
@@ -375,6 +376,7 @@ struct sol_memdesc_ops_array {
      */
     int (*resize)(const struct sol_memdesc *desc, void *memory, size_t length);
 };
+typedef struct sol_memdesc_ops_array sol_memdesc_ops_array;
 
 /**
  * @brief Operations specific to SOL_MEMDESC_TYPE_ENUMERATION.
@@ -413,6 +415,7 @@ struct sol_memdesc_ops_enumeration {
      */
     int (*from_str)(const struct sol_memdesc *desc, void *ptr_return, const struct sol_str_slice str);
 };
+typedef struct sol_memdesc_ops_enumeration sol_memdesc_ops_enumeration;
 
 /**
  * @brief override operations to be used in this memory description.
@@ -502,6 +505,7 @@ struct sol_memdesc_ops {
         const struct sol_memdesc_ops_enumeration *enumeration;
     };
 };
+typedef struct sol_memdesc_ops sol_memdesc_ops;
 
 /**
  * @brief Data type to describe a memory region.
@@ -605,6 +609,7 @@ struct sol_memdesc {
      */
     const struct sol_memdesc_ops *ops;
 };
+typedef struct sol_memdesc sol_memdesc;
 
 /**
  * @brief Description of a structure member.
@@ -658,6 +663,7 @@ struct sol_memdesc_structure_member {
      */
     bool detail : 1;
 };
+typedef struct sol_memdesc_structure_member sol_memdesc_structure_member;
 
 /**
  * @brief operations to handle struct sol_vector.
@@ -1979,6 +1985,7 @@ struct sol_memdesc_serialize_options {
         bool show_index;
     } array;
 };
+typedef struct sol_memdesc_serialize_options sol_memdesc_serialize_options;
 
 /**
  * @brief the default struct sol_memdesc_serialize_options.

--- a/src/lib/datatypes/include/sol-str-slice.h
+++ b/src/lib/datatypes/include/sol-str-slice.h
@@ -87,6 +87,7 @@ struct sol_str_slice {
     size_t len; /**< @brief Slice length */
     const char *data; /**< @brief Slice data */
 };
+typedef struct sol_str_slice sol_str_slice;
 
 /**
  * @brief Checks if the content of the slice is equal to the string.

--- a/src/lib/datatypes/include/sol-str-table.h
+++ b/src/lib/datatypes/include/sol-str-table.h
@@ -55,6 +55,7 @@ struct sol_str_table {
     uint16_t len; /**< @brief Key string length */
     int16_t val; /**< @brief Value (16 bits integer) */
 };
+typedef struct sol_str_table sol_str_table;
 
 /**
  * @def SOL_STR_TABLE_ITEM(_key, _val)
@@ -147,6 +148,7 @@ struct sol_str_table_ptr {
     const void *val; /**< @brief Value (pointer) */
     size_t len; /**< @brief Key string length */
 };
+typedef struct sol_str_table_ptr sol_str_table_ptr;
 
 /**
  * @def SOL_STR_TABLE_PTR_ITEM(_key, _val)

--- a/src/lib/datatypes/include/sol-vector.h
+++ b/src/lib/datatypes/include/sol-vector.h
@@ -62,6 +62,7 @@ struct sol_vector {
     uint16_t len; /**< @brief Vector length */
     uint16_t elem_size; /**< @brief Size of each element in bytes */
 };
+typedef struct sol_vector sol_vector;
 
 /**
  * @def SOL_VECTOR_INIT(TYPE)
@@ -313,6 +314,7 @@ sol_vector_steal_data(struct sol_vector *v)
 struct sol_ptr_vector {
     struct sol_vector base;
 };
+typedef struct sol_ptr_vector sol_ptr_vector;
 
 /**
  * @def SOL_PTR_VECTOR_INIT

--- a/src/lib/flow/include/sol-flow-builder.h
+++ b/src/lib/flow/include/sol-flow-builder.h
@@ -56,6 +56,7 @@ extern "C" {
  * @brief Builder's handle.
  */
 struct sol_flow_builder;
+typedef struct sol_flow_builder sol_flow_builder;
 
 /**
  * @brief Creates a new instance of a @ref sol_flow_builder.

--- a/src/lib/flow/include/sol-flow-inspector.h
+++ b/src/lib/flow/include/sol-flow-inspector.h
@@ -118,6 +118,7 @@ struct sol_flow_inspector {
      */
     void (*will_deliver_packet)(const struct sol_flow_inspector *inspector, const struct sol_flow_node *dst_node, uint16_t dst_port, uint16_t dst_conn_id, const struct sol_flow_packet *packet);
 };
+typedef struct sol_flow_inspector sol_flow_inspector;
 
 /**
  * @brief Provide a set of inspecting routines to flow's runtime inspector.

--- a/src/lib/flow/include/sol-flow-metatype.h
+++ b/src/lib/flow/include/sol-flow-metatype.h
@@ -119,6 +119,7 @@ struct sol_flow_metatype_context {
         const struct sol_flow_metatype_context *ctx,
         struct sol_flow_node_type *type);
 };
+typedef struct sol_flow_metatype_context sol_flow_metatype_context;
 
 /**
  * @brief Struct that describes the meta type ports.
@@ -136,6 +137,7 @@ struct sol_flow_metatype_port_description {
     int array_size; /**< If the port is an array this field should be > 0. */
     int idx; /**< The port index. */
 };
+typedef struct sol_flow_metatype_port_description sol_flow_metatype_port_description;
 
 /**
  * @brief Struct that describes the meta type options.
@@ -151,6 +153,7 @@ struct sol_flow_metatype_option_description {
     char *name; /**< The option name. */
     char *data_type; /**< The option type (int, float, blob and etc). */
 };
+typedef struct sol_flow_metatype_option_description sol_flow_metatype_option_description;
 
 /**
  * @brief A callback used to create the meta type itself.
@@ -321,6 +324,7 @@ struct sol_flow_metatype {
     sol_flow_metatype_ports_description_func ports_description; /**< A callback used to fetch the meta type port description. */
     sol_flow_metatype_options_description_func options_description; /**< A callback used to fetch the meta type options description. */
 };
+typedef struct sol_flow_metatype sol_flow_metatype;
 
 #ifdef SOL_FLOW_METATYPE_MODULE_EXTERNAL
 /**

--- a/src/lib/flow/include/sol-flow-packet.h
+++ b/src/lib/flow/include/sol-flow-packet.h
@@ -51,6 +51,7 @@ extern "C" {
  * @brief A packet is a generic container for different kinds (types) of contents.
  */
 struct sol_flow_packet;
+typedef struct sol_flow_packet sol_flow_packet;
 
 /**
  * @brief A packet type defines what's the content of a packet and how it's stored and
@@ -103,6 +104,7 @@ struct sol_flow_packet_type {
      * */
     struct sol_flow_packet *(*get_constant)(const struct sol_flow_packet_type *packet_type, const void *value);
 };
+typedef struct sol_flow_packet_type sol_flow_packet_type;
 
 /**
  * @brief Creates a packet.

--- a/src/lib/flow/include/sol-flow-parser.h
+++ b/src/lib/flow/include/sol-flow-parser.h
@@ -53,6 +53,7 @@ extern "C" {
  * @brief Flow Parser handle.
  */
 struct sol_flow_parser;
+typedef struct sol_flow_parser sol_flow_parser;
 
 /**
  * @brief Flow Parser's client structure.
@@ -79,6 +80,7 @@ struct sol_flow_parser_client {
      */
     int (*read_file)(void *data, const char *name, struct sol_buffer *buf);
 };
+typedef struct sol_flow_parser_client sol_flow_parser_client;
 
 /**
  * @brief Creates a new instance of @ref sol_flow_parser.

--- a/src/lib/flow/include/sol-flow-resolver.h
+++ b/src/lib/flow/include/sol-flow-resolver.h
@@ -73,6 +73,7 @@ struct sol_flow_resolver {
      */
     int (*resolve)(void *data, const char *id, struct sol_flow_node_type const **type, struct sol_flow_node_named_options *named_opts);
 };
+typedef struct sol_flow_resolver sol_flow_resolver;
 
 /**
  * @brief The default resolver set at compile time.

--- a/src/lib/flow/include/sol-flow-simple-c-type.h
+++ b/src/lib/flow/include/sol-flow-simple-c-type.h
@@ -87,6 +87,7 @@ struct sol_flow_simple_c_type_event {
     const struct sol_flow_node_options *options; /* @brief If type is SOL_FLOW_SIMPLE_C_TYPE_EVENT_TYPE_OPEN, the given options */
     const struct sol_flow_packet *packet; /* @brief If type is SOL_FLOW_SIMPLE_C_TYPE_EVENT_TYPE_PORT_IN_PROCESS, the incoming packet */
 };
+typedef struct sol_flow_simple_c_type_event sol_flow_simple_c_type_event;
 
 /**
  * @brief Input port identifier

--- a/src/lib/flow/include/sol-flow-single.h
+++ b/src/lib/flow/include/sol-flow-single.h
@@ -156,6 +156,7 @@ struct sol_flow_single_options {
      */
     const uint16_t *connected_ports_out;
 };
+typedef struct sol_flow_single_options sol_flow_single_options;
 
 /**
  * @def SOL_FLOW_SINGLE_OPTIONS_DEFAULTS()

--- a/src/lib/flow/include/sol-flow-static.h
+++ b/src/lib/flow/include/sol-flow-static.h
@@ -54,6 +54,7 @@ struct sol_flow_static_node_spec {
     const char *name; /**< @brief Name for the specific type's instance */
     const struct sol_flow_node_options *opts; /**< @brief Options for the specific type's instance */
 };
+typedef struct sol_flow_static_node_spec sol_flow_static_node_spec;
 
 /**
  * @brief Structure for the specification of a connection.
@@ -64,6 +65,7 @@ struct sol_flow_static_conn_spec {
     uint16_t dst; /**< @brief Destination node index */
     uint16_t dst_port; /**< @brief Destination node port index */
 };
+typedef struct sol_flow_static_conn_spec sol_flow_static_conn_spec;
 
 /**
  * @brief Structure for the specification of node ports
@@ -72,6 +74,7 @@ struct sol_flow_static_port_spec {
     uint16_t node; /**< @brief Node index */
     uint16_t port; /**< @brief Port index */
 };
+typedef struct sol_flow_static_port_spec sol_flow_static_port_spec;
 
 /* Use these guards as the last element of the spec arrays. */
 
@@ -156,6 +159,7 @@ struct sol_flow_static_spec {
      */
     void (*dispose)(const void *type_data);
 };
+typedef struct sol_flow_static_spec sol_flow_static_spec;
 
 /**
  * @brief Creates a new "static flow" node.

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -78,6 +78,7 @@ struct sol_flow_port;
  * their output ports.
  */
 struct sol_flow_node;
+typedef struct sol_flow_node sol_flow_node;
 
 /**
  * @brief Creates a new node.
@@ -565,6 +566,7 @@ struct sol_flow_node_options {
     uint16_t sub_api; /**< @brief To version each subclass */
 #endif
 };
+typedef struct sol_flow_node_options sol_flow_node_options;
 
 /**
  * @brief Possible types for option attributes (or members).
@@ -619,6 +621,7 @@ struct sol_flow_node_named_options_member {
         double f; /**< @brief Value of a float member */
     };
 };
+typedef struct sol_flow_node_named_options_member sol_flow_node_named_options_member;
 
 /**
  * @brief Named options is an intermediate structure to handle Node Options parsing
@@ -629,6 +632,7 @@ struct sol_flow_node_named_options {
     struct sol_flow_node_named_options_member *members; /**< @brief List of option members */
     uint16_t count; /**< @brief Number of members */
 };
+typedef struct sol_flow_node_named_options sol_flow_node_named_options;
 
 /**
  * @brief Creates a new Node Options.
@@ -707,6 +711,7 @@ struct sol_flow_port_description {
      */
     bool required;
 };
+typedef struct sol_flow_port_description sol_flow_port_description;
 
 /**
  * @brief Description object used for introspection of Node options members.
@@ -731,6 +736,7 @@ struct sol_flow_node_options_member_description {
     uint16_t size; /**< @brief Option member's size inside the final options blob for a node */
     bool required; /**< @brief Whether the option member is mandatory or not when creating a node */
 };
+typedef struct sol_flow_node_options_member_description sol_flow_node_options_member_description;
 
 /**
  * @brief Description object used for introspection of Node options.
@@ -743,6 +749,7 @@ struct sol_flow_node_options_description {
 #endif
     bool required; /**< @brief If true then options must be given for the node (if not, the node has no parameters) */
 };
+typedef struct sol_flow_node_options_description sol_flow_node_options_description;
 
 /**
  * @brief Description object used for introspection of Node types.
@@ -785,6 +792,7 @@ struct sol_flow_node_type_description {
     const struct sol_flow_port_description *const *ports_out; /**< @brief @c NULL terminated output ports array */
     const struct sol_flow_node_options_description *options; /**< @brief Node options */
 };
+typedef struct sol_flow_node_type_description sol_flow_node_type_description;
 #endif
 
 /**
@@ -857,6 +865,7 @@ struct sol_flow_node_type {
     const struct sol_flow_node_type_description *description; /**< @brief Pointer to node's description */
 #endif
 };
+typedef struct sol_flow_node_type sol_flow_node_type;
 
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
 /**
@@ -995,6 +1004,7 @@ struct sol_flow_node_container_type {
      */
     void (*remove)(struct sol_flow_node *container, struct sol_flow_node *node);
 };
+typedef struct sol_flow_node_container_type sol_flow_node_container_type;
 
 /**
  * @brief Node's Output port structure.
@@ -1016,6 +1026,7 @@ struct sol_flow_port_type_out {
      */
     int (*disconnect)(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id);
 };
+typedef struct sol_flow_port_type_out sol_flow_port_type_out;
 
 /**
  * @brief Node's Input port structure.
@@ -1034,6 +1045,7 @@ struct sol_flow_port_type_in {
     int (*connect)(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id); /**< member function issued every time a new connection is made to the port */
     int (*disconnect)(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id); /**< member function issued every time a connection is unmade on the port */
 };
+typedef struct sol_flow_port_type_in sol_flow_port_type_in;
 
 /**
  * @def sol_flow_get_node_type(_mod, _type, _var)

--- a/src/lib/io/include/sol-aio.h
+++ b/src/lib/io/include/sol-aio.h
@@ -51,6 +51,7 @@ extern "C" {
  * @see sol_aio_pending_cancel()
  */
 struct sol_aio;
+typedef struct sol_aio sol_aio;
 
 /**
  * @struct sol_aio_pending
@@ -59,6 +60,7 @@ struct sol_aio;
  * @see sol_aio_pending_cancel()
  */
 struct sol_aio_pending;
+typedef struct sol_aio_pending sol_aio_pending;
 
 /**
  * @brief Open the given board @c pin by its label to be used as Analog I/O.

--- a/src/lib/io/include/sol-gpio.h
+++ b/src/lib/io/include/sol-gpio.h
@@ -61,6 +61,7 @@ extern "C" {
  * @see sol_gpio_write()
  */
 struct sol_gpio;
+typedef struct sol_gpio sol_gpio;
 
 /**
  * @brief Possible values for the direction of a GPIO.
@@ -236,6 +237,7 @@ struct sol_gpio_config {
         } out;
     };
 };
+typedef struct sol_gpio_config sol_gpio_config;
 
 /**
  * @brief Converts a string GPIO direction to sol_gpio_direction.

--- a/src/lib/io/include/sol-iio.h
+++ b/src/lib/io/include/sol-iio.h
@@ -48,6 +48,7 @@ extern "C" {
  * @see sol_iio_device_start_buffer()
  */
 struct sol_iio_device;
+typedef struct sol_iio_device sol_iio_device;
 
 /**
  * @struct sol_iio_channel
@@ -59,6 +60,7 @@ struct sol_iio_device;
  * @see SOL_IIO_CHANNEL_CONFIG_INIT()
  */
 struct sol_iio_channel;
+typedef struct sol_iio_channel sol_iio_channel;
 
 /**
  * @brief A configuration struct for an IIO device
@@ -76,6 +78,7 @@ struct sol_iio_config {
     int buffer_size; /**< The size of reading buffer. 0: use device default; -1: disable buffer and readings will be performed on channel files on sysfs. */
     int sampling_frequency; /**< Device sampling frequency. -1 uses device default */
 };
+typedef struct sol_iio_config sol_iio_config;
 
 /**
  * @brief A configuration struct for an IIO channel
@@ -91,6 +94,7 @@ struct sol_iio_channel_config {
     int offset; /**< Channel offset, to be added to raw readings. Some devices share offset among all channels, so changing one will change all. If, in this case, different channels set different offsets the result is unknown. */
     bool use_custom_offset; /**< If true, will use user defined offset on member #offset of this struct */
 };
+typedef struct sol_iio_channel_config sol_iio_channel_config;
 
 /**
  * @brief Macro that may be used for initialized a @ref sol_iio_channel_config

--- a/src/lib/io/include/sol-memmap-storage.h
+++ b/src/lib/io/include/sol-memmap-storage.h
@@ -123,6 +123,7 @@ struct sol_memmap_map {
                        * writing operations until it expires, when real writing will be performed */
     const struct sol_str_table_ptr *entries; /**< Entries on map, containing name, offset and size */ /* Memory trick in place, must be last on struct*/
 };
+typedef struct sol_memmap_map sol_memmap_map;
 
 /**
  * @struct sol_memmap_entry
@@ -137,6 +138,7 @@ struct sol_memmap_entry {
     uint32_t bit_size; /**< Total size of this entry on storage, in bits. Must be up to <tt>size * 8</tt>. If zero, it will be assumed as <tt>size * 8</tt>. Note that this will be ignored if @c size is greater than 8. */
     uint8_t bit_offset; /**< Bit offset on first byte. Note that this will be ignored if @c size is greater than 8. */
 };
+typedef struct sol_memmap_entry sol_memmap_entry;
 
 /**
  * @brief Writes buffer contents to storage.

--- a/src/lib/io/include/sol-pwm.h
+++ b/src/lib/io/include/sol-pwm.h
@@ -58,6 +58,7 @@ extern "C" {
  * @see sol_pwm_set_enabled()
  */
 struct sol_pwm;
+typedef struct sol_pwm sol_pwm;
 
 /**
  * @brief Alignment determines how the pulse is aligned within the PWM period.
@@ -102,6 +103,7 @@ struct sol_pwm_config {
     enum sol_pwm_polarity polarity; /**< The PWM polarity. @see sol_pwm_polarity */
     bool enabled; /**< Set to @c true to for enabled @c false for disabled */
 };
+typedef struct sol_pwm_config sol_pwm_config;
 
 /**
  * @brief Converts a string PWM alignment to sol_pwm_alignment

--- a/src/lib/io/include/sol-spi.h
+++ b/src/lib/io/include/sol-spi.h
@@ -50,6 +50,7 @@ extern "C" {
  * @see sol_spi_transfer()
  */
 struct sol_spi;
+typedef struct sol_spi sol_spi;
 
 /**
  * @brief SPI Transfer Modes.
@@ -95,6 +96,7 @@ struct sol_spi_config {
     uint32_t frequency; /**< Clock frequency in Hz */
     uint8_t bits_per_word; /**< Number of bits per word */
 };
+typedef struct sol_spi_config sol_spi_config;
 
 /**
  * @brief Converts a string SPI mode name to sol_spi_mode

--- a/src/lib/io/include/sol-uart.h
+++ b/src/lib/io/include/sol-uart.h
@@ -52,6 +52,7 @@ extern "C" {
  * @see sol_uart_feed()
  */
 struct sol_uart;
+typedef struct sol_uart sol_uart;
 
 /**
  * @brief Baud rate is the number of times the signal can switch states in one second.
@@ -149,6 +150,7 @@ struct sol_uart_config {
     enum sol_uart_stop_bits stop_bits; /**< The stop bits value */
     bool flow_control; /**< Enables software flow control(XOFF and XON) */
 };
+typedef struct sol_uart_config sol_uart_config;
 
 /**
  * @brief Converts a string UART baudRate to sol_uart_baud_rate

--- a/src/lib/parsers/include/sol-json.h
+++ b/src/lib/parsers/include/sol-json.h
@@ -64,6 +64,7 @@ struct sol_json_scanner {
     const char *mem_end; /**< @brief End of this portion of the JSON document. */
     const char *current; /**< @brief Current point in the JSON document that needs to be processed. */
 };
+typedef struct sol_json_scanner sol_json_scanner;
 
 /**
  * @brief Type describing a JSON token
@@ -74,6 +75,7 @@ struct sol_json_token {
     const char *start; /**< @brief Token start */
     const char *end; /**< @brief Token end. Non-inclusive */
 };
+typedef struct sol_json_token sol_json_token;
 
 /**
  * @brief Token type enumeration.
@@ -950,6 +952,7 @@ struct sol_json_path_scanner {
      */
     const char *current;
 };
+typedef struct sol_json_path_scanner sol_json_path_scanner;
 
 /**
  * @brief Get the element referenced by the JSON Path @a path in a JSON Object


### PR DESCRIPTION
Soletta already use "sol_" namespace and usually some other
module-specific namespace making its identifiers large. By removing the
need of explicitly use "struct " we save some bytes and reduce the noise
in client code.

This patch only adds typedef for public facing structs, per discussion
with the team. The typedefs were added after the declaration/definition
of the structs, to avoid messing with Doxygen documentation.

Fixes #1982.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>