### PR TITLE
all: add typedefs to public API structs [v2]

### DIFF
--- a/src/lib/common/include/sol-certificate.h
+++ b/src/lib/common/include/sol-certificate.h
@@ -38,13 +38,14 @@ extern "C" {
  */
 
 /**
- * @struct sol_cert
+ * @typedef sol_cert
  *
  * @brief Certificate handler
  *
  * This object is the abstraction of certificate.
  */
 struct sol_cert;
+typedef struct sol_cert sol_cert;
 
 /**
  * @brief Load a certificate from an id

--- a/src/lib/common/include/sol-file-reader.h
+++ b/src/lib/common/include/sol-file-reader.h
@@ -31,10 +31,11 @@ extern "C" {
 #endif
 
 /**
- * @struct sol_file_reader
+ * @typedef sol_file_reader
  * @brief Opaque handler for a file reader.
  */
 struct sol_file_reader;
+typedef struct sol_file_reader sol_file_reader;
 
 /**
  * @brief Open a file using its filename.

--- a/src/lib/common/include/sol-log.h
+++ b/src/lib/common/include/sol-log.h
@@ -411,11 +411,11 @@ enum sol_log_level {
 /**
  * @brief Structure containing the attributes of the domain used for logging.
  */
-struct sol_log_domain {
+typedef struct sol_log_domain {
     const char *color; /**< @brief Color to be used */
     const char *name; /**< @brief Domain name */
     uint8_t level; /**< @brief Maximum level to log for this domain */
-};
+} sol_log_domain;
 
 /**
  * @brief Global logging domain.

--- a/src/lib/common/include/sol-mainloop.h
+++ b/src/lib/common/include/sol-mainloop.h
@@ -343,11 +343,12 @@ void sol_quit_with_code(int return_code);
 void sol_shutdown(void);
 
 /**
- * @struct sol_timeout
+ * @typedef sol_timeout
  *
  * @brief Handle for timers tracking the timeouts.
  */
 struct sol_timeout;
+typedef struct sol_timeout sol_timeout;
 
 /**
  * @brief Adds a function to be called periodically by the main loop.
@@ -381,13 +382,14 @@ struct sol_timeout *sol_timeout_add(uint32_t timeout_ms, bool (*cb)(void *data),
 bool sol_timeout_del(struct sol_timeout *handle);
 
 /**
- * @struct sol_idle
+ * @typedef sol_idle
  *
  * @brief Handle for idlers.
  *
  * This structure is used to help setup and control Idlers.
  */
 struct sol_idle;
+typedef struct sol_idle sol_idle;
 
 /**
  * @brief Adds a function to be called when the application goes idle.
@@ -477,10 +479,11 @@ enum sol_fd_flags {
 };
 
 /**
- * @struct sol_fd
+ * @typedef sol_fd
  * @brief A handle to a fd watcher
  */
 struct sol_fd;
+typedef struct sol_fd sol_fd;
 
 /**
  * @brief Adds a function to be called when the requested events are triggered by the
@@ -575,12 +578,13 @@ uint32_t sol_fd_get_flags(const struct sol_fd *handle);
 #ifdef SOL_MAINLOOP_FORK_WATCH_ENABLED
 
 /**
- * @struct sol_child_watch
+ * @typedef sol_child_watch
  * @brief Handle for child process.
  *
  * This structure is used to setup and control children process.
  */
 struct sol_child_watch;
+typedef struct sol_child_watch sol_child_watch;
 
 /**
  * @brief Watch for a child process' termination.
@@ -660,7 +664,7 @@ bool sol_child_watch_del(struct sol_child_watch *handle);
 /**
  * @brief Structure representing the type of a source of mainloop events.
  */
-struct sol_mainloop_source_type {
+typedef struct sol_mainloop_source_type {
 #ifndef SOL_NO_API_VERSION
 #define SOL_MAINLOOP_SOURCE_TYPE_API_VERSION (1)  /**< @brief Compile time API version to be checked during runtime */
     /**
@@ -748,13 +752,14 @@ struct sol_mainloop_source_type {
      * May be NULL.
      */
     void (*dispose)(void *data);
-};
+} sol_mainloop_source_type;
 
 /**
- * @struct sol_mainloop_source
+ * @typedef sol_mainloop_source
  * @brief Structure of a Source of mainloop events.
  */
 struct sol_mainloop_source;
+typedef struct sol_mainloop_source sol_mainloop_source;
 
 /**
  * @brief Create a new source of events to the main loop.
@@ -838,7 +843,7 @@ void *sol_mainloop_source_get_data(const struct sol_mainloop_source *handle);
 /**
  * @brief Structure representing a mainloop implementation (hooks).
  */
-struct sol_mainloop_implementation {
+typedef struct sol_mainloop_implementation {
 #ifndef SOL_NO_API_VERSION
 #define SOL_MAINLOOP_IMPLEMENTATION_API_VERSION (1)  /**< compile time API version to be checked during runtime */
     /**
@@ -1142,7 +1147,8 @@ struct sol_mainloop_implementation {
      * Must not be NULL.
      */
     void *(*source_get_data)(const void *handle);
-};
+} sol_mainloop_implementation;
+
 
 /**
  * Pointer to Soletta's internal mainloop implementation, that is the
@@ -1237,7 +1243,7 @@ void sol_set_args(int argc, char *argv[]);
  * the @c startup and @c shutdown callbacks of the application that
  * will be called by @ref SOL_MAIN_DEFAULT when appropriated.
  */
-struct sol_main_callbacks {
+typedef struct sol_main_callbacks {
 #ifndef SOL_NO_API_VERSION
 #define SOL_MAIN_CALLBACKS_API_VERSION (1)
     uint16_t api_version; /**< @brief API version */
@@ -1245,7 +1251,7 @@ struct sol_main_callbacks {
     uint16_t flags; /**< @brief Application flags */
     void (*startup)(void); /**< @brief Application @c startup function */
     void (*shutdown)(void); /**< @brief Application @c shutdown function */
-};
+} sol_main_callbacks;
 
 /**
  * @brief Helper function called by @ref SOL_MAIN. Shouldn't be called directly.

--- a/src/lib/common/include/sol-pin-mux-modules.h
+++ b/src/lib/common/include/sol-pin-mux-modules.h
@@ -45,7 +45,7 @@ extern "C" {
 /**
  * @brief Structure defining the API of a Pin Multiplexer module
  */
-struct sol_pin_mux {
+typedef struct sol_pin_mux {
 #ifndef SOL_NO_API_VERSION
 #define SOL_PIN_MUX_API_VERSION (2)
     uint16_t api_version; /**< @brief API version */
@@ -133,7 +133,7 @@ struct sol_pin_mux {
      */
     int (*pwm)(int device, int channel);
 
-};
+} sol_pin_mux;
 
 /**
  * @def SOL_PIN_MUX_DECLARE(_NAME, decl ...)

--- a/src/lib/common/include/sol-platform-linux-micro.h
+++ b/src/lib/common/include/sol-platform-linux-micro.h
@@ -40,7 +40,7 @@ extern "C" {
  * @brief struct that describes the Linux micro module
  * @see SOL_PLATFORM_LINUX_MICRO_MODULE()
  */
-struct sol_platform_linux_micro_module {
+typedef struct sol_platform_linux_micro_module {
 #ifndef SOL_NO_API_VERSION
 #define SOL_PLATFORM_LINUX_MICRO_MODULE_API_VERSION (1) /**< Compile time API version to be checked during runtime */
     uint16_t api_version; /**< The API version */
@@ -104,7 +104,7 @@ struct sol_platform_linux_micro_module {
      * @return @c 0 on success @c -errno on error.
      */
     int (*stop_monitor)(const struct sol_platform_linux_micro_module *module, const char *service);
-};
+} sol_platform_linux_micro_module;
 
 /**
  * @brief Inform the service observers the current state of the @c service

--- a/src/lib/common/include/sol-platform-linux.h
+++ b/src/lib/common/include/sol-platform-linux.h
@@ -171,13 +171,13 @@ int sol_platform_linux_mount(const char *dev, const char *mpoint, const char *fs
  * @see sol_platform_linux_uevent_subscribe()
  * @see sol_platform_linux_uevent_unsubscribe()
  */
-struct sol_uevent {
+typedef struct sol_uevent {
     struct sol_str_slice modalias; /**<  The alias */
     struct sol_str_slice action; /**< The uevent action */
     struct sol_str_slice subsystem; /**< The event subsystem*/
     struct sol_str_slice devtype; /**< The device type */
     struct sol_str_slice devname; /**< The device name */
-};
+} sol_uevent;
 
 /**
  * @brief Subscribe to monitor linux's uevent events

--- a/src/lib/common/include/sol-reentrant.h
+++ b/src/lib/common/include/sol-reentrant.h
@@ -34,15 +34,13 @@ extern "C" {
  */
 
 /**
- * @struct sol_reentrant
- *
  * @brief Structure containing the flags for safely freeing a larger structure
  *
  * This structure is meant to be used inside larger structures which are
  * affected by calls to external callbacks that in turn end up calling library
  * APIs. The possibility of a double free is particularly likely in such cases.
  */
-struct sol_reentrant {
+typedef struct sol_reentrant {
     /**
      * @brief Structure is in use
      */
@@ -51,7 +49,7 @@ struct sol_reentrant {
      * @brief Structure is stale and should be freed as soon as possible
      */
     bool delete_me;
-};
+} sol_reentrant;
 
 /**
  * @brief Wraps a function call to an external callback

--- a/src/lib/common/include/sol-types.h
+++ b/src/lib/common/include/sol-types.h
@@ -122,13 +122,13 @@ extern "C" {
 /**
  * @brief Data type to describe a direction vector.
  */
-struct sol_direction_vector {
+typedef struct sol_direction_vector {
     double x; /**< @brief X coordinate */
     double y; /**< @brief Y coordinate */
     double z; /**< @brief Z coordinate */
     double min; /**< @brief Minimum value of a coordinate for all axis */
     double max; /**< @brief Maximum value of a coordinate for all axis */
-};
+} sol_direction_vector;
 
 /**
  * @brief Checks the ranges of @c var0 and @c var1 for equality.
@@ -143,23 +143,23 @@ bool sol_direction_vector_eq(const struct sol_direction_vector *var0, const stru
 /**
  * @brief Data type to describe a location.
  */
-struct sol_location {
+typedef struct sol_location {
     double lat; /**< @brief Latitude */
     double lon; /**< @brief Longitude */
     double alt; /**< @brief Altitude */
-};
+} sol_location;
 
 /**
  * @brief Data type to describe a RGB color.
  */
-struct sol_rgb {
+typedef struct sol_rgb {
     uint32_t red; /**< @brief Red component */
     uint32_t green; /**< @brief Green component */
     uint32_t blue; /**< @brief Blue component */
     uint32_t red_max; /**< @brief Red component maximum value */
     uint32_t green_max; /**< @brief Green component maximum value */
     uint32_t blue_max; /**< @brief Blue component maximum value */
-};
+} sol_rgb;
 
 /**
  * @brief Checks the ranges of @c var0 and @c var1 for equality.
@@ -184,23 +184,23 @@ int sol_rgb_set_max(struct sol_rgb *color, uint32_t max_value);
 /**
  * @brief Data type describing a Double range.
  */
-struct sol_drange {
+typedef struct sol_drange {
     double val; /**< @brief Current value */
     double min; /**< @brief Range minimum value */
     double max; /**< @brief Range maximum value */
     double step; /**< @brief Range step */
-};
+} sol_drange;
 
 /**
  * @brief Data type describing a spec for Double ranges.
  *
  * A range spec is composed by the range limits and step.
  */
-struct sol_drange_spec {
+typedef struct sol_drange_spec {
     double min; /**< @brief Range minimum value */
     double max; /**< @brief Range maximum value */
     double step; /**< @brief Range step */
-};
+} sol_drange_spec;
 
 /**
  * @brief Helper macro to initialize a double range with default values.
@@ -324,23 +324,23 @@ int sol_drange_compose(const struct sol_drange_spec *spec, double value, struct 
 /**
  * @brief Data type describing Integer ranges.
  */
-struct sol_irange {
+typedef struct sol_irange {
     int32_t val; /**< @brief Current value */
     int32_t min; /**< @brief Range minimum value */
     int32_t max; /**< @brief Range maximum value */
     int32_t step; /**< @brief Range step */
-};
+} sol_irange;
 
 /**
  * @brief Data type describing a spec for Integer ranges.
  *
  * A range spec is composed by the range limits and step.
  */
-struct sol_irange_spec {
+typedef struct sol_irange_spec {
     int32_t min; /**< @brief Range minimum value */
     int32_t max; /**< @brief Range maximum value */
     int32_t step; /**< @brief Range step */
-};
+} sol_irange_spec;
 
 /**
  * @brief Helper macro to initialize an integer range with default values.
@@ -465,13 +465,13 @@ struct sol_blob_type;
 /**
  * @brief Data type describing the default blob implementation.
  */
-struct sol_blob {
+typedef struct sol_blob {
     const struct sol_blob_type *type; /**< @brief Blob type */
     struct sol_blob *parent; /**< @brief Pointer to the parent Blob */
     void *mem; /**< @brief Blob data */
     size_t size; /**< @brief Blob size */
     uint16_t refcnt; /**< @brief Blob reference counter */
-};
+} sol_blob;
 
 /**
  * @brief Data type describing a blob type.
@@ -479,14 +479,14 @@ struct sol_blob {
  * This should be used by different kinds of Blob implementation to make than
  * compatible to our blob API.
  */
-struct sol_blob_type {
+typedef struct sol_blob_type {
 #ifndef SOL_NO_API_VERSION
 #define SOL_BLOB_TYPE_API_VERSION (1)
     uint16_t api_version; /**< @brief API version */
     uint16_t sub_api; /**< @brief Type API version */
 #endif
     void (*free)(struct sol_blob *blob); /**< @brief Callback to free an instance */
-};
+} sol_blob_type;
 
 /**
  * @brief Blob type object for the default implementation.
@@ -626,10 +626,10 @@ sol_blob_new_dup_str(const char *str)
 /**
  * @brief Data type to describe <key, value> pairs of strings.
  */
-struct sol_key_value {
+typedef struct sol_key_value {
     const char *key; /**< @brief Pair's key */
     const char *value; /**< @brief Pair's value */
-};
+} sol_key_value;
 
 /**
  * @}

--- a/src/lib/common/include/sol-update-modules.h
+++ b/src/lib/common/include/sol-update-modules.h
@@ -44,7 +44,7 @@ extern "C" {
  * @brief Structure containing function that need to be implemented by Soletta
  * update modules.
  */
-struct sol_update {
+typedef struct sol_update {
 #ifndef SOL_NO_API_VERSION
 #define SOL_UPDATE_API_VERSION (1)
     uint16_t api_version; /**< @brief API version */
@@ -106,7 +106,7 @@ struct sol_update {
      * Cleanup tasks can be performed when this function is called.
      */
     void (*shutdown)(void);
-};
+} sol_update;
 
 /**
  * @def SOL_UPDATE_DECLARE(_NAME, decl ...)

--- a/src/lib/common/include/sol-update.h
+++ b/src/lib/common/include/sol-update.h
@@ -54,19 +54,20 @@ extern "C" {
  */
 
 /**
- * @struct sol_update_handle
+ * @typedef sol_update_handle
  *
  * @brief Handle returned by some sol_update* calls, so they can be cancelled
  * appropriately.
  */
 struct sol_update_handle;
+typedef struct sol_update_handle sol_update_handle;
 
 /**
  * @brief Contains update info got via @c sol_update_check call.
  *
  * @see sol_update_check
  */
-struct sol_update_info {
+typedef struct sol_update_info {
 #ifndef SOL_NO_API_VERSION
 #define SOL_UPDATE_INFO_API_VERSION (1)
     uint16_t api_version;
@@ -74,7 +75,7 @@ struct sol_update_info {
     const char *version; /**< @brief Current version of update file */
     uint64_t size; /**< @brief Size of update file. Useful to warn user about big downloads. */
     bool need_update; /**< @brief If version of update is newer than current, so the update is necessary. */
-};
+} sol_update_info;
 
 /**
  * @brief Check if there's an update to get.

--- a/src/lib/common/include/sol-worker-thread.h
+++ b/src/lib/common/include/sol-worker-thread.h
@@ -40,18 +40,18 @@ extern "C" {
 
 
 /**
- * @struct sol_worker_thread
+ * @typedef sol_worker_thread
  * @brief A worker thread handle
  * @see sol_worker_thread_new()
  */
 // TODO abstract locks? see eina_lock.h
 struct sol_worker_thread;
+typedef struct sol_worker_thread sol_worker_thread;
 
 /**
- * @struct sol_worker_thread_config
  * @brief Worker thread functions and context data configuration.
  */
-struct sol_worker_thread_config {
+typedef struct sol_worker_thread_config {
 #ifndef SOL_NO_API_VERSION
 #define SOL_WORKER_THREAD_CONFIG_API_VERSION (1)
     /** must match SOL_WORKER_THREAD_CONFIG_API_VERSION in runtime */
@@ -106,7 +106,7 @@ struct sol_worker_thread_config {
      * done.
      */
     void (*feedback)(void *data);
-};
+} sol_worker_thread_config;
 
 /**
  * Create and run a worker thread.

--- a/src/lib/common/sol-bus.h
+++ b/src/lib/common/sol-bus.h
@@ -105,9 +105,11 @@ struct sol_bus_interfaces {
 };
 
 /**
+ * @typedef sol_bus_client
  * Represents an remote service on a bus.
  */
 struct sol_bus_client;
+typedef struct sol_bus_client sol_bus_client;
 
 /**
  * Opens and returns an connection to the system bus.

--- a/src/lib/comms/include/sol-bluetooth.h
+++ b/src/lib/comms/include/sol-bluetooth.h
@@ -73,7 +73,7 @@ enum sol_bt_uuid_type {
  *
  * @see #sol_bt_uuid_type
  */
-struct sol_bt_uuid {
+typedef struct sol_bt_uuid {
     enum sol_bt_uuid_type type;
     union {
         uint16_t val16;
@@ -81,7 +81,7 @@ struct sol_bt_uuid {
         uint8_t val128[16];
         uint8_t val[0];
     };
-};
+} sol_bt_uuid;
 
 /**
  * @brief Convert a string to a UUID.
@@ -117,13 +117,14 @@ int sol_bt_uuid_to_str(const struct sol_bt_uuid *uuid, struct sol_buffer *buffer
 bool sol_bt_uuid_eq(const struct sol_bt_uuid *u1, const struct sol_bt_uuid *u2);
 
 /**
- * @struct sol_bt_conn
+ * @typedef sol_bt_conn
  * @brief Represents an active connection to a Bluetooth device.
  *
  * The connection is established with sol_bt_connect(), and its lifetime is
  * managed by sol_bt_conn_ref()/sol_bt_conn_unref().
  */
 struct sol_bt_conn;
+typedef struct sol_bt_conn sol_bt_conn;
 
 /**
  * @brief Increases the reference count of a connection.
@@ -192,7 +193,7 @@ struct sol_bt_conn *sol_bt_connect(const struct sol_network_link_addr *addr,
 int sol_bt_disconnect(struct sol_bt_conn *conn);
 
 /**
- * @struct sol_bt_session
+ * @typedef sol_bt_session
  * @brief Represents a Bluetooth usage session
  *
  * Because Bluetooth usage may increase the power comsuption, there's
@@ -200,6 +201,7 @@ int sol_bt_disconnect(struct sol_bt_conn *conn);
  * keep Bluetooth turned off if it's not used.
  */
 struct sol_bt_session;
+typedef struct sol_bt_session sol_bt_session;
 
 /**
  * @brief Enables the local Bluetooth controller.
@@ -237,7 +239,7 @@ int sol_bt_disable(struct sol_bt_session *session);
 /**
  * @brief Represents a information about a remote device.
  */
-struct sol_bt_device_info {
+typedef struct sol_bt_device_info {
     /**
      * @brief Network address of the remote device.
      */
@@ -266,7 +268,7 @@ struct sol_bt_device_info {
      * @brief Whether the devices is currently in range.
      */
     bool in_range;
-};
+} sol_bt_device_info;
 
 /**
  * @brief Over which transport should a scan be performed.
@@ -301,12 +303,13 @@ const char *sol_bt_transport_to_str(enum sol_bt_transport transport);
 enum sol_bt_transport sol_bt_transport_from_str(const char *str);
 
 /**
- * @struct sol_bt_scan_pending
+ * @typedef sol_bt_scan_pending
  * @brief Represents a pending scan session
  *
  * Represents a pending scan session, @see sol_bt_start_scan().
  */
 struct sol_bt_scan_pending;
+typedef struct sol_bt_scan_pending sol_bt_scan_pending;
 
 /**
  * @brief Start scanning for devices.

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -241,18 +241,20 @@ enum sol_coap_flags {
 };
 
 /**
- * @struct sol_coap_packet
+ * @typedef sol_coap_packet
  *
  * @brief Opaque handler for a CoAP packet.
  */
 struct sol_coap_packet;
+typedef struct sol_coap_packet sol_coap_packet;
 
 /**
- * @struct sol_coap_server
+ * @typedef sol_coap_server
  *
  * @brief Opaque handler for a CoAP server.
  */
 struct sol_coap_server;
+typedef struct sol_coap_server sol_coap_server;
 
 /**
  * @brief Description for a CoAP resource.
@@ -262,7 +264,7 @@ struct sol_coap_server;
  * are registered using this struct and the sol_coap_server_register_resource()
  * function.
  */
-struct sol_coap_resource {
+typedef struct sol_coap_resource {
 #ifndef SOL_NO_API_VERSION
 #define SOL_COAP_RESOURCE_API_VERSION (1)
     /** @brief API version */
@@ -343,7 +345,7 @@ struct sol_coap_resource {
      * any separators. Last slice should be empty.
      */
     struct sol_str_slice path[];
-};
+} sol_coap_resource;
 
 /**
  * @brief Gets the CoAP protocol version of the packet.

--- a/src/lib/comms/include/sol-gatt.h
+++ b/src/lib/comms/include/sol-gatt.h
@@ -122,7 +122,7 @@ enum sol_gatt_desc_flags {
 };
 
 /**
- * @struct sol_gatt_pending
+ * @typedef sol_gatt_pending
  * @brief Represents a pending request
  *
  * So a response to a GATT operation can be returned asynchronously,
@@ -131,6 +131,7 @@ enum sol_gatt_desc_flags {
  * is complete.
  */
 struct sol_gatt_pending;
+typedef struct sol_gatt_pending sol_gatt_pending;
 
 /**
  * @brief Returns the attribute referenced by a pending operation
@@ -145,7 +146,7 @@ const struct sol_gatt_attr *sol_gatt_pending_get_attr(
 /**
  * @brief Representation of a GATT Attribute
  */
-struct sol_gatt_attr {
+typedef struct sol_gatt_attr {
     struct sol_bt_uuid uuid;
     enum sol_gatt_attr_type type;
     uint16_t flags;
@@ -174,7 +175,7 @@ struct sol_gatt_attr {
     void *user_data;
 
     void *_priv;
-};
+} sol_gatt_attr;
 
 /**
  * @brief Returns a response to an asynchronous operation

--- a/src/lib/comms/include/sol-http-client.h
+++ b/src/lib/comms/include/sol-http-client.h
@@ -47,7 +47,7 @@ extern "C" {
 
 
 /**
- * @struct sol_http_client_connection
+ * @typedef sol_http_client_connection
  * @brief Opaque handler for an HTTP client connection.
  *
  * It's created when a request is made with
@@ -57,6 +57,7 @@ extern "C" {
  * A connection may be canceled with sol_http_client_connection_cancel().
  */
 struct sol_http_client_connection;
+typedef struct sol_http_client_connection sol_http_client_connection;
 
 /**
  * @brief The HTTP request interface to use when creating a new request.
@@ -67,7 +68,7 @@ struct sol_http_client_connection;
  * @see sol_http_client_request_with_interface()
  * @note HTTP client follows the Soletta stream design pattern, which can be found here: @ref streams
  */
-struct sol_http_request_interface {
+typedef struct sol_http_request_interface {
 #ifndef SOL_NO_API_VERSION
 #define SOL_HTTP_REQUEST_INTERFACE_API_VERSION (1)
     /**
@@ -136,7 +137,7 @@ struct sol_http_request_interface {
      * @see sol_http_request_interface::on_data
      */
     size_t data_buffer_size;
-};
+} sol_http_request_interface;
 
 /**
  * @brief Create a request for the specified URL using the given method. The result of

--- a/src/lib/comms/include/sol-http-server.h
+++ b/src/lib/comms/include/sol-http-server.h
@@ -47,22 +47,22 @@ extern "C" {
  */
 
 /**
- * @struct sol_http_server
+ * @typedef sol_http_server
  * @brief Opaque handler for an HTTP server instance.
  *
  * It's created with sol_http_server_new() and should be later
  * deleted with sol_http_server_del()
  */
 struct sol_http_server;
+typedef struct sol_http_server sol_http_server;
 
 /**
- * @struct sol_http_server_config
  * @brief
  *
  * It's created with sol_http_server_new() and should be later
  * deleted with sol_http_server_del()
  */
-struct sol_http_server_config {
+typedef struct sol_http_server_config {
 #ifndef SOL_NO_API_VERSION
 #define SOL_HTTP_SERVER_CONFIG_API_VERSION (1)  /**< compile time API version to be checked during runtime */
     /**
@@ -76,10 +76,10 @@ struct sol_http_server_config {
         const struct sol_cert *cert;
         const struct sol_cert *key;
     } security;
-};
+} sol_http_server_config;
 
 /**
- * @struct sol_http_request
+ * @typedef sol_http_request
  * @brief Opaque handler for a request made to an HTTP server.
  *
  * Request properties can be queried with:
@@ -91,9 +91,10 @@ struct sol_http_server_config {
  * A response to a request can be send with sol_http_server_send_response()
  */
 struct sol_http_request;
+typedef struct sol_http_request sol_http_request;
 
 /**
- * @struct sol_http_progressive_response
+ * @typedef sol_http_progressive_response
  * @brief Opaque handler used for send data progressively.
  *
  * Progressive responses can be used to create server sent events.
@@ -103,6 +104,7 @@ struct sol_http_request;
  * To delete it use sol_http_progressive_response_del().
  */
 struct sol_http_progressive_response;
+typedef struct sol_http_progressive_response sol_http_progressive_response;
 
 /**
  * @brief Creates an HTTP server, binding on all interfaces
@@ -281,11 +283,10 @@ sol_http_response_set_sse_headers(struct sol_http_response *response)
 
 /**
  * @brief Progressive server response configuration.
- * @struct sol_http_server_progressive_config
  * @see sol_http_server_send_progressive_response()
  * @note HTTP server follows the Soletta stream design pattern, which can be found here: @ref streams
  */
-struct sol_http_server_progressive_config {
+typedef struct sol_http_server_progressive_config {
 #ifndef SOL_NO_API_VERSION
 #define SOL_HTTP_SERVER_PROGRESSIVE_CONFIG_API_VERSION (1)
     /**
@@ -327,7 +328,7 @@ struct sol_http_server_progressive_config {
      * @see sol_http_progressive_response_feed()
      */
     size_t feed_size;
-};
+} sol_http_server_progressive_config;
 
 /**
  * @brief Send the response and keep connection alive to request given in the

--- a/src/lib/comms/include/sol-http.h
+++ b/src/lib/comms/include/sol-http.h
@@ -175,7 +175,7 @@ enum sol_http_status_code {
  * sol_http_client_request() or sol_http_client_request_with_interface()
  * or to create URIs, with sol_http_create_uri() and variants.
  */
-struct sol_http_params {
+typedef struct sol_http_params {
 #ifndef SOL_NO_API_VERSION
 #define SOL_HTTP_PARAM_API_VERSION (1)
     uint16_t api_version;
@@ -183,7 +183,7 @@ struct sol_http_params {
 
     struct sol_vector params; /**< vector of parameters, struct @ref sol_http_param_value */
     struct sol_arena *arena; /**< arena with copied parameter slices */
-};
+} sol_http_params;
 
 /**
  * @brief Used to rank content type priorities.
@@ -212,7 +212,7 @@ struct sol_http_content_type_priority {
  * It may be a key-value parameter, authentication (user-password),
  * or data.
  */
-struct sol_http_param_value {
+typedef struct sol_http_param_value {
     enum sol_http_param_type type;
     union {
         struct {
@@ -235,7 +235,7 @@ struct sol_http_param_value {
             struct sol_str_slice filename;
         } data;
     } value;
-};
+} sol_http_param_value;
 
 /**
  * @brief Handle for an HTTP response
@@ -245,7 +245,7 @@ struct sol_http_param_value {
  * definition of content type, like "text" or "application/json",
  * and the response content itself.
  */
-struct sol_http_response {
+typedef struct sol_http_response {
 #ifndef SOL_NO_API_VERSION
 #define SOL_HTTP_RESPONSE_API_VERSION (1)
     uint16_t api_version;
@@ -256,16 +256,16 @@ struct sol_http_response {
     struct sol_buffer content;
     struct sol_http_params param;
     int response_code;
-};
+} sol_http_response;
 
 /**
  * @brief Handle for an HTTP URL
  *
  * Uniform Resource Locator conforms to the following syntax:
  *
- * scheme:[//[user:password@]host[:port]][/]path[?query][#fragment]
+ * scheme:[//[user:password@]host[:port]][/]path[?query][\c \#fragment]
  */
-struct sol_http_url {
+typedef struct sol_http_url {
     struct sol_str_slice scheme;
     struct sol_str_slice user;
     struct sol_str_slice password;
@@ -274,7 +274,7 @@ struct sol_http_url {
     struct sol_str_slice query;
     struct sol_str_slice fragment;
     uint32_t port; /**< If set to 0 it'll be ignored */
-};
+} sol_http_url;
 
 #ifndef SOL_NO_API_VERSION
 /**

--- a/src/lib/comms/include/sol-lwm2m.h
+++ b/src/lib/comms/include/sol-lwm2m.h
@@ -67,45 +67,51 @@ extern "C" {
 #define SOL_LWM2M_DEFAULT_SERVER_PORT (5683)
 
 /**
- * @struct sol_lwm2m_client
+ * @typedef sol_lwm2m_client
  * @brief A handle to a LWM2M client.
  * @see sol_lwm2m_client_new().
  */
 struct sol_lwm2m_client;
+typedef struct sol_lwm2m_client sol_lwm2m_client;
 
 /**
- * @struct sol_lwm2m_server
+ * @typedef sol_lwm2m_server
  * @brief A handle to a LWM2M server.
  * @see sol_lwm2m_server_new()
  */
 struct sol_lwm2m_server;
+typedef struct sol_lwm2m_server sol_lwm2m_server;
 
 /**
- * @struct sol_lwm2m_bootstrap_server
+ * @typedef sol_lwm2m_bootstrap_server
  * @brief A handle to a LWM2M bootstrap server.
  * @see sol_lwm2m_bootstrap_server_new()
  */
 struct sol_lwm2m_bootstrap_server;
+typedef struct sol_lwm2m_bootstrap_server sol_lwm2m_bootstrap_server;
 
 /**
- * @struct sol_lwm2m_bootstrap_client_info
+ * @typedef sol_lwm2m_bootstrap_client_info
  * @brief A handle that contains information about a bootstrapping LWM2M client.
  */
 struct sol_lwm2m_bootstrap_client_info;
+typedef struct sol_lwm2m_bootstrap_client_info sol_lwm2m_bootstrap_client_info;
 
 /**
- * @struct sol_lwm2m_client_info
+ * @typedef sol_lwm2m_client_info
  * @brief A handle that contains information about a registered LWM2M client.
  * @see sol_lwm2m_server_get_clients()
  */
 struct sol_lwm2m_client_info;
+typedef struct sol_lwm2m_client_info sol_lwm2m_client_info;
 
 /**
- * @struct sol_lwm2m_client_object
+ * @typedef sol_lwm2m_client_object
  * @brief A handle of a client's object.
  * @see sol_lwm2m_client_info_get_objects()
  */
 struct sol_lwm2m_client_object;
+typedef struct sol_lwm2m_client_object sol_lwm2m_client_object;
 
 /**
  * @brief LWM2M Client binding mode.
@@ -327,7 +333,7 @@ enum sol_lwm2m_resource_type {
  *
  * @see sol_lwm2m_parse_tlv()
  */
-struct sol_lwm2m_tlv {
+typedef struct sol_lwm2m_tlv {
 #ifndef SOL_NO_API_VERSION
 #define SOL_LWM2M_TLV_API_VERSION (1)
     /** @brief API version */
@@ -340,13 +346,13 @@ struct sol_lwm2m_tlv {
     uint16_t id;
     /** @brief The TLV content */
     struct sol_buffer content;
-};
+} sol_lwm2m_tlv;
 
 /**
  * @brief Struct that represents a LWM2M resource.
  * @see sol_lwm2m_resource_init()
  */
-struct sol_lwm2m_resource {
+typedef struct sol_lwm2m_resource {
 #ifndef SOL_NO_API_VERSION
 #define SOL_LWM2M_RESOURCE_API_VERSION (1)
     /** @brief API version */
@@ -371,7 +377,7 @@ struct sol_lwm2m_resource {
         /** @brief The resource is a bool value */
         bool b;
     } *data;
-};
+} sol_lwm2m_resource;
 
 /**
  * @brief Convinent macro to initialize a LWM2M resource.
@@ -430,7 +436,7 @@ struct sol_lwm2m_resource {
  * @see sol_lwm2m_content_type
  * @see struct sol_lwm2m_object::create
  */
-struct sol_lwm2m_payload {
+typedef struct sol_lwm2m_payload {
     /** @brief The payload type
      * @see sol_lwm2m_content_type
      */
@@ -443,7 +449,7 @@ struct sol_lwm2m_payload {
         /** @brief The payload content in bytes. */
         struct sol_str_slice slice_content;
     } payload /** @brief The payload data */;
-};
+} sol_lwm2m_payload;
 
 /** @brief A LWM2M object implementation.
  *
@@ -462,7 +468,7 @@ struct sol_lwm2m_payload {
  *
  * @see sol_lwm2m_client_new()
  */
-struct sol_lwm2m_object {
+typedef struct sol_lwm2m_object {
 #ifndef SOL_NO_API_VERSION
 #define SOL_LWM2M_OBJECT_API_VERSION (1)
     /** @brief API version */
@@ -591,7 +597,7 @@ struct sol_lwm2m_object {
      */
     int (*del)(void *instance_data, void *user_data,
         struct sol_lwm2m_client *client, uint16_t instance_id);
-};
+} sol_lwm2m_object;
 
 /**
  *

--- a/src/lib/comms/include/sol-mavlink.h
+++ b/src/lib/comms/include/sol-mavlink.h
@@ -41,7 +41,7 @@ extern "C" {
  */
 
 /**
- * @struct sol_mavlink
+ * @typedef sol_mavlink
  *
  * @brief Mavlink Object
  *
@@ -52,6 +52,7 @@ extern "C" {
  * sol_mavlink_connect() API.
  */
 struct sol_mavlink;
+typedef struct sol_mavlink sol_mavlink;
 
 /**
  * @enum sol_mavlink_mode
@@ -163,11 +164,9 @@ enum sol_mavlink_mode {
 };
 
 /**
- * @struct sol_mavlink_position
- *
  * @brief Mavlink position structure
  */
-struct sol_mavlink_position {
+typedef struct sol_mavlink_position {
     /** Latitude in degrees */
     float latitude;
 
@@ -185,14 +184,12 @@ struct sol_mavlink_position {
 
     /** Local Z position of this position in the local coordinate frame */
     float z;
-};
+} sol_mavlink_position;
 
 /**
- * @struct sol_mavlink_handlers
- *
  * @brief Mavlink callback handlers
  */
-struct sol_mavlink_handlers {
+typedef struct sol_mavlink_handlers {
 #ifndef SOL_NO_API_VERSION
 #define SOL_MAVLINK_HANDLERS_API_VERSION (1)
     /**
@@ -280,14 +277,12 @@ struct sol_mavlink_handlers {
      * destination.
      */
     void (*mission_reached) (void *data, struct sol_mavlink *mavlink);
-};
+} sol_mavlink_handlers;
 
 /**
- * @struct sol_mavlink_config
- *
  * @brief Server Configuration
  */
-struct sol_mavlink_config {
+typedef struct sol_mavlink_config {
 #ifndef SOL_NO_API_VERSION
 #define SOL_MAVLINK_CONFIG_API_VERSION (1)
     /**
@@ -305,7 +300,7 @@ struct sol_mavlink_config {
      * In case of serial protocol set the baud_rate, default set to 115200.
      */
     int baud_rate;
-};
+} sol_mavlink_config;
 
 /**
  * @brief Connect to a mavlink server

--- a/src/lib/comms/include/sol-mqtt.h
+++ b/src/lib/comms/include/sol-mqtt.h
@@ -119,7 +119,7 @@ enum sol_mqtt_conn_status {
 };
 
 /**
- * @struct sol_mqtt
+ * @typedef sol_mqtt
  *
  * @brief MQTT Object
  *
@@ -130,16 +130,15 @@ enum sol_mqtt_conn_status {
  * sol_mqtt_connect() API.
  */
 struct sol_mqtt;
+typedef struct sol_mqtt sol_mqtt;
 
 /**
- * @struct sol_mqtt_message
- *
  * @brief MQTT Message
  *
  * This object is the abstraction of a MQTT message and is the base for
  * publishing and receiving data to/from the broker.
  */
-struct sol_mqtt_message {
+typedef struct sol_mqtt_message {
 #ifndef SOL_NO_API_VERSION
 #define SOL_MQTT_MESSAGE_API_VERSION (1)
     /**
@@ -172,14 +171,12 @@ struct sol_mqtt_message {
      * If true, the message will be retained by the broker
      */
     bool retain;
-};
+} sol_mqtt_message;
 
 /**
- * @struct sol_mqtt_handlers
- *
  * @brief MQTT callback handlers
  */
-struct sol_mqtt_handlers {
+typedef struct sol_mqtt_handlers {
 #ifndef SOL_NO_API_VERSION
 #define SOL_MQTT_HANDLERS_API_VERSION (1)
     /**
@@ -266,14 +263,12 @@ struct sol_mqtt_handlers {
      * Callback called when a unsubscribe request has been processed.
      */
     void (*unsubscribe) (void *data, struct sol_mqtt *mqtt);
-};
+} sol_mqtt_handlers;
 
 /**
- * @struct sol_mqtt_config
- *
  * @brief Server Configuration
  */
-struct sol_mqtt_config {
+typedef struct sol_mqtt_config {
 #ifndef SOL_NO_API_VERSION
 #define SOL_MQTT_CONFIG_API_VERSION (1)
     /**
@@ -349,7 +344,7 @@ struct sol_mqtt_config {
      * Handlers to be used with this connection
      */
     const struct sol_mqtt_handlers handlers;
-};
+} sol_mqtt_config;
 
 /**
  * @brief Connect to a MQTT broker

--- a/src/lib/comms/include/sol-netctl.h
+++ b/src/lib/comms/include/sol-netctl.h
@@ -30,22 +30,21 @@ extern "C" {
 #endif
 
 /**
- * @struct sol_netctl_service
+ * @typedef sol_netctl_service
  *
  * @brief service struct
  */
 struct sol_netctl_service;
+typedef struct sol_netctl_service sol_netctl_service;
 
 /**
- * @struct sol_netctl_network_params
- *
  * @brief network params
  *
  * This struct contains the information of a network.
  * it has the addr of network link addr, the network of
  * netmask and its gateway of network.
  */
-struct sol_netctl_network_params {
+typedef struct sol_netctl_network_params {
     /**
      * @brief The network devices address
      */
@@ -58,7 +57,7 @@ struct sol_netctl_network_params {
      * @brief The network gateway
      */
     struct sol_network_link_addr gateway;
-};
+} sol_netctl_network_params;
 
 /**
  * @enum sol_netctl_service_state

--- a/src/lib/comms/include/sol-network.h
+++ b/src/lib/comms/include/sol-network.h
@@ -66,7 +66,7 @@ extern "C" {
 #define SOL_BLUETOOTH_ADDR_STRLEN 18
 
 /**
- * @struct sol_network_hostname_pending
+ * @typedef sol_network_hostname_pending
  *
  * @brief A handle returned by sol_network_get_hostname_address_info()
  *
@@ -78,6 +78,7 @@ extern "C" {
  * @see sol_network_hostname_pending_cancel()
  */
 struct sol_network_hostname_pending;
+typedef struct sol_network_hostname_pending sol_network_hostname_pending;
 
 /**
  * @brief Type of events generated for a network link.
@@ -140,7 +141,7 @@ enum sol_network_bt_addr_type {
 /**
  * @brief Structure to represent a network address, both IPv6 and IPv4 are valid.
  */
-struct sol_network_link_addr {
+typedef struct sol_network_link_addr {
     enum sol_network_family family; /**< @brief IPv4 or IPv6 family */
     union {
         uint8_t in[4];
@@ -151,7 +152,7 @@ struct sol_network_link_addr {
         };
     } addr; /**< @brief The address itself */
     uint16_t port; /**< @brief The port associed with the IP address */
-};
+} sol_network_link_addr;
 
 /**
  * @brief Structure to represent a network link.
@@ -161,7 +162,7 @@ struct sol_network_link_addr {
  * index (the value used by the SO to identify the link) and its
  * address @ref sol_network_link_addr.
  */
-struct sol_network_link {
+typedef struct sol_network_link {
 #ifndef SOL_NO_API_VERSION
 #define SOL_NETWORK_LINK_API_VERSION (1)
     uint16_t api_version; /**< @brief API version */
@@ -173,7 +174,7 @@ struct sol_network_link {
      * @see sol_network_link_addr
      **/
     struct sol_vector addrs;
-};
+} sol_network_link;
 
 #ifndef SOL_NO_API_VERSION
 /**

--- a/src/lib/comms/include/sol-oic-client.h
+++ b/src/lib/comms/include/sol-oic-client.h
@@ -46,16 +46,17 @@ extern "C" {
  */
 
 /**
- * @struct sol_oic_client
+ * @typedef sol_oic_client
  * @brief Opaque handler for an OIC client instance.
  *
  * It's created with sol_oic_client_new() and should be later
  * deleted with sol_oic_client_del()
  */
 struct sol_oic_client;
+typedef struct sol_oic_client sol_oic_client;
 
 /**
- * @struct sol_oic_pending
+ * @typedef sol_oic_pending
  * @brief Represents a pending OIC client call
  *
  * This can be used to cancel the pending call. Note that the context
@@ -65,6 +66,7 @@ struct sol_oic_client;
  *
  */
 struct sol_oic_pending;
+typedef struct sol_oic_pending sol_oic_pending;
 
 /**
  * @brief Structure defining an OIC resource. It's open to the API
@@ -72,7 +74,7 @@ struct sol_oic_pending;
  * are marked as const to emphasize that the user must not alter any
  * of them.
  */
-struct sol_oic_resource {
+typedef struct sol_oic_resource {
 #ifndef SOL_NO_API_VERSION
 #define SOL_OIC_RESOURCE_API_VERSION (1)
     uint16_t api_version; /**< @brief API version */
@@ -107,7 +109,7 @@ struct sol_oic_resource {
      * server is secure.
      */
     const bool secure;
-};
+} sol_oic_resource;
 
 /**
  * @brief Creates a new OIC client intance.

--- a/src/lib/comms/include/sol-oic-server.h
+++ b/src/lib/comms/include/sol-oic-server.h
@@ -42,20 +42,19 @@ extern "C" {
  */
 
 /**
- * @struct sol_oic_server_resource
+ * @typedef sol_oic_server_resource
  *
  * @brief Opaque handler for a server resource
  */
 struct sol_oic_server_resource;
+typedef struct sol_oic_server_resource sol_oic_server_resource;
 
 /**
- * @struct sol_oic_resource_type
- *
  * @brief structure defining the type of a resource.
  *
  * @see sol_oic_server_register_resource
  */
-struct sol_oic_resource_type {
+typedef struct sol_oic_resource_type {
 #ifndef SOL_NO_API_VERSION
 #define SOL_OIC_RESOURCE_TYPE_API_VERSION (1)
     uint16_t api_version; /**< @brief API version */
@@ -151,7 +150,7 @@ struct sol_oic_resource_type {
      * @see sol_oic_server_send_response
      */
         del;
-};
+} sol_oic_resource_type;
 
 /**
  * @brief Add resource to OIC server.

--- a/src/lib/comms/include/sol-oic.h
+++ b/src/lib/comms/include/sol-oic.h
@@ -52,7 +52,7 @@ extern "C" {
  * callbacks returning an instance do so with a @c const modifier. The
  * user must never change these fields, ever.
  */
-struct sol_oic_platform_info {
+typedef struct sol_oic_platform_info {
 #ifndef SOL_NO_API_VERSION
 #define SOL_OIC_PLATFORM_INFO_API_VERSION (1)
     uint16_t api_version; /**< @brief API version */
@@ -110,7 +110,7 @@ struct sol_oic_platform_info {
      * @brief Current system time in the device
      */
     struct sol_str_slice system_time;
-};
+} sol_oic_platform_info;
 
 /**
  * @brief Flags to set when adding a new resource to a server.
@@ -172,7 +172,7 @@ enum sol_oic_resource_flag {
  * returning an instance do so with a @c const modifier. The user must
  * never change these fields, ever.
  */
-struct sol_oic_device_info {
+typedef struct sol_oic_device_info {
 #ifndef SOL_NO_API_VERSION
 #define SOL_OIC_DEVICE_INFO_API_VERSION (1)
     uint16_t api_version; /**< @brief API version */
@@ -194,7 +194,7 @@ struct sol_oic_device_info {
      * @brief Spec version of data model.
      */
     struct sol_str_slice data_model_version;
-};
+} sol_oic_device_info;
 
 /**
  * @brief field type of sol_oic_repr_field structure.
@@ -222,7 +222,7 @@ enum sol_oic_repr_type {
  * @see sol_oic_map_append()
  * @see SOL_OIC_MAP_LOOP()
  */
-struct sol_oic_repr_field {
+typedef struct sol_oic_repr_field {
     /**
      * @brief type of the data of this field.
      */
@@ -270,7 +270,7 @@ struct sol_oic_repr_field {
          */
         bool v_boolean;
     };
-};
+} sol_oic_repr_field;
 
 /**
  * @brief Helper macro to create a #sol_oic_repr_field.
@@ -370,7 +370,7 @@ struct sol_oic_repr_field {
     SOL_OIC_REPR_FIELD(key_, SOL_OIC_REPR_TYPE_DOUBLE, .v_double = (value_))
 
 /**
- * @struct sol_oic_map_writer
+ * @typedef sol_oic_map_writer
  *
  * @brief Opaque handler for an OIC packet map writer.
  *
@@ -381,6 +381,7 @@ struct sol_oic_repr_field {
  * @see sol_oic_client_resource_request()
  */
 struct sol_oic_map_writer;
+typedef struct sol_oic_map_writer sol_oic_map_writer;
 
 /**
  * @brief Used in @ref sol_oic_map_writer to state if the map has a content or not
@@ -427,32 +428,34 @@ enum sol_oic_map_type {
  *
  * @see SOL_OIC_MAP_LOOP.
  */
-struct sol_oic_map_reader {
+typedef struct sol_oic_map_reader {
     const void *parser;
     const void *ptr;
     const uint32_t remaining;
     const uint16_t extra;
     const uint8_t type;
     const uint8_t flags;
-};
+} sol_oic_map_reader;
 
 /**
- * @struct sol_oic_request
+ * @typedef sol_oic_request
  *
  * @brief Information about a client request.
  *
  * @see sol_oic_server_send_response
  */
 struct sol_oic_request;
+typedef struct sol_oic_request sol_oic_request;
 
 /**
- * @struct sol_oic_response
+ * @typedef sol_oic_response
  *
  * @brief Information about a server response.
  *
  * @see sol_oic_server_send_response
  */
 struct sol_oic_response;
+typedef struct sol_oic_response sol_oic_response;
 
 /**
  * @brief Possible reasons a @ref SOL_OIC_MAP_LOOP was terminated.

--- a/src/lib/comms/include/sol-socket.h
+++ b/src/lib/comms/include/sol-socket.h
@@ -34,18 +34,17 @@ extern "C" {
  */
 
 /**
- * @struct sol_socket
+ * @typedef sol_socket
  *
  * @brief Opaque handler for a socket
  */
 struct sol_socket;
+typedef struct sol_socket sol_socket;
 
 /**
- * @struct sol_socket_options
- *
  * @brief Defines the behaviour of a socket instance
  */
-struct sol_socket_options {
+typedef struct sol_socket_options {
 #ifndef SOL_NO_API_VERSION
 #define SOL_SOCKET_OPTIONS_API_VERSION (1)  /**< compile time API version to be checked during runtime */
     /**
@@ -83,15 +82,13 @@ struct sol_socket_options {
      * on_can_write()
      */
     const void *data;
-};
+} sol_socket_options;
 
 /**
- * @struct sol_socket_options
- *
  * @brief Defines specific IP layer related behaviour of a socket
  * instance
  */
-struct sol_socket_ip_options {
+typedef struct sol_socket_ip_options {
     struct sol_socket_options base;
 #ifndef SOL_NO_API_VERSION
 #define SOL_SOCKET_IP_OPTIONS_SUB_API_VERSION (1)  /**< compile time API version to be checked during runtime */
@@ -119,7 +116,7 @@ struct sol_socket_ip_options {
      * sol_socket_bind()
      */
     bool reuse_addr;
-};
+} sol_socket_ip_options;
 
 /**
  * @brief Structure to represent a socket class.
@@ -128,7 +125,7 @@ struct sol_socket_ip_options {
  * socket. This contains the methods necessary to create a new socket
  * type.
  */
-struct sol_socket_type {
+typedef struct sol_socket_type {
 #ifndef SOL_NO_API_VERSION
 #define SOL_SOCKET_TYPE_API_VERSION (1)  /**< compile time API version to be checked during runtime */
     /**
@@ -218,16 +215,16 @@ struct sol_socket_type {
      *     is returned.
      */
     int (*bind)(struct sol_socket *s, const struct sol_network_link_addr *addr);
-};
+} sol_socket_type;
 
 /**
  * @brief Structure to represent a socket.
  *
  * @see sol_socket_type
  */
-struct sol_socket {
+typedef struct sol_socket {
     const struct sol_socket_type *type;
-};
+} sol_socket;
 
 /**
  * @brief Creates an endpoint for communication.

--- a/src/lib/crypto/include/sol-message-digest.h
+++ b/src/lib/crypto/include/sol-message-digest.h
@@ -80,10 +80,11 @@ extern "C" {
  */
 
 /**
- * @struct sol_message_digest
+ * @typedef sol_message_digest
  * @brief A handle for a message digest
  */
 struct sol_message_digest;
+typedef struct sol_message_digest sol_message_digest;
 
 /**
  * The message digest configuration to use when creating a new handle.
@@ -91,7 +92,7 @@ struct sol_message_digest;
  * @note Message digest follows the Soletta stream design pattern, which can be found here: @ref streams
  * @see sol_message_digest_new()
  */
-struct sol_message_digest_config {
+typedef struct sol_message_digest_config {
 #ifndef SOL_NO_API_VERSION
 #define SOL_MESSAGE_DIGEST_CONFIG_API_VERSION (1)
     /**
@@ -177,7 +178,7 @@ struct sol_message_digest_config {
      * @see sol_message_digest_feed()
      */
     size_t feed_size;
-};
+} sol_message_digest_config;
 
 /**
  * Create a new handle to feed the message to digest.

--- a/src/lib/datatypes/include/sol-arena.h
+++ b/src/lib/datatypes/include/sol-arena.h
@@ -44,13 +44,14 @@ extern "C" {
  */
 
 /**
- * @struct sol_arena
+ * @typedef sol_arena
  *
  * @brief Sol Arena type.
  *
  * See also @ref sol_buffer if you just need a single re-sizable buffer.
  */
 struct sol_arena;
+typedef struct sol_arena sol_arena;
 
 /**
  * @brief Creates an Arena.

--- a/src/lib/datatypes/include/sol-buffer.h
+++ b/src/lib/datatypes/include/sol-buffer.h
@@ -117,8 +117,6 @@ enum sol_buffer_flags {
     (!(buf->flags & (SOL_BUFFER_FLAGS_FIXED_CAPACITY | SOL_BUFFER_FLAGS_MEMORY_NOT_OWNED)))
 
 /**
- * @struct sol_buffer
- *
  * @brief A sol_buffer is a dynamic array, that can be resized if needed.
  *
  * It grows exponentially but also supports setting a specific size.
@@ -129,12 +127,12 @@ enum sol_buffer_flags {
  * See also @ref sol_arena if you are allocating multiple pieces of data
  * that will be deallocated twice.
  */
-struct sol_buffer {
+typedef struct sol_buffer {
     void *data; /**< @brief Buffer data */
     size_t capacity; /**< @brief Buffer capacity in bytes */
     size_t used;  /**< @brief Used size in bytes */
     enum sol_buffer_flags flags; /**< @brief Buffer flags */
-};
+} sol_buffer;
 
 /**
  * @brief Case of a string to be decoded.

--- a/src/lib/datatypes/include/sol-list.h
+++ b/src/lib/datatypes/include/sol-list.h
@@ -45,8 +45,6 @@ extern "C" {
  */
 
 /**
- * @struct sol_list
- *
  * @brief Structure to add list support to a type.
  *
  * To make possible for instances of a given type to be part of a @c sol_list,
@@ -59,10 +57,10 @@ extern "C" {
  * }
  * @endcode
  */
-struct sol_list {
+typedef struct sol_list {
     struct sol_list *next; /**< @brief Link to the next node in the list */
     struct sol_list *prev; /**< @brief Link to the previous node in the list */
-};
+} sol_list;
 
 /**
  * @def SOL_LIST_INIT

--- a/src/lib/datatypes/include/sol-memdesc.h
+++ b/src/lib/datatypes/include/sol-memdesc.h
@@ -52,9 +52,6 @@ extern "C" {
  * @{
  */
 
-/**
- * @struct sol_memdesc
- */
 struct sol_memdesc;
 
 /**
@@ -326,7 +323,7 @@ extern const uint16_t SOL_MEMDESC_API_VERSION_COMPILED;
  * @see struct sol_memdesc_ops
  * @see struct sol_memdesc
  */
-struct sol_memdesc_ops_array {
+typedef struct sol_memdesc_ops_array {
 #ifndef SOL_NO_API_VERSION
 #define SOL_MEMDESC_OPS_ARRAY_API_VERSION (1) /**< API version to use in struct sol_memdesc_ops_array::api_version */
     uint16_t api_version; /**< @brief API version, must match SOL_MEMDESC_OPS_ARRAY_API_VERSION at runtime */
@@ -374,7 +371,7 @@ struct sol_memdesc_ops_array {
      * @see sol_memdesc_resize_array()
      */
     int (*resize)(const struct sol_memdesc *desc, void *memory, size_t length);
-};
+} sol_memdesc_ops_array;
 
 /**
  * @brief Operations specific to SOL_MEMDESC_TYPE_ENUMERATION.
@@ -385,7 +382,7 @@ struct sol_memdesc_ops_array {
  * @see struct sol_memdesc_ops
  * @see struct sol_memdesc
  */
-struct sol_memdesc_ops_enumeration {
+typedef struct sol_memdesc_ops_enumeration {
 #ifndef SOL_NO_API_VERSION
 #define SOL_MEMDESC_OPS_ENUMERATION_API_VERSION (1) /**< API version to use in struct sol_memdesc_ops_enumeration::api_version */
     uint16_t api_version; /**< @brief API version, must match SOL_MEMDESC_OPS_ENUMERATION_API_VERSION at runtime */
@@ -412,7 +409,7 @@ struct sol_memdesc_ops_enumeration {
      * @see sol_memdesc_enumeration_from_str()
      */
     int (*from_str)(const struct sol_memdesc *desc, void *ptr_return, const struct sol_str_slice str);
-};
+} sol_memdesc_ops_enumeration;
 
 /**
  * @brief override operations to be used in this memory description.
@@ -427,7 +424,7 @@ struct sol_memdesc_ops_enumeration {
  * To map struct sol_vector, use SOL_MEMDESC_OPS_VECTOR. to map
  * struct sol_ptr_vector use SOL_MEMDESC_OPS_PTR_VECTOR.
  */
-struct sol_memdesc_ops {
+typedef struct sol_memdesc_ops {
 #ifndef SOL_NO_API_VERSION
 #define SOL_MEMDESC_OPS_API_VERSION (1) /**< API version to use in struct sol_memdesc_ops::api_version */
     uint16_t api_version; /**< @brief API version, must match SOL_MEMDESC_OPS_API_VERSION at runtime */
@@ -501,12 +498,12 @@ struct sol_memdesc_ops {
         const struct sol_memdesc_ops_array *array;
         const struct sol_memdesc_ops_enumeration *enumeration;
     };
-};
+} sol_memdesc_ops;
 
 /**
  * @brief Data type to describe a memory region.
  */
-struct sol_memdesc {
+typedef struct sol_memdesc {
 #ifndef SOL_NO_API_VERSION
 #define SOL_MEMDESC_API_VERSION (1) /**< @brief API version to use in struct sol_memdesc::api_version */
     uint16_t api_version; /**< @brief API version, must match SOL_MEMDESC_API_VERSION at runtime */
@@ -604,7 +601,7 @@ struct sol_memdesc {
      * May be NULL to use the default operations.
      */
     const struct sol_memdesc_ops *ops;
-};
+} sol_memdesc;
 
 /**
  * @brief Description of a structure member.
@@ -614,7 +611,7 @@ struct sol_memdesc {
  *
  * @see struct sol_memdesc
  */
-struct sol_memdesc_structure_member {
+typedef struct sol_memdesc_structure_member {
     struct sol_memdesc base;
     /**
      * @brief memory name, such as the member name in a structure.
@@ -657,7 +654,7 @@ struct sol_memdesc_structure_member {
      * wanted.
      */
     bool detail : 1;
-};
+} sol_memdesc_structure_member;
 
 /**
  * @brief operations to handle struct sol_vector.
@@ -1707,7 +1704,7 @@ sol_memdesc_is_signed_integer(const struct sol_memdesc *desc)
 /**
  * @brief Options on how to serialize a memory given its description.
  */
-struct sol_memdesc_serialize_options {
+typedef struct sol_memdesc_serialize_options {
 #ifndef SOL_NO_API_VERSION
 #define SOL_MEMDESC_SERIALIZE_OPTIONS_API_VERSION (1) /**< @brief API version to use in struct sol_memdesc_serialize_options::api_version */
     uint16_t api_version; /**< @brief API version, must match SOL_MEMDESC_SERIALIZE_OPTIONS_API_VERSION at runtime */
@@ -1978,7 +1975,7 @@ struct sol_memdesc_serialize_options {
          */
         bool show_index;
     } array;
-};
+} sol_memdesc_serialize_options;
 
 /**
  * @brief the default struct sol_memdesc_serialize_options.

--- a/src/lib/datatypes/include/sol-str-slice.h
+++ b/src/lib/datatypes/include/sol-str-slice.h
@@ -78,15 +78,13 @@ extern "C" {
 #define SOL_STR_SLICE_PRINT(_s) (int)(_s).len, (_s).data
 
 /**
- * @struct sol_str_slice
- *
  * @brief String slice type
  *
  */
-struct sol_str_slice {
+typedef struct sol_str_slice {
     size_t len; /**< @brief Slice length */
     const char *data; /**< @brief Slice data */
-};
+} sol_str_slice;
 
 /**
  * @brief Checks if the content of the slice is equal to the string.

--- a/src/lib/datatypes/include/sol-str-table.h
+++ b/src/lib/datatypes/include/sol-str-table.h
@@ -43,18 +43,16 @@ extern "C" {
  */
 
 /**
- * @struct sol_str_table
- *
  * @brief String table element type.
  *
  * For larger integers see struct sol_str_table_int64, for pointers see
  * struct sol_str_table_ptr.
  */
-struct sol_str_table {
+typedef struct sol_str_table {
     const char *key; /**< @brief Key string */
     uint16_t len; /**< @brief Key string length */
     int16_t val; /**< @brief Value (16 bits integer) */
-};
+} sol_str_table;
 
 /**
  * @def SOL_STR_TABLE_ITEM(_key, _val)
@@ -138,15 +136,13 @@ int16_t sol_str_table_lookup_fallback(const struct sol_str_table *table,
     })
 
 /**
- * @struct sol_str_table_ptr
- *
  * @brief String/Pointer table type
  */
-struct sol_str_table_ptr {
+typedef struct sol_str_table_ptr {
     const char *key; /**< @brief Key string */
     const void *val; /**< @brief Value (pointer) */
     size_t len; /**< @brief Key string length */
-};
+} sol_str_table_ptr;
 
 /**
  * @def SOL_STR_TABLE_PTR_ITEM(_key, _val)
@@ -223,15 +219,13 @@ const struct sol_str_table_ptr *sol_str_table_ptr_entry_lookup(const struct sol_
     })
 
 /**
- * @struct sol_str_table_int64
- *
  * @brief String/int64_t table type
  */
-struct sol_str_table_int64 {
+typedef struct sol_str_table_int64 {
     const char *key; /**< @brief Key string */
     size_t len; /**< @brief Key string length */
     int64_t val; /**< @brief Value (int64_t) */
-};
+} sol_str_table_int64;
 
 /**
  * @def SOL_STR_TABLE_INT64_ITEM(_key, _val)

--- a/src/lib/datatypes/include/sol-vector.h
+++ b/src/lib/datatypes/include/sol-vector.h
@@ -49,19 +49,18 @@ extern "C" {
  */
 
 /**
- * @struct sol_vector
- *
  * @brief Soletta vector is an array that grows dynamically.
  *
  * For storing pointers, see @ref sol_ptr_vector.
  *
  * @see sol_ptr_vector
  */
-struct sol_vector {
+typedef struct sol_vector {
     void *data; /**< @brief Vector data */
     uint16_t len; /**< @brief Vector length */
     uint16_t elem_size; /**< @brief Size of each element in bytes */
-};
+} sol_vector;
+
 
 /**
  * @def SOL_VECTOR_INIT(TYPE)
@@ -299,8 +298,6 @@ sol_vector_steal_data(struct sol_vector *v)
  */
 
 /**
- * @struct sol_ptr_vector
- *
  * @brief Soletta pointer vector is a wrapper around vector with an API
  * more convenient to handle pointers.
  *
@@ -308,11 +305,11 @@ sol_vector_steal_data(struct sol_vector *v)
  * some functions will return @c NULL as an error when failing to retrieve
  * the data from vector elements.
  *
- * @see struct sol_vector.
+ * @see struct sol_vector
  */
-struct sol_ptr_vector {
+typedef struct sol_ptr_vector {
     struct sol_vector base;
-};
+} sol_ptr_vector;
 
 /**
  * @def SOL_PTR_VECTOR_INIT

--- a/src/lib/flow/include/sol-flow-builder.h
+++ b/src/lib/flow/include/sol-flow-builder.h
@@ -51,11 +51,12 @@ extern "C" {
  */
 
 /**
- * @struct sol_flow_builder
+ * @typedef sol_flow_builder
  *
  * @brief Builder's handle.
  */
 struct sol_flow_builder;
+typedef struct sol_flow_builder sol_flow_builder;
 
 /**
  * @brief Creates a new instance of a @ref sol_flow_builder.

--- a/src/lib/flow/include/sol-flow-inspector.h
+++ b/src/lib/flow/include/sol-flow-inspector.h
@@ -46,7 +46,7 @@ extern "C" {
  * This structure is used to setup the inspector with a set of routines that should
  * be called in specific point and actions that happens during the execution of a flow.
  */
-struct sol_flow_inspector {
+typedef struct sol_flow_inspector {
 #ifndef SOL_NO_API_VERSION
     uint16_t api_version; /**< @brief API version */
 #define SOL_FLOW_INSPECTOR_API_VERSION (1)
@@ -117,7 +117,7 @@ struct sol_flow_inspector {
      * @param packet The packet
      */
     void (*will_deliver_packet)(const struct sol_flow_inspector *inspector, const struct sol_flow_node *dst_node, uint16_t dst_port, uint16_t dst_conn_id, const struct sol_flow_packet *packet);
-};
+} sol_flow_inspector;
 
 /**
  * @brief Provide a set of inspecting routines to flow's runtime inspector.

--- a/src/lib/flow/include/sol-flow-metatype.h
+++ b/src/lib/flow/include/sol-flow-metatype.h
@@ -84,7 +84,7 @@ extern "C" {
  * some helper functions.
  *
  */
-struct sol_flow_metatype_context {
+typedef struct sol_flow_metatype_context {
     struct sol_str_slice name; /**< The node name that is being created. */
     struct sol_str_slice contents; /**< Parameters for the metatype that is being created. */
 
@@ -118,7 +118,7 @@ struct sol_flow_metatype_context {
     int (*store_type)(
         const struct sol_flow_metatype_context *ctx,
         struct sol_flow_node_type *type);
-};
+} sol_flow_metatype_context;
 
 /**
  * @brief Struct that describes the meta type ports.
@@ -130,12 +130,12 @@ struct sol_flow_metatype_context {
  * @see sol_flow_metatype_ports_description_func()
  * @see sol_flow_metatype_get_ports_description_func()
  */
-struct sol_flow_metatype_port_description {
+typedef struct sol_flow_metatype_port_description {
     char *name; /**< The port name. */
     char *type; /**< The port type (int, float, blob and etc). */
     int array_size; /**< If the port is an array this field should be > 0. */
     int idx; /**< The port index. */
-};
+} sol_flow_metatype_port_description;
 
 /**
  * @brief Struct that describes the meta type options.
@@ -147,10 +147,10 @@ struct sol_flow_metatype_port_description {
  * @see sol_flow_metatype_options_description_func()
  * @see sol_flow_metatype_get_options_description_func()
  */
-struct sol_flow_metatype_option_description {
+typedef struct sol_flow_metatype_option_description {
     char *name; /**< The option name. */
     char *data_type; /**< The option type (int, float, blob and etc). */
-};
+} sol_flow_metatype_option_description;
 
 /**
  * @brief A callback used to create the meta type itself.
@@ -306,7 +306,7 @@ const char *sol_flow_metatype_get_options_symbol(const struct sol_str_slice name
  * @see sol_flow_metatype_ports_description_func()
  * @see sol_flow_metatype_generate_code_func()
  */
-struct sol_flow_metatype {
+typedef struct sol_flow_metatype {
 #ifndef SOL_NO_API_VERSION
     uint16_t api_version; /**< The API version. It is autocamically set by @ref SOL_FLOW_METATYPE macro. */
 #endif
@@ -320,7 +320,7 @@ struct sol_flow_metatype {
     sol_flow_metatype_generate_code_func generate_type_end; /**< A callback used to generate the meta type end code. */
     sol_flow_metatype_ports_description_func ports_description; /**< A callback used to fetch the meta type port description. */
     sol_flow_metatype_options_description_func options_description; /**< A callback used to fetch the meta type options description. */
-};
+} sol_flow_metatype;
 
 #ifdef SOL_FLOW_METATYPE_MODULE_EXTERNAL
 /**

--- a/src/lib/flow/include/sol-flow-packet.h
+++ b/src/lib/flow/include/sol-flow-packet.h
@@ -46,17 +46,18 @@ extern "C" {
  */
 
 /**
- * @struct sol_flow_packet
+ * @typedef sol_flow_packet
  *
  * @brief A packet is a generic container for different kinds (types) of contents.
  */
 struct sol_flow_packet;
+typedef struct sol_flow_packet sol_flow_packet;
 
 /**
  * @brief A packet type defines what's the content of a packet and how it's stored and
  * retrieved.
  */
-struct sol_flow_packet_type {
+typedef struct sol_flow_packet_type {
 #ifndef SOL_NO_API_VERSION
 #define SOL_FLOW_PACKET_TYPE_API_VERSION (1)
     uint16_t api_version; /**< @brief API version number */
@@ -102,7 +103,7 @@ struct sol_flow_packet_type {
      * @param value Constant initial value
      * */
     struct sol_flow_packet *(*get_constant)(const struct sol_flow_packet_type *packet_type, const void *value);
-};
+} sol_flow_packet_type;
 
 /**
  * @brief Creates a packet.

--- a/src/lib/flow/include/sol-flow-parser.h
+++ b/src/lib/flow/include/sol-flow-parser.h
@@ -48,16 +48,17 @@ extern "C" {
  */
 
 /**
- * @struct sol_flow_parser
+ * @typedef sol_flow_parser
  *
  * @brief Flow Parser handle.
  */
 struct sol_flow_parser;
+typedef struct sol_flow_parser sol_flow_parser;
 
 /**
  * @brief Flow Parser's client structure.
  */
-struct sol_flow_parser_client {
+typedef struct sol_flow_parser_client {
 #ifndef SOL_NO_API_VERSION
 #define SOL_FLOW_PARSER_CLIENT_API_VERSION (1)
     uint16_t api_version; /**< @brief API version */
@@ -78,7 +79,7 @@ struct sol_flow_parser_client {
      * @return @c 0 on success, error code (always negative) otherwise
      */
     int (*read_file)(void *data, const char *name, struct sol_buffer *buf);
-};
+} sol_flow_parser_client;
 
 /**
  * @brief Creates a new instance of @ref sol_flow_parser.

--- a/src/lib/flow/include/sol-flow-resolver.h
+++ b/src/lib/flow/include/sol-flow-resolver.h
@@ -51,7 +51,7 @@ extern "C" {
 /**
  * @brief Resolver's structure.
  */
-struct sol_flow_resolver {
+typedef struct sol_flow_resolver {
 #ifndef SOL_NO_API_VERSION
 #define SOL_FLOW_RESOLVER_API_VERSION (1) /**< @brief Current API version number */
     uint16_t api_version; /**< @brief API version number */
@@ -72,7 +72,7 @@ struct sol_flow_resolver {
      * @return @c 0 in case of success, error code (always negative) otherwise
      */
     int (*resolve)(void *data, const char *id, struct sol_flow_node_type const **type, struct sol_flow_node_named_options *named_opts);
-};
+} sol_flow_resolver;
 
 /**
  * @brief The default resolver set at compile time.

--- a/src/lib/flow/include/sol-flow-simple-c-type.h
+++ b/src/lib/flow/include/sol-flow-simple-c-type.h
@@ -66,7 +66,7 @@
 /**
  * @brief @c Simple @c C event structure.
  */
-struct sol_flow_simple_c_type_event {
+typedef struct sol_flow_simple_c_type_event {
     /**
      * @brief Event type.
      *
@@ -86,7 +86,7 @@ struct sol_flow_simple_c_type_event {
     const char *port_name; /* @brief If type is one of SOL_FLOW_SIMPLE_C_TYPE_EVENT_TYPE_PORT_* events, the port name (copy of the string given to sol_flow_simple_c_type_new_full() */
     const struct sol_flow_node_options *options; /* @brief If type is SOL_FLOW_SIMPLE_C_TYPE_EVENT_TYPE_OPEN, the given options */
     const struct sol_flow_packet *packet; /* @brief If type is SOL_FLOW_SIMPLE_C_TYPE_EVENT_TYPE_PORT_IN_PROCESS, the incoming packet */
-};
+} sol_flow_simple_c_type_event;
 
 /**
  * @brief Input port identifier

--- a/src/lib/flow/include/sol-flow-single.h
+++ b/src/lib/flow/include/sol-flow-single.h
@@ -76,7 +76,7 @@ extern "C" {
  * with #SOL_FLOW_SINGLE_OPTIONS_API_VERSION, or use
  * SOL_FLOW_SINGLE_OPTIONS_DEFAULTS() to help you.
  */
-struct sol_flow_single_options {
+typedef struct sol_flow_single_options {
     /**
      * @brief base guarantees sol_flow_node_options compatibility.
      *
@@ -155,7 +155,7 @@ struct sol_flow_single_options {
      *       packets, but this is not checked due performance reasons.
      */
     const uint16_t *connected_ports_out;
-};
+} sol_flow_single_options;
 
 /**
  * @def SOL_FLOW_SINGLE_OPTIONS_DEFAULTS()

--- a/src/lib/flow/include/sol-flow-static.h
+++ b/src/lib/flow/include/sol-flow-static.h
@@ -49,29 +49,29 @@ extern "C" {
 /**
  * @brief Structure for the specification of a node.
  */
-struct sol_flow_static_node_spec {
+typedef struct sol_flow_static_node_spec {
     const struct sol_flow_node_type *type; /**< @brief Node type */
     const char *name; /**< @brief Name for the specific type's instance */
     const struct sol_flow_node_options *opts; /**< @brief Options for the specific type's instance */
-};
+} sol_flow_static_node_spec;
 
 /**
  * @brief Structure for the specification of a connection.
  */
-struct sol_flow_static_conn_spec {
+typedef struct sol_flow_static_conn_spec {
     uint16_t src; /**< @brief Source node index */
     uint16_t src_port; /**< @brief Source node port index */
     uint16_t dst; /**< @brief Destination node index */
     uint16_t dst_port; /**< @brief Destination node port index */
-};
+} sol_flow_static_conn_spec;
 
 /**
  * @brief Structure for the specification of node ports
  */
-struct sol_flow_static_port_spec {
+typedef struct sol_flow_static_port_spec {
     uint16_t node; /**< @brief Node index */
     uint16_t port; /**< @brief Port index */
-};
+} sol_flow_static_port_spec;
 
 /* Use these guards as the last element of the spec arrays. */
 
@@ -97,7 +97,7 @@ struct sol_flow_static_port_spec {
  * @note Note that the arrays and functions provided are assumed to be available
  * and valid while the static flow type created from it is being used.
  */
-struct sol_flow_static_spec {
+typedef struct sol_flow_static_spec {
 #ifndef SOL_NO_API_VERSION
 #define SOL_FLOW_STATIC_API_VERSION (1) /**< @brief Current API version number */
     uint16_t api_version; /**< @brief API version number */
@@ -155,7 +155,7 @@ struct sol_flow_static_spec {
      * reference to extra resources to be disposed.
      */
     void (*dispose)(const void *type_data);
-};
+} sol_flow_static_spec;
 
 /**
  * @brief Creates a new "static flow" node.

--- a/src/lib/flow/include/sol-flow.h
+++ b/src/lib/flow/include/sol-flow.h
@@ -67,7 +67,7 @@ struct sol_flow_packet_type;
 struct sol_flow_port;
 
 /**
- * @struct sol_flow_node
+ * @typedef sol_flow_node
  *
  * @brief A node is an entity that has input/output ports.
  *
@@ -78,6 +78,7 @@ struct sol_flow_port;
  * their output ports.
  */
 struct sol_flow_node;
+typedef struct sol_flow_node sol_flow_node;
 
 /**
  * @brief Creates a new node.
@@ -558,13 +559,13 @@ const struct sol_flow_node_type *sol_flow_node_get_type(const struct sol_flow_no
  * @brief Node options are a set of attributes defined by the Node Type that
  * can change the behavior of a Node.
  */
-struct sol_flow_node_options {
+typedef struct sol_flow_node_options {
 #ifndef SOL_NO_API_VERSION
 #define SOL_FLOW_NODE_OPTIONS_API_VERSION (1) /**< @brief Compile time API version to be checked during runtime */
     uint16_t api_version; /**< @brief Must match SOL_FLOW_NODE_OPTIONS_API_VERSION at runtime */
     uint16_t sub_api; /**< @brief To version each subclass */
 #endif
-};
+} sol_flow_node_options;
 
 /**
  * @brief Possible types for option attributes (or members).
@@ -604,7 +605,7 @@ enum sol_flow_node_options_member_type sol_flow_node_options_member_type_from_st
 /**
  * @brief Structure of a Options Member
  */
-struct sol_flow_node_named_options_member {
+typedef struct sol_flow_node_named_options_member {
     const char *name; /**< @brief Member's name */
     enum sol_flow_node_options_member_type type; /**< Member's type */
     union {
@@ -618,17 +619,17 @@ struct sol_flow_node_named_options_member {
         const char *string; /**< @brief Value of a string member */
         double f; /**< @brief Value of a float member */
     };
-};
+} sol_flow_node_named_options_member;
 
 /**
  * @brief Named options is an intermediate structure to handle Node Options parsing
  *
  * Used to help the options parser to parse an options string.
  */
-struct sol_flow_node_named_options {
+typedef struct sol_flow_node_named_options {
     struct sol_flow_node_named_options_member *members; /**< @brief List of option members */
     uint16_t count; /**< @brief Number of members */
-};
+} sol_flow_node_named_options;
 
 /**
  * @brief Creates a new Node Options.
@@ -693,7 +694,7 @@ void sol_flow_node_named_options_fini(struct sol_flow_node_named_options *named_
 /**
  * @brief Description object used for introspection of Ports.
  */
-struct sol_flow_port_description {
+typedef struct sol_flow_port_description {
     const char *name; /**< @brief Port's name */
     const char *description; /**< @brief Port's description */
     const char *data_type; /**< @brief Textual representation of the port's accepted packet data type(s), e. g. "int" */
@@ -706,12 +707,12 @@ struct sol_flow_port_description {
      * that can output flows/code from visual representations of a flow
      */
     bool required;
-};
+} sol_flow_port_description;
 
 /**
  * @brief Description object used for introspection of Node options members.
  */
-struct sol_flow_node_options_member_description {
+typedef struct sol_flow_node_options_member_description {
     const char *name; /**< @brief Option member's name */
     const char *description; /**< @brief Option member's description */
     const char *data_type; /**< @brief Textual representation of the options data type(s), e. g. "int" */
@@ -730,19 +731,19 @@ struct sol_flow_node_options_member_description {
     uint16_t offset; /**< @brief Option member's offset inside the final options blob for a node */
     uint16_t size; /**< @brief Option member's size inside the final options blob for a node */
     bool required; /**< @brief Whether the option member is mandatory or not when creating a node */
-};
+} sol_flow_node_options_member_description;
 
 /**
  * @brief Description object used for introspection of Node options.
  */
-struct sol_flow_node_options_description {
+typedef struct sol_flow_node_options_description {
     const struct sol_flow_node_options_member_description *members; /**< @brief Node options members (@c NULL terminated) */
     uint16_t data_size; /**< @brief Size of the whole sol_flow_node_options derivate */
 #ifndef SOL_NO_API_VERSION
     uint16_t sub_api; /**< @brief What goes in sol_flow_node_options::sub_api */
 #endif
     bool required; /**< @brief If true then options must be given for the node (if not, the node has no parameters) */
-};
+} sol_flow_node_options_description;
 
 /**
  * @brief Description object used for introspection of Node types.
@@ -751,7 +752,7 @@ struct sol_flow_node_options_description {
  * type, such as textual description, name, URL, version, author as
  * well as ports and options meta information.
  */
-struct sol_flow_node_type_description {
+typedef struct sol_flow_node_type_description {
 #ifndef SOL_NO_API_VERSION
     /**
      * @brief Compile time API version to be checked during runtime
@@ -784,7 +785,7 @@ struct sol_flow_node_type_description {
     const struct sol_flow_port_description *const *ports_in; /**< @brief @c NULL terminated input ports array */
     const struct sol_flow_port_description *const *ports_out; /**< @brief @c NULL terminated output ports array */
     const struct sol_flow_node_options_description *options; /**< @brief Node options */
-};
+} sol_flow_node_type_description;
 #endif
 
 /**
@@ -802,7 +803,7 @@ enum sol_flow_node_type_flags {
  * This description is usually defined as @c const @c static
  * and shared by many different nodes.
  */
-struct sol_flow_node_type {
+typedef struct sol_flow_node_type {
 #define SOL_FLOW_NODE_PORT_ERROR (UINT16_MAX - 1) /**< @brief Built-in output port's number, common to every node, meant to output error packets */
 #ifndef SOL_NO_API_VERSION
 #define SOL_FLOW_NODE_TYPE_API_VERSION (1) /**< @brief Compile time API version to be checked during runtime */
@@ -856,7 +857,7 @@ struct sol_flow_node_type {
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
     const struct sol_flow_node_type_description *description; /**< @brief Pointer to node's description */
 #endif
-};
+} sol_flow_node_type;
 
 #ifdef SOL_FLOW_NODE_TYPE_DESCRIPTION_ENABLED
 /**
@@ -965,7 +966,7 @@ uint16_t sol_flow_node_find_port_out(const struct sol_flow_node_type *type, cons
  * When a node type is a container (i.e. may act as parent of other nodes),
  * it should provide extra operations. This is the case of the "static flow" node.
  */
-struct sol_flow_node_container_type {
+typedef struct sol_flow_node_container_type {
     struct sol_flow_node_type base; /**< @brief base part of the container node */
 
     /**
@@ -994,12 +995,12 @@ struct sol_flow_node_container_type {
      * @brief Member function that, if not @c NULL, is issued when child nodes of an instance of this type this are deleted
      */
     void (*remove)(struct sol_flow_node *container, struct sol_flow_node *node);
-};
+} sol_flow_node_container_type;
 
 /**
  * @brief Node's Output port structure.
  */
-struct sol_flow_port_type_out {
+typedef struct sol_flow_port_type_out {
 #ifndef SOL_NO_API_VERSION
 #define SOL_FLOW_PORT_TYPE_OUT_API_VERSION (1) /**< @brief Compile time API version to be checked during runtime */
     uint16_t api_version; /**< @brief Must match SOL_FLOW_PORT_TYPE_OUT_API_VERSION at runtime */
@@ -1015,12 +1016,12 @@ struct sol_flow_port_type_out {
      * @brief Member function issued every time a connection is unmade on the port
      */
     int (*disconnect)(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id);
-};
+} sol_flow_port_type_out;
 
 /**
  * @brief Node's Input port structure.
  */
-struct sol_flow_port_type_in {
+typedef struct sol_flow_port_type_in {
 #ifndef SOL_NO_API_VERSION
 #define SOL_FLOW_PORT_TYPE_IN_API_VERSION (1) /**< Compile time API version to be checked during runtime */
     uint16_t api_version; /**< Must match SOL_FLOW_PORT_TYPE_OUT_API_VERSION at runtime */
@@ -1033,7 +1034,7 @@ struct sol_flow_port_type_in {
     int (*process)(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id, const struct sol_flow_packet *packet);
     int (*connect)(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id); /**< member function issued every time a new connection is made to the port */
     int (*disconnect)(struct sol_flow_node *node, void *data, uint16_t port, uint16_t conn_id); /**< member function issued every time a connection is unmade on the port */
-};
+} sol_flow_port_type_in;
 
 /**
  * @def sol_flow_get_node_type(_mod, _type, _var)

--- a/src/lib/io/include/sol-aio.h
+++ b/src/lib/io/include/sol-aio.h
@@ -41,7 +41,7 @@ extern "C" {
  */
 
 /**
- * @struct sol_aio
+ * @typedef sol_aio
  * @brief AIO handle structure
  * @see sol_aio_open_by_label()
  * @see sol_aio_open()
@@ -51,14 +51,16 @@ extern "C" {
  * @see sol_aio_pending_cancel()
  */
 struct sol_aio;
+typedef struct sol_aio sol_aio;
 
 /**
- * @struct sol_aio_pending
+ * @typedef sol_aio_pending
  * @brief AIO pending operation handle structure
  * @see sol_aio_get_value()
  * @see sol_aio_pending_cancel()
  */
 struct sol_aio_pending;
+typedef struct sol_aio_pending sol_aio_pending;
 
 /**
  * @brief Open the given board @c pin by its label to be used as Analog I/O.

--- a/src/lib/io/include/sol-gpio.h
+++ b/src/lib/io/include/sol-gpio.h
@@ -50,7 +50,7 @@ extern "C" {
  */
 
 /**
- * @struct sol_gpio
+ * @typedef sol_gpio
  * @brief A handle to a GPIO
  *
  * @see sol_gpio_open_by_label()
@@ -61,6 +61,7 @@ extern "C" {
  * @see sol_gpio_write()
  */
 struct sol_gpio;
+typedef struct sol_gpio sol_gpio;
 
 /**
  * @brief Possible values for the direction of a GPIO.
@@ -146,7 +147,7 @@ enum sol_gpio_drive {
  * If there's a need to change any of these parameters, the GPIO must be closed
  * and opened again with a new configuration.
  */
-struct sol_gpio_config {
+typedef struct sol_gpio_config {
 #ifndef SOL_NO_API_VERSION
 #define SOL_GPIO_CONFIG_API_VERSION (1)
     uint16_t api_version; /**< The API version */
@@ -235,7 +236,7 @@ struct sol_gpio_config {
             bool value;
         } out;
     };
-};
+} sol_gpio_config;
 
 /**
  * @brief Converts a string GPIO direction to sol_gpio_direction.

--- a/src/lib/io/include/sol-i2c.h
+++ b/src/lib/io/include/sol-i2c.h
@@ -44,7 +44,7 @@ extern "C" {
  */
 
 /**
- * @struct sol_i2c
+ * @typedef sol_i2c
  * @brief I2C handle structure
  * @see sol_i2c_open()
  * @see sol_i2c_open_raw()
@@ -61,9 +61,11 @@ extern "C" {
  * @see sol_i2c_pending_cancel()
  */
 struct sol_i2c;
+typedef struct sol_i2c sol_i2c;
+
 
 /**
- * @struct sol_i2c_pending
+ * @typedef sol_i2c_pending
  * @brief I2C pending operation handle structure
  * @see sol_i2c_write_quick()
  * @see sol_i2c_read()
@@ -74,6 +76,7 @@ struct sol_i2c;
  * @see sol_i2c_pending_cancel()
  */
 struct sol_i2c_pending;
+typedef struct sol_i2c_pending sol_i2c_pending;
 
 /**
  * @brief Enum for I2C bus speed.
@@ -434,10 +437,11 @@ struct sol_i2c_op {
 };
 
 /**
- * @struct sol_i2c_op_set_pending
+ * @typedef sol_i2c_op_set_pending
  * @brief I2C Dispatcher pending operation set handle structure
  */
 struct sol_i2c_op_set_pending;
+typedef struct sol_i2c_op_set_pending sol_i2c_op_set_pending;
 
 /**
  * @brief Add an operation set in the dispatcher's queue of a given I2C bus.

--- a/src/lib/io/include/sol-iio.h
+++ b/src/lib/io/include/sol-iio.h
@@ -40,7 +40,7 @@ extern "C" {
  */
 
 /**
- * @struct sol_iio_device
+ * @typedef sol_iio_device
  * @brief An IIO device handle
  * @see sol_iio_open()
  * @see sol_iio_close()
@@ -48,9 +48,10 @@ extern "C" {
  * @see sol_iio_device_start_buffer()
  */
 struct sol_iio_device;
+typedef struct sol_iio_device sol_iio_device;
 
 /**
- * @struct sol_iio_channel
+ * @typedef sol_iio_channel
  * @brief An IIO channel handle
  * @see sol_iio_add_channel()
  * @see sol_iio_read_channel_value()
@@ -59,13 +60,14 @@ struct sol_iio_device;
  * @see SOL_IIO_CHANNEL_CONFIG_INIT()
  */
 struct sol_iio_channel;
+typedef struct sol_iio_channel sol_iio_channel;
 
 /**
  * @brief A configuration struct for an IIO device
  *
  * @see sol_iio_open()
  */
-struct sol_iio_config {
+typedef struct sol_iio_config {
 #ifndef SOL_NO_API_VERSION
 #define SOL_IIO_CONFIG_API_VERSION (1)
     uint16_t api_version; /**< The API version */
@@ -75,14 +77,14 @@ struct sol_iio_config {
     const void *data; /**< User defined data to be sent to sol_iio_reader_cb */
     int buffer_size; /**< The size of reading buffer. 0: use device default; -1: disable buffer and readings will be performed on channel files on sysfs. */
     int sampling_frequency; /**< Device sampling frequency. -1 uses device default */
-};
+} sol_iio_config;
 
 /**
  * @brief A configuration struct for an IIO channel
  *
  * @see sol_iio_add_channel()
  */
-struct sol_iio_channel_config {
+typedef struct sol_iio_channel_config {
 #ifndef SOL_NO_API_VERSION
 #define SOL_IIO_CHANNEL_CONFIG_API_VERSION (1)
     uint16_t api_version; /**< The API version */
@@ -90,7 +92,7 @@ struct sol_iio_channel_config {
     double scale; /**< Channel scale, to be applied to raw readings. -1 uses device default. Some devices share scale among all channels, so changing one will change all. If, in this case, different channels set different scales the result is unknown. */
     int offset; /**< Channel offset, to be added to raw readings. Some devices share offset among all channels, so changing one will change all. If, in this case, different channels set different offsets the result is unknown. */
     bool use_custom_offset; /**< If true, will use user defined offset on member #offset of this struct */
-};
+} sol_iio_channel_config;
 
 /**
  * @brief Macro that may be used for initialized a @ref sol_iio_channel_config

--- a/src/lib/io/include/sol-memmap-storage.h
+++ b/src/lib/io/include/sol-memmap-storage.h
@@ -89,13 +89,11 @@ extern "C" {
     SOL_MEMMAP_ENTRY_BIT_SIZE(_name, _offset, 1, _bit_offset, 1)
 
 /**
- * @struct sol_memmap_map
- *
  * @brief Memory map basic struct.
  *
  * This struct holds informations about a memory map.
  */
-struct sol_memmap_map {
+typedef struct sol_memmap_map {
     uint8_t version; /**< Version of map. Functions will refuse to read/write on storage if this version and the one storad differs */
     const char *path; /**< Where to find the storage. On Linux, it is
                        * the file mapping the storage, like @c
@@ -122,21 +120,19 @@ struct sol_memmap_map {
     uint32_t timeout; /**< Timeout, in milliseconds, of writing operations. After a write is requested, a timer will run and group all
                        * writing operations until it expires, when real writing will be performed */
     const struct sol_str_table_ptr *entries; /**< Entries on map, containing name, offset and size */ /* Memory trick in place, must be last on struct*/
-};
+} sol_memmap_map;
 
 /**
- * @struct sol_memmap_entry
- *
  * @brief A memory map entry.
  *
  * @see sol_memmap_map
  */
-struct sol_memmap_entry {
+typedef struct sol_memmap_entry {
     size_t offset; /**< Offset of this entry on storage, in bytes. If zero, it will be calculated from previous entry on @c entries array */
     size_t size; /**< Total size of this entry on storage, in bytes. */
     uint32_t bit_size; /**< Total size of this entry on storage, in bits. Must be up to <tt>size * 8</tt>. If zero, it will be assumed as <tt>size * 8</tt>. Note that this will be ignored if @c size is greater than 8. */
     uint8_t bit_offset; /**< Bit offset on first byte. Note that this will be ignored if @c size is greater than 8. */
-};
+} sol_memmap_entry;
 
 /**
  * @brief Writes buffer contents to storage.

--- a/src/lib/io/include/sol-pwm.h
+++ b/src/lib/io/include/sol-pwm.h
@@ -43,7 +43,7 @@ extern "C" {
  */
 
 /**
- * @struct sol_pwm
+ * @typedef sol_pwm
  * @brief A handle to a PWM
  *
  * @see sol_pwm_open_by_label()
@@ -58,6 +58,7 @@ extern "C" {
  * @see sol_pwm_set_enabled()
  */
 struct sol_pwm;
+typedef struct sol_pwm sol_pwm;
 
 /**
  * @brief Alignment determines how the pulse is aligned within the PWM period.
@@ -91,7 +92,7 @@ enum sol_pwm_polarity {
  * @see sol_pwm_open()
  * @see sol_pwm_open_raw()
  */
-struct sol_pwm_config {
+typedef struct sol_pwm_config {
 #ifndef SOL_NO_API_VERSION
 #define SOL_PWM_CONFIG_API_VERSION (1)
     uint16_t api_version; /**< The API version */
@@ -101,7 +102,7 @@ struct sol_pwm_config {
     enum sol_pwm_alignment alignment; /**< The PWM alignment. @see sol_pwm_alignment */
     enum sol_pwm_polarity polarity; /**< The PWM polarity. @see sol_pwm_polarity */
     bool enabled; /**< Set to @c true to for enabled @c false for disabled */
-};
+} sol_pwm_config;
 
 /**
  * @brief Converts a string PWM alignment to sol_pwm_alignment

--- a/src/lib/io/include/sol-spi.h
+++ b/src/lib/io/include/sol-spi.h
@@ -43,13 +43,14 @@ extern "C" {
  */
 
 /**
- * @struct sol_spi
+ * @typedef sol_spi
  * @brief A handle to a SPI bus
  * @see sol_spi_open()
  * @see sol_spi_close()
  * @see sol_spi_transfer()
  */
 struct sol_spi;
+typedef struct sol_spi sol_spi;
 
 /**
  * @brief SPI Transfer Modes.
@@ -85,7 +86,7 @@ enum sol_spi_mode {
  *
  * @see sol_spi_open()
  */
-struct sol_spi_config {
+typedef struct sol_spi_config {
 #ifndef SOL_NO_API_VERSION
 #define SOL_SPI_CONFIG_API_VERSION (1)
     uint16_t api_version; /**< The API version. */
@@ -94,7 +95,7 @@ struct sol_spi_config {
     enum sol_spi_mode mode; /**< The SPI operation mode */
     uint32_t frequency; /**< Clock frequency in Hz */
     uint8_t bits_per_word; /**< Number of bits per word */
-};
+} sol_spi_config;
 
 /**
  * @brief Converts a string SPI mode name to sol_spi_mode

--- a/src/lib/io/include/sol-uart.h
+++ b/src/lib/io/include/sol-uart.h
@@ -45,13 +45,14 @@ extern "C" {
  */
 
 /**
- * @struct sol_uart
+ * @typedef sol_uart
  * @brief A handle to a UART device.
  * @see sol_uart_open()
  * @see sol_uart_close()
  * @see sol_uart_feed()
  */
 struct sol_uart;
+typedef struct sol_uart sol_uart;
 
 /**
  * @brief Baud rate is the number of times the signal can switch states in one second.
@@ -95,13 +96,12 @@ enum sol_uart_stop_bits {
 };
 
 /**
- * @struct sol_uart_config
  * @brief A configuration struct used to set the UART paramenters.
  *
  * @see sol_uart_open()
  * @note UART follows the Soletta stream design pattern, which can be found here: @ref streams
  */
-struct sol_uart_config {
+typedef struct sol_uart_config {
 #ifndef SOL_NO_API_VERSION
 #define SOL_UART_CONFIG_API_VERSION (1) /**< compile time API version to be checked during runtime */
     uint16_t api_version; /**< must match #SOL_UART_CONFIG_API_VERSION at runtime */
@@ -148,7 +148,7 @@ struct sol_uart_config {
     enum sol_uart_parity parity; /**< The parity value*/
     enum sol_uart_stop_bits stop_bits; /**< The stop bits value */
     bool flow_control; /**< Enables software flow control(XOFF and XON) */
-};
+} sol_uart_config;
 
 /**
  * @brief Converts a string UART baudRate to sol_uart_baud_rate

--- a/src/lib/parsers/include/sol-json.h
+++ b/src/lib/parsers/include/sol-json.h
@@ -59,21 +59,21 @@ extern "C" {
 /**
  * @brief Structure to track a JSON document (or a portion of it) being parsed.
  */
-struct sol_json_scanner {
+typedef struct sol_json_scanner {
     const char *mem; /**< @brief Start of this portion of the JSON document. */
     const char *mem_end; /**< @brief End of this portion of the JSON document. */
     const char *current; /**< @brief Current point in the JSON document that needs to be processed. */
-};
+} sol_json_scanner;
 
 /**
  * @brief Type describing a JSON token
  *
  * Used to point and delimit JSON element while parsing a JSON document.
  */
-struct sol_json_token {
+typedef struct sol_json_token {
     const char *start; /**< @brief Token start */
     const char *end; /**< @brief Token end. Non-inclusive */
-};
+} sol_json_token;
 
 /**
  * @brief Token type enumeration.
@@ -931,8 +931,6 @@ int sol_json_object_get_value_by_key(struct sol_json_scanner *scanner, const str
 int sol_json_array_get_at_index(struct sol_json_scanner *scanner, uint16_t i, struct sol_json_token *value);
 
 /**
- * @struct sol_json_path_scanner
- *
  * @brief Scanner used to go through segments of a JSON Path.
  *
  * @note JSONPath syntax is available at http://goessner.net/articles/JsonPath/.
@@ -941,7 +939,7 @@ int sol_json_array_get_at_index(struct sol_json_scanner *scanner, uint16_t i, st
  * @see sol_json_path_get_next_segment()
  * @see SOL_JSON_PATH_FOREACH()
  */
-struct sol_json_path_scanner {
+typedef struct sol_json_path_scanner {
     const char *path; /**< @brief The JSONPath string. */
     const char *end; /**< @brief Points to last character from path. */
     /**
@@ -949,7 +947,7 @@ struct sol_json_path_scanner {
      * next segment.
      */
     const char *current;
-};
+} sol_json_path_scanner;
 
 /**
  * @brief Get the element referenced by the JSON Path @a path in a JSON Object


### PR DESCRIPTION
Soletta already uses "sol_" namespace and most of the time a secondary
namespace that is module-specific. This makes the identifiers very
large. By removing the need of explicitly use "struct" the client code
has less noise.

The convention for Doxygen documentation was:

- Opaque structs appear in typedefs section of the
  documentation. @typedef doxygen marker is used.

- Public structs appear both in data structures and typedefs
  sections. The documentation is not marked so it applies to both (some
  markers were removed).

This patch includes a change in documentation of sol_http_url struct to
escape "#fragment" properly, so Doxygen stops warning. This was
preventing "make doc" to work -- due to a check done after doxygen call.

Fixes #1982.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>