### PR TITLE
build: improve make doxygen rule

### DIFF
--- a/tools/build/Makefile.targets
+++ b/tools/build/Makefile.targets
@@ -163,6 +163,7 @@ ifeq (yyy,$(HAVE_DOXYGEN)$(HAVE_BZIP2)$(HAVE_TAR))
 $(DOXYGEN_GENERATED): $(DOXYGEN_RESOURCES) $(shell find $(top_srcdir)src/ -name '*.h' -type f)
 	$(Q)$(MKDIR) -p $(build_doxygen_targetdir)
 	$(Q)$(RM) $(build_doxygen_logfile)
+	$(Q)$(RM) $(build_doxygen_success)
 	$(Q)$(RM) -rf $(build_doxygen_targetdir)/*
 	$(Q) cat $(top_srcdir)doc/doxygen/examples_head.dox >> $(build_doxygen_targetdir)/examples.dox
 	$(Q) find $(top_srcdir)src/samples -type f -name *.c -printf "@example %h/%f\n" | sort >> $(build_doxygen_targetdir)/examples.dox
@@ -171,6 +172,7 @@ $(DOXYGEN_GENERATED): $(DOXYGEN_RESOURCES) $(shell find $(top_srcdir)src/ -name 
 	$(Q) test `du $(build_doxygen_logfile) | cut -f1` -eq 0 || (echo "Failed to build doc" && cat $(build_doxygen_logfile) && exit 1)
 	$(Q) cd $(build_doxygen_targetdir)/html/; for i in `find . -name "_2src*.html"`; do mv $$i $${i#./_2}; done
 	$(Q) cd $(build_doxygen_targetdir)/html/; find . -name "*.html" -exec sed -i -e 's/_2src/src/g' {} \;
+	$(Q) touch $(build_doxygen_success)
 
 
 $(build_doxygendir)$(PACKAGE_DOCNAME).tar.bz2: $(DOXYGEN_GENERATED)

--- a/tools/build/Makefile.vars
+++ b/tools/build/Makefile.vars
@@ -161,6 +161,7 @@ PACKAGE_DOCNAME := soletta-$(SOL_VERSION)-doc
 build_doxygendir := $(build_docdir)doxygen/
 export build_doxygen_targetdir := $(build_doxygendir)$(PACKAGE_DOCNAME)/
 export build_doxygen_logfile := $(build_doxygendir)log.txt
+export build_doxygen_success := $(build_doxygendir)success.txt
 
 SOLETTA_INSTALL_ROOT := $(build_sysroot)
 export SOLETTA_INSTALL_ROOT
@@ -483,7 +484,8 @@ SVG_OUTPUT_DIR := $(build_docdir)node-types-html/svg
 DOXYGEN_GENERATED := \
 	$(build_doxygen_targetdir)html/index.html \
 	$(build_doxygen_targetdir)latex/index.tex \
-	$(build_doxygen_targetdir)man/man3/index.3
+	$(build_doxygen_targetdir)man/man3/index.3 \
+	$(build_doxygen_success)
 
 PC_GEN := $(build_pcdir)soletta.pc
 PC_GEN_IN := $(top_srcdir)pc/soletta.pc.in


### PR DESCRIPTION
Make sure it won't consider make doxygen is done
when it fails (it has warnings).

For that create a success file when everything is
checked.

Fix #2258

Signed-off-by: Bruno Dilly <bruno.dilly@intel.com>