### PR TITLE
mqtt: fix connect to broker failed

### DIFF
--- a/src/lib/comms/sol-mqtt-impl-mosquitto.c
+++ b/src/lib/comms/sol-mqtt-impl-mosquitto.c
@@ -419,7 +419,7 @@ sol_mqtt_connect(const struct sol_mqtt_config *config)
         goto error;
     }
 
-    mqtt->socket_watch = sol_fd_add(mqtt->socket_fd, SOL_FD_FLAGS_IN | SOL_FD_FLAGS_PRI,
+    mqtt->socket_watch = sol_fd_add(mqtt->socket_fd, SOL_FD_FLAGS_IN | SOL_FD_FLAGS_PRI | SOL_FD_FLAGS_OUT,
         sol_mqtt_event_loop, mqtt);
     SOL_NULL_CHECK_GOTO(mqtt->socket_watch, error);
 


### PR DESCRIPTION
mosquitto_connect_async() will do connect() and write("CONNECT") to broker.
Get the following result:
a) connect() return "Operation now in progress"
b) write("CONNECT") return "Resource temporarily unavailable"

When using asynchronous socket, we need to wait for
"POLLOUT (Writing now will not block) event" then only can do write().

Now sol_mqtt_event_loop() callback can be invoke when the "POLLOUT event" happen.
Then the mosquitto_loop_write() in sol_mqtt_event_loop() will continue the
write("CONNECT") that is failed in the first attempt.

Signed-off-by: Lay, Kuan Loon <kuan.loon.lay@intel.com>