### PR TITLE
LWM2M: Support for DTLS with Pre-Shared Key security mode

### DIFF
--- a/data/scripts/libsoletta.sym
+++ b/data/scripts/libsoletta.sym
@@ -135,6 +135,7 @@ global:
         sol_coap_server_set_unknown_resource_handler;
         sol_coap_server_unref;
         sol_coap_server_unregister_resource;
+        sol_coap_server_is_secure;
         sol_coap_unobserve_by_token;
 
         sol_direction_vector_eq;

--- a/src/lib/comms/Makefile
+++ b/src/lib/comms/Makefile
@@ -143,7 +143,8 @@ obj-networking-$(LWM2M) += \
     sol-lwm2m-common.o \
     sol-lwm2m-client.o \
     sol-lwm2m-server.o \
-    sol-lwm2m-bs-server.o
+    sol-lwm2m-bs-server.o \
+    sol-lwm2m-security.o
 
 obj-bluetooth-$(BLUETOOTH) += \
 	sol-bluetooth.o

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -477,9 +477,20 @@ int sol_coap_header_set_code(struct sol_coap_packet *pkt, uint8_t code);
 int sol_coap_header_set_id(struct sol_coap_packet *pkt, uint16_t id);
 
 /**
+ * @brief Check if a given CoAP server instance is running over DTLS or not.
+ *
+ * @param server The server to be checked.
+ *
+ * @return True if this server uses DTLS to encrypt communication with its
+ * endpoints; false otherwise.
+ *
+ */
+bool sol_coap_server_is_secure(const struct sol_coap_server *server);
+
+/**
  * @brief Creates a new CoAP server instance.
  *
- * Creates a new, unsecured, CoAP server instance listening on address
+ * Creates a new, CoAP server instance listening on address
  * @a addr. If the server cannot be created, NULL will be returned and
  * @c errno will be set to indicate the reason.
  *

--- a/src/lib/comms/include/sol-lwm2m-bs-server.h
+++ b/src/lib/comms/include/sol-lwm2m-bs-server.h
@@ -60,10 +60,13 @@ typedef struct sol_lwm2m_bootstrap_client_info sol_lwm2m_bootstrap_client_info;
  *
  * @param port The UDP port to be used.
  * @param known_clients An array with the name of all clients this server has Bootstrap Information for.
+ * @param sec_mode The DTLS Security Mode to be used.
+ * @param known_psks The Clients' Pre-Shared Keys this Bootstrap Server has previous knowledge of.
  * @return The LWM2M bootstrap server or @c NULL on error.
  */
 struct sol_lwm2m_bootstrap_server *sol_lwm2m_bootstrap_server_new(uint16_t port,
-    const char **known_clients);
+    const char **known_clients, enum sol_lwm2m_security_mode sec_mode,
+    struct sol_vector *known_psks);
 
 /**
  * @brief Adds a bootstrap request monitor to the server.

--- a/src/lib/comms/include/sol-lwm2m-server.h
+++ b/src/lib/comms/include/sol-lwm2m-server.h
@@ -84,10 +84,15 @@ enum sol_lwm2m_registration_event {
  *
  * The server will be immediately operational and waiting for connections.
  *
- * @param port The UDP port to be used.
+ * @param coap_port The UDP port to be used for the NoSec CoAP Server.
+ * @param dtls_port The UDP port to be used for the Secure DTLS Server.
+ * @param sec_mode The DTLS Security Mode to be used for the Secure CoAP Server.
+ * @param known_psks The Clients' Pre-Shared Keys this Server has previous knowledge of.
  * @return The LWM2M server or @c NULL on error.
  */
-struct sol_lwm2m_server *sol_lwm2m_server_new(uint16_t port);
+struct sol_lwm2m_server *sol_lwm2m_server_new(uint16_t coap_port,
+    uint16_t dtls_port, enum sol_lwm2m_security_mode sec_mode,
+    struct sol_vector *known_psks);
 
 /**
  * @brief Adds a registration monitor.

--- a/src/lib/comms/include/sol-lwm2m.h
+++ b/src/lib/comms/include/sol-lwm2m.h
@@ -46,15 +46,17 @@ extern "C" {
  * @brief Routines that handle the LWM2M protocol.
  *
  * Supported features:
+ * - Bootstrap interface.
  * - Registration interface.
  * - Management interface.
  * - Observation interface.
  * - TLV format.
+ * - Data Access Control.
+ * - CoAP Data Encryption.
  *
  * Unsupported features for now:
  * - LWM2M JSON.
  * - Queue Mode operation (only 'U' is supported for now).
- * - Data encryption.
  *
  * @warning Experimental API. Changes are expected in future releases.
  *
@@ -131,6 +133,41 @@ enum sol_lwm2m_binding_mode {
      * It was not possible to determine the client binding.
      */
     SOL_LWM2M_BINDING_MODE_UNKNOWN = -1,
+};
+
+/**
+ * @brief Enum that represents the UDP Security Mode.
+ *
+ * @note Only Pre-Shared Key and NoSec modes are currently supported.
+ */
+enum sol_lwm2m_security_mode {
+    /**
+     * Pre-Shared Key security mode with Cipher Suite TLS_PSK_WITH_AES_128_CCM_8
+     * In this case, the following Resource IDs have to be filled as well:
+     * /3 "Public Key or Identity":    PSK Identity [16 bytes; UTF-8 String];
+     * /5 "Secret Key":                PSK [128-bit AES Key; 16 Opaque bytes];
+     */
+    SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY = 0,
+    /**
+     * Raw Public Key security mode with Cipher Suite TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8
+     * In this case, the following Resource IDs have to be filled as well:
+     * /3 "Public Key or Identity":                    Client's Raw Public Key [256-bit ECC key; 32 Opaque bytes];
+     * /4 "Server Public Key or Identity Resource":    [Expected] Server's Raw Public Key [256-bit ECC key; 32 Opaque bytes];
+     * /5 "Secret Key":                                Client's Private Key [256-bit ECC key; 32 Opaque bytes];
+     */
+    SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY = 1,
+    /**
+     * Certificate security mode with Cipher Suite TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8
+     * In this case, the following Resource IDs have to be filled as well:
+     * /3 "Public Key or Identity":                    X.509v3 Certificate [Opaque];
+     * /4 "Server Public Key or Identity Resource":    [Expected] Server's X.509v3 Certificate [Opaque];
+     * /5 "Secret Key":                                Client's Private Key [256-bit ECC key; 32 Opaque bytes];
+     */
+    SOL_LWM2M_SECURITY_MODE_CERTIFICATE = 2,
+    /**
+     * No security ("NoSec") mode (CoAP without DTLS)
+     */
+    SOL_LWM2M_SECURITY_MODE_NO_SEC = 3
 };
 
 /**

--- a/src/lib/comms/include/sol-lwm2m.h
+++ b/src/lib/comms/include/sol-lwm2m.h
@@ -64,9 +64,14 @@ extern "C" {
  */
 
 /**
- * @brief Macro that defines the default port for a LWM2M server.
+ * @brief Macro that defines the default port for a NoSec LWM2M server.
  */
-#define SOL_LWM2M_DEFAULT_SERVER_PORT (5683)
+#define SOL_LWM2M_DEFAULT_SERVER_PORT_COAP (5683)
+
+/**
+ * @brief Macro that defines the default port for a DTLS-secured LWM2M server.
+ */
+#define SOL_LWM2M_DEFAULT_SERVER_PORT_DTLS (5684)
 
 /**
  * @typedef sol_lwm2m_client_object
@@ -273,6 +278,22 @@ enum sol_lwm2m_resource_type {
      */
     SOL_LWM2M_RESOURCE_TYPE_UNKNOWN = -1
 };
+
+/**
+ * @brief Struct that represents a Pre-Shared Key (PSK).
+ *
+ * A sol_vector holding elements of this type is used by the LWM2M Server
+ * and LWM2M Bootstrap Server to keep a list of known Clients' Pre-Shared Keys.
+ *
+ * @see sol_lwm2m_server_new()
+ * @see sol_lwm2m_bootstrap_server_new()
+ */
+typedef struct sol_lwm2m_security_psk {
+    /** @brief The PSK Identity, composed of a 16-bytes UTF-8 String */
+    struct sol_blob *id;
+    /** @brief The PSK Key, composed of an Opaque 16-bytes (128-bit) AES Key */
+    struct sol_blob *key;
+} sol_lwm2m_security_psk;
 
 /**
  * @brief Struct that represents TLV data.

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -89,6 +89,7 @@ struct sol_coap_server {
         const struct sol_network_link_addr *cliaddr);
     const void *unknown_handler_data;
     int refcnt;
+    bool secure;
 };
 
 struct resource_context {
@@ -144,6 +145,14 @@ sol_coap_server_get_socket(const struct sol_coap_server *server)
     SOL_NULL_CHECK_ERRNO(server, EINVAL, NULL);
 
     return server->socket;
+}
+
+SOL_API bool
+sol_coap_server_is_secure(const struct sol_coap_server *server)
+{
+    SOL_NULL_CHECK_ERRNO(server, EINVAL, NULL);
+
+    return server->secure;
 }
 
 SOL_API int
@@ -1917,6 +1926,8 @@ sol_coap_server_new_full(struct sol_socket_ip_options *options, const struct sol
     }
 
     sol_network_subscribe_events(network_event, server);
+
+    server->secure = options->secure;
 
     SOL_DBG("New server %p on port %d%s", server, servaddr->port,
         !options->secure ? "" : " (secure)");

--- a/src/lib/comms/sol-lwm2m-bs-server.c
+++ b/src/lib/comms/sol-lwm2m-bs-server.c
@@ -41,13 +41,6 @@
 
 SOL_LOG_INTERNAL_DECLARE_STATIC(_lwm2m_bs_server_domain, "lwm2m-bs-server");
 
-struct sol_lwm2m_bootstrap_server {
-    struct sol_coap_server *coap;
-    struct sol_ptr_vector clients;
-    struct sol_monitors bootstrap;
-    const char **known_clients;
-};
-
 struct sol_lwm2m_bootstrap_client_info {
     char *name;
     struct sol_network_link_addr cliaddr;

--- a/src/lib/comms/sol-lwm2m-bs-server.c
+++ b/src/lib/comms/sol-lwm2m-bs-server.c
@@ -30,6 +30,7 @@
 #include "sol-lwm2m.h"
 #include "sol-lwm2m-common.h"
 #include "sol-lwm2m-bs-server.h"
+#include "sol-lwm2m-security.h"
 #include "sol-macros.h"
 #include "sol-mainloop.h"
 #include "sol-monitors.h"
@@ -210,22 +211,57 @@ static const struct sol_coap_resource bootstrap_request_interface = {
 };
 
 SOL_API struct sol_lwm2m_bootstrap_server *
-sol_lwm2m_bootstrap_server_new(uint16_t port, const char **known_clients)
+sol_lwm2m_bootstrap_server_new(uint16_t port, const char **known_clients,
+    enum sol_lwm2m_security_mode sec_mode, struct sol_vector *known_psks)
 {
     struct sol_lwm2m_bootstrap_server *server;
     struct sol_network_link_addr servaddr = { .family = SOL_NETWORK_FAMILY_INET6,
                                               .port = port };
     int r;
+    const char *sec_mode_str;
 
     SOL_LOG_INTERNAL_INIT_ONCE;
 
     SOL_NULL_CHECK(known_clients, NULL);
+    switch (sec_mode) {
+    case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
+        SOL_NULL_CHECK(known_psks, NULL);
+        sec_mode_str = "Pre-Shared Key";
+        break;
+    case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
+        sec_mode_str = "Raw Public Key";
+        SOL_WRN("Raw Public Key security mode is not supported yet.");
+        return NULL;
+    case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
+        sec_mode_str = "Certificate";
+        SOL_WRN("Certificate security mode is not supported yet.");
+        return NULL;
+    case SOL_LWM2M_SECURITY_MODE_NO_SEC:
+        SOL_WRN("Bootstrap Server MUST use DTLS.");
+        return NULL;
+    default:
+        SOL_WRN("Unknown DTLS Security Mode: %d", sec_mode);
+        return NULL;
+    }
 
     server = calloc(1, sizeof(struct sol_lwm2m_bootstrap_server));
     SOL_NULL_CHECK(server, NULL);
 
-    server->coap = sol_coap_server_new(&servaddr, false);
+    //LWM2M Bootstrap Server MUST always use DTLS
+    if (sec_mode == SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY)
+        server->known_psks = known_psks;
+
+    server->coap = sol_coap_server_new(&servaddr, true);
     SOL_NULL_CHECK_GOTO(server->coap, err_coap);
+
+    server->security = sol_lwm2m_bootstrap_server_security_add(server, sec_mode);
+    if (!server->security) {
+        SOL_ERR("Could not enable %s security mode for LWM2M Bootstrap Server",
+            sec_mode_str);
+        goto err_security;
+    } else {
+        SOL_DBG("Using %s security mode", sec_mode_str);
+    }
 
     server->known_clients = known_clients;
 
@@ -235,11 +271,11 @@ sol_lwm2m_bootstrap_server_new(uint16_t port, const char **known_clients)
 
     r = sol_coap_server_register_resource(server->coap,
         &bootstrap_request_interface, server);
-    SOL_INT_CHECK_GOTO(r, < 0, err_register);
+    SOL_INT_CHECK_GOTO(r, < 0, err_security);
 
     return server;
 
-err_register:
+err_security:
     sol_coap_server_unref(server->coap);
 err_coap:
     free(server);
@@ -255,6 +291,8 @@ sol_lwm2m_bootstrap_server_del(struct sol_lwm2m_bootstrap_server *server)
     SOL_NULL_CHECK(server);
 
     sol_coap_server_unref(server->coap);
+
+    sol_lwm2m_bootstrap_server_security_del(server->security);
 
     SOL_PTR_VECTOR_FOREACH_IDX (&server->clients, bs_cinfo, i)
         bootstrap_client_info_del(bs_cinfo);

--- a/src/lib/comms/sol-lwm2m-client.c
+++ b/src/lib/comms/sol-lwm2m-client.c
@@ -170,6 +170,10 @@ obj_instance_clear(struct sol_lwm2m_client *client, struct obj_ctx *obj_ctx,
         if (!client->removed && res_ctx->res) {
             sol_coap_server_unregister_resource(client->coap_server,
                 res_ctx->res);
+
+            if (client->security)
+                sol_coap_server_unregister_resource(client->dtls_server,
+                    res_ctx->res);
         }
         free(res_ctx->res);
         free(res_ctx->str_id);
@@ -178,6 +182,10 @@ obj_instance_clear(struct sol_lwm2m_client *client, struct obj_ctx *obj_ctx,
     if (!client->removed && obj_instance->instance_res) {
         sol_coap_server_unregister_resource(client->coap_server,
             obj_instance->instance_res);
+
+        if (client->security)
+            sol_coap_server_unregister_resource(client->dtls_server,
+                obj_instance->instance_res);
     }
     free(obj_instance->instance_res);
     free(obj_instance->str_id);
@@ -265,6 +273,12 @@ setup_resources_ctx(struct sol_lwm2m_client *client, struct obj_ctx *obj_ctx,
             r = sol_coap_server_register_resource(client->coap_server,
                 res_ctx->res, client);
             SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+
+            if (client->security) {
+                r = sol_coap_server_register_resource(client->dtls_server,
+                    res_ctx->res, client);
+                SOL_INT_CHECK(r, < 0, r);
+            }
         }
     }
 
@@ -275,6 +289,11 @@ err_exit:
         if (res_ctx->res) {
             sol_coap_server_unregister_resource(client->coap_server,
                 res_ctx->res);
+
+            if (client->security)
+                sol_coap_server_unregister_resource(client->dtls_server,
+                    res_ctx->res);
+
             free(res_ctx->res);
         }
         free(res_ctx->str_id);
@@ -324,6 +343,12 @@ setup_instance_resource(struct sol_lwm2m_client *client,
         r = sol_coap_server_register_resource(client->coap_server,
             obj_instance->instance_res, client);
         SOL_INT_CHECK_GOTO(r, < 0, err_register);
+
+        if (client->security) {
+            r = sol_coap_server_register_resource(client->dtls_server,
+                obj_instance->instance_res, client);
+            SOL_INT_CHECK(r, < 0, r);
+        }
     }
 
     r = setup_resources_ctx(client, obj_ctx, obj_instance, register_with_coap);
@@ -334,6 +359,10 @@ setup_instance_resource(struct sol_lwm2m_client *client,
 err_resources:
     sol_coap_server_unregister_resource(client->coap_server,
         obj_instance->instance_res);
+
+    if (client->security)
+        sol_coap_server_unregister_resource(client->dtls_server,
+            obj_instance->instance_res);
 err_register:
     free(obj_instance->instance_res);
     obj_instance->instance_res = NULL;
@@ -1125,8 +1154,7 @@ notification_cb(void *data, struct sol_coap_server *server,
 
     r = get_server_id_by_link_addr(&ctx->client->connections, addr, &server_id);
     SOL_INT_CHECK_GOTO(r, < 0, err_exit);
-
-    *pkt = sol_coap_packet_new_notification(ctx->client->coap_server, resource);
+    *pkt = sol_coap_packet_new_notification(server, resource);
     SOL_NULL_CHECK(*pkt, false);
 
     r = sol_coap_header_set_type(*pkt, SOL_COAP_MESSAGE_TYPE_CON);
@@ -1552,7 +1580,6 @@ sol_lwm2m_client_new(const char *name, const char *path, const char *sms,
 
         if (obj_ctx->obj->id == ACCESS_CONTROL_OBJECT_ID) {
             client->supports_access_control = true;
-            client->need_to_setup_access_control = true;
         }
     }
 
@@ -1567,12 +1594,28 @@ sol_lwm2m_client_new(const char *name, const char *path, const char *sms,
     client->coap_server = sol_coap_server_new(&servaddr, false);
     SOL_NULL_CHECK_GOTO(client->coap_server, err_coap);
 
+    client->dtls_server = sol_coap_server_new(&servaddr, true);
+    if (!client->dtls_server) {
+        if (errno == ENOSYS) {
+            SOL_INF("DTLS support not built in, LWM2M client"
+                " running only \"NoSec\" security mode");
+        } else {
+            SOL_WRN("DTLS server could not be created for LWM2M client: %s",
+                sol_util_strerrora(errno));
+            goto err_dtls;
+        }
+    }
+
     sol_monitors_init(&client->bootstrap, NULL);
+
+    client->first_time_starting = true;
 
     client->user_data = data;
 
     return client;
 
+err_dtls:
+    sol_coap_server_unref(client->coap_server);
 err_coap:
     free(client->sms);
 err_sms:
@@ -1654,6 +1697,12 @@ sol_lwm2m_client_del(struct sol_lwm2m_client *client)
 
     sol_coap_server_unref(client->coap_server);
 
+    if (client->dtls_server)
+        sol_coap_server_unref(client->dtls_server);
+
+    if (client->security)
+        sol_lwm2m_client_security_del(client->security);
+
     SOL_VECTOR_FOREACH_IDX (&client->objects, ctx, i)
         obj_ctx_clear(client, ctx);
 
@@ -1695,7 +1744,7 @@ sol_lwm2m_client_add_object_instance(struct sol_lwm2m_client *client,
     SOL_INT_CHECK_GOTO(r, < 0, err_exit);
 
     if (client->supports_access_control &&
-        ctx->obj->id != SECURITY_SERVER_OBJECT_ID &&
+        ctx->obj->id != SECURITY_OBJECT_ID &&
         ctx->obj->id != ACCESS_CONTROL_OBJECT_ID) {
         //Since this API is expected to be used only in Factory Bootstrap mode,
         // the owner of this Access Control Object Instance will be the
@@ -1985,7 +2034,8 @@ register_with_server(struct sol_lwm2m_client *client,
     SOL_DBG("Connecting with LWM2M server - binding '%.*s' -"
         "lifetime '%" PRId64 "'", SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(binding)),
         conn_ctx->lifetime);
-    r = sol_coap_send_packet_with_reply(client->coap_server,
+    r = sol_coap_send_packet_with_reply(
+        conn_ctx->secure ? client->dtls_server : client->coap_server,
         pkt,
         sol_vector_get_no_check(&conn_ctx->server_addr_list,
         conn_ctx->addr_list_idx),
@@ -2066,7 +2116,7 @@ bootstrap_with_server(struct sol_lwm2m_client *client,
     ADD_QUERY("ep", "%s", client->name);
 
     SOL_DBG("Sending Bootstrap Request to LWM2M Bootstrap Server");
-    r = sol_coap_send_packet_with_reply(client->coap_server,
+    r = sol_coap_send_packet_with_reply(client->dtls_server,
         pkt,
         sol_vector_get_no_check(&conn_ctx->server_addr_list,
         conn_ctx->addr_list_idx), bootstrap_request_reply, conn_ctx);
@@ -2115,7 +2165,7 @@ err_exit:
 
 static struct server_conn_ctx *
 server_connection_ctx_new(struct sol_lwm2m_client *client,
-    const struct sol_str_slice str_addr, int64_t server_id)
+    const struct sol_str_slice str_addr, int64_t server_id, bool secure)
 {
     struct server_conn_ctx *conn_ctx;
     struct sol_http_url uri;
@@ -2131,11 +2181,12 @@ server_connection_ctx_new(struct sol_lwm2m_client *client,
     SOL_INT_CHECK_GOTO(r, < 0, err_append);
     conn_ctx->client = client;
     conn_ctx->server_id = server_id;
+    conn_ctx->secure = secure;
     sol_vector_init(&conn_ctx->server_addr_list,
         sizeof(struct sol_network_link_addr));
 
     if (!uri.port)
-        conn_ctx->port = SOL_LWM2M_DEFAULT_SERVER_PORT;
+        conn_ctx->port = SOL_LWM2M_DEFAULT_SERVER_PORT_COAP;
     else
         conn_ctx->port = uri.port;
 
@@ -2254,16 +2305,16 @@ client_bootstrap(void *data)
     //Try client-initiated bootstrap:
     conn_ctx = server_connection_ctx_new(client,
         sol_str_slice_from_blob(client->bootstrap_ctx.server_uri),
-        DEFAULT_SHORT_SERVER_ID);
+        DEFAULT_SHORT_SERVER_ID, true);
 
     if (!conn_ctx) {
         SOL_WRN("Could not perform Client-initiated Bootstrap with server %.*s",
             SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(client->bootstrap_ctx.server_uri)));
 
-        if (sol_coap_server_set_unknown_resource_handler(client->coap_server,
+        if (sol_coap_server_set_unknown_resource_handler(client->dtls_server,
             NULL, client) < 0)
             SOL_WRN("Could not unregister Bootstrap Unknown resource for client.");
-        if (sol_coap_server_unregister_resource(client->coap_server,
+        if (sol_coap_server_unregister_resource(client->dtls_server,
             &bootstrap_finish_interface) < 0)
             SOL_WRN("Could not unregister Bootstrap Finish resource for client.");
     }
@@ -2294,7 +2345,7 @@ setup_access_control_object_instance_for_instance(
     // Access Control Object Instances, and Security Object Instances
     // can only be managed by Bootstrap Servers, so there's no sense in
     // creating Access Control Object Instances or ACLs for them
-    if (target_object_id == SECURITY_SERVER_OBJECT_ID ||
+    if (target_object_id == SECURITY_OBJECT_ID ||
         target_object_id == ACCESS_CONTROL_OBJECT_ID) {
         return 0;
     }
@@ -2410,7 +2461,7 @@ setup_access_control_object_instances(struct sol_lwm2m_client *client)
     SOL_VECTOR_FOREACH_IDX (&client->objects, obj_ctx, i) {
         //No one is allowed to 'C'reate Security Objects, Server Objects,
         // and Access Control Objects
-        if (obj_ctx->obj->id != SECURITY_SERVER_OBJECT_ID &&
+        if (obj_ctx->obj->id != SECURITY_OBJECT_ID &&
             obj_ctx->obj->id != SERVER_OBJECT_ID &&
             obj_ctx->obj->id != ACCESS_CONTROL_OBJECT_ID) {
             SOL_SET_API_VERSION(res.api_version = SOL_LWM2M_RESOURCE_API_VERSION; )
@@ -2466,15 +2517,18 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
 
     SOL_NULL_CHECK(client, -EINVAL);
 
+    if (!client->first_time_starting && client->security)
+        sol_lwm2m_client_security_del(client->security);
+
     if (client->supports_access_control &&
-        client->need_to_setup_access_control) {
+        client->first_time_starting) {
         r = setup_access_control_object_instances(client);
         SOL_INT_CHECK_GOTO(r, < 0, err_access_control);
-
-        client->need_to_setup_access_control = false;
     }
 
-    ctx = find_object_ctx_by_id(client, SECURITY_SERVER_OBJECT_ID);
+    client->first_time_starting = false;
+
+    ctx = find_object_ctx_by_id(client, SECURITY_OBJECT_ID);
     if (!ctx) {
         SOL_WRN("LWM2M Security object not provided!");
         return -ENOENT;
@@ -2487,10 +2541,48 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
 
     //Try to register with all available [non-bootstrap] servers
     SOL_VECTOR_FOREACH_IDX (&ctx->instances, instance, i) {
+        bool secure = true;
+        //Setup DTLS parameters
         r = read_resources(client, ctx, instance, res, 1,
-            SECURITY_SERVER_IS_BOOTSTRAP);
+            SECURITY_SECURITY_MODE);
         SOL_INT_CHECK_GOTO(r, < 0, err_exit);
 
+        switch (res[0].data[0].content.integer) {
+        case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
+            client->security = sol_lwm2m_client_security_add(client,
+                SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY);
+            if (!client->security) {
+                r = -errno;
+                SOL_ERR("Could not enable Pre-Shared Key security mode for LWM2M client");
+                goto err_clear_1;
+            } else {
+                SOL_DBG("Using Pre-Shared Key security mode");
+            }
+            break;
+        case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
+            SOL_WRN("Raw Public Key security mode is not supported yet.");
+            r = -ENOTSUP;
+            goto err_clear_1;
+        case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
+            SOL_WRN("Certificate security mode is not supported yet.");
+            r = -ENOTSUP;
+            goto err_clear_1;
+        case SOL_LWM2M_SECURITY_MODE_NO_SEC:
+            secure = false;
+            SOL_DBG("Using NoSec Security Mode (No DTLS).");
+            break;
+        default:
+            SOL_WRN("Unknown DTLS [Security Mode] Resource from Security Object: %"
+                PRId64, res[0].data[0].content.integer);
+            r = -EINVAL;
+            goto err_clear_1;
+        }
+
+        sol_lwm2m_resource_clear(&res[0]);
+
+        r = read_resources(client, ctx, instance, res, 1,
+            SECURITY_IS_BOOTSTRAP);
+        SOL_INT_CHECK_GOTO(r, < 0, err_exit);
         //Is it a bootstap?
         if (!res[0].data[0].content.b) {
             sol_lwm2m_resource_clear(&res[0]);
@@ -2499,7 +2591,7 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
             SOL_INT_CHECK_GOTO(r, < 0, err_exit);
 
             conn_ctx = server_connection_ctx_new(client, sol_str_slice_from_blob(res[0].data[0].content.blob),
-                res[1].data[0].content.integer);
+                res[1].data[0].content.integer, secure);
             r = -ENOMEM;
             SOL_NULL_CHECK_GOTO(conn_ctx, err_clear_2);
             has_server = true;
@@ -2520,16 +2612,16 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
 
         r = read_resources(client, ctx,
             sol_vector_get_no_check(&ctx->instances, bootstrap_account_idx), res, 3,
-            SECURITY_SERVER_URI, SECURITY_SERVER_CLIENT_HOLD_OFF_TIME,
-            SECURITY_SERVER_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT);
+            SECURITY_SERVER_URI, SECURITY_CLIENT_HOLD_OFF_TIME,
+            SECURITY_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT);
 
         //Create '/bs' CoAP resource to receive Bootstrap Finish notification
-        r = sol_coap_server_register_resource(client->coap_server,
+        r = sol_coap_server_register_resource(client->dtls_server,
             &bootstrap_finish_interface, client);
         SOL_INT_CHECK_GOTO(r, < 0, err_clear_3);
 
         //Create unknown CoAP resource to handle Bootstrap Write and Bootstrap Delete
-        r = sol_coap_server_set_unknown_resource_handler(client->coap_server,
+        r = sol_coap_server_set_unknown_resource_handler(client->dtls_server,
             &handle_unknown_bootstrap_resource, client);
         SOL_INT_CHECK_GOTO(r, < 0, err_unregister_bs);
 
@@ -2554,15 +2646,33 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
             ctx->obj_res, client);
         SOL_INT_CHECK(r, < 0, r);
 
+        if (client->security) {
+            r = sol_coap_server_register_resource(client->dtls_server,
+                ctx->obj_res, client);
+            SOL_INT_CHECK(r, < 0, r);
+        }
+
         SOL_VECTOR_FOREACH_IDX (&ctx->instances, instance, j) {
             r = sol_coap_server_register_resource(client->coap_server,
                 instance->instance_res, client);
             SOL_INT_CHECK(r, < 0, r);
 
+            if (client->security) {
+                r = sol_coap_server_register_resource(client->dtls_server,
+                    instance->instance_res, client);
+                SOL_INT_CHECK(r, < 0, r);
+            }
+
             SOL_VECTOR_FOREACH_IDX (&instance->resources_ctx, res_ctx, k) {
                 r = sol_coap_server_register_resource(client->coap_server,
                     res_ctx->res, client);
                 SOL_INT_CHECK(r, < 0, r);
+
+                if (client->security) {
+                    r = sol_coap_server_register_resource(client->dtls_server,
+                        res_ctx->res, client);
+                    SOL_INT_CHECK(r, < 0, r);
+                }
             }
         }
     }
@@ -2580,15 +2690,16 @@ err_access_control:
         sol_vector_clear(&ctx->instances);
     }
 err_unregister_unknown:
-    if (sol_coap_server_set_unknown_resource_handler(client->coap_server, NULL, client) < 0)
+    if (sol_coap_server_set_unknown_resource_handler(client->dtls_server, NULL, client) < 0)
         SOL_WRN("Could not unregister Bootstrap Unknown resource for client.");
 err_unregister_bs:
-    if (sol_coap_server_unregister_resource(client->coap_server, &bootstrap_finish_interface) < 0)
+    if (sol_coap_server_unregister_resource(client->dtls_server, &bootstrap_finish_interface) < 0)
         SOL_WRN("Could not unregister Bootstrap Finish resource for client.");
 err_clear_3:
     sol_lwm2m_resource_clear(&res[2]);
 err_clear_2:
     sol_lwm2m_resource_clear(&res[1]);
+err_clear_1:
     sol_lwm2m_resource_clear(&res[0]);
 err_exit:
     return r;
@@ -2603,7 +2714,8 @@ send_client_delete_request(struct sol_lwm2m_client *client,
 
     //Did not receive reply yet.
     if (!conn_ctx->location) {
-        r = sol_coap_cancel_send_packet(client->coap_server,
+        r = sol_coap_cancel_send_packet(
+            conn_ctx->secure ? client->dtls_server : client->coap_server,
             conn_ctx->pending_pkt,
             sol_vector_get_no_check(&conn_ctx->server_addr_list,
             conn_ctx->addr_list_idx));
@@ -2623,7 +2735,8 @@ send_client_delete_request(struct sol_lwm2m_client *client,
         conn_ctx->location, strlen(conn_ctx->location));
     SOL_INT_CHECK_GOTO(r, < 0, err_exit);
 
-    return sol_coap_send_packet(client->coap_server, pkt,
+    return sol_coap_send_packet(
+        conn_ctx->secure ? client->dtls_server : client->coap_server, pkt,
         sol_vector_get_no_check(&conn_ctx->server_addr_list,
         conn_ctx->addr_list_idx));
 
@@ -2652,7 +2765,8 @@ sol_lwm2m_client_stop(struct sol_lwm2m_client *client)
         }
 
         if (conn_ctx->pending_pkt) {
-            r = sol_coap_cancel_send_packet(client->coap_server,
+            r = sol_coap_cancel_send_packet(
+                conn_ctx->secure ? client->dtls_server : client->coap_server,
                 conn_ctx->pending_pkt,
                 sol_vector_get_no_check(&conn_ctx->server_addr_list,
                 conn_ctx->addr_list_idx));
@@ -2668,15 +2782,33 @@ sol_lwm2m_client_stop(struct sol_lwm2m_client *client)
                 ctx->obj_res);
             SOL_INT_CHECK(r, < 0, r);
 
+            if (client->security) {
+                r = sol_coap_server_unregister_resource(client->dtls_server,
+                    ctx->obj_res);
+                SOL_INT_CHECK(r, < 0, r);
+            }
+
             SOL_VECTOR_FOREACH_IDX (&ctx->instances, instance, j) {
                 r = sol_coap_server_unregister_resource(client->coap_server,
                     instance->instance_res);
                 SOL_INT_CHECK(r, < 0, r);
 
+                if (client->security) {
+                    r = sol_coap_server_unregister_resource(client->dtls_server,
+                        instance->instance_res);
+                    SOL_INT_CHECK(r, < 0, r);
+                }
+
                 SOL_VECTOR_FOREACH_IDX (&instance->resources_ctx, res_ctx, k) {
                     r = sol_coap_server_unregister_resource(client->coap_server,
                         res_ctx->res);
                     SOL_INT_CHECK(r, < 0, r);
+
+                    if (client->security) {
+                        r = sol_coap_server_unregister_resource(client->dtls_server,
+                            res_ctx->res);
+                        SOL_INT_CHECK(r, < 0, r);
+                    }
                 }
             }
         }
@@ -2787,6 +2919,12 @@ sol_lwm2m_client_notify(struct sol_lwm2m_client *client, const char **paths)
                 notification_cb, &ctx);
             SOL_INT_CHECK_GOTO(r, < 0, err_exit);
 
+            if (client->security) {
+                r = sol_coap_notify_by_callback(client->dtls_server, obj_ctx->obj_res,
+                    notification_cb, &ctx);
+                SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+            }
+
             r = sol_ptr_vector_append(&already_sent, obj_ctx);
             SOL_INT_CHECK_GOTO(r, < 0, err_exit);
         }
@@ -2797,6 +2935,12 @@ sol_lwm2m_client_notify(struct sol_lwm2m_client *client, const char **paths)
                 notification_cb, &ctx);
             SOL_INT_CHECK_GOTO(r, < 0, err_exit);
 
+            if (client->security) {
+                r = sol_coap_notify_by_callback(client->dtls_server, obj_instance->instance_res,
+                    notification_cb, &ctx);
+                SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+            }
+
             r = sol_ptr_vector_append(&already_sent, obj_instance);
             SOL_INT_CHECK_GOTO(r, < 0, err_exit);
         }
@@ -2805,6 +2949,12 @@ sol_lwm2m_client_notify(struct sol_lwm2m_client *client, const char **paths)
         r = sol_coap_notify_by_callback(client->coap_server, res_ctx->res,
             notification_cb, &ctx);
         SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+
+        if (client->security) {
+            r = sol_coap_notify_by_callback(client->dtls_server, res_ctx->res,
+                notification_cb, &ctx);
+            SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+        }
     }
 
     sol_ptr_vector_clear(&already_sent);

--- a/src/lib/comms/sol-lwm2m-client.c
+++ b/src/lib/comms/sol-lwm2m-client.c
@@ -30,6 +30,7 @@
 #include "sol-lwm2m.h"
 #include "sol-lwm2m-common.h"
 #include "sol-lwm2m-client.h"
+#include "sol-lwm2m-security.h"
 #include "sol-macros.h"
 #include "sol-mainloop.h"
 #include "sol-monitors.h"

--- a/src/lib/comms/sol-lwm2m-common.c
+++ b/src/lib/comms/sol-lwm2m-common.c
@@ -44,6 +44,90 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_lwm2m_common_domain, "lwm2m-common");
 int sol_lwm2m_common_init(void);
 void sol_lwm2m_common_shutdown(void);
 
+int
+read_resources(struct sol_lwm2m_client *client,
+    struct obj_ctx *obj_ctx, struct obj_instance *instance,
+    struct sol_lwm2m_resource *res, size_t res_len, ...)
+{
+    size_t i;
+    int r = 0;
+    va_list ap;
+
+    SOL_NULL_CHECK(obj_ctx->obj->read, -ENOTSUP);
+
+    va_start(ap, res_len);
+
+    // The va_list contains the resources IDs that should be read.
+    for (i = 0; i < res_len; i++) {
+        r = obj_ctx->obj->read((void *)instance->data,
+            (void *)client->user_data, client, instance->id,
+            (uint16_t)va_arg(ap, int), &res[i]);
+
+        if (r == -ENOENT) {
+            res[i].data_len = 0;
+            res[i].data = NULL;
+            continue;
+        }
+
+        LWM2M_RESOURCE_CHECK_API_GOTO(res[i], err_exit_api);
+        SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+    }
+
+    va_end(ap);
+    return 0;
+
+#ifndef SOL_NO_API_VERSION
+err_exit_api:
+    r = -EINVAL;
+#endif
+err_exit:
+    clear_resource_array(res, i);
+    va_end(ap);
+    return r;
+}
+
+struct obj_ctx *
+find_object_ctx_by_id(struct sol_lwm2m_client *client, uint16_t id)
+{
+    uint16_t i;
+    struct obj_ctx *ctx;
+
+    SOL_VECTOR_FOREACH_IDX (&client->objects, ctx, i) {
+        if (ctx->obj->id == id)
+            return ctx;
+    }
+
+    return NULL;
+}
+
+void
+clear_resource_array(struct sol_lwm2m_resource *array, uint16_t len)
+{
+    uint16_t i;
+
+    for (i = 0; i < len; i++)
+        sol_lwm2m_resource_clear(&array[i]);
+}
+
+int
+get_server_id_by_link_addr(const struct sol_ptr_vector *connections,
+    const struct sol_network_link_addr *cliaddr, int64_t *server_id)
+{
+    struct server_conn_ctx *conn_ctx;
+    struct sol_network_link_addr *server_addr;
+    uint16_t i;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (connections, conn_ctx, i) {
+        server_addr = sol_vector_get_no_check(&conn_ctx->server_addr_list, conn_ctx->addr_list_idx);
+        if (sol_network_link_addr_eq(cliaddr, server_addr)) {
+            *server_id = conn_ctx->server_id;
+            return 0;
+        }
+    }
+
+    return -ENOENT;
+}
+
 void
 send_ack_if_needed(struct sol_coap_server *coap, struct sol_coap_packet *msg,
     const struct sol_network_link_addr *cliaddr)

--- a/src/lib/comms/sol-lwm2m-common.c
+++ b/src/lib/comms/sol-lwm2m-common.c
@@ -120,7 +120,10 @@ get_server_id_by_link_addr(const struct sol_ptr_vector *connections,
     SOL_PTR_VECTOR_FOREACH_IDX (connections, conn_ctx, i) {
         server_addr = sol_vector_get_no_check(&conn_ctx->server_addr_list, conn_ctx->addr_list_idx);
         if (sol_network_link_addr_eq(cliaddr, server_addr)) {
-            *server_id = conn_ctx->server_id;
+            if (conn_ctx->server_id == DEFAULT_SHORT_SERVER_ID)
+                *server_id = UINT16_MAX;
+            else
+                *server_id = conn_ctx->server_id;
             return 0;
         }
     }

--- a/src/lib/comms/sol-lwm2m-common.h
+++ b/src/lib/comms/sol-lwm2m-common.h
@@ -44,12 +44,16 @@
 #define UINT24_MAX (16777215)
 #define ONE_SECOND (1000)
 
-#define SECURITY_SERVER_OBJECT_ID (0)
+#define SECURITY_OBJECT_ID (0)
 #define SECURITY_SERVER_URI (0)
-#define SECURITY_SERVER_IS_BOOTSTRAP (1)
+#define SECURITY_IS_BOOTSTRAP (1)
+#define SECURITY_SECURITY_MODE (2)
+#define SECURITY_PUBLIC_KEY_OR_IDENTITY (3)
+#define SECURITY_SERVER_PUBLIC_KEY (4)
+#define SECURITY_SECRET_KEY (5)
 #define SECURITY_SERVER_ID (10)
-#define SECURITY_SERVER_CLIENT_HOLD_OFF_TIME (11)
-#define SECURITY_SERVER_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT (12)
+#define SECURITY_CLIENT_HOLD_OFF_TIME (11)
+#define SECURITY_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT (12)
 
 #define SERVER_OBJECT_ID (1)
 #define SERVER_OBJECT_SERVER_ID (0)
@@ -157,6 +161,7 @@ struct server_conn_ctx {
     uint16_t addr_list_idx;
     time_t registration_time;
     char *location;
+    bool secure;
 };
 
 struct obj_instance {
@@ -185,6 +190,8 @@ struct sol_lwm2m_client {
         struct sol_timeout *timeout;
         struct sol_blob *server_uri;
     } bootstrap_ctx;
+    struct sol_coap_server *dtls_server;
+    struct sol_lwm2m_security *security;
     const void *user_data;
     uint16_t splitted_path_len;
     char *name;
@@ -194,7 +201,7 @@ struct sol_lwm2m_client {
     bool removed;
     bool is_bootstrapping;
     bool supports_access_control;
-    bool need_to_setup_access_control;
+    bool first_time_starting;
 };
 
 struct sol_lwm2m_server {

--- a/src/lib/comms/sol-lwm2m-common.h
+++ b/src/lib/comms/sol-lwm2m-common.h
@@ -211,6 +211,9 @@ struct sol_lwm2m_server {
     struct sol_monitors registration;
     struct sol_ptr_vector observers;
     struct lifetime_ctx lifetime_ctx;
+    struct sol_coap_server *dtls_server;
+    struct sol_lwm2m_security *security;
+    struct sol_vector *known_psks;
 };
 
 struct sol_lwm2m_bootstrap_server {

--- a/src/lib/comms/sol-lwm2m-common.h
+++ b/src/lib/comms/sol-lwm2m-common.h
@@ -145,6 +145,87 @@ struct sol_lwm2m_client_object {
     uint16_t id;
 };
 
+struct server_conn_ctx {
+    struct sol_network_hostname_pending *hostname_handle;
+    struct sol_lwm2m_client *client;
+    struct sol_vector server_addr_list;
+    struct sol_coap_packet *pending_pkt; //Pending registration or bootstrap reply
+    int64_t server_id;
+    int64_t lifetime;
+    uint16_t port;
+    uint16_t addr_list_idx;
+    time_t registration_time;
+    char *location;
+};
+
+struct obj_instance {
+    uint16_t id;
+    bool should_delete;
+    char *str_id;
+    const void *data;
+    struct sol_vector resources_ctx;
+    struct sol_coap_resource *instance_res;
+};
+
+struct obj_ctx {
+    const struct sol_lwm2m_object *obj;
+    char *str_id;
+    struct sol_vector instances;
+    struct sol_coap_resource *obj_res;
+};
+
+struct sol_lwm2m_client {
+    struct sol_coap_server *coap_server;
+    struct lifetime_ctx lifetime_ctx;
+    struct sol_ptr_vector connections;
+    struct sol_vector objects;
+    struct sol_monitors bootstrap;
+    struct {
+        struct sol_timeout *timeout;
+        struct sol_blob *server_uri;
+    } bootstrap_ctx;
+    const void *user_data;
+    uint16_t splitted_path_len;
+    char *name;
+    char **splitted_path;
+    char *sms;
+    bool running;
+    bool removed;
+    bool is_bootstrapping;
+    bool supports_access_control;
+    bool need_to_setup_access_control;
+};
+
+struct sol_lwm2m_server {
+    struct sol_coap_server *coap;
+    struct sol_ptr_vector clients;
+    struct sol_ptr_vector clients_to_delete;
+    struct sol_monitors registration;
+    struct sol_ptr_vector observers;
+    struct lifetime_ctx lifetime_ctx;
+};
+
+struct sol_lwm2m_bootstrap_server {
+    struct sol_coap_server *coap;
+    struct sol_ptr_vector clients;
+    struct sol_monitors bootstrap;
+    const char **known_clients;
+};
+
+int
+read_resources(struct sol_lwm2m_client *client,
+    struct obj_ctx *obj_ctx, struct obj_instance *instance,
+    struct sol_lwm2m_resource *res, size_t res_len, ...);
+
+struct obj_ctx *
+find_object_ctx_by_id(struct sol_lwm2m_client *client, uint16_t id);
+
+void
+clear_resource_array(struct sol_lwm2m_resource *array, uint16_t len);
+
+int get_server_id_by_link_addr(const struct sol_ptr_vector *connections,
+    const struct sol_network_link_addr *cliaddr, int64_t *server_id);
+
 void
 send_ack_if_needed(struct sol_coap_server *coap, struct sol_coap_packet *msg,
     const struct sol_network_link_addr *cliaddr);

--- a/src/lib/comms/sol-lwm2m-common.h
+++ b/src/lib/comms/sol-lwm2m-common.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "sol-lwm2m.h"
+#include "sol-lwm2m-security.h"
 #include "sol-monitors.h"
 
 #define LWM2M_BOOTSTRAP_QUERY_PARAMS (1)

--- a/src/lib/comms/sol-lwm2m-common.h
+++ b/src/lib/comms/sol-lwm2m-common.h
@@ -217,6 +217,8 @@ struct sol_lwm2m_bootstrap_server {
     struct sol_coap_server *coap;
     struct sol_ptr_vector clients;
     struct sol_monitors bootstrap;
+    struct sol_lwm2m_security *security;
+    struct sol_vector *known_psks;
     const char **known_clients;
 };
 

--- a/src/lib/comms/sol-lwm2m-security.c
+++ b/src/lib/comms/sol-lwm2m-security.c
@@ -1,0 +1,470 @@
+/*
+ * This file is part of the Soletta (TM) Project
+ *
+ * Copyright (C) 2016 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define SOL_LOG_DOMAIN &_lwm2m_security_domain
+
+#include "sol-log-internal.h"
+#include "sol-util-internal.h"
+#include "sol-coap.h"
+#include "sol-lwm2m-security.h"
+#include "sol-platform.h"
+#include "sol-socket-dtls.h"
+#include "sol-socket.h"
+#include "sol-str-slice.h"
+#include "sol-util-internal.h"
+#include "sol-vector.h"
+
+SOL_LOG_INTERNAL_DECLARE(_lwm2m_security_domain, "lwm2m-security");
+
+#ifdef DTLS
+
+struct sol_socket *sol_coap_server_get_socket(const struct sol_coap_server *server);
+
+static ssize_t
+get_psk_from_server_or_bs_server(const void *data, struct sol_str_slice id,
+    char *psk, size_t psk_len)
+{
+    const struct sol_lwm2m_security *ctx = data;
+    struct sol_lwm2m_server *lwm2m_server;
+    struct sol_lwm2m_bootstrap_server *lwm2m_bs_server;
+    struct sol_vector *known_psks;
+    struct sol_lwm2m_security_psk *stored_psk;
+    uint16_t i;
+
+    SOL_DBG("Looking for PSK with ID=%.*s", SOL_STR_SLICE_PRINT(id));
+
+    //If the caller expects a PSK_LEN less than 16 bytes
+    if (psk_len < SOL_DTLS_PSK_KEY_LEN)
+        return -ENOBUFS;
+
+    if (ctx->type == LWM2M_SERVER) {
+        SOL_DBG("ctx->type = LWM2M_SERVER");
+        lwm2m_server = ctx->entity;
+        known_psks = lwm2m_server->known_psks;
+    } else {
+        SOL_DBG("ctx->type = LWM2M_BOOTSTRAP_SERVER");
+        lwm2m_bs_server = ctx->entity;
+        known_psks = lwm2m_bs_server->known_psks;
+    }
+
+    SOL_VECTOR_FOREACH_IDX (known_psks, stored_psk, i) {
+        if (sol_str_slice_eq(sol_str_slice_from_blob(stored_psk->id), id)) {
+            if (stored_psk->key->size != SOL_DTLS_PSK_KEY_LEN) {
+                SOL_WRN("The PSK '%.*s' is %zu-bytes long; expecting a %d-bytes long PSK",
+                    SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(stored_psk->key)),
+                    stored_psk->key->size, SOL_DTLS_PSK_KEY_LEN);
+                return -EINVAL;
+            }
+
+            memcpy(psk, stored_psk->key->mem, stored_psk->key->size);
+            return (ssize_t)SOL_DTLS_PSK_KEY_LEN;
+        }
+    }
+
+    return -ENOENT;
+}
+
+static ssize_t
+get_psk_from_client(const void *data, struct sol_str_slice id,
+    char *psk, size_t psk_len)
+{
+    const struct sol_lwm2m_security *ctx = data;
+    struct sol_lwm2m_client *lwm2m_client = ctx->entity;
+    struct obj_ctx *obj_ctx;
+    struct obj_instance *instance;
+    struct sol_lwm2m_resource res[3] = { };
+    uint16_t i;
+    int r;
+
+    SOL_DBG("Looking for PSK with ID=%.*s", SOL_STR_SLICE_PRINT(id));
+
+    //If the caller expects a PSK_LEN less than 16 bytes
+    if (psk_len < SOL_DTLS_PSK_KEY_LEN)
+        return -ENOBUFS;
+
+    obj_ctx = find_object_ctx_by_id(lwm2m_client, SECURITY_OBJECT_ID);
+    if (!obj_ctx) {
+        SOL_WRN("LWM2M Security object not provided!");
+        return -ENOENT;
+    }
+
+    if (!obj_ctx->instances.len) {
+        SOL_WRN("There are no Security Server instances");
+        return -ENOENT;
+    }
+
+    SOL_VECTOR_FOREACH_IDX (&obj_ctx->instances, instance, i) {
+        r = read_resources(lwm2m_client, obj_ctx, instance, res, 3,
+            SECURITY_SECURITY_MODE,
+            SECURITY_PUBLIC_KEY_OR_IDENTITY,
+            SECURITY_SECRET_KEY);
+        SOL_INT_CHECK_GOTO(r, < 0, err_clear);
+
+        //If -ENOENT when reading SECURITY_SECRET_KEY or
+        // SECURITY_SECURITY_MODE != SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY
+        if (res[2].data_len == 0 ||
+            res[0].data[0].content.integer != SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY) {
+            clear_resource_array(res, sol_util_array_size(res));
+            continue;
+        }
+
+        if (sol_str_slice_eq(sol_str_slice_from_blob(res[1].data[0].content.blob), id)) {
+            if (res[2].data[0].content.blob->size != SOL_DTLS_PSK_KEY_LEN) {
+                SOL_WRN("The PSK '%.*s' is %zu-bytes long; expecting a %d-bytes long PSK",
+                    SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(res[2].data[0].content.blob)),
+                    res[2].data[0].content.blob->size, SOL_DTLS_PSK_KEY_LEN);
+                r = -EINVAL;
+                goto err_clear;
+            }
+
+            memcpy(psk, res[2].data[0].content.blob->mem, res[2].data[0].content.blob->size);
+            clear_resource_array(res, sol_util_array_size(res));
+            return (ssize_t)SOL_DTLS_PSK_KEY_LEN;
+        }
+
+        clear_resource_array(res, sol_util_array_size(res));
+    }
+
+    return -ENOENT;
+
+err_clear:
+    clear_resource_array(res, sol_util_array_size(res));
+    return r;
+}
+
+static ssize_t
+get_id_from_server_or_bs_server(const void *data, struct sol_network_link_addr *addr,
+    char *id, size_t id_len)
+{
+    //XXX: Assuming Clients' Endpoint Name will be used as PSK ID.
+    // Any UTF-8 String would do, (such as IP Addresses in dotted notation,
+    // domain names, etc) [RFC4279#section-5.1] and should be previously
+    // agreed upon between communication parties.
+    //XXX: Assuming communication with an LWM2M Client called cli1.
+    struct sol_str_slice cli_name;
+    const struct sol_lwm2m_security *ctx = data;
+    struct sol_lwm2m_server *lwm2m_server;
+    struct sol_lwm2m_bootstrap_server *lwm2m_bs_server;
+    struct sol_vector *known_psks;
+    struct sol_lwm2m_security_psk *stored_psk;
+    uint16_t i;
+
+    //If the caller expects a PSK_ID_LEN less than 16 bytes
+    if (id_len < SOL_DTLS_PSK_ID_LEN)
+        return -ENOBUFS;
+
+    if (ctx->type == LWM2M_SERVER) {
+        SOL_DBG("ctx->type = LWM2M_SERVER");
+        lwm2m_server = ctx->entity;
+        known_psks = lwm2m_server->known_psks;
+        cli_name = sol_str_slice_from_str("cli1");
+    } else {
+        SOL_DBG("ctx->type = LWM2M_BOOTSTRAP_SERVER");
+        lwm2m_bs_server = ctx->entity;
+        known_psks = lwm2m_bs_server->known_psks;
+        cli_name = sol_str_slice_from_str("cli1-bs");
+    }
+
+    SOL_VECTOR_FOREACH_IDX (known_psks, stored_psk, i) {
+        if (sol_str_slice_eq(sol_str_slice_from_blob(stored_psk->id), cli_name)) {
+            size_t psk_id_len = stored_psk->id->size;
+
+            if (psk_id_len > SOL_DTLS_PSK_ID_LEN) {
+                SOL_WRN("The PSK ID '%.*s' is %zu-bytes long;"
+                    " expecting a PSK ID at most %d-bytes long",
+                    SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(stored_psk->id)),
+                    psk_id_len, SOL_DTLS_PSK_KEY_LEN);
+                return -EINVAL;
+            }
+
+            memcpy(id, stored_psk->id->mem, psk_id_len);
+            return (ssize_t)psk_id_len;
+        }
+    }
+
+    return -ENOENT;
+}
+
+static ssize_t
+get_id_from_client(const void *data, struct sol_network_link_addr *addr, char *id, size_t id_len)
+{
+    const struct sol_lwm2m_security *ctx = data;
+    struct sol_lwm2m_client *lwm2m_client = ctx->entity;
+    struct obj_ctx *obj_ctx;
+    struct obj_instance *instance;
+    struct sol_lwm2m_resource res[4] = { };
+    int64_t server_id;
+    uint16_t i;
+    int r;
+
+    //If the caller expects a PSK_ID_LEN less than 16 bytes
+    if (id_len < SOL_DTLS_PSK_ID_LEN)
+        return -ENOBUFS;
+
+    SOL_BUFFER_DECLARE_STATIC(addr_str, SOL_NETWORK_INET_ADDR_STR_LEN);
+
+    r = get_server_id_by_link_addr(&lwm2m_client->connections, addr, &server_id);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (!sol_network_link_addr_to_str(addr, &addr_str))
+        SOL_WRN("Could not convert the server address to string");
+    else
+        SOL_DBG("Looking for PSK ID for communication with server_id=%" PRId64
+            " and server_addr=%.*s", server_id,
+            SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr_str)));
+
+    obj_ctx = find_object_ctx_by_id(lwm2m_client, SECURITY_OBJECT_ID);
+    if (!obj_ctx) {
+        SOL_WRN("LWM2M Security Object not provided!");
+        return -ENOENT;
+    }
+
+    if (!obj_ctx->instances.len) {
+        SOL_WRN("There are no Security Object instances");
+        return -ENOENT;
+    }
+
+    SOL_VECTOR_FOREACH_IDX (&obj_ctx->instances, instance, i) {
+        r = read_resources(lwm2m_client, obj_ctx, instance, res, 4,
+            SECURITY_SECURITY_MODE,
+            SECURITY_SERVER_ID,
+            SECURITY_PUBLIC_KEY_OR_IDENTITY,
+            SECURITY_IS_BOOTSTRAP);
+        SOL_INT_CHECK_GOTO(r, < 0, err_clear);
+
+        //If -ENOENT when reading SECURITY_PUBLIC_KEY_OR_IDENTITY or
+        // SECURITY_SECURITY_MODE != SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY
+        if (res[2].data_len == 0 ||
+            res[0].data[0].content.integer != SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY) {
+            clear_resource_array(res, sol_util_array_size(res));
+            continue;
+        }
+
+        if (res[1].data[0].content.integer == server_id ||
+            (res[3].data[0].content.b && (UINT16_MAX == server_id))) {
+            size_t psk_id_len;
+
+            if (res[2].data[0].content.blob->size > SOL_DTLS_PSK_ID_LEN) {
+                SOL_WRN("The PSK ID '%.*s' is %zu-bytes long;"
+                    " expecting a PSK ID at most %d-bytes long",
+                    SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(res[2].data[0].content.blob)),
+                    res[2].data[0].content.blob->size, SOL_DTLS_PSK_ID_LEN);
+                r = -EINVAL;
+                goto err_clear;
+            }
+
+            psk_id_len = res[2].data[0].content.blob->size;
+
+            memcpy(id, res[2].data[0].content.blob->mem, psk_id_len);
+            clear_resource_array(res, sol_util_array_size(res));
+
+            return (ssize_t)psk_id_len;
+        }
+
+        clear_resource_array(res, sol_util_array_size(res));
+    }
+
+    return -ENOENT;
+
+err_clear:
+    clear_resource_array(res, sol_util_array_size(res));
+    return r;
+}
+
+static void
+sol_lwm2m_security_del_full(struct sol_lwm2m_security *security,
+    enum lwm2m_entity_type type)
+{
+    SOL_NULL_CHECK(security);
+
+    switch (type) {
+    case LWM2M_CLIENT:
+        ((struct sol_lwm2m_client *)(security->entity))->security = NULL;
+        break;
+    case LWM2M_SERVER:
+        ((struct sol_lwm2m_server *)(security->entity))->security = NULL;
+        break;
+    case LWM2M_BOOTSTRAP_SERVER:
+        ((struct sol_lwm2m_bootstrap_server *)(security->entity))->security = NULL;
+        break;
+    }
+
+    sol_util_clear_memory_secure(security, sizeof(*security));
+    free(security);
+}
+
+static struct sol_lwm2m_security *
+sol_lwm2m_security_add_full(void *entity, enum lwm2m_entity_type type,
+    enum sol_lwm2m_security_mode sec_mode)
+{
+    struct sol_lwm2m_security *security;
+    struct sol_socket *socket_dtls = NULL;
+    int r = 0;
+
+    ssize_t (*get_psk_cb)(const void *creds, struct sol_str_slice id,
+        char *psk, size_t psk_len) = NULL;
+    ssize_t (*get_id_cb)(const void *creds, struct sol_network_link_addr *addr,
+        char *id, size_t id_len) = NULL;
+    bool has_security = false;
+
+    SOL_LOG_INTERNAL_INIT_ONCE;
+
+    switch (type) {
+    case LWM2M_CLIENT:
+        get_psk_cb = get_psk_from_client;
+        get_id_cb = get_id_from_client;
+        socket_dtls = sol_coap_server_get_socket(
+            ((struct sol_lwm2m_client *)entity)->dtls_server);
+        if (((struct sol_lwm2m_client *)entity)->security) {
+            security = ((struct sol_lwm2m_client *)entity)->security;
+            has_security = true;
+        }
+        break;
+    case LWM2M_SERVER:
+        get_psk_cb = get_psk_from_server_or_bs_server;
+        get_id_cb = get_id_from_server_or_bs_server;
+        socket_dtls = sol_coap_server_get_socket(
+            ((struct sol_lwm2m_server *)entity)->dtls_server);
+        if (((struct sol_lwm2m_server *)entity)->security) {
+            security = ((struct sol_lwm2m_server *)entity)->security;
+            has_security = true;
+        }
+        break;
+    case LWM2M_BOOTSTRAP_SERVER:
+        get_psk_cb = get_psk_from_server_or_bs_server;
+        get_id_cb = get_id_from_server_or_bs_server;
+        socket_dtls = sol_coap_server_get_socket(
+            ((struct sol_lwm2m_bootstrap_server *)entity)->coap);
+        if (((struct sol_lwm2m_bootstrap_server *)entity)->security) {
+            security = ((struct sol_lwm2m_bootstrap_server *)entity)->security;
+            has_security = true;
+        }
+        break;
+    }
+    if (!socket_dtls) {
+        r = -errno;
+        goto err_socket_dtls;
+    }
+
+    if (!has_security) {
+        security = calloc(1, sizeof(struct sol_lwm2m_security));
+        SOL_NULL_CHECK_ERRNO(security, ENOMEM, NULL);
+
+        security->callbacks = (struct sol_socket_dtls_credential_cb) {
+            .data = security,
+            .get_id = get_id_cb
+        };
+        r = sol_socket_dtls_set_credentials_callbacks(socket_dtls,
+            &security->callbacks);
+        if (r < 0) {
+            SOL_WRN("Passed DTLS socket is not a valid sol_socket_dtls");
+            goto err_sec;
+        }
+
+        security->type = type;
+        security->entity = entity;
+    }
+
+    switch (sec_mode) {
+    case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
+        security->callbacks.get_psk = get_psk_cb;
+        break;
+    case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
+        SOL_WRN("Raw Public Key security mode is not supported yet.");
+        r = -ENOTSUP;
+        goto err_sec;
+    case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
+        SOL_WRN("Certificate security mode is not supported yet.");
+        r = -ENOTSUP;
+        goto err_sec;
+    case SOL_LWM2M_SECURITY_MODE_NO_SEC:
+        SOL_WRN("NoSec Security Mode does not use DTLS.");
+        r = -EINVAL;
+        goto err_sec;
+    default:
+        SOL_WRN("Unknown DTLS [Security Mode] Resource from Security Object: %d", sec_mode);
+        r = -EINVAL;
+        goto err_sec;
+    }
+
+    return security;
+
+err_sec:
+    free(security);
+err_socket_dtls:
+    errno = -r;
+    return NULL;
+}
+#endif
+
+struct sol_lwm2m_security *
+sol_lwm2m_client_security_add(struct sol_lwm2m_client *lwm2m_client,
+    enum sol_lwm2m_security_mode sec_mode)
+{
+#ifdef DTLS
+    return sol_lwm2m_security_add_full(lwm2m_client, LWM2M_CLIENT, sec_mode);
+#else
+    return NULL;
+#endif
+}
+
+void
+sol_lwm2m_client_security_del(struct sol_lwm2m_security *security)
+{
+#ifdef DTLS
+    sol_lwm2m_security_del_full(security, LWM2M_CLIENT);
+#endif
+}
+
+struct sol_lwm2m_security *
+sol_lwm2m_server_security_add(struct sol_lwm2m_server *lwm2m_server,
+    enum sol_lwm2m_security_mode sec_mode)
+{
+#ifdef DTLS
+    return sol_lwm2m_security_add_full(lwm2m_server, LWM2M_SERVER, sec_mode);
+#else
+    return NULL;
+#endif
+}
+
+void
+sol_lwm2m_server_security_del(struct sol_lwm2m_security *security)
+{
+#ifdef DTLS
+    sol_lwm2m_security_del_full(security, LWM2M_SERVER);
+#endif
+}
+
+struct sol_lwm2m_security *
+sol_lwm2m_bootstrap_server_security_add(struct sol_lwm2m_bootstrap_server *lwm2m_bs_server,
+    enum sol_lwm2m_security_mode sec_mode)
+{
+#ifdef DTLS
+    return sol_lwm2m_security_add_full(lwm2m_bs_server, LWM2M_BOOTSTRAP_SERVER, sec_mode);
+#else
+    return NULL;
+#endif
+}
+
+void
+sol_lwm2m_bootstrap_server_security_del(struct sol_lwm2m_security *security)
+{
+#ifdef DTLS
+    sol_lwm2m_security_del_full(security, LWM2M_BOOTSTRAP_SERVER);
+#endif
+}

--- a/src/lib/comms/sol-lwm2m-security.h
+++ b/src/lib/comms/sol-lwm2m-security.h
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the Soletta (TM) Project
+ *
+ * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "sol-coap.h"
+#include "sol-lwm2m.h"
+#include "sol-lwm2m-common.h"
+#include "sol-lwm2m-client.h"
+#include "sol-lwm2m-server.h"
+#include "sol-lwm2m-bs-server.h"
+#include "sol-socket-dtls.h"
+#include "sol-socket.h"
+
+enum lwm2m_entity_type {
+    LWM2M_CLIENT,
+    LWM2M_SERVER,
+    LWM2M_BOOTSTRAP_SERVER
+};
+
+struct sol_lwm2m_security {
+    struct sol_socket_dtls_credential_cb callbacks;
+    enum lwm2m_entity_type type;
+    /* entity MUST have one of the following types:
+     * struct sol_lwm2m_client
+     * struct sol_lwm2m_server
+     * struct sol_lwm2m_bootstrap_server
+     */
+    void *entity;
+};
+
+struct sol_lwm2m_security *sol_lwm2m_client_security_add(
+    struct sol_lwm2m_client *lwm2m_client, enum sol_lwm2m_security_mode sec_mode);
+
+void sol_lwm2m_client_security_del(struct sol_lwm2m_security *security);
+
+struct sol_lwm2m_security *sol_lwm2m_server_security_add(
+    struct sol_lwm2m_server *lwm2m_server, enum sol_lwm2m_security_mode sec_mode);
+
+void sol_lwm2m_server_security_del(struct sol_lwm2m_security *security);
+
+struct sol_lwm2m_security *sol_lwm2m_bootstrap_server_security_add(
+    struct sol_lwm2m_bootstrap_server *lwm2m_bs_server, enum sol_lwm2m_security_mode sec_mode);
+
+void sol_lwm2m_bootstrap_server_security_del(struct sol_lwm2m_security *security);

--- a/src/lib/comms/sol-lwm2m-server.c
+++ b/src/lib/comms/sol-lwm2m-server.c
@@ -41,15 +41,6 @@
 
 SOL_LOG_INTERNAL_DECLARE_STATIC(_lwm2m_server_domain, "lwm2m-server");
 
-struct sol_lwm2m_server {
-    struct sol_coap_server *coap;
-    struct sol_ptr_vector clients;
-    struct sol_ptr_vector clients_to_delete;
-    struct sol_monitors registration;
-    struct sol_ptr_vector observers;
-    struct lifetime_ctx lifetime_ctx;
-};
-
 struct sol_lwm2m_client_info {
     struct sol_ptr_vector objects;
     char *name;

--- a/src/lib/comms/sol-lwm2m-server.c
+++ b/src/lib/comms/sol-lwm2m-server.c
@@ -30,6 +30,7 @@
 #include "sol-lwm2m.h"
 #include "sol-lwm2m-common.h"
 #include "sol-lwm2m-server.h"
+#include "sol-lwm2m-security.h"
 #include "sol-macros.h"
 #include "sol-mainloop.h"
 #include "sol-monitors.h"
@@ -43,6 +44,7 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_lwm2m_server_domain, "lwm2m-server");
 
 struct sol_lwm2m_client_info {
     struct sol_ptr_vector objects;
+    bool secure;
     char *name;
     char *location;
     char *sms;
@@ -132,7 +134,9 @@ remove_all_observer_entries_from_client(struct sol_lwm2m_server *server,
         if (entry->cinfo == cinfo) {
             token = entry->token;
             entry->removed = true;
-            sol_coap_unobserve_by_token(server->coap, &cinfo->cliaddr,
+            sol_coap_unobserve_by_token(
+                cinfo->secure ? cinfo->server->dtls_server : cinfo->server->coap,
+                &cinfo->cliaddr,
                 (uint8_t *)&token, sizeof(token));
         }
     }
@@ -149,7 +153,8 @@ remove_client(struct sol_lwm2m_client_info *cinfo, bool del)
     if (r < 0)
         SOL_WRN("Could not remove the client %s from the clients list",
             cinfo->name);
-    r = sol_coap_server_unregister_resource(cinfo->server->coap,
+    r = sol_coap_server_unregister_resource(
+        cinfo->secure ? cinfo->server->dtls_server : cinfo->server->coap,
         &cinfo->resource);
     if (r < 0)
         SOL_WRN("Could not unregister coap resource for the client: %s",
@@ -657,9 +662,13 @@ registration_request(void *data, struct sol_coap_server *coap,
         remove_client(old_cinfo, true);
     }
 
-    r = sol_coap_server_register_resource(server->coap, &cinfo->resource,
+    //Register CoAP Resource at the CoAP Server in which the Registration Request
+    // was made; which can be either server->coap or server->dtls_server
+    r = sol_coap_server_register_resource(coap, &cinfo->resource,
         cinfo);
     SOL_INT_CHECK_GOTO(r, < 0, err_exit_del_client);
+
+    cinfo->secure = sol_coap_server_is_secure(coap);
 
     r = sol_ptr_vector_append(&server->clients, cinfo);
     SOL_INT_CHECK_GOTO(r, < 0, err_exit_unregister);
@@ -678,9 +687,10 @@ registration_request(void *data, struct sol_coap_server *coap,
     SOL_INT_CHECK_GOTO(r, < 0, err_exit_unregister);
 
     SOL_DBG("Client %s registered. Location: %s, SMS: %s, binding: %u,"
-        " lifetime: %" PRIu32 " objects paths: %s",
+        " lifetime: %" PRIu32 " objects paths: %s%s",
         cinfo->name, cinfo->location, cinfo->sms,
-        cinfo->binding, cinfo->lifetime, cinfo->objects_path);
+        cinfo->binding, cinfo->lifetime, cinfo->objects_path,
+        cinfo->secure ? " (secure)" : "");
 
     r = sol_coap_send_packet(coap, response, cliaddr);
     dispatch_registration_event(server, cinfo,
@@ -688,7 +698,7 @@ registration_request(void *data, struct sol_coap_server *coap,
     return r;
 
 err_exit_unregister:
-    if (sol_coap_server_unregister_resource(server->coap, &cinfo->resource) < 0)
+    if (sol_coap_server_unregister_resource(coap, &cinfo->resource) < 0)
         SOL_WRN("Could not unregister resource for client: %s", cinfo->name);
 err_exit_del_client:
     client_info_del(cinfo);
@@ -802,20 +812,62 @@ observer_entry_del_monitor(struct observer_entry *entry,
 }
 
 SOL_API struct sol_lwm2m_server *
-sol_lwm2m_server_new(uint16_t port)
+sol_lwm2m_server_new(uint16_t coap_port, uint16_t dtls_port,
+    enum sol_lwm2m_security_mode sec_mode, struct sol_vector *known_psks)
 {
     struct sol_lwm2m_server *server;
-    struct sol_network_link_addr servaddr = { .family = SOL_NETWORK_FAMILY_INET6,
-                                              .port = port };
+    struct sol_network_link_addr servaddr_coap = { .family = SOL_NETWORK_FAMILY_INET6,
+                                                   .port = coap_port };
+    struct sol_network_link_addr servaddr_dtls = { .family = SOL_NETWORK_FAMILY_INET6,
+                                                   .port = dtls_port };
     int r;
+    const char *sec_mode_str;
 
     SOL_LOG_INTERNAL_INIT_ONCE;
+
+    switch (sec_mode) {
+    case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
+        SOL_NULL_CHECK(known_psks, NULL);
+        sec_mode_str = "Pre-Shared Key";
+        break;
+    case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
+        sec_mode_str = "Raw Public Key";
+        SOL_WRN("Raw Public Key security mode is not supported yet.");
+        return NULL;
+    case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
+        sec_mode_str = "Certificate";
+        SOL_WRN("Certificate security mode is not supported yet.");
+        return NULL;
+    case SOL_LWM2M_SECURITY_MODE_NO_SEC:
+        sec_mode_str = "NoSec";
+        SOL_DBG("Using NoSec Security Mode (No DTLS).");
+        break;
+    default:
+        SOL_WRN("Unknown DTLS Security Mode: %d", sec_mode);
+        return NULL;
+    }
 
     server = calloc(1, sizeof(struct sol_lwm2m_server));
     SOL_NULL_CHECK(server, NULL);
 
-    server->coap = sol_coap_server_new(&servaddr, false);
+    server->coap = sol_coap_server_new(&servaddr_coap, false);
     SOL_NULL_CHECK_GOTO(server->coap, err_coap);
+
+    if (sec_mode != SOL_LWM2M_SECURITY_MODE_NO_SEC) {
+        if (sec_mode == SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY)
+            server->known_psks = known_psks;
+
+        server->dtls_server = sol_coap_server_new(&servaddr_dtls, true);
+        SOL_NULL_CHECK_GOTO(server->dtls_server, err_dtls);
+
+        server->security = sol_lwm2m_server_security_add(server, sec_mode);
+        if (!server->security) {
+            sol_coap_server_unref(server->dtls_server);
+            SOL_WRN("Could not enable %s security mode for LWM2M Server", sec_mode_str);
+        } else {
+            SOL_DBG("Using %s security mode", sec_mode_str);
+        }
+    }
 
     sol_ptr_vector_init(&server->clients);
     sol_ptr_vector_init(&server->clients_to_delete);
@@ -824,11 +876,23 @@ sol_lwm2m_server_new(uint16_t port)
 
     r = sol_coap_server_register_resource(server->coap,
         &registration_interface, server);
-    SOL_INT_CHECK_GOTO(r, < 0, err_register);
+    SOL_INT_CHECK_GOTO(r, < 0, err_register_coap);
+
+    if (server->security) {
+        r = sol_coap_server_register_resource(server->dtls_server,
+            &registration_interface, server);
+        SOL_INT_CHECK_GOTO(r, < 0, err_register_dtls);
+    }
 
     return server;
 
-err_register:
+err_register_dtls:
+    if (sol_coap_server_unregister_resource(server->coap, &registration_interface) < 0)
+        SOL_WRN("Could not unregister resource for"
+            " Registration Interface at insecure CoAP Server");
+err_register_coap:
+    sol_coap_server_unref(server->dtls_server);
+err_dtls:
     sol_coap_server_unref(server->coap);
 err_coap:
     free(server);
@@ -848,6 +912,11 @@ sol_lwm2m_server_del(struct sol_lwm2m_server *server)
         entry->removed = true;
 
     sol_coap_server_unref(server->coap);
+
+    if (server->security) {
+        sol_coap_server_unref(server->dtls_server);
+        sol_lwm2m_server_security_del(server->security);
+    }
 
     SOL_PTR_VECTOR_FOREACH_IDX (&server->clients, cinfo, i)
         client_info_del(cinfo);
@@ -1067,7 +1136,9 @@ sol_lwm2m_server_add_observer(struct sol_lwm2m_server *server,
         client->objects_path, path, &obs, &entry->token, NULL, NULL, NULL, NULL, 0, NULL, &pkt);
     SOL_INT_CHECK(r, < 0, r);
 
-    return sol_coap_send_packet_with_reply(server->coap, pkt, &client->cliaddr,
+    return sol_coap_send_packet_with_reply(
+        client->secure ? client->server->dtls_server : client->server->coap,
+        pkt, &client->cliaddr,
         observation_request_reply, entry);
 }
 
@@ -1104,7 +1175,9 @@ sol_lwm2m_server_del_observer(struct sol_lwm2m_server *server,
     entry->removed = true;
     token = entry->token;
 
-    return sol_coap_unobserve_by_token(server->coap, &entry->cinfo->cliaddr,
+    return sol_coap_unobserve_by_token(
+        client->secure ? client->server->dtls_server : client->server->coap,
+        &entry->cinfo->cliaddr,
         (uint8_t *)&token, sizeof(token));
 }
 
@@ -1170,7 +1243,9 @@ send_management_packet(struct sol_lwm2m_server *server,
     SOL_INT_CHECK(r, < 0, r);
 
     if (!cb)
-        return sol_coap_send_packet(server->coap, pkt, &client->cliaddr);
+        return sol_coap_send_packet(
+            client->secure ? client->server->dtls_server : client->server->coap,
+            pkt, &client->cliaddr);
 
     ctx = malloc(sizeof(struct management_ctx));
     SOL_NULL_CHECK_GOTO(ctx, err_exit);
@@ -1183,7 +1258,9 @@ send_management_packet(struct sol_lwm2m_server *server,
     ctx->data = data;
     ctx->cb = cb;
 
-    return sol_coap_send_packet_with_reply(server->coap, pkt, &client->cliaddr,
+    return sol_coap_send_packet_with_reply(
+        client->secure ? client->server->dtls_server : client->server->coap,
+        pkt, &client->cliaddr,
         management_reply, ctx);
 
 err_exit:

--- a/src/lib/comms/sol-oic-security.c
+++ b/src/lib/comms/sol-oic-security.c
@@ -96,7 +96,8 @@ creds_get_psk(const void *data, struct sol_str_slice id,
 }
 
 static ssize_t
-creds_get_id(const void *data, char *id, size_t id_len)
+creds_get_id(const void *data, struct sol_network_link_addr *addr,
+    char *id, size_t id_len)
 {
     const uint8_t *machine_id = sol_platform_get_machine_id_as_bytes();
     size_t len = SOL_DTLS_PSK_ID_LEN;

--- a/src/lib/comms/sol-socket-dtls-impl-tinydtls.c
+++ b/src/lib/comms/sol-socket-dtls-impl-tinydtls.c
@@ -629,7 +629,7 @@ get_psk_info(struct dtls_context_t *ctx, const session_t *session,
 
         len = socket->credentials->get_id(socket->credentials->data, &addr,
             result, result_len);
-        if (len != SOL_DTLS_PSK_ID_LEN) {
+        if (len > SOL_DTLS_PSK_ID_LEN) {
             SOL_DBG("Not enough space to write key ID");
             r = dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR);
         } else {

--- a/src/lib/comms/sol-socket-dtls-impl-tinydtls.c
+++ b/src/lib/comms/sol-socket-dtls-impl-tinydtls.c
@@ -276,7 +276,7 @@ init_dtls_if_needed(void)
 
 /* Called whenever the wrapped socket can be read. This receives a packet
  * from that socket, and passes to TinyDTLS. When it's done decrypting
- * the payload, dtls_handle_message() will call sol_dtls_read(), which
+ * the payload, dtls_handle_message() will call call_user_read_cb(), which
  * in turn will call the user callback with the decrypted data. */
 static bool
 read_encrypted(void *data, struct sol_socket *wrapped)
@@ -348,10 +348,10 @@ no_item:
 }
 
 /* Called whenever the wrapped socket can be written to. This gets the
- * unencrypted data previously set with sol_socket_sendmsg() and cached in
+ * unencrypted data previously set with sol_socket_dtls_sendmsg() and cached in
  * the sol_socket_dtls struct, passes through TinyDTLS, and when it's done
- * encrypting the payload, it calls sol_socket_sendmsg() to finally pass it
- * to the wire.  */
+ * encrypting the payload, it calls write_encrypted() to finally pass it to
+ * the wire through sol_socket_sendmsg().  */
 static bool
 encrypt_payload(struct sol_socket_dtls *s)
 {
@@ -616,12 +616,19 @@ get_psk_info(struct dtls_context_t *ctx, const session_t *session,
     }
 
     if (type == DTLS_PSK_IDENTITY || type == DTLS_PSK_HINT) {
+        struct sol_network_link_addr addr;
+
         SOL_DBG("Server asked for PSK %s with %zu bytes, have %d",
             type == DTLS_PSK_IDENTITY ? "identity" : "hint",
             result_len, SOL_DTLS_PSK_ID_LEN);
 
-        len = socket->credentials->get_id(socket->credentials->data, result,
-            result_len);
+        if (from_sockaddr(&session->addr.sa, session->size, &addr) < 0) {
+            SOL_DBG("Could not get link address from session");
+            return -EINVAL;
+        }
+
+        len = socket->credentials->get_id(socket->credentials->data, &addr,
+            result, result_len);
         if (len != SOL_DTLS_PSK_ID_LEN) {
             SOL_DBG("Not enough space to write key ID");
             r = dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR);

--- a/src/lib/comms/sol-socket-dtls.h
+++ b/src/lib/comms/sol-socket-dtls.h
@@ -40,7 +40,8 @@ struct sol_socket_dtls_credential_cb {
     int (*init)(const void *data);
     void (*clear)(void *creds);
 
-    ssize_t (*get_id)(const void *creds, char *id, size_t id_len);
+    ssize_t (*get_id)(const void *creds, struct sol_network_link_addr *addr,
+        char *id, size_t id_len);
     ssize_t (*get_psk)(const void *creds, struct sol_str_slice id,
         char *psk, size_t psk_len);
 };

--- a/src/samples/coap/lwm2m-client.c
+++ b/src/samples/coap/lwm2m-client.c
@@ -17,19 +17,19 @@
  */
 
 /*
-   To run: ./lwm2m-sample-client <client name> [bootstrap]
-   If [bootstrap] argument is not given:
-   This LWM2M client sample will try to connect to a LWM2M server @ locahost:5683.
+   To run: ./lwm2m-sample-client <client name> [-b] [-s SEC_MODE]
+   If [-b] argument is not given:
+   This LWM2M client sample will try to connect to a LWM2M server @ locahost:5683
+   (or @ localhost:5684 if -s is given).
    If a location object is created by the LWM2M server, it will report its location
    every one second.
 
-   If [bootstrap] argument is given:
-   This LWM2M client sample will try to connect to a LWM2M server @ locahost:5683.
-   It should fail and thus will expect a server-initiated bootstrap.
+   If [-b] argument is given:
+   This LWM2M client sample expect a server-initiated bootstrap.
    If it doesn't happen in 5s, it will try to connect to a LWM2M bootstrap server
    @ localhost:5783 and perform client-initiated bootstrap.
    If the bootstrap is successfull, it will try to connect and register with the
-   server received in the bootstrap information.
+   server(s) received in the bootstrap information.
  */
 
 #include "sol-lwm2m-client.h"
@@ -41,6 +41,7 @@
 #include <stdbool.h>
 #include <errno.h>
 #include <time.h>
+#include <unistd.h>
 
 #define LOCATION_OBJ_ID (6)
 #define LOCATION_OBJ_LATITUDE_RES_ID (0)
@@ -62,12 +63,16 @@
 #define ACCESS_CONTROL_OBJ_ACL_RES_ID (2)
 #define ACCESS_CONTROL_OBJ_OWNER_RES_ID (3)
 
-#define SECURITY_SERVER_OBJ_ID (0)
-#define SECURITY_SERVER_SERVER_URI_RES_ID (0)
-#define SECURITY_SERVER_IS_BOOTSTRAP_RES_ID (1)
-#define SECURITY_SERVER_SERVER_ID_RES_ID (10)
-#define SECURITY_SERVER_CLIENT_HOLD_OFF_TIME_RES_ID (11)
-#define SECURITY_SERVER_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT_RES_ID (12)
+#define SECURITY_OBJ_ID (0)
+#define SECURITY_SERVER_URI_RES_ID (0)
+#define SECURITY_IS_BOOTSTRAP_RES_ID (1)
+#define SECURITY_SECURITY_MODE_RES_ID (2)
+#define SECURITY_PUBLIC_KEY_OR_IDENTITY_RES_ID (3)
+#define SECURITY_SERVER_PUBLIC_KEY_RES_ID (4)
+#define SECURITY_SECRET_KEY_RES_ID (5)
+#define SECURITY_SERVER_ID_RES_ID (10)
+#define SECURITY_CLIENT_HOLD_OFF_TIME_RES_ID (11)
+#define SECURITY_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT_RES_ID (12)
 
 struct client_data_ctx {
     bool has_location_instance;
@@ -78,6 +83,10 @@ struct security_obj_instance_ctx {
     struct sol_lwm2m_client *client;
     struct sol_blob *server_uri;
     bool is_bootstrap;
+    int64_t security_mode;
+    struct sol_blob *public_key_or_id;
+    struct sol_blob *server_public_key;
+    struct sol_blob *secret_key;
     int64_t server_id;
     int64_t client_hold_off_time;
     int64_t bootstrap_server_account_timeout;
@@ -114,16 +123,57 @@ struct location_obj_instance_ctx {
 static struct sol_blob bootstrap_server_addr = {
     .type = &SOL_BLOB_TYPE_NO_FREE,
     .parent = NULL,
-    .mem = (void *)"coap://localhost:5783",
-    .size = sizeof("coap://localhost:5783") - 1,
+    .mem = (void *)"coaps://localhost:5783",
+    .size = sizeof("coaps://localhost:5783") - 1,
     .refcnt = 1
 };
 
-static struct sol_blob server_addr = {
+static struct sol_blob server_addr_coap = {
     .type = &SOL_BLOB_TYPE_NO_FREE,
     .parent = NULL,
     .mem = (void *)"coap://localhost:5683",
     .size = sizeof("coap://localhost:5683") - 1,
+    .refcnt = 1
+};
+
+static struct sol_blob server_addr_dtls = {
+    .type = &SOL_BLOB_TYPE_NO_FREE,
+    .parent = NULL,
+    .mem = (void *)"coaps://localhost:5684",
+    .size = sizeof("coaps://localhost:5684") - 1,
+    .refcnt = 1
+};
+
+//FIXME: UNSEC: Hardcoded Crypto Keys
+static struct sol_blob psk_id = {
+    .type = &SOL_BLOB_TYPE_NO_FREE,
+    .parent = NULL,
+    .mem = (void *)"cli1",
+    .size = sizeof("cli1") - 1,
+    .refcnt = 1
+};
+
+static struct sol_blob psk_key = {
+    .type = &SOL_BLOB_TYPE_NO_FREE,
+    .parent = NULL,
+    .mem = (void *)"0123456789ABCDEF",
+    .size = sizeof("0123456789ABCDEF") - 1,
+    .refcnt = 1
+};
+
+static struct sol_blob psk_bs_id = {
+    .type = &SOL_BLOB_TYPE_NO_FREE,
+    .parent = NULL,
+    .mem = (void *)"cli1-bs",
+    .size = sizeof("cli1-bs") - 1,
+    .refcnt = 1
+};
+
+static struct sol_blob psk_bs_key = {
+    .type = &SOL_BLOB_TYPE_NO_FREE,
+    .parent = NULL,
+    .mem = (void *)"FEDCBA9876543210",
+    .size = sizeof("FEDCBA9876543210") - 1,
     .refcnt = 1
 };
 
@@ -317,28 +367,50 @@ read_security_obj(void *instance_data, void *user_data,
     struct security_obj_instance_ctx *ctx = instance_data;
     int r;
 
-    //It implements only the necassary info to connect to a LWM2M server
-    // or bootstrap server without encryption.
     switch (res_id) {
-    case SECURITY_SERVER_SERVER_URI_RES_ID:
+    case SECURITY_SERVER_URI_RES_ID:
         SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, res_id,
             SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, ctx->server_uri);
         break;
-    case SECURITY_SERVER_IS_BOOTSTRAP_RES_ID:
+    case SECURITY_IS_BOOTSTRAP_RES_ID:
         SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, res_id,
             SOL_LWM2M_RESOURCE_DATA_TYPE_BOOL, ctx->is_bootstrap);
         break;
-    case SECURITY_SERVER_SERVER_ID_RES_ID:
+    case SECURITY_SECURITY_MODE_RES_ID:
+        SOL_LWM2M_RESOURCE_SINGLE_INT_INIT(r, res, res_id, ctx->security_mode);
+        break;
+    case SECURITY_PUBLIC_KEY_OR_IDENTITY_RES_ID:
+        if (!ctx->public_key_or_id)
+            r = -ENOENT;
+        else
+            SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, res_id,
+                SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, ctx->public_key_or_id);
+        break;
+    case SECURITY_SERVER_PUBLIC_KEY_RES_ID:
+        if (!ctx->server_public_key)
+            r = -ENOENT;
+        else
+            SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, res_id,
+                SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, ctx->server_public_key);
+        break;
+    case SECURITY_SECRET_KEY_RES_ID:
+        if (!ctx->secret_key)
+            r = -ENOENT;
+        else
+            SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, res_id,
+                SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, ctx->secret_key);
+        break;
+    case SECURITY_SERVER_ID_RES_ID:
         SOL_LWM2M_RESOURCE_SINGLE_INT_INIT(r, res, res_id, ctx->server_id);
         break;
-    case SECURITY_SERVER_CLIENT_HOLD_OFF_TIME_RES_ID:
+    case SECURITY_CLIENT_HOLD_OFF_TIME_RES_ID:
         SOL_LWM2M_RESOURCE_SINGLE_INT_INIT(r, res, res_id, ctx->client_hold_off_time);
         break;
-    case SECURITY_SERVER_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT_RES_ID:
+    case SECURITY_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT_RES_ID:
         SOL_LWM2M_RESOURCE_SINGLE_INT_INIT(r, res, res_id, ctx->bootstrap_server_account_timeout);
         break;
     default:
-        if (res_id >= 2 && res_id <= 9)
+        if (res_id >= 6 && res_id <= 9)
             r = -ENOENT;
         else
             r = -EINVAL;
@@ -356,24 +428,39 @@ write_security_res(void *instance_data, void *user_data,
     int r = 0;
 
     switch (res->id) {
-    case SECURITY_SERVER_SERVER_URI_RES_ID:
+    case SECURITY_SERVER_URI_RES_ID:
         sol_blob_unref(instance_ctx->server_uri);
         instance_ctx->server_uri = sol_blob_ref(res->data->content.blob);
         break;
-    case SECURITY_SERVER_IS_BOOTSTRAP_RES_ID:
+    case SECURITY_IS_BOOTSTRAP_RES_ID:
         instance_ctx->is_bootstrap = res->data->content.b;
         break;
-    case SECURITY_SERVER_SERVER_ID_RES_ID:
+    case SECURITY_SECURITY_MODE_RES_ID:
+        instance_ctx->security_mode = res->data->content.integer;
+        break;
+    case SECURITY_PUBLIC_KEY_OR_IDENTITY_RES_ID:
+        sol_blob_unref(instance_ctx->public_key_or_id);
+        instance_ctx->public_key_or_id = sol_blob_ref(res->data->content.blob);
+        break;
+    case SECURITY_SERVER_PUBLIC_KEY_RES_ID:
+        sol_blob_unref(instance_ctx->server_public_key);
+        instance_ctx->server_public_key = sol_blob_ref(res->data->content.blob);
+        break;
+    case SECURITY_SECRET_KEY_RES_ID:
+        sol_blob_unref(instance_ctx->secret_key);
+        instance_ctx->secret_key = sol_blob_ref(res->data->content.blob);
+        break;
+    case SECURITY_SERVER_ID_RES_ID:
         instance_ctx->server_id = res->data->content.integer;
         break;
-    case SECURITY_SERVER_CLIENT_HOLD_OFF_TIME_RES_ID:
+    case SECURITY_CLIENT_HOLD_OFF_TIME_RES_ID:
         instance_ctx->client_hold_off_time = res->data->content.integer;
         break;
-    case SECURITY_SERVER_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT_RES_ID:
+    case SECURITY_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT_RES_ID:
         instance_ctx->bootstrap_server_account_timeout = res->data->content.integer;
         break;
     default:
-        if (res->id >= 2 && res->id <= 9)
+        if (res->id >= 6 && res->id <= 9)
             r = -ENOENT;
         else
             r = -EINVAL;
@@ -399,7 +486,7 @@ write_security_tlv(void *instance_data, void *user_data,
         SOL_BUFFER_DECLARE_STATIC(buf, 64);
 
         switch (tlv->id) {
-        case SECURITY_SERVER_SERVER_URI_RES_ID:
+        case SECURITY_SERVER_URI_RES_ID:
             r = sol_lwm2m_tlv_get_bytes(tlv, &buf);
             if (r < 0)
                 return r;
@@ -408,22 +495,54 @@ write_security_tlv(void *instance_data, void *user_data,
             if (!instance_ctx->server_uri)
                 return -EINVAL;
             break;
-        case SECURITY_SERVER_IS_BOOTSTRAP_RES_ID:
+        case SECURITY_IS_BOOTSTRAP_RES_ID:
             r = sol_lwm2m_tlv_get_bool(tlv, &instance_ctx->is_bootstrap);
             if (r < 0)
                 return r;
             break;
-        case SECURITY_SERVER_SERVER_ID_RES_ID:
+        case SECURITY_SECURITY_MODE_RES_ID:
+            r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->security_mode);
+            if (r < 0)
+                return r;
+            break;
+        case SECURITY_PUBLIC_KEY_OR_IDENTITY_RES_ID:
+            r = sol_lwm2m_tlv_get_bytes(tlv, &buf);
+            if (r < 0)
+                return r;
+            sol_blob_unref(instance_ctx->public_key_or_id);
+            instance_ctx->public_key_or_id = sol_buffer_to_blob(&buf);
+            if (!instance_ctx->public_key_or_id)
+                return -EINVAL;
+            break;
+        case SECURITY_SERVER_PUBLIC_KEY_RES_ID:
+            r = sol_lwm2m_tlv_get_bytes(tlv, &buf);
+            if (r < 0)
+                return r;
+            sol_blob_unref(instance_ctx->server_public_key);
+            instance_ctx->server_public_key = sol_buffer_to_blob(&buf);
+            if (!instance_ctx->server_public_key)
+                return -EINVAL;
+            break;
+        case SECURITY_SECRET_KEY_RES_ID:
+            r = sol_lwm2m_tlv_get_bytes(tlv, &buf);
+            if (r < 0)
+                return r;
+            sol_blob_unref(instance_ctx->secret_key);
+            instance_ctx->secret_key = sol_buffer_to_blob(&buf);
+            if (!instance_ctx->secret_key)
+                return -EINVAL;
+            break;
+        case SECURITY_SERVER_ID_RES_ID:
             r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->server_id);
             if (r < 0)
                 return r;
             break;
-        case SECURITY_SERVER_CLIENT_HOLD_OFF_TIME_RES_ID:
+        case SECURITY_CLIENT_HOLD_OFF_TIME_RES_ID:
             r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->client_hold_off_time);
             if (r < 0)
                 return r;
             break;
-        case SECURITY_SERVER_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT_RES_ID:
+        case SECURITY_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT_RES_ID:
             r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->bootstrap_server_account_timeout);
             if (r < 0)
                 return r;
@@ -470,7 +589,7 @@ create_security_obj(void *user_data, struct sol_lwm2m_client *client,
     SOL_VECTOR_FOREACH_IDX (&payload.payload.tlv_content, tlv, i) {
         SOL_BUFFER_DECLARE_STATIC(buf, 64);
 
-        if (tlv->id == SECURITY_SERVER_SERVER_URI_RES_ID) {
+        if (tlv->id == SECURITY_SERVER_URI_RES_ID) {
             r = sol_lwm2m_tlv_get_bytes(tlv, &buf);
             if (r < 0)
                 goto err_free_instance;
@@ -479,13 +598,42 @@ create_security_obj(void *user_data, struct sol_lwm2m_client *client,
                 fprintf(stderr, "Could not set server_uri resource\n");
                 goto err_free_instance;
             }
-        } else if (tlv->id == SECURITY_SERVER_IS_BOOTSTRAP_RES_ID) {
+        } else if (tlv->id == SECURITY_IS_BOOTSTRAP_RES_ID) {
             r = sol_lwm2m_tlv_get_bool(tlv, &instance_ctx->is_bootstrap);
-        } else if (tlv->id == SECURITY_SERVER_SERVER_ID_RES_ID) {
+        } else if (tlv->id == SECURITY_SECURITY_MODE_RES_ID) {
+            r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->security_mode);
+        } else if (tlv->id == SECURITY_PUBLIC_KEY_OR_IDENTITY_RES_ID) {
+            r = sol_lwm2m_tlv_get_bytes(tlv, &buf);
+            if (r < 0)
+                goto err_free_instance;
+            instance_ctx->public_key_or_id = sol_buffer_to_blob(&buf);
+            if (!instance_ctx->public_key_or_id) {
+                fprintf(stderr, "Could not set public_key_or_id resource\n");
+                goto err_free_instance;
+            }
+        } else if (tlv->id == SECURITY_SERVER_PUBLIC_KEY_RES_ID) {
+            r = sol_lwm2m_tlv_get_bytes(tlv, &buf);
+            if (r < 0)
+                goto err_free_instance;
+            instance_ctx->server_public_key = sol_buffer_to_blob(&buf);
+            if (!instance_ctx->server_public_key) {
+                fprintf(stderr, "Could not set server_public_key resource\n");
+                goto err_free_instance;
+            }
+        } else if (tlv->id == SECURITY_SECRET_KEY_RES_ID) {
+            r = sol_lwm2m_tlv_get_bytes(tlv, &buf);
+            if (r < 0)
+                goto err_free_instance;
+            instance_ctx->secret_key = sol_buffer_to_blob(&buf);
+            if (!instance_ctx->secret_key) {
+                fprintf(stderr, "Could not set secret_key resource\n");
+                goto err_free_instance;
+            }
+        } else if (tlv->id == SECURITY_SERVER_ID_RES_ID) {
             r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->server_id);
-        } else if (tlv->id == SECURITY_SERVER_CLIENT_HOLD_OFF_TIME_RES_ID) {
+        } else if (tlv->id == SECURITY_CLIENT_HOLD_OFF_TIME_RES_ID) {
             r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->client_hold_off_time);
-        } else if (tlv->id == SECURITY_SERVER_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT_RES_ID) {
+        } else if (tlv->id == SECURITY_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT_RES_ID) {
             r = sol_lwm2m_tlv_get_int(tlv, &instance_ctx->bootstrap_server_account_timeout);
         }
 
@@ -503,6 +651,13 @@ create_security_obj(void *user_data, struct sol_lwm2m_client *client,
     return 0;
 
 err_free_instance:
+    sol_blob_unref(instance_ctx->server_uri);
+    if (instance_ctx->public_key_or_id)
+        sol_blob_unref(instance_ctx->public_key_or_id);
+    if (instance_ctx->server_public_key)
+        sol_blob_unref(instance_ctx->server_public_key);
+    if (instance_ctx->secret_key)
+        sol_blob_unref(instance_ctx->secret_key);
     free(instance_ctx);
     return r;
 }
@@ -514,6 +669,12 @@ del_security_obj(void *instance_data, void *user_data,
     struct security_obj_instance_ctx *instance_ctx = instance_data;
 
     sol_blob_unref(instance_ctx->server_uri);
+    if (instance_ctx->public_key_or_id)
+        sol_blob_unref(instance_ctx->public_key_or_id);
+    if (instance_ctx->server_public_key)
+        sol_blob_unref(instance_ctx->server_public_key);
+    if (instance_ctx->secret_key)
+        sol_blob_unref(instance_ctx->secret_key);
     free(instance_ctx);
     return 0;
 }
@@ -526,8 +687,6 @@ read_server_obj(void *instance_data, void *user_data,
     struct server_obj_instance_ctx *ctx = instance_data;
     int r;
 
-    //It implements only the necassary info to connect to a LWM2M server
-    // without encryption.
     switch (res_id) {
     case SERVER_OBJ_SHORT_RES_ID:
         SOL_LWM2M_RESOURCE_SINGLE_INT_INIT(r, res, res_id, ctx->server_id);
@@ -1016,7 +1175,7 @@ static const struct sol_lwm2m_object location_object = {
 
 static const struct sol_lwm2m_object security_object = {
     SOL_SET_API_VERSION(.api_version = SOL_LWM2M_OBJECT_API_VERSION, )
-    .id = SECURITY_SERVER_OBJ_ID,
+    .id = SECURITY_OBJ_ID,
     .resources_count = 12,
     .read = read_security_obj,
     .create = create_security_obj,
@@ -1058,20 +1217,55 @@ main(int argc, char *argv[])
     struct security_obj_instance_ctx *security_data;
     struct server_obj_instance_ctx *server_data;
     int r;
+    enum sol_lwm2m_security_mode sec_mode = SOL_LWM2M_SECURITY_MODE_NO_SEC;
+    char *cli_name = NULL;
+    char usage[256];
 
     srand(time(NULL));
-    if (argc < 2) {
-        fprintf(stderr, "Usage: ./lwm2m-sample-client <client-name> [bootstrap]\n");
+
+    snprintf(usage, sizeof(usage), "Usage: ./lwm2m-sample-client <client-name> [-b] [-s SEC_MODE]\n"
+        "Where Factory Bootstrap is default and SEC_MODE is an integer as per:\n"
+        "\tPRE_SHARED_KEY=%d\n"
+        "\tRAW_PUBLIC_KEY=%d\n"
+        "\tCERTIFICATE=%d\n"
+        "\tNO_SEC=%d (default)\n",
+        SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY,
+        SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY,
+        SOL_LWM2M_SECURITY_MODE_CERTIFICATE,
+        SOL_LWM2M_SECURITY_MODE_NO_SEC);
+
+    while ((r = getopt(argc, argv, "bs:")) != -1) {
+        switch (r) {
+        case 'b':
+            data_ctx.is_bootstrap = true;
+            break;
+        case 's':
+            sec_mode = atoi(optarg);
+            if (sec_mode < 0 || sec_mode > 3) {
+                fprintf(stderr, "%s", usage);
+                return -1;
+            }
+            break;
+        default:
+            fprintf(stderr, "%s", usage);
+            return -1;
+        }
+    }
+
+    cli_name = argv[optind];
+    if (!cli_name) {
+        fprintf(stderr, "%s", usage);
+        return -1;
+    }
+
+    if (data_ctx.is_bootstrap && (sec_mode == SOL_LWM2M_SECURITY_MODE_NO_SEC)) {
+        fprintf(stderr, "Non-Factory Bootstrap Mode needs DTLS security enabled\n");
         return -1;
     }
 
     sol_init();
 
-    if (argv[2])
-        data_ctx.is_bootstrap = true;
-
-    client = sol_lwm2m_client_new(argv[1], NULL, NULL, objects,
-        &data_ctx);
+    client = sol_lwm2m_client_new(cli_name, NULL, NULL, objects, &data_ctx);
 
     if (!client) {
         r = -1;
@@ -1086,6 +1280,7 @@ main(int argc, char *argv[])
     }
 
     security_data->client = client;
+    security_data->security_mode = sec_mode;
 
     if (!data_ctx.is_bootstrap) {
         server_data = calloc(1, sizeof(struct server_obj_instance_ctx));
@@ -1106,8 +1301,11 @@ main(int argc, char *argv[])
             goto exit_del;
         }
 
-        security_data->server_uri = &server_addr;
+        security_data->server_uri = (sec_mode == SOL_LWM2M_SECURITY_MODE_NO_SEC) ?
+            &server_addr_coap : &server_addr_dtls;
         security_data->is_bootstrap = false;
+        security_data->public_key_or_id = &psk_id;
+        security_data->secret_key = &psk_key;
         security_data->server_id = 101;
     } else {
         r = sol_lwm2m_client_add_bootstrap_finish_monitor(client, bootstrap_cb,
@@ -1120,6 +1318,8 @@ main(int argc, char *argv[])
 
         security_data->server_uri = &bootstrap_server_addr;
         security_data->is_bootstrap = true;
+        security_data->public_key_or_id = &psk_bs_id;
+        security_data->secret_key = &psk_bs_key;
         security_data->client_hold_off_time = 5;
         security_data->bootstrap_server_account_timeout = 0;
     }

--- a/src/test/test-lwm2m.c
+++ b/src/test/test-lwm2m.c
@@ -627,7 +627,9 @@ main(int argc, char *argv[])
     r = sol_init();
     ASSERT(!r);
 
-    server = sol_lwm2m_server_new(SOL_LWM2M_DEFAULT_SERVER_PORT);
+    server = sol_lwm2m_server_new(SOL_LWM2M_DEFAULT_SERVER_PORT_COAP,
+        SOL_LWM2M_DEFAULT_SERVER_PORT_DTLS,
+        SOL_LWM2M_SECURITY_MODE_NO_SEC, NULL);
     ASSERT(server != NULL);
 
     r = sol_lwm2m_server_add_registration_monitor(server, registration_event_cb,

--- a/src/test/test-lwm2m.c
+++ b/src/test/test-lwm2m.c
@@ -45,9 +45,10 @@
 #define ARRAY_VALUE_ONE (INT64_MAX)
 #define ARRAY_VALUE_TWO (INT64_MIN)
 
-#define SECURITY_SERVER_OBJECT_ID (0)
+#define SECURITY_OBJECT_ID (0)
 #define SECURITY_SERVER_URI (0)
-#define SECURITY_SERVER_IS_BOOTSTRAP (1)
+#define SECURITY_IS_BOOTSTRAP (1)
+#define SECURITY_SECURITY_MODE (2)
 #define SECURITY_SERVER_ID (10)
 
 #define SERVER_OBJECT_ID (1)
@@ -107,9 +108,12 @@ security_object_read(void *instance_data, void *user_data,
         SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, 0,
             SOL_LWM2M_RESOURCE_DATA_TYPE_STRING, &addr);
         break;
-    case SECURITY_SERVER_IS_BOOTSTRAP:
+    case SECURITY_IS_BOOTSTRAP:
         SOL_LWM2M_RESOURCE_SINGLE_INIT(r, res, 1,
             SOL_LWM2M_RESOURCE_DATA_TYPE_BOOL, false);
+        break;
+    case SECURITY_SECURITY_MODE:
+        SOL_LWM2M_RESOURCE_SINGLE_INT_INIT(r, res, 2, SOL_LWM2M_SECURITY_MODE_NO_SEC);
         break;
     case SECURITY_SERVER_ID:
         SOL_LWM2M_RESOURCE_SINGLE_INT_INIT(r, res, 10, 101);
@@ -368,7 +372,7 @@ del_dummy(void *instance_data, void *user_data,
 
 static const struct sol_lwm2m_object security_object = {
     SOL_SET_API_VERSION(.api_version = SOL_LWM2M_OBJECT_API_VERSION, )
-    .id = SECURITY_SERVER_OBJECT_ID,
+    .id = SECURITY_OBJECT_ID,
     .resources_count = 12,
     .read = security_object_read
 };
@@ -591,7 +595,7 @@ registration_event_cb(void *data, struct sol_lwm2m_server *server,
             uint16_t obj_id;
             r = sol_lwm2m_client_object_get_id(object, &obj_id);
             ASSERT(r == 0);
-            if (obj_id == SECURITY_SERVER_OBJECT_ID ||
+            if (obj_id == SECURITY_OBJECT_ID ||
                 obj_id == SERVER_OBJECT_ID || obj_id == DUMMY_OBJECT_ID)
                 objects_found++;
         }


### PR DESCRIPTION
This patch adds support for CoAP Data Encryption using DTLS with Pre-Shared Key mode (using `TLS_PSK_WITH_AES_128_CCM_8` Cipher Suite).

It includes modifications on the LWM2M Samples to demonstrate the support as well.

This patch depends on #2271.

Signed-off-by: Bruno Melo bsilva.melo@gmail.com