### PR TITLE
libmicrohttp: bump version requirement.

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -642,7 +642,7 @@
       "dependency": "libmicrohttpd",
       "type": "pkg-config",
       "pkgname": "libmicrohttpd",
-      "atleast-version": "0.9.43"
+      "atleast-version": "0.9.47"
     },
     {
       "dependency": "tinycbor_src",


### PR DESCRIPTION
This slipped in wrong for v1 and nobody noticed. With version before
that one make check-fbp fail big time.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>