### PR TITLE
lwm2m: Handle error condition correctly

### DIFF
--- a/src/lib/comms/sol-lwm2m-client.c
+++ b/src/lib/comms/sol-lwm2m-client.c
@@ -904,7 +904,7 @@ handle_create(struct sol_lwm2m_client *client,
         } else if (r != SOL_COAP_RESPONSE_CODE_CHANGED && r != SOL_COAP_RESPONSE_CODE_CREATED) {
             SOL_WRN("Failed to create Access Control Object Instance for Object /%"
                 PRIu16 "/%" PRIu16, obj_ctx->obj->id, obj_instance->id);
-            return -ECANCELED;
+            goto err_exit;
         }
     }
 


### PR DESCRIPTION
The function returns an uint8_t, so returning negative values is wrong.
It's also leaking the handles in the case of an error, as it's not
following the clean-up path.

Signed-off-by: Iván Briano <ivan.briano@intel.com>