### PR TITLE
LWM2M: Fix check_authorization() for Access Control Objects [v2]

### DIFF
--- a/src/lib/comms/sol-lwm2m-client.c
+++ b/src/lib/comms/sol-lwm2m-client.c
@@ -452,6 +452,31 @@ check_authorization(struct sol_lwm2m_client *client,
     }
 
     obj_ctx = find_object_ctx_by_id(client, ACCESS_CONTROL_OBJECT_ID);
+    //If the target Object is an Access Control Object itself,
+    // the server is authorized iff it is the owner of the object instance.
+    if (obj_id == ACCESS_CONTROL_OBJECT_ID) {
+        SOL_VECTOR_FOREACH_IDX (&obj_ctx->instances, obj_instance, i) {
+            if (obj_instance->id == instance_id) {
+                r = read_resources(client, obj_ctx, obj_instance, res, 1,
+                    ACCESS_CONTROL_OBJECT_OWNER_RES_ID);
+                if (r < 0) {
+                    SOL_WRN("Could not read Access Control"
+                        " Object's [Owner ID] resource\n");
+                    goto exit_clear_1;
+                }
+
+                if (res[0].data[0].content.integer == server_id)
+                    r = 1;
+                else
+                    r = 0;
+                goto exit_clear_1;
+            }
+        }
+
+        r = -ENOENT;
+        goto exit_clear_1;
+    }
+
     SOL_VECTOR_FOREACH_IDX (&obj_ctx->instances, obj_instance, i) {
         r = read_resources(client, obj_ctx, obj_instance, res, 2,
             ACCESS_CONTROL_OBJECT_OBJECT_RES_ID,
@@ -459,7 +484,7 @@ check_authorization(struct sol_lwm2m_client *client,
         if (r < 0) {
             SOL_WRN("Could not read Access Control Object's"
                 " [Object ID] and [Instance ID] resources\n");
-            goto exit;
+            goto exit_clear_2;
         }
 
         //Retrieve the associated Access Control Object Instance, by matching Object ID
@@ -478,7 +503,7 @@ check_authorization(struct sol_lwm2m_client *client,
             if (r < 0) {
                 SOL_WRN("Could not read Access Control"
                     " Object's [ACL] and [Owner ID] resources\n");
-                goto exit;
+                goto exit_clear_2;
             }
 
             //Retrive this server's ACL Resource Instance
@@ -486,10 +511,10 @@ check_authorization(struct sol_lwm2m_client *client,
                 if (res[0].data[i].id == server_id) {
                     if (res[0].data[i].content.integer & rights_needed) {
                         r = 1;
-                        goto exit;
+                        goto exit_clear_2;
                     } else {
                         r = 0;
-                        goto exit;
+                        goto exit_clear_2;
                     }
                 }
 
@@ -502,26 +527,30 @@ check_authorization(struct sol_lwm2m_client *client,
             // If owner and no specific ACL Resource Instance, then full access rights.
             if (res[1].data[0].content.integer == server_id) {
                 r = 1;
-                goto exit;
+                goto exit_clear_2;
             }
 
             //If no ACL and not owner, check if the default ACL Resource Instance applies
             if (default_acl & rights_needed) {
                 r = 1;
-                goto exit;
+                goto exit_clear_2;
             }
 
             //If not Observe operation on Object level, do not check next instance;
             // only break and return
             if (!(instance_id == -1 && (rights_needed & SOL_LWM2M_ACL_READ)))
-                goto exit;
+                goto exit_clear_2;
         }
 
         clear_resource_array(res, sol_util_array_size(res));
     }
 
-exit:
-    clear_resource_array(res, sol_util_array_size(res));
+    return -ENOENT;
+
+exit_clear_2:
+    sol_lwm2m_resource_clear(&res[1]);
+exit_clear_1:
+    sol_lwm2m_resource_clear(&res[0]);
 
     return r;
 }


### PR DESCRIPTION
Changes from v1 (#2281):
- Added error returning.

This patch fixes a bug when a given LWM2M Server who owns a given
Access Control Object Instance tries to modify it (for instance,
to add or remove an ACL for a given third-party LWM2M Server).

There was no way to modify an Access Control Object Instance, since
the check_authorization() would fail, not finding an Access Control
Object Instance related to the target instance - which should not
exist anyway. To fix it, a new condition was added in case the target
'obj_id' == 'ACCESS_CONTROL_OBJECT_ID', in which we should only look
for the target 'instance_id' itself and then inside the OWNER Resource,
not looking for ACLs or anything else.

Signed-off-by: Bruno Melo <bsilva.melo@gmail.com>