### PR TITLE
Network: Add parameter to sol_network_link_addr_eq()

### DIFF
--- a/data/scripts/sol-oic-gen.py
+++ b/data/scripts/sol-oic-gen.py
@@ -1167,7 +1167,7 @@ state_changed(void *data, enum sol_coap_response_code response_code, struct sol_
     if (!cliaddr || !repr_vec)
         return;
 
-    if (!sol_network_link_addr_eq(cliaddr, &resource->resource->addr)) {
+    if (!sol_network_link_addr_eq(cliaddr, &resource->resource->addr, false)) {
         SOL_BUFFER_DECLARE_STATIC(resaddr, SOL_NETWORK_INET_ADDR_STR_LEN);
         SOL_BUFFER_DECLARE_STATIC(respaddr, SOL_NETWORK_INET_ADDR_STR_LEN);
 

--- a/src/lib/comms/include/sol-network.h
+++ b/src/lib/comms/include/sol-network.h
@@ -228,14 +228,18 @@ const struct sol_network_link_addr *sol_network_link_addr_from_str(struct sol_ne
  *
  * @param a The first address to be compared.
  * @param b The second address to be compared.
+ * @param include_port Indicates if the port should be included in the comparison as well.
  *
  * @return @c true if they are equal, otherwise @c false.
  */
 static inline bool
 sol_network_link_addr_eq(const struct sol_network_link_addr *a,
-    const struct sol_network_link_addr *b)
+    const struct sol_network_link_addr *b, bool include_port)
 {
     size_t bytes;
+
+    if (include_port && (a->port != b->port))
+        return false;
 
     if (a->family == b->family) {
         const uint8_t *addr_a, *addr_b;

--- a/src/lib/comms/sol-bluetooth-impl-bluez.c
+++ b/src/lib/comms/sol-bluetooth-impl-bluez.c
@@ -1288,7 +1288,7 @@ find_device_by_addr(struct context *ctx,
     SOL_PTR_VECTOR_FOREACH_IDX (&ctx->devices, d, i) {
         const struct sol_bt_device_info *info = &d->info;
 
-        if (sol_network_link_addr_eq(addr, &info->addr))
+        if (sol_network_link_addr_eq(addr, &info->addr, false))
             return d;
     }
 

--- a/src/lib/comms/sol-lwm2m-client.c
+++ b/src/lib/comms/sol-lwm2m-client.c
@@ -1230,7 +1230,7 @@ get_server_id_by_link_addr(const struct sol_ptr_vector *connections,
 
     SOL_PTR_VECTOR_FOREACH_IDX (connections, conn_ctx, i) {
         server_addr = sol_vector_get_no_check(&conn_ctx->server_addr_list, conn_ctx->addr_list_idx);
-        if (sol_network_link_addr_eq(cliaddr, server_addr)) {
+        if (sol_network_link_addr_eq(cliaddr, server_addr, true)) {
             *server_id = conn_ctx->server_id;
             return 0;
         }
@@ -2385,7 +2385,7 @@ bootstrap_finish(void *data, struct sol_coap_server *coap,
 
     SOL_PTR_VECTOR_FOREACH_IDX (&client->connections, conn_ctx, i) {
         server_addr = sol_vector_get_no_check(&conn_ctx->server_addr_list, conn_ctx->addr_list_idx);
-        if (sol_network_link_addr_eq(cliaddr, server_addr)) {
+        if (sol_network_link_addr_eq(cliaddr, server_addr, true)) {
             server_connection_ctx_remove(&client->connections, conn_ctx);
             break;
         }

--- a/src/samples/bluetooth/browse.c
+++ b/src/samples/bluetooth/browse.c
@@ -141,7 +141,7 @@ found_device(void *user_data, const struct sol_bt_device_info *device)
         return;
 
     if (browse_addr.family != SOL_NETWORK_FAMILY_UNSPEC) {
-        if (!sol_network_link_addr_eq(&browse_addr, &device->addr))
+        if (!sol_network_link_addr_eq(&browse_addr, &device->addr, false))
             return;
 
         sol_bt_stop_scan(scan);


### PR DESCRIPTION
This patch adds a boolean parameter to the function
`sol_network_link_addr_eq()`, to indicate whether or not the `port`
field inside the `struct sol_network_link_addr` should be considered
for address comparison as well.

Signed-off-by: Bruno Melo <bsilva.melo@gmail.com>