### PR TITLE
Network: New API sol_network_link_addr_eq_full()

### DIFF
--- a/src/lib/comms/include/sol-network.h
+++ b/src/lib/comms/include/sol-network.h
@@ -222,20 +222,24 @@ const char *sol_network_link_addr_to_str(const struct sol_network_link_addr *add
 const struct sol_network_link_addr *sol_network_link_addr_from_str(struct sol_network_link_addr *addr, const char *buf);
 
 /**
- * @brief Checks if two address are equal.
+ * @brief Checks if two address are equal - possibly including the port field.
  *
  * This function compares two addresses to see if they are the same.
  *
  * @param a The first address to be compared.
  * @param b The second address to be compared.
+ * @param compare_ports Indicates if the port should be included in the comparison as well.
  *
  * @return @c true if they are equal, otherwise @c false.
  */
 static inline bool
-sol_network_link_addr_eq(const struct sol_network_link_addr *a,
-    const struct sol_network_link_addr *b)
+sol_network_link_addr_eq_full(const struct sol_network_link_addr *a,
+    const struct sol_network_link_addr *b, bool compare_ports)
 {
     size_t bytes;
+
+    if (compare_ports && (a->port != b->port))
+        return false;
 
     if (a->family == b->family) {
         const uint8_t *addr_a, *addr_b;
@@ -297,6 +301,22 @@ sol_network_link_addr_eq(const struct sol_network_link_addr *a,
     return false;
 }
 
+/**
+ * @brief Checks if two address are equal.
+ *
+ * This function compares two addresses to see if they are the same.
+ *
+ * @param a The first address to be compared.
+ * @param b The second address to be compared.
+ *
+ * @return @c true if they are equal, otherwise @c false.
+ */
+static inline bool
+sol_network_link_addr_eq(const struct sol_network_link_addr *a,
+    const struct sol_network_link_addr *b)
+{
+    return sol_network_link_addr_eq_full(a, b, false);
+}
 /**
  * @brief Subscribes to receive network link events.
  *

--- a/src/lib/comms/sol-lwm2m-client.c
+++ b/src/lib/comms/sol-lwm2m-client.c
@@ -1230,7 +1230,7 @@ get_server_id_by_link_addr(const struct sol_ptr_vector *connections,
 
     SOL_PTR_VECTOR_FOREACH_IDX (connections, conn_ctx, i) {
         server_addr = sol_vector_get_no_check(&conn_ctx->server_addr_list, conn_ctx->addr_list_idx);
-        if (sol_network_link_addr_eq(cliaddr, server_addr)) {
+        if (sol_network_link_addr_eq_full(cliaddr, server_addr, true)) {
             *server_id = conn_ctx->server_id;
             return 0;
         }
@@ -2385,7 +2385,7 @@ bootstrap_finish(void *data, struct sol_coap_server *coap,
 
     SOL_PTR_VECTOR_FOREACH_IDX (&client->connections, conn_ctx, i) {
         server_addr = sol_vector_get_no_check(&conn_ctx->server_addr_list, conn_ctx->addr_list_idx);
-        if (sol_network_link_addr_eq(cliaddr, server_addr)) {
+        if (sol_network_link_addr_eq_full(cliaddr, server_addr, true)) {
             server_connection_ctx_remove(&client->connections, conn_ctx);
             break;
         }


### PR DESCRIPTION
This patch adds a boolean parameter to the function sol_network_link_addr_eq(),
renaming it to sol_network_link_addr_eq_full(). The additional
parameter indicates whether or not the port field inside the
struct sol_network_link_addr should be considered for the comparison.

The old function sol_network_link_addr_eq() is still present, and now
only calls sol_network_link_addr_eq_full() passing false to the new parameter.

Signed-off-by: Bruno Melo <bsilva.melo@gmail.com>