### PR TITLE
comms: Add sol-netctl agent API

### DIFF
--- a/data/scripts/libsoletta.sym
+++ b/data/scripts/libsoletta.sym
@@ -613,6 +613,9 @@ global:
         sol_netctl_service_state_from_str;
         sol_netctl_service_state_to_str;
         sol_netctl_set_radios_offline;
+        sol_netctl_register_agent;
+        sol_netctl_report_error;
+        sol_netctl_request_input;
 
         sol_network_get_available_links;
         sol_network_get_hostname_address_info;

--- a/src/lib/comms/include/sol-netctl.h
+++ b/src/lib/comms/include/sol-netctl.h
@@ -643,9 +643,9 @@ const struct sol_ptr_vector *sol_netctl_get_services(void);
  */
 enum sol_netctl_service_state sol_netctl_service_state_from_str(const char *state)
 #ifndef DOXYGEN_RUN
-    SOL_ATTR_WARN_UNUSED_RESULT
+SOL_ATTR_WARN_UNUSED_RESULT
 #endif
-    ;
+;
 
 /**
  * @brief Converts sol_netctl_service_state to a string name.
@@ -660,9 +660,9 @@ enum sol_netctl_service_state sol_netctl_service_state_from_str(const char *stat
  */
 const char *sol_netctl_service_state_to_str(enum sol_netctl_service_state state)
 #ifndef DOXYGEN_RUN
-    SOL_ATTR_WARN_UNUSED_RESULT
+SOL_ATTR_WARN_UNUSED_RESULT
 #endif
-    ;
+;
 
 /**
  * @brief get so_netctl_service structure from serivce name.


### PR DESCRIPTION
The agent is necessary in the process of network connection,
that will receive input information from the user and send it
to the network(such as AP and so on).

The API is based on connman D-Bus APIs, it provides register agent,
input login information and so on netctl agent API.

Signed-off-by: Wu Zheng <wu.zheng@intel.com>