### PR TITLE
LWM2M: Support for DTLS with Raw Public Key security mode

### DIFF
--- a/data/scripts/libsoletta.sym
+++ b/data/scripts/libsoletta.sym
@@ -130,6 +130,7 @@ global:
         sol_coap_send_packet;
         sol_coap_send_packet_with_reply;
         sol_coap_server_new;
+        sol_coap_server_new_by_cipher_suites;
         sol_coap_server_ref;
         sol_coap_server_register_resource;
         sol_coap_server_set_unknown_resource_handler;

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <sol-socket.h>
 #include <sol-network.h>
 #include <sol-str-slice.h>
 
@@ -502,6 +503,25 @@ bool sol_coap_server_is_secure(const struct sol_coap_server *server);
  *
  */
 struct sol_coap_server *sol_coap_server_new(const struct sol_network_link_addr *addr, bool secure);
+
+/**
+ * @brief Creates a new DTLS-Secured CoAP server instance.
+ *
+ * Creates a new, DTLS-Secured CoAP server instance listening on address
+ * @a addr. If the server cannot be created, NULL will be returned and
+ * @c errno will be set to indicate the reason.
+ *
+ * @param addr The address where the server will listen on.
+ * @param cipher_suites Indicates the desired cipher suites to use.
+ * @param cipher_suites_len Indicates the length of the @c cipher_suites array.
+ *
+ * @return A new server instance, or NULL in case of failure.
+ *
+ */
+struct sol_coap_server *sol_coap_server_new_by_cipher_suites(
+    const struct sol_network_link_addr *addr,
+    enum sol_socket_dtls_cipher *cipher_suites,
+    uint16_t cipher_suites_len);
 
 /**
  * @brief Take a reference of the given server.

--- a/src/lib/comms/include/sol-lwm2m-bs-server.h
+++ b/src/lib/comms/include/sol-lwm2m-bs-server.h
@@ -60,13 +60,20 @@ typedef struct sol_lwm2m_bootstrap_client_info sol_lwm2m_bootstrap_client_info;
  *
  * @param port The UDP port to be used.
  * @param known_clients An array with the name of all clients this server has Bootstrap Information for.
- * @param sec_mode The DTLS Security Mode to be used.
- * @param known_psks The Clients' Pre-Shared Keys this Bootstrap Server has previous knowledge of.
+ * @param num_sec_modes The number of DTLS Security Modes this Bootstrap Server will support.
+ * @param ... At least one @c sol_lwm2m_security_mode followed by its relevant parameters, as per the table below:
+ *
+ * Security Mode | Follow-up arguments | Description
+ * ------------- | ------------------- | ------------------
+ * SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY | struct sol_lwm2m_security_psk **known_psks | @c known_psks The Clients' Pre-Shared Keys this Bootstrap Server has previous knowledge of.
+ * SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY | struct sol_lwm2m_security_rpk *rpk, struct sol_blob **known_pub_keys | @c rpk This Bootstrap Server's Key Pair - @c known_pub_keys The Clients' Public Keys this Bootstrap Server has previous knowledge of.
+ *
+ * @note: SOL_LWM2M_SECURITY_MODE_CERTIFICATE is not supported yet.
+ *
  * @return The LWM2M bootstrap server or @c NULL on error.
  */
 struct sol_lwm2m_bootstrap_server *sol_lwm2m_bootstrap_server_new(uint16_t port,
-    const char **known_clients, enum sol_lwm2m_security_mode sec_mode,
-    struct sol_vector *known_psks);
+    const char **known_clients, uint16_t num_sec_modes, ...);
 
 /**
  * @brief Adds a bootstrap request monitor to the server.

--- a/src/lib/comms/include/sol-lwm2m-server.h
+++ b/src/lib/comms/include/sol-lwm2m-server.h
@@ -85,14 +85,20 @@ enum sol_lwm2m_registration_event {
  * The server will be immediately operational and waiting for connections.
  *
  * @param coap_port The UDP port to be used for the NoSec CoAP Server.
- * @param dtls_port The UDP port to be used for the Secure DTLS Server.
- * @param sec_mode The DTLS Security Mode to be used for the Secure CoAP Server.
- * @param known_psks The Clients' Pre-Shared Keys this Server has previous knowledge of.
+ * @param num_sec_modes The number of DTLS Security Modes this Bootstrap Server will support.
+ * @param ... An @c uint16_t indicating the UDP port to be used for the Secure DTLS Server; and at least one @c sol_lwm2m_security_mode followed by its relevant parameters, as per the table below:
+ *
+ * Security Mode | Follow-up arguments | Description
+ * ------------- | ------------------- | ------------------
+ * SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY | struct sol_lwm2m_security_psk **known_psks | @c known_psks The Clients' Pre-Shared Keys this Server has previous knowledge of.
+ * SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY | struct sol_lwm2m_security_rpk *rpk, struct sol_blob **known_pub_keys | @c rpk This Server's Key Pair - @c known_pub_keys The Clients' Public Keys this Bootstrap Server has previous knowledge of.
+ *
+ * @note: SOL_LWM2M_SECURITY_MODE_CERTIFICATE is not supported yet.
+ *
  * @return The LWM2M server or @c NULL on error.
  */
 struct sol_lwm2m_server *sol_lwm2m_server_new(uint16_t coap_port,
-    uint16_t dtls_port, enum sol_lwm2m_security_mode sec_mode,
-    struct sol_vector *known_psks);
+    uint16_t num_sec_modes, ...);
 
 /**
  * @brief Adds a registration monitor.

--- a/src/lib/comms/include/sol-lwm2m.h
+++ b/src/lib/comms/include/sol-lwm2m.h
@@ -52,7 +52,7 @@ extern "C" {
  * - Observation interface.
  * - TLV format.
  * - Data Access Control.
- * - CoAP Data Encryption.
+ * - CoAP Data Encryption (Pre-Shared Key and Raw Public Key modes).
  *
  * Unsupported features for now:
  * - LWM2M JSON.
@@ -143,7 +143,7 @@ enum sol_lwm2m_binding_mode {
 /**
  * @brief Enum that represents the UDP Security Mode.
  *
- * @note Only Pre-Shared Key and NoSec modes are currently supported.
+ * @note Certificate mode is not supported yet.
  */
 enum sol_lwm2m_security_mode {
     /**
@@ -156,8 +156,8 @@ enum sol_lwm2m_security_mode {
     /**
      * Raw Public Key security mode with Cipher Suite TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8
      * In this case, the following Resource IDs have to be filled as well:
-     * /3 "Public Key or Identity":                    Client's Raw Public Key [256-bit ECC key; 32 Opaque bytes];
-     * /4 "Server Public Key or Identity Resource":    [Expected] Server's Raw Public Key [256-bit ECC key; 32 Opaque bytes];
+     * /3 "Public Key or Identity":                    Client's Raw Public Key [2x256-bit ECC key (one for each ECC Coordinate); 64 Opaque bytes];
+     * /4 "Server Public Key or Identity Resource":    [Expected] Server's Raw Public Key [2x256-bit ECC key (one for each ECC Coordinate); 64 Opaque bytes];
      * /5 "Secret Key":                                Client's Private Key [256-bit ECC key; 32 Opaque bytes];
      */
     SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY = 1,
@@ -294,6 +294,27 @@ typedef struct sol_lwm2m_security_psk {
     /** @brief The PSK Key, composed of an Opaque 16-bytes (128-bit) AES Key */
     struct sol_blob *key;
 } sol_lwm2m_security_psk;
+
+/**
+ * @brief Struct that represents a Raw Public Key (RPK) pair.
+ *
+ * An element of this type is used by the LWM2M Server
+ * and LWM2M Bootstrap Server to store its own Private and Public keys.
+ *
+ * @see sol_lwm2m_server_new()
+ * @see sol_lwm2m_bootstrap_server_new()
+ */
+typedef struct sol_lwm2m_security_rpk {
+    /** @brief The Private Key, composed of an Opaque 32-bytes (128-bit) ECC key */
+    struct sol_blob *private_key;
+    /** @brief The Public Key, composed of an Opaque 64-bytes (2x256-bit) ECC key.
+     *
+     * This represents the X and Y coordinates in a contiguous set of bytes. An array of
+     * @c sol_blob following this structure is used by the LWM2M Server and LWM2M
+     * Bootstrap Server to keep a list of known Clients' Public Keys.
+     */
+    struct sol_blob *public_key;
+} sol_lwm2m_security_rpk;
 
 /**
  * @brief Struct that represents TLV data.

--- a/src/lib/comms/include/sol-lwm2m.h
+++ b/src/lib/comms/include/sol-lwm2m.h
@@ -524,11 +524,11 @@ void sol_lwm2m_resource_clear(struct sol_lwm2m_resource *resource);
  *
  * Resource type | Last argument type
  * ------------- | ------------------
- * SOL_LWM2M_RESOURCE_DATA_TYPE_STRING | struct sol_str_slice
+ * SOL_LWM2M_RESOURCE_DATA_TYPE_STRING | struct sol_blob *
  * SOL_LWM2M_RESOURCE_DATA_TYPE_INT | int64_t
  * SOL_LWM2M_RESOURCE_DATA_TYPE_FLOAT | double
  * SOL_LWM2M_RESOURCE_DATA_TYPE_BOOL | bool
- * SOL_LWM2M_RESOURCE_DATA_TYPE_OPAQUE | struct sol_str_slice
+ * SOL_LWM2M_RESOURCE_DATA_TYPE_OPAQUE | struct sol_blob *
  * SOL_LWM2M_RESOURCE_DATA_TYPE_TIME | int64_t
  * SOL_LWM2M_RESOURCE_DATA_TYPE_OBJ_LINK | uint16_t, uint16_t
  *

--- a/src/lib/comms/include/sol-lwm2m.h
+++ b/src/lib/comms/include/sol-lwm2m.h
@@ -282,7 +282,7 @@ enum sol_lwm2m_resource_type {
 /**
  * @brief Struct that represents a Pre-Shared Key (PSK).
  *
- * A sol_vector holding elements of this type is used by the LWM2M Server
+ * An array holding elements of this type is used by the LWM2M Server
  * and LWM2M Bootstrap Server to keep a list of known Clients' Pre-Shared Keys.
  *
  * @see sol_lwm2m_server_new()

--- a/src/lib/comms/include/sol-socket.h
+++ b/src/lib/comms/include/sol-socket.h
@@ -42,6 +42,15 @@ struct sol_socket;
 typedef struct sol_socket sol_socket;
 
 /**
+ * @brief Represents supported Cipher Suites for use with DTLS.
+ */
+enum sol_socket_dtls_cipher {
+    SOL_SOCKET_DTLS_CIPHER_ECDH_ANON_AES128_CBC_SHA256,
+    SOL_SOCKET_DTLS_CIPHER_PSK_AES128_CCM8,
+    SOL_SOCKET_DTLS_CIPHER_ECDHE_ECDSA_AES128_CCM8,
+};
+
+/**
  * @brief Defines the behaviour of a socket instance
  */
 typedef struct sol_socket_options {
@@ -116,6 +125,19 @@ typedef struct sol_socket_ip_options {
      * sol_socket_bind()
      */
     bool reuse_addr;
+
+    /**
+     * @brief If @c secure is true, this should be considered.
+     * It indicates which DTLS cipher suites are supported and could
+     * be used for communication.
+     */
+    enum sol_socket_dtls_cipher *cipher_suites;
+
+    /**
+     * @brief If @c secure is true, this should be considered.
+     * It indicates the length of the @c cipher_suites array.
+     */
+    uint16_t cipher_suites_len;
 } sol_socket_ip_options;
 
 /**

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -1885,6 +1885,9 @@ sol_coap_server_new_full(struct sol_socket_ip_options *options, const struct sol
         goto err_bind;
     }
 
+    SOL_DBG("server=%p, socket=%p, addr=%p, port=%" PRIu16 ", reuse_addr=%s binded!",
+        server, s, servaddr, servaddr->port, options->reuse_addr ? "True" : "False");
+
     server->refcnt = 1;
 
     sol_vector_init(&server->contexts, sizeof(struct resource_context));
@@ -1944,19 +1947,43 @@ err:
 }
 
 SOL_API struct sol_coap_server *
-sol_coap_server_new(const struct sol_network_link_addr *addr, bool secure)
+sol_coap_server_new(const struct sol_network_link_addr *addr,
+    bool secure)
 {
     return sol_coap_server_new_full(&((struct sol_socket_ip_options) {
-        .base = {
-            SOL_SET_API_VERSION(.api_version = SOL_SOCKET_OPTIONS_API_VERSION, )
-            SOL_SET_API_VERSION(.sub_api = SOL_SOCKET_IP_OPTIONS_SUB_API_VERSION, )
-            .on_can_read = on_can_read,
-            .on_can_write = on_can_write,
-        },
-        .family = addr->family,
-        .secure = secure,
-        .reuse_addr = addr->port ? true : false,
-    }), addr);
+            .base = {
+                SOL_SET_API_VERSION(.api_version = SOL_SOCKET_OPTIONS_API_VERSION, )
+                SOL_SET_API_VERSION(.sub_api = SOL_SOCKET_IP_OPTIONS_SUB_API_VERSION, )
+                .on_can_read = on_can_read,
+                .on_can_write = on_can_write,
+            },
+            .family = addr->family,
+            .secure = secure,
+            .cipher_suites = secure ?
+            (enum sol_socket_dtls_cipher []){ SOL_SOCKET_DTLS_CIPHER_PSK_AES128_CCM8 } : NULL,
+            .cipher_suites_len = secure ? 1 : 0,
+            .reuse_addr = addr->port ? true : false,
+        }), addr);
+}
+
+SOL_API struct sol_coap_server *
+sol_coap_server_new_by_cipher_suites(
+    const struct sol_network_link_addr *addr,
+    enum sol_socket_dtls_cipher *cipher_suites, uint16_t cipher_suites_len)
+{
+    return sol_coap_server_new_full(&((struct sol_socket_ip_options) {
+            .base = {
+                SOL_SET_API_VERSION(.api_version = SOL_SOCKET_OPTIONS_API_VERSION, )
+                SOL_SET_API_VERSION(.sub_api = SOL_SOCKET_IP_OPTIONS_SUB_API_VERSION, )
+                .on_can_read = on_can_read,
+                .on_can_write = on_can_write,
+            },
+            .family = addr->family,
+            .secure = true,
+            .cipher_suites = cipher_suites,
+            .cipher_suites_len = cipher_suites_len,
+            .reuse_addr = addr->port ? true : false,
+        }), addr);
 }
 
 SOL_API bool

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -48,7 +48,7 @@ SOL_LOG_INTERNAL_DECLARE(_sol_coap_log_domain, "coap");
  * FIXME: use a random number between ACK_TIMEOUT (2000ms)
  * and ACK_TIMEOUT * ACK_RANDOM_FACTOR (3000ms)
  */
-#define ACK_TIMEOUT_MS 2345
+#define ACK_TIMEOUT_MS 12345
 #define MAX_RETRANSMIT 4
 #define MAX_PKT_TIMEOUT_MS (ACK_TIMEOUT_MS << MAX_RETRANSMIT)
 

--- a/src/lib/comms/sol-lwm2m-bs-server.c
+++ b/src/lib/comms/sol-lwm2m-bs-server.c
@@ -27,6 +27,7 @@
 #include "sol-log-internal.h"
 #include "sol-util-internal.h"
 #include "sol-list.h"
+#include "sol-socket.h"
 #include "sol-lwm2m.h"
 #include "sol-lwm2m-common.h"
 #include "sol-lwm2m-bs-server.h"
@@ -212,66 +213,94 @@ static const struct sol_coap_resource bootstrap_request_interface = {
 
 SOL_API struct sol_lwm2m_bootstrap_server *
 sol_lwm2m_bootstrap_server_new(uint16_t port, const char **known_clients,
-    enum sol_lwm2m_security_mode sec_mode, struct sol_vector *known_psks)
+    uint16_t num_sec_modes, ...)
 {
     struct sol_lwm2m_bootstrap_server *server;
     struct sol_network_link_addr servaddr = { .family = SOL_NETWORK_FAMILY_INET6,
                                               .port = port };
     int r;
-    const char *sec_mode_str;
-    struct sol_lwm2m_security_psk *psk, *given_psk;
+    struct sol_lwm2m_security_psk **known_psks = NULL;
+    struct sol_lwm2m_security_rpk *my_rpk = NULL;
+    struct sol_blob **known_pub_keys = NULL;
+    enum sol_lwm2m_security_mode *sec_modes;
+    enum sol_socket_dtls_cipher *cipher_suites;
     uint16_t i;
+    va_list ap;
 
     SOL_LOG_INTERNAL_INIT_ONCE;
 
     SOL_NULL_CHECK(known_clients, NULL);
-    switch (sec_mode) {
-    case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
-        SOL_NULL_CHECK(known_psks, NULL);
-        sec_mode_str = "Pre-Shared Key";
-        break;
-    case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
-        sec_mode_str = "Raw Public Key";
-        SOL_WRN("Raw Public Key security mode is not supported yet.");
-        return NULL;
-    case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
-        sec_mode_str = "Certificate";
-        SOL_WRN("Certificate security mode is not supported yet.");
-        return NULL;
-    case SOL_LWM2M_SECURITY_MODE_NO_SEC:
-        SOL_WRN("Bootstrap Server MUST use DTLS.");
-        return NULL;
-    default:
-        SOL_WRN("Unknown DTLS Security Mode: %d", sec_mode);
-        return NULL;
-    }
 
-    server = calloc(1, sizeof(struct sol_lwm2m_bootstrap_server));
-    SOL_NULL_CHECK(server, NULL);
+    va_start(ap, num_sec_modes);
 
-    //LWM2M Bootstrap Server MUST always use DTLS
-    if (sec_mode == SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY) {
-        sol_vector_init(&server->known_psks, sizeof(sol_lwm2m_security_psk));
+    cipher_suites = calloc(num_sec_modes, sizeof(enum sol_socket_dtls_cipher));
+    SOL_NULL_CHECK_GOTO(cipher_suites, err_va_list);
 
-        SOL_VECTOR_FOREACH_IDX (known_psks, given_psk, i) {
-            psk = sol_vector_append(&server->known_psks);
-            SOL_NULL_CHECK_GOTO(psk, err_psk);
-            psk->id = sol_blob_ref(given_psk->id);
-            psk->key = sol_blob_ref(given_psk->key);
+    sec_modes = calloc(num_sec_modes, sizeof(enum sol_lwm2m_security_mode));
+    SOL_NULL_CHECK_GOTO(sec_modes, err_cipher_suites);
+
+    for (i = 0; i < num_sec_modes; i++) {
+        sec_modes[i] = va_arg(ap, enum sol_lwm2m_security_mode);
+
+        switch (sec_modes[i]) {
+        case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
+            known_psks = va_arg(ap, struct sol_lwm2m_security_psk **);
+            SOL_NULL_CHECK_GOTO(known_psks, err_sec_modes);
+
+            cipher_suites[i] = SOL_SOCKET_DTLS_CIPHER_PSK_AES128_CCM8;
+            break;
+        case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
+            my_rpk = va_arg(ap, struct sol_lwm2m_security_rpk *);
+            SOL_NULL_CHECK_GOTO(my_rpk, err_sec_modes);
+            known_pub_keys = va_arg(ap, struct sol_blob **);
+            SOL_NULL_CHECK_GOTO(known_pub_keys, err_sec_modes);
+
+            cipher_suites[i] = SOL_SOCKET_DTLS_CIPHER_ECDHE_ECDSA_AES128_CCM8;
+            break;
+        case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
+            SOL_WRN("Certificate security mode is not supported yet.");
+            goto err_sec_modes;
+        case SOL_LWM2M_SECURITY_MODE_NO_SEC:
+            SOL_WRN("Bootstrap Server MUST use DTLS.");
+            goto err_sec_modes;
+        default:
+            SOL_WRN("Unknown DTLS Security Mode: %d", sec_modes[i]);
+            goto err_sec_modes;
         }
     }
 
-    server->coap = sol_coap_server_new(&servaddr, true);
-    SOL_NULL_CHECK_GOTO(server->coap, err_coap);
+    server = calloc(1, sizeof(struct sol_lwm2m_bootstrap_server));
+    SOL_NULL_CHECK_GOTO(server, err_sec_modes);
 
-    server->security = sol_lwm2m_bootstrap_server_security_add(server, sec_mode);
-    if (!server->security) {
-        SOL_ERR("Could not enable %s security mode for LWM2M Bootstrap Server",
-            sec_mode_str);
-        goto err_security;
-    } else {
-        SOL_DBG("Using %s security mode", sec_mode_str);
+    //LWM2M Bootstrap Server MUST always use DTLS
+    for (i = 0; i < num_sec_modes; i++) {
+        if (sec_modes[i] == SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY) {
+            server->known_psks = known_psks;
+        } else if (sec_modes[i] == SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY) {
+            server->rpk_pair.private_key = sol_blob_ref(my_rpk->private_key);
+            server->rpk_pair.public_key = sol_blob_ref(my_rpk->public_key);
+
+            server->known_pub_keys = known_pub_keys;
+        }
     }
+
+    server->coap = sol_coap_server_new_by_cipher_suites(&servaddr,
+        cipher_suites, num_sec_modes);
+    SOL_NULL_CHECK_GOTO(server->coap, err_rpk_pair);
+
+    for (i = 0; i < num_sec_modes; i++) {
+        server->security = sol_lwm2m_bootstrap_server_security_add(server, sec_modes[i]);
+        if (!server->security) {
+            SOL_ERR("Could not enable %s security mode for LWM2M Bootstrap Server",
+                get_security_mode_str(sec_modes[i]));
+            goto err_security;
+        } else {
+            SOL_DBG("Using %s security mode", get_security_mode_str(sec_modes[i]));
+        }
+    }
+
+    free(sec_modes);
+    free(cipher_suites);
 
     server->known_clients = known_clients;
 
@@ -283,20 +312,27 @@ sol_lwm2m_bootstrap_server_new(uint16_t port, const char **known_clients,
         &bootstrap_request_interface, server);
     SOL_INT_CHECK_GOTO(r, < 0, err_security);
 
+    va_end(ap);
+
     return server;
 
 err_security:
     sol_coap_server_unref(server->coap);
-err_psk:
-    if (sec_mode == SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY) {
-        SOL_VECTOR_FOREACH_IDX (&server->known_psks, psk, i) {
-            sol_blob_unref(psk->id);
-            sol_blob_unref(psk->key);
+    sol_lwm2m_bootstrap_server_security_del(server->security);
+err_rpk_pair:
+    for (i = 0; i < num_sec_modes; i++) {
+        if (sec_modes[i] == SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY) {
+            sol_blob_unref(server->rpk_pair.private_key);
+            sol_blob_unref(server->rpk_pair.public_key);
         }
-        sol_vector_clear(&server->known_psks);
     }
-err_coap:
     free(server);
+err_sec_modes:
+    free(sec_modes);
+err_cipher_suites:
+    free(cipher_suites);
+err_va_list:
+    va_end(ap);
     return NULL;
 }
 
@@ -310,16 +346,12 @@ sol_lwm2m_bootstrap_server_del(struct sol_lwm2m_bootstrap_server *server)
 
     sol_coap_server_unref(server->coap);
 
-    sol_lwm2m_bootstrap_server_security_del(server->security);
-    if (&server->known_psks) {
-        struct sol_lwm2m_security_psk *psk;
-
-        SOL_VECTOR_FOREACH_IDX (&server->known_psks, psk, i) {
-            sol_blob_unref(psk->id);
-            sol_blob_unref(psk->key);
-        }
-        sol_vector_clear(&server->known_psks);
+    if (sol_lwm2m_security_supports_security_mode(server->security,
+        SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY)) {
+        sol_blob_unref(server->rpk_pair.private_key);
+        sol_blob_unref(server->rpk_pair.public_key);
     }
+    sol_lwm2m_bootstrap_server_security_del(server->security);
 
     SOL_PTR_VECTOR_FOREACH_IDX (&server->clients, bs_cinfo, i)
         bootstrap_client_info_del(bs_cinfo);

--- a/src/lib/comms/sol-lwm2m-common.c
+++ b/src/lib/comms/sol-lwm2m-common.c
@@ -44,6 +44,23 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_lwm2m_common_domain, "lwm2m-common");
 int sol_lwm2m_common_init(void);
 void sol_lwm2m_common_shutdown(void);
 
+const char *
+get_security_mode_str(enum sol_lwm2m_security_mode sec_mode)
+{
+    switch (sec_mode) {
+    case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
+        return "Pre-Shared Key";
+    case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
+        return "Raw Public Key";
+    case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
+        return "Certificate";
+    case SOL_LWM2M_SECURITY_MODE_NO_SEC:
+        return "NoSec";
+    default:
+        return "Unknown";
+    }
+}
+
 int
 read_resources(struct sol_lwm2m_client *client,
     struct obj_ctx *obj_ctx, struct obj_instance *instance,

--- a/src/lib/comms/sol-lwm2m-common.h
+++ b/src/lib/comms/sol-lwm2m-common.h
@@ -213,7 +213,9 @@ struct sol_lwm2m_server {
     struct lifetime_ctx lifetime_ctx;
     struct sol_coap_server *dtls_server;
     struct sol_lwm2m_security *security;
-    struct sol_vector known_psks;
+    struct sol_lwm2m_security_psk **known_psks;
+    struct sol_blob **known_pub_keys;
+    struct sol_lwm2m_security_rpk rpk_pair;
 };
 
 struct sol_lwm2m_bootstrap_server {

--- a/src/lib/comms/sol-lwm2m-common.h
+++ b/src/lib/comms/sol-lwm2m-common.h
@@ -221,7 +221,9 @@ struct sol_lwm2m_bootstrap_server {
     struct sol_ptr_vector clients;
     struct sol_monitors bootstrap;
     struct sol_lwm2m_security *security;
-    struct sol_vector known_psks;
+    struct sol_lwm2m_security_psk **known_psks;
+    struct sol_blob **known_pub_keys;
+    struct sol_lwm2m_security_rpk rpk_pair;
     const char **known_clients;
 };
 
@@ -231,6 +233,9 @@ enum sol_lwm2m_path_props {
     PATH_HAS_INSTANCE = (1 << 2),
     PATH_HAS_RESOURCE = (1 << 3)
 };
+
+const char *
+get_security_mode_str(enum sol_lwm2m_security_mode sec_mode);
 
 int
 read_resources(struct sol_lwm2m_client *client,

--- a/src/lib/comms/sol-lwm2m-common.h
+++ b/src/lib/comms/sol-lwm2m-common.h
@@ -161,7 +161,7 @@ struct server_conn_ctx {
     uint16_t addr_list_idx;
     time_t registration_time;
     char *location;
-    bool secure;
+    enum sol_lwm2m_security_mode sec_mode;
 };
 
 struct obj_instance {
@@ -189,8 +189,10 @@ struct sol_lwm2m_client {
     struct {
         struct sol_timeout *timeout;
         struct sol_blob *server_uri;
+        enum sol_lwm2m_security_mode sec_mode;
     } bootstrap_ctx;
-    struct sol_coap_server *dtls_server;
+    struct sol_coap_server *dtls_server_psk;
+    struct sol_coap_server *dtls_server_rpk;
     struct sol_lwm2m_security *security;
     const void *user_data;
     uint16_t splitted_path_len;

--- a/src/lib/comms/sol-lwm2m-security.c
+++ b/src/lib/comms/sol-lwm2m-security.c
@@ -33,6 +33,14 @@ SOL_LOG_INTERNAL_DECLARE(_lwm2m_security_domain, "lwm2m-security");
 
 #ifdef DTLS
 
+enum ecdsa_field_type {
+    PRIVATE_KEY,
+    PUBLIC_KEY_X,
+    PUBLIC_KEY_Y,
+    SERVER_PUBLIC_KEY_X,
+    SERVER_PUBLIC_KEY_Y
+};
+
 struct sol_socket *sol_coap_server_get_socket(const struct sol_coap_server *server);
 
 static ssize_t
@@ -42,8 +50,7 @@ get_psk_from_server_or_bs_server(const void *data, struct sol_str_slice id,
     const struct sol_lwm2m_security *ctx = data;
     struct sol_lwm2m_server *lwm2m_server;
     struct sol_lwm2m_bootstrap_server *lwm2m_bs_server;
-    struct sol_vector *known_psks;
-    struct sol_lwm2m_security_psk *stored_psk;
+    struct sol_lwm2m_security_psk **known_psks;
     uint16_t i;
 
     SOL_DBG("Looking for PSK with ID=%.*s", SOL_STR_SLICE_PRINT(id));
@@ -55,23 +62,23 @@ get_psk_from_server_or_bs_server(const void *data, struct sol_str_slice id,
     if (ctx->type == LWM2M_SERVER) {
         SOL_DBG("ctx->type = LWM2M_SERVER");
         lwm2m_server = ctx->entity;
-        known_psks = &lwm2m_server->known_psks;
+        known_psks = lwm2m_server->known_psks;
     } else {
         SOL_DBG("ctx->type = LWM2M_BOOTSTRAP_SERVER");
         lwm2m_bs_server = ctx->entity;
-        known_psks = &lwm2m_bs_server->known_psks;
+        known_psks = lwm2m_bs_server->known_psks;
     }
 
-    SOL_VECTOR_FOREACH_IDX (known_psks, stored_psk, i) {
-        if (sol_str_slice_eq(sol_str_slice_from_blob(stored_psk->id), id)) {
-            if (stored_psk->key->size != SOL_DTLS_PSK_KEY_LEN) {
+    for (i = 0; known_psks[i]; i++) {
+        if (sol_str_slice_eq(sol_str_slice_from_blob(known_psks[i]->id), id)) {
+            if (known_psks[i]->key->size != SOL_DTLS_PSK_KEY_LEN) {
                 SOL_WRN("The PSK '%.*s' is %zu-bytes long; expecting a %d-bytes long PSK",
-                    SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(stored_psk->key)),
-                    stored_psk->key->size, SOL_DTLS_PSK_KEY_LEN);
+                    SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(known_psks[i]->key)),
+                    known_psks[i]->key->size, SOL_DTLS_PSK_KEY_LEN);
                 return -EINVAL;
             }
 
-            memcpy(psk, stored_psk->key->mem, stored_psk->key->size);
+            memcpy(psk, known_psks[i]->key->mem, known_psks[i]->key->size);
             return (ssize_t)SOL_DTLS_PSK_KEY_LEN;
         }
     }
@@ -255,6 +262,327 @@ err_clear:
     return r;
 }
 
+static int
+get_ecdsa_field_from_server_or_bs_server(const void *data,
+    struct sol_network_link_addr *addr,
+    unsigned char *field, enum ecdsa_field_type type)
+{
+    const struct sol_lwm2m_security *ctx = data;
+    struct sol_lwm2m_server *lwm2m_server;
+    struct sol_lwm2m_bootstrap_server *lwm2m_bs_server;
+    struct sol_lwm2m_security_rpk *server_rpk;
+    struct sol_blob *src_field;
+    size_t type_len;
+    int offset = 0;
+    const char *desc;
+
+    if (ctx->type == LWM2M_SERVER) {
+        SOL_DBG("ctx->type = LWM2M_SERVER");
+        lwm2m_server = ctx->entity;
+        server_rpk = &lwm2m_server->rpk_pair;
+    } else {
+        SOL_DBG("ctx->type = LWM2M_BOOTSTRAP_SERVER");
+        lwm2m_bs_server = ctx->entity;
+        server_rpk = &lwm2m_bs_server->rpk_pair;
+    }
+
+    switch (type) {
+    case PRIVATE_KEY:
+        desc = "Private Key";
+        type_len = SOL_DTLS_ECDSA_PRIV_KEY_LEN;
+        src_field = server_rpk->private_key;
+        break;
+    case PUBLIC_KEY_X:
+        desc = "Public Key (x coord.)";
+        type_len = SOL_DTLS_ECDSA_PUB_KEY_X_LEN;
+        src_field = server_rpk->public_key;
+        break;
+    case PUBLIC_KEY_Y:
+        desc = "Public Key (y coord.)";
+        type_len = SOL_DTLS_ECDSA_PUB_KEY_Y_LEN;
+        src_field = server_rpk->public_key;
+        offset = SOL_DTLS_ECDSA_PUB_KEY_X_LEN;
+        break;
+    default:
+        return -EINVAL;
+    }
+
+    if (src_field->size !=
+        (type == PRIVATE_KEY ? SOL_DTLS_ECDSA_PRIV_KEY_LEN :
+        SOL_DTLS_ECDSA_PUB_KEY_X_LEN + SOL_DTLS_ECDSA_PUB_KEY_Y_LEN)) {
+        SOL_WRN("The %s '%.*s' is %zu-bytes long; expecting a %d-bytes long %s",
+            desc, SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(src_field)),
+            src_field->size, type == PRIVATE_KEY ? SOL_DTLS_ECDSA_PRIV_KEY_LEN :
+            SOL_DTLS_ECDSA_PUB_KEY_X_LEN + SOL_DTLS_ECDSA_PUB_KEY_Y_LEN, desc);
+        return -EINVAL;
+    } else {
+        SOL_DBG("Found %s!", desc);
+        memcpy(field, (unsigned char *)src_field->mem + offset, type_len);
+        return 0;
+    }
+
+}
+
+static int
+get_ecdsa_priv_key_from_server_or_bs_server(const void *data,
+    struct sol_network_link_addr *addr,
+    unsigned char *ecdsa_priv_key)
+{
+    return get_ecdsa_field_from_server_or_bs_server(data, addr,
+        ecdsa_priv_key, PRIVATE_KEY);
+}
+
+static int
+get_ecdsa_pub_key_x_from_server_or_bs_server(const void *data,
+    struct sol_network_link_addr *addr,
+    unsigned char *ecdsa_pub_key_x)
+{
+    return get_ecdsa_field_from_server_or_bs_server(data, addr,
+        ecdsa_pub_key_x, PUBLIC_KEY_X);
+}
+
+static int
+get_ecdsa_pub_key_y_from_server_or_bs_server(const void *data,
+    struct sol_network_link_addr *addr,
+    unsigned char *ecdsa_pub_key_y)
+{
+    return get_ecdsa_field_from_server_or_bs_server(data, addr,
+        ecdsa_pub_key_y, PUBLIC_KEY_Y);
+}
+
+static int
+get_ecdsa_field_from_res_id(const void *data,
+    struct sol_network_link_addr *addr,
+    unsigned char *field, enum ecdsa_field_type type, int res_id)
+{
+    const struct sol_lwm2m_security *ctx = data;
+    struct sol_lwm2m_client *lwm2m_client = ctx->entity;
+    struct obj_ctx *obj_ctx;
+    struct obj_instance *instance;
+    struct sol_lwm2m_resource res[4] = { };
+    int64_t server_id, server_id_res;
+    uint16_t i;
+    int r, offset = 0; //offset is used for the y coordinate only
+    size_t type_len;
+    const char *desc;
+
+    SOL_BUFFER_DECLARE_STATIC(addr_str, SOL_NETWORK_INET_ADDR_STR_LEN);
+
+    switch (type) {
+    case PRIVATE_KEY:
+        desc = "Private Key";
+        type_len = SOL_DTLS_ECDSA_PRIV_KEY_LEN;
+        break;
+    case PUBLIC_KEY_X:
+        desc = "Public Key (x coord.)";
+        type_len = SOL_DTLS_ECDSA_PUB_KEY_X_LEN;
+        break;
+    case PUBLIC_KEY_Y:
+        desc = "Public Key (y coord.)";
+        type_len = SOL_DTLS_ECDSA_PUB_KEY_Y_LEN;
+        offset = SOL_DTLS_ECDSA_PUB_KEY_X_LEN;
+        break;
+    case SERVER_PUBLIC_KEY_X:
+        desc = "Server's Public Key (x coord.)";
+        type_len = SOL_DTLS_ECDSA_PUB_KEY_X_LEN;
+        break;
+    case SERVER_PUBLIC_KEY_Y:
+        desc = "Server's Public Key (y coord.)";
+        type_len = SOL_DTLS_ECDSA_PUB_KEY_Y_LEN;
+        offset = SOL_DTLS_ECDSA_PUB_KEY_X_LEN;
+        break;
+    default:
+        return -EINVAL;
+    }
+
+    r = get_server_id_by_link_addr(&lwm2m_client->connections, addr, &server_id);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (!sol_network_link_addr_to_str(addr, &addr_str))
+        SOL_WRN("Could not convert the server address to string");
+    else
+        SOL_DBG("Looking for %s for communication with server_id=%" PRId64
+            " and server_addr=%.*s", desc, server_id,
+            SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr_str)));
+
+    obj_ctx = find_object_ctx_by_id(lwm2m_client, SECURITY_OBJECT_ID);
+    if (!obj_ctx) {
+        SOL_WRN("LWM2M Security object not provided!");
+        return -ENOENT;
+    }
+
+    if (!obj_ctx->instances.len) {
+        SOL_WRN("There are no Security Server instances");
+        return -ENOENT;
+    }
+
+    SOL_VECTOR_FOREACH_IDX (&obj_ctx->instances, instance, i) {
+        r = read_resources(lwm2m_client, obj_ctx, instance, res, 4,
+            SECURITY_IS_BOOTSTRAP,
+            SECURITY_SECURITY_MODE,
+            res_id,
+            SECURITY_SERVER_ID);
+        SOL_INT_CHECK_GOTO(r, < 0, err_clear);
+
+        //If -ENOENT when reading res_id or
+        // SECURITY_SECURITY_MODE != SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY
+        if (res[2].data_len == 0 ||
+            res[1].data[0].content.integer != SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY) {
+            clear_resource_array(res, sol_util_array_size(res));
+            continue;
+        }
+
+        //If it's a Bootstrap Server, the comparison should be done with UINT16_MAX,
+        // not the value from SECURITY_SERVER_ID (which is 0/NULL for a Bootstrap Server)
+        if (res[0].data[0].content.b == true)
+            server_id_res = UINT16_MAX;
+        else
+            server_id_res = res[3].data[0].content.integer;
+
+        SOL_DBG("Looking for %s. server_id=%" PRId64 " server_id_res=%" PRId64 "."
+            " Instance /0/%" PRIu16 " i=%" PRIu16 ".",
+            desc, server_id, server_id_res,
+            instance->id, i);
+        if (server_id == server_id_res) {
+            if (res[2].data[0].content.blob->size !=
+                (type == PRIVATE_KEY ? SOL_DTLS_ECDSA_PRIV_KEY_LEN :
+                SOL_DTLS_ECDSA_PUB_KEY_X_LEN + SOL_DTLS_ECDSA_PUB_KEY_Y_LEN)) {
+                SOL_WRN("The %s '%.*s' is %zu-bytes long; expecting a %d-bytes long %s",
+                    desc, SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(res[2].data[0].content.blob)),
+                    res[2].data[0].content.blob->size, type == PRIVATE_KEY ? SOL_DTLS_ECDSA_PRIV_KEY_LEN :
+                    SOL_DTLS_ECDSA_PUB_KEY_X_LEN + SOL_DTLS_ECDSA_PUB_KEY_Y_LEN, desc);
+                r = -EINVAL;
+                goto err_clear;
+            }
+
+            memcpy(field, (unsigned char *)res[2].data[0].content.blob->mem + offset, type_len);
+            clear_resource_array(res, sol_util_array_size(res));
+            return 0;
+        }
+
+        clear_resource_array(res, sol_util_array_size(res));
+    }
+
+    SOL_WRN("Could not find %s for communication with server_id=%" PRId64
+        " and server_addr=%.*s", desc, server_id,
+        SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr_str)));
+
+    return -ENOENT;
+
+err_clear:
+    clear_resource_array(res, sol_util_array_size(res));
+    return r;
+}
+
+static int
+get_ecdsa_priv_key_from_client(const void *data,
+    struct sol_network_link_addr *addr,
+    unsigned char *ecdsa_priv_key)
+{
+    return get_ecdsa_field_from_res_id(data, addr, ecdsa_priv_key,
+        PRIVATE_KEY, SECURITY_SECRET_KEY);
+}
+
+static int
+get_ecdsa_pub_key_x_from_client(const void *data,
+    struct sol_network_link_addr *addr,
+    unsigned char *ecdsa_pub_key_x)
+{
+    return get_ecdsa_field_from_res_id(data, addr, ecdsa_pub_key_x,
+        PUBLIC_KEY_X, SECURITY_PUBLIC_KEY_OR_IDENTITY);
+}
+
+static int
+get_ecdsa_pub_key_y_from_client(const void *data,
+    struct sol_network_link_addr *addr,
+    unsigned char *ecdsa_pub_key_y)
+{
+    return get_ecdsa_field_from_res_id(data, addr, ecdsa_pub_key_y,
+        PUBLIC_KEY_Y, SECURITY_PUBLIC_KEY_OR_IDENTITY);
+}
+
+static int
+verify_ecdsa_key_from_server_or_bs_server(const void *data,
+    struct sol_network_link_addr *addr, const unsigned char *other_pub_x,
+    const unsigned char *other_pub_y, size_t key_size)
+{
+    unsigned char buf_aux[SOL_DTLS_ECDSA_PUB_KEY_X_LEN];
+    int r;
+
+    r = get_ecdsa_field_from_res_id(data, addr, buf_aux,
+        SERVER_PUBLIC_KEY_X, SECURITY_SERVER_PUBLIC_KEY);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (!memcmp(other_pub_x, buf_aux, SOL_DTLS_ECDSA_PUB_KEY_X_LEN))
+        SOL_DBG("Server's Public Key (x coord.) matches");
+    else {
+        SOL_WRN("Server's Public Key (x coord.) does not match");
+        return -EINVAL;
+    }
+
+    r = get_ecdsa_field_from_res_id(data, addr, buf_aux,
+        SERVER_PUBLIC_KEY_Y, SECURITY_SERVER_PUBLIC_KEY);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (!memcmp(other_pub_y, buf_aux, SOL_DTLS_ECDSA_PUB_KEY_Y_LEN))
+        SOL_DBG("Server's Public Key (y coord.) matches");
+    else {
+        SOL_WRN("Server's Public Key (y coord.) does not match");
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+static int
+verify_ecdsa_key_from_client(const void *data,
+    struct sol_network_link_addr *addr, const unsigned char *other_pub_x,
+    const unsigned char *other_pub_y, size_t key_size)
+{
+    const struct sol_lwm2m_security *ctx = data;
+    struct sol_lwm2m_server *lwm2m_server;
+    struct sol_lwm2m_bootstrap_server *lwm2m_bs_server;
+    struct sol_blob **known_pub_keys;
+    uint16_t i;
+
+    if (ctx->type == LWM2M_SERVER) {
+        SOL_DBG("ctx->type = LWM2M_SERVER");
+        lwm2m_server = ctx->entity;
+        known_pub_keys = lwm2m_server->known_pub_keys;
+    } else {
+        SOL_DBG("ctx->type = LWM2M_BOOTSTRAP_SERVER");
+        lwm2m_bs_server = ctx->entity;
+        known_pub_keys = lwm2m_bs_server->known_pub_keys;
+    }
+
+    for (i = 0; known_pub_keys[i]; i++) {
+        if (known_pub_keys[i]->size !=
+            (SOL_DTLS_ECDSA_PUB_KEY_X_LEN + SOL_DTLS_ECDSA_PUB_KEY_Y_LEN)) {
+            SOL_WRN("The stored Client's Public Key '%.*s' is %zu-bytes long;"
+                " expecting a %d-bytes long Public Key",
+                SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(known_pub_keys[i])),
+                known_pub_keys[i]->size,
+                SOL_DTLS_ECDSA_PUB_KEY_X_LEN + SOL_DTLS_ECDSA_PUB_KEY_Y_LEN);
+            return -EINVAL;
+        }
+
+        if (!memcmp(other_pub_x, known_pub_keys[i]->mem, SOL_DTLS_ECDSA_PUB_KEY_X_LEN)) {
+            SOL_DBG("Stored Client's Public Key (x coord.) matches");
+            if (!memcmp(other_pub_y,
+                (unsigned char *)known_pub_keys[i]->mem + SOL_DTLS_ECDSA_PUB_KEY_X_LEN,
+                SOL_DTLS_ECDSA_PUB_KEY_Y_LEN)) {
+                SOL_DBG("Stored Client's Public Key (y coord.) matches");
+                return 0;
+            }
+        }
+    }
+
+    SOL_WRN("Could not find a stored Client's Public Key matching the"
+        " Public Key presented by the Client");
+
+    return -ENOENT;
+}
+
 static void
 sol_lwm2m_security_del_full(struct sol_lwm2m_security *security,
     enum lwm2m_entity_type type)
@@ -270,13 +598,24 @@ sol_lwm2m_security_add_full(void *entity, enum lwm2m_entity_type type,
     enum sol_lwm2m_security_mode sec_mode)
 {
     struct sol_lwm2m_security *security;
-    struct sol_socket *socket_dtls = NULL;
+    struct sol_socket *socket_dtls;
     int r = 0;
 
     ssize_t (*get_psk_cb)(const void *creds, struct sol_str_slice id,
         char *psk, size_t psk_len) = NULL;
     ssize_t (*get_id_cb)(const void *creds, struct sol_network_link_addr *addr,
         char *id, size_t id_len) = NULL;
+
+    int (*get_ecdsa_priv_key_cb)(const void *creds, struct sol_network_link_addr *addr,
+        unsigned char *ecdsa_priv_key) = NULL;
+    int (*get_ecdsa_pub_key_x_cb)(const void *creds, struct sol_network_link_addr *addr,
+        unsigned char *ecdsa_pub_key_x) = NULL;
+    int (*get_ecdsa_pub_key_y_cb)(const void *creds, struct sol_network_link_addr *addr,
+        unsigned char *ecdsa_pub_key_y) = NULL;
+    int (*verify_ecdsa_key_cb)(const void *data, struct sol_network_link_addr *addr,
+        const unsigned char *other_pub_x, const unsigned char *other_pub_y,
+        size_t key_size) = NULL;
+
     bool has_security = false;
 
     SOL_LOG_INTERNAL_INIT_ONCE;
@@ -285,8 +624,34 @@ sol_lwm2m_security_add_full(void *entity, enum lwm2m_entity_type type,
     case LWM2M_CLIENT:
         get_psk_cb = get_psk_from_client;
         get_id_cb = get_id_from_client;
-        socket_dtls = sol_coap_server_get_socket(
-            ((struct sol_lwm2m_client *)entity)->dtls_server);
+        get_ecdsa_priv_key_cb = get_ecdsa_priv_key_from_client;
+        get_ecdsa_pub_key_x_cb = get_ecdsa_pub_key_x_from_client;
+        get_ecdsa_pub_key_y_cb = get_ecdsa_pub_key_y_from_client;
+        verify_ecdsa_key_cb = verify_ecdsa_key_from_server_or_bs_server;
+
+        switch (sec_mode) {
+        case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
+            socket_dtls = sol_coap_server_get_socket(
+                ((struct sol_lwm2m_client *)entity)->dtls_server_psk);
+            break;
+        case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
+            socket_dtls = sol_coap_server_get_socket(
+                ((struct sol_lwm2m_client *)entity)->dtls_server_rpk);
+            break;
+        case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
+            SOL_WRN("Certificate security mode is not supported yet.");
+            errno = ENOTSUP;
+            return NULL;
+        case SOL_LWM2M_SECURITY_MODE_NO_SEC:
+            SOL_WRN("NoSec Security Mode does not use DTLS.");
+            errno = EINVAL;
+            return NULL;
+        default:
+            SOL_WRN("Unknown DTLS [Security Mode] Resource from Security Object: %d", sec_mode);
+            errno = EINVAL;
+            return NULL;
+        }
+
         if (((struct sol_lwm2m_client *)entity)->security) {
             security = ((struct sol_lwm2m_client *)entity)->security;
             has_security = true;
@@ -295,8 +660,14 @@ sol_lwm2m_security_add_full(void *entity, enum lwm2m_entity_type type,
     case LWM2M_SERVER:
         get_psk_cb = get_psk_from_server_or_bs_server;
         get_id_cb = get_id_from_server_or_bs_server;
+        get_ecdsa_priv_key_cb = get_ecdsa_priv_key_from_server_or_bs_server;
+        get_ecdsa_pub_key_x_cb = get_ecdsa_pub_key_x_from_server_or_bs_server;
+        get_ecdsa_pub_key_y_cb = get_ecdsa_pub_key_y_from_server_or_bs_server;
+        verify_ecdsa_key_cb = verify_ecdsa_key_from_client;
+
         socket_dtls = sol_coap_server_get_socket(
             ((struct sol_lwm2m_server *)entity)->dtls_server);
+
         if (((struct sol_lwm2m_server *)entity)->security) {
             security = ((struct sol_lwm2m_server *)entity)->security;
             has_security = true;
@@ -305,8 +676,14 @@ sol_lwm2m_security_add_full(void *entity, enum lwm2m_entity_type type,
     case LWM2M_BOOTSTRAP_SERVER:
         get_psk_cb = get_psk_from_server_or_bs_server;
         get_id_cb = get_id_from_server_or_bs_server;
+        get_ecdsa_priv_key_cb = get_ecdsa_priv_key_from_server_or_bs_server;
+        get_ecdsa_pub_key_x_cb = get_ecdsa_pub_key_x_from_server_or_bs_server;
+        get_ecdsa_pub_key_y_cb = get_ecdsa_pub_key_y_from_server_or_bs_server;
+        verify_ecdsa_key_cb = verify_ecdsa_key_from_client;
+
         socket_dtls = sol_coap_server_get_socket(
             ((struct sol_lwm2m_bootstrap_server *)entity)->coap);
+
         if (((struct sol_lwm2m_bootstrap_server *)entity)->security) {
             security = ((struct sol_lwm2m_bootstrap_server *)entity)->security;
             has_security = true;
@@ -327,15 +704,8 @@ sol_lwm2m_security_add_full(void *entity, enum lwm2m_entity_type type,
         SOL_NULL_CHECK_ERRNO(security, ENOMEM, NULL);
 
         security->callbacks = (struct sol_socket_dtls_credential_cb) {
-            .data = security,
-            .get_id = get_id_cb
+            .data = security
         };
-        r = sol_socket_dtls_set_credentials_callbacks(socket_dtls,
-            &security->callbacks);
-        if (r < 0) {
-            SOL_WRN("Passed DTLS socket is not a valid sol_socket_dtls");
-            goto err_sec;
-        }
 
         security->type = type;
         security->entity = entity;
@@ -343,12 +713,35 @@ sol_lwm2m_security_add_full(void *entity, enum lwm2m_entity_type type,
 
     switch (sec_mode) {
     case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
+        security->callbacks.get_id = get_id_cb;
         security->callbacks.get_psk = get_psk_cb;
+
+        SOL_DBG("Setting PSK credential_cb %p to sol_socket_dtls %p",
+            &security->callbacks, socket_dtls);
+
+        r = sol_socket_dtls_set_credentials_callbacks(socket_dtls,
+            &security->callbacks);
+        if (r < 0) {
+            SOL_DBG("Passed DTLS socket is not a valid sol_socket_dtls");
+            goto err_sec;
+        }
         break;
     case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
-        SOL_WRN("Raw Public Key security mode is not supported yet.");
-        r = -ENOTSUP;
-        goto err_sec;
+        security->callbacks.get_ecdsa_priv_key = get_ecdsa_priv_key_cb;
+        security->callbacks.get_ecdsa_pub_key_x = get_ecdsa_pub_key_x_cb;
+        security->callbacks.get_ecdsa_pub_key_y = get_ecdsa_pub_key_y_cb;
+        security->callbacks.verify_ecdsa_key = verify_ecdsa_key_cb;
+
+        SOL_DBG("Setting RPK credential_cb %p to sol_socket_dtls %p",
+            &security->callbacks, socket_dtls);
+
+        r = sol_socket_dtls_set_credentials_callbacks(socket_dtls,
+            &security->callbacks);
+        if (r < 0) {
+            SOL_WRN("Passed DTLS socket is not a valid sol_socket_dtls");
+            goto err_sec;
+        }
+        break;
     case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
         SOL_WRN("Certificate security mode is not supported yet.");
         r = -ENOTSUP;
@@ -366,12 +759,39 @@ sol_lwm2m_security_add_full(void *entity, enum lwm2m_entity_type type,
     return security;
 
 err_sec:
-    free(security);
+    sol_lwm2m_security_del_full(security, type);
 err_socket_dtls:
     errno = -r;
     return NULL;
 }
 #endif
+
+bool
+sol_lwm2m_security_supports_security_mode(struct sol_lwm2m_security *security,
+    enum sol_lwm2m_security_mode sec_mode)
+{
+    SOL_NULL_CHECK(security, false);
+
+    switch (sec_mode) {
+    case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
+        return security->callbacks.get_id &&
+               security->callbacks.get_psk;
+    case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
+        return security->callbacks.get_ecdsa_priv_key &&
+               security->callbacks.get_ecdsa_pub_key_x &&
+               security->callbacks.get_ecdsa_pub_key_y &&
+               security->callbacks.verify_ecdsa_key;
+    case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
+        SOL_WRN("Certificate security mode is not supported yet.");
+        return false;
+    case SOL_LWM2M_SECURITY_MODE_NO_SEC:
+        SOL_WRN("NoSec Security Mode does not use DTLS.");
+        return false;
+    default:
+        SOL_WRN("Unknown DTLS [Security Mode] Resource from Security Object: %d", sec_mode);
+        return false;
+    }
+}
 
 struct sol_lwm2m_security *
 sol_lwm2m_client_security_add(struct sol_lwm2m_client *lwm2m_client,

--- a/src/lib/comms/sol-lwm2m-security.h
+++ b/src/lib/comms/sol-lwm2m-security.h
@@ -44,6 +44,10 @@ struct sol_lwm2m_security {
     void *entity;
 };
 
+bool
+sol_lwm2m_security_supports_security_mode(struct sol_lwm2m_security *security,
+    enum sol_lwm2m_security_mode sec_mode);
+
 struct sol_lwm2m_security *sol_lwm2m_client_security_add(
     struct sol_lwm2m_client *lwm2m_client, enum sol_lwm2m_security_mode sec_mode);
 

--- a/src/lib/comms/sol-socket-dtls.h
+++ b/src/lib/comms/sol-socket-dtls.h
@@ -28,6 +28,9 @@
 #define SOL_DTLS_PSK_ID_LEN 16
 #define SOL_DTLS_PSK_KEY_LEN 16
 
+#define SOL_DTLS_ECDSA_PRIV_KEY_LEN 32
+#define SOL_DTLS_ECDSA_PUB_KEY_X_LEN 32
+#define SOL_DTLS_ECDSA_PUB_KEY_Y_LEN 32
 
 struct sol_socket_dtls_credential_cb {
     const void *data;
@@ -39,6 +42,16 @@ struct sol_socket_dtls_credential_cb {
         char *id, size_t id_len);
     ssize_t (*get_psk)(const void *creds, struct sol_str_slice id,
         char *psk, size_t psk_len);
+
+    int (*get_ecdsa_priv_key)(const void *creds, struct sol_network_link_addr *addr,
+        unsigned char *ecdsa_priv_key);
+    int (*get_ecdsa_pub_key_x)(const void *creds, struct sol_network_link_addr *addr,
+        unsigned char *ecdsa_pub_key_x);
+    int (*get_ecdsa_pub_key_y)(const void *creds, struct sol_network_link_addr *addr,
+        unsigned char *ecdsa_pub_key_y);
+    int (*verify_ecdsa_key)(const void *creds, struct sol_network_link_addr *addr,
+        const unsigned char *other_pub_x, const unsigned char *other_pub_y,
+        size_t key_size);
 };
 
 struct sol_socket *sol_socket_dtls_wrap_socket(struct sol_socket *socket);

--- a/src/lib/comms/sol-socket-dtls.h
+++ b/src/lib/comms/sol-socket-dtls.h
@@ -28,11 +28,6 @@
 #define SOL_DTLS_PSK_ID_LEN 16
 #define SOL_DTLS_PSK_KEY_LEN 16
 
-enum sol_socket_dtls_cipher {
-    SOL_SOCKET_DTLS_CIPHER_ECDH_ANON_AES128_CBC_SHA256,
-    SOL_SOCKET_DTLS_CIPHER_PSK_AES128_CCM8,
-    SOL_SOCKET_DTLS_CIPHER_ECDHE_ECDSA_AES128_CCM8
-};
 
 struct sol_socket_dtls_credential_cb {
     const void *data;

--- a/src/samples/coap/lwm2m-client.c
+++ b/src/samples/coap/lwm2m-client.c
@@ -74,6 +74,24 @@
 #define SECURITY_CLIENT_HOLD_OFF_TIME_RES_ID (11)
 #define SECURITY_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT_RES_ID (12)
 
+#define PSK_KEY_LEN 16
+#define RPK_PRIVATE_KEY_LEN 32
+#define RPK_PUBLIC_KEY_LEN (2 * RPK_PRIVATE_KEY_LEN)
+
+//FIXME: UNSEC: Hardcoded Crypto Keys
+#define CLIENT_BS_PSK_ID ("cli1-bs")
+#define CLIENT_BS_PSK_KEY ("FEDCBA9876543210")
+#define CLIENT_SERVER_PSK_ID ("cli1")
+#define CLIENT_SERVER_PSK_KEY ("0123456789ABCDEF")
+
+#define CLIENT_PRIVATE_KEY ("D9E2707A72DA6A0504995C86EDDBE3EFC7F1CD74838F7570C8072D0A76261BD4")
+#define CLIENT_PUBLIC_KEY ("D055EE14084D6E0615599DB583913E4A3E4526A2704D61F27A4CCFBA9758EF9A" \
+    "B418B64AFE8030DA1DDCF4F42E2F2631D043B1FB03E22F4D17DE43F9F9ADEE70")
+#define BS_SERVER_PUBLIC_KEY ("cd4110e97bbd6e7e5a800028079d02915c70b915ea4596402098deea585eb7ad" \
+    "f3e080487327f70758b13bc0583f4293d13288a0164a8e324779aa4f7ada26c1")
+#define SERVER_PUBLIC_KEY ("3b88c213ca5ccfd9c5a7f73715760d7d9a5220768f2992d2628ae1389cbca4c6" \
+    "d1b73cc6d61ae58783135749fb03eaaa64a7a1adab8062ed5fc0d7b86ba2d5ca")
+
 struct client_data_ctx {
     bool has_location_instance;
     bool is_bootstrap;
@@ -141,39 +159,6 @@ static struct sol_blob server_addr_dtls = {
     .parent = NULL,
     .mem = (void *)"coaps://localhost:5684",
     .size = sizeof("coaps://localhost:5684") - 1,
-    .refcnt = 1
-};
-
-//FIXME: UNSEC: Hardcoded Crypto Keys
-static struct sol_blob psk_id = {
-    .type = &SOL_BLOB_TYPE_NO_FREE,
-    .parent = NULL,
-    .mem = (void *)"cli1",
-    .size = sizeof("cli1") - 1,
-    .refcnt = 1
-};
-
-static struct sol_blob psk_key = {
-    .type = &SOL_BLOB_TYPE_NO_FREE,
-    .parent = NULL,
-    .mem = (void *)"0123456789ABCDEF",
-    .size = sizeof("0123456789ABCDEF") - 1,
-    .refcnt = 1
-};
-
-static struct sol_blob psk_bs_id = {
-    .type = &SOL_BLOB_TYPE_NO_FREE,
-    .parent = NULL,
-    .mem = (void *)"cli1-bs",
-    .size = sizeof("cli1-bs") - 1,
-    .refcnt = 1
-};
-
-static struct sol_blob psk_bs_key = {
-    .type = &SOL_BLOB_TYPE_NO_FREE,
-    .parent = NULL,
-    .mem = (void *)"FEDCBA9876543210",
-    .size = sizeof("FEDCBA9876543210") - 1,
     .refcnt = 1
 };
 
@@ -1218,6 +1203,8 @@ main(int argc, char *argv[])
     struct server_obj_instance_ctx *server_data;
     int r;
     enum sol_lwm2m_security_mode sec_mode = SOL_LWM2M_SECURITY_MODE_NO_SEC;
+    unsigned char buf_aux[RPK_PUBLIC_KEY_LEN];
+    struct sol_blob *public_key_or_id, *server_public_key, *secret_key;
     char *cli_name = NULL;
     char usage[256];
 
@@ -1263,6 +1250,46 @@ main(int argc, char *argv[])
         return -1;
     }
 
+    switch (sec_mode) {
+    case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
+        if (data_ctx.is_bootstrap) {
+            public_key_or_id = sol_blob_new_dup(CLIENT_BS_PSK_ID,
+                sizeof(CLIENT_BS_PSK_ID) - 1);
+            secret_key = sol_blob_new_dup(CLIENT_BS_PSK_KEY, PSK_KEY_LEN);
+        } else {
+            public_key_or_id = sol_blob_new_dup(CLIENT_SERVER_PSK_ID,
+                sizeof(CLIENT_SERVER_PSK_ID) - 1);
+            secret_key = sol_blob_new_dup(CLIENT_SERVER_PSK_KEY, PSK_KEY_LEN);
+        }
+        server_public_key = NULL;
+        break;
+    case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
+        r = sol_util_base16_decode(buf_aux, sizeof(buf_aux),
+            sol_str_slice_from_str(CLIENT_PRIVATE_KEY), SOL_DECODE_BOTH);
+        secret_key = sol_blob_new_dup(buf_aux, RPK_PRIVATE_KEY_LEN);
+        r = sol_util_base16_decode(buf_aux, sizeof(buf_aux),
+            sol_str_slice_from_str(CLIENT_PUBLIC_KEY), SOL_DECODE_BOTH);
+        public_key_or_id = sol_blob_new_dup(buf_aux, RPK_PUBLIC_KEY_LEN);
+
+        if (data_ctx.is_bootstrap) {
+            r = sol_util_base16_decode(buf_aux, sizeof(buf_aux),
+                sol_str_slice_from_str(BS_SERVER_PUBLIC_KEY), SOL_DECODE_BOTH);
+            server_public_key = sol_blob_new_dup(buf_aux, RPK_PUBLIC_KEY_LEN);
+        } else {
+            r = sol_util_base16_decode(buf_aux, sizeof(buf_aux),
+                sol_str_slice_from_str(SERVER_PUBLIC_KEY), SOL_DECODE_BOTH);
+            server_public_key = sol_blob_new_dup(buf_aux, RPK_PUBLIC_KEY_LEN);
+        }
+        break;
+    case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
+    case SOL_LWM2M_SECURITY_MODE_NO_SEC:
+    default:
+        public_key_or_id = NULL;
+        server_public_key = NULL;
+        secret_key = NULL;
+        break;
+    }
+
     sol_init();
 
     client = sol_lwm2m_client_new(cli_name, NULL, NULL, objects, &data_ctx);
@@ -1281,6 +1308,9 @@ main(int argc, char *argv[])
 
     security_data->client = client;
     security_data->security_mode = sec_mode;
+    security_data->public_key_or_id = public_key_or_id;
+    security_data->server_public_key = server_public_key;
+    security_data->secret_key = secret_key;
 
     if (!data_ctx.is_bootstrap) {
         server_data = calloc(1, sizeof(struct server_obj_instance_ctx));
@@ -1304,8 +1334,6 @@ main(int argc, char *argv[])
         security_data->server_uri = (sec_mode == SOL_LWM2M_SECURITY_MODE_NO_SEC) ?
             &server_addr_coap : &server_addr_dtls;
         security_data->is_bootstrap = false;
-        security_data->public_key_or_id = &psk_id;
-        security_data->secret_key = &psk_key;
         security_data->server_id = 101;
     } else {
         r = sol_lwm2m_client_add_bootstrap_finish_monitor(client, bootstrap_cb,
@@ -1318,9 +1346,7 @@ main(int argc, char *argv[])
 
         security_data->server_uri = &bootstrap_server_addr;
         security_data->is_bootstrap = true;
-        security_data->public_key_or_id = &psk_bs_id;
-        security_data->secret_key = &psk_bs_key;
-        security_data->client_hold_off_time = 5;
+        security_data->client_hold_off_time = 0;
         security_data->bootstrap_server_account_timeout = 0;
     }
 


### PR DESCRIPTION
This patch adds support for CoAP Data Encryption using DTLS with Raw Public Key mode (using `TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8` Cipher Suite).

It includes modifications on the LWM2M Samples and LWM2M Tests to demonstrate the support as well.

Signed-off-by: Bruno Melo bsilva.melo@gmail.com