### PR TITLE
LWM2M: Support for DTLS with Raw Public Key security mode [v3]

### DIFF
--- a/data/scripts/libsoletta.sym
+++ b/data/scripts/libsoletta.sym
@@ -130,6 +130,7 @@ global:
         sol_coap_send_packet;
         sol_coap_send_packet_with_reply;
         sol_coap_server_new;
+        sol_coap_server_new_by_cipher_suites;
         sol_coap_server_ref;
         sol_coap_server_register_resource;
         sol_coap_server_set_unknown_resource_handler;

--- a/src/lib/comms/include/sol-coap.h
+++ b/src/lib/comms/include/sol-coap.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <sol-socket.h>
 #include <sol-network.h>
 #include <sol-str-slice.h>
 
@@ -496,12 +497,38 @@ bool sol_coap_server_is_secure(const struct sol_coap_server *server);
  *
  * @param addr The address where the server will listen on.
  * @param secure Set to @c true to create a server that will encrypt communication with its
- * endpoints using DTLS or @c false otherwise
+ * endpoints using DTLS or @c false otherwise.
+ *
+ * @note If @c secure is @c true, this function will create a @c sol_coap_server
+ * over a DTLS Socket supporting @b only the #SOL_SOCKET_DTLS_CIPHER_PSK_AES128_CCM8
+ * Cipher Suite. The recommended function for creating secure @c sol_coap_server is
+ * @c sol_coap_server_new_by_cipher_suites.
+ *
+ * @return A new server instance, or NULL in case of failure.
+ *
+ * @see sol_coap_server_new_by_cipher_suites
+ *
+ */
+struct sol_coap_server *sol_coap_server_new(const struct sol_network_link_addr *addr, bool secure);
+
+/**
+ * @brief Creates a new DTLS-Secured CoAP server instance.
+ *
+ * Creates a new, DTLS-Secured CoAP server instance listening on address
+ * @a addr. If the server cannot be created, NULL will be returned and
+ * @c errno will be set to indicate the reason.
+ *
+ * @param addr The address where the server will listen on.
+ * @param cipher_suites Indicates the desired cipher suites to use.
+ * @param cipher_suites_len Indicates the length of the @c cipher_suites array.
  *
  * @return A new server instance, or NULL in case of failure.
  *
  */
-struct sol_coap_server *sol_coap_server_new(const struct sol_network_link_addr *addr, bool secure);
+struct sol_coap_server *sol_coap_server_new_by_cipher_suites(
+    const struct sol_network_link_addr *addr,
+    enum sol_socket_dtls_cipher *cipher_suites,
+    uint16_t cipher_suites_len);
 
 /**
  * @brief Take a reference of the given server.

--- a/src/lib/comms/include/sol-lwm2m-bs-server.h
+++ b/src/lib/comms/include/sol-lwm2m-bs-server.h
@@ -59,14 +59,21 @@ typedef struct sol_lwm2m_bootstrap_client_info sol_lwm2m_bootstrap_client_info;
  * The server will be immediately operational and waiting for connections.
  *
  * @param port The UDP port to be used.
- * @param known_clients An array with the name of all clients this server has Bootstrap Information for.
- * @param sec_mode The DTLS Security Mode to be used.
- * @param known_psks The Clients' Pre-Shared Keys this Bootstrap Server has previous knowledge of.
+ * @param known_clients A NULL-terminated array with the name of all clients this server has Bootstrap Information for.
+ * @param num_sec_modes The number of DTLS Security Modes this Bootstrap Server will support.
+ * @param ... At least one @c sol_lwm2m_security_mode followed by its relevant parameters, as per the table below:
+ *
+ * Security Mode | Follow-up arguments | Description
+ * ------------- | ------------------- | ------------------
+ * SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY | struct sol_lwm2m_security_psk **known_psks | @c known_psks The Clients' Pre-Shared Keys this Bootstrap Server has previous knowledge of.  It MUST be a NULL-terminated array.
+ * SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY | struct sol_lwm2m_security_rpk *rpk, struct sol_blob **known_pub_keys | @c rpk This Bootstrap Server's Key Pair - @c known_pub_keys The Clients' Public Keys this Bootstrap Server has previous knowledge of.  It MUST be a NULL-terminated array.
+ *
+ * @note: SOL_LWM2M_SECURITY_MODE_CERTIFICATE is not supported yet.
+ *
  * @return The LWM2M bootstrap server or @c NULL on error.
  */
 struct sol_lwm2m_bootstrap_server *sol_lwm2m_bootstrap_server_new(uint16_t port,
-    const char **known_clients, enum sol_lwm2m_security_mode sec_mode,
-    struct sol_vector *known_psks);
+    const char **known_clients, uint16_t num_sec_modes, ...);
 
 /**
  * @brief Adds a bootstrap request monitor to the server.

--- a/src/lib/comms/include/sol-lwm2m-server.h
+++ b/src/lib/comms/include/sol-lwm2m-server.h
@@ -85,14 +85,20 @@ enum sol_lwm2m_registration_event {
  * The server will be immediately operational and waiting for connections.
  *
  * @param coap_port The UDP port to be used for the NoSec CoAP Server.
- * @param dtls_port The UDP port to be used for the Secure DTLS Server.
- * @param sec_mode The DTLS Security Mode to be used for the Secure CoAP Server.
- * @param known_psks The Clients' Pre-Shared Keys this Server has previous knowledge of.
+ * @param num_sec_modes The number of DTLS Security Modes this Bootstrap Server will support.
+ * @param ... An @c uint16_t indicating the UDP port to be used for the Secure DTLS Server; and at least one @c sol_lwm2m_security_mode followed by its relevant parameters, as per the table below:
+ *
+ * Security Mode | Follow-up arguments | Description
+ * ------------- | ------------------- | ------------------
+ * SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY | struct sol_lwm2m_security_psk **known_psks | @c known_psks The Clients' Pre-Shared Keys this Server has previous knowledge of. It MUST be a NULL-terminated array.
+ * SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY | struct sol_lwm2m_security_rpk *rpk, struct sol_blob **known_pub_keys | @c rpk This Server's Key Pair - @c known_pub_keys The Clients' Public Keys this Bootstrap Server has previous knowledge of. It MUST be a NULL-terminated array.
+ *
+ * @note: SOL_LWM2M_SECURITY_MODE_CERTIFICATE is not supported yet.
+ *
  * @return The LWM2M server or @c NULL on error.
  */
 struct sol_lwm2m_server *sol_lwm2m_server_new(uint16_t coap_port,
-    uint16_t dtls_port, enum sol_lwm2m_security_mode sec_mode,
-    struct sol_vector *known_psks);
+    uint16_t num_sec_modes, ...);
 
 /**
  * @brief Adds a registration monitor.

--- a/src/lib/comms/include/sol-lwm2m.h
+++ b/src/lib/comms/include/sol-lwm2m.h
@@ -52,7 +52,7 @@ extern "C" {
  * - Observation interface.
  * - TLV format.
  * - Data Access Control.
- * - CoAP Data Encryption.
+ * - CoAP Data Encryption (Pre-Shared Key and Raw Public Key modes).
  *
  * Unsupported features for now:
  * - LWM2M JSON.
@@ -143,7 +143,7 @@ enum sol_lwm2m_binding_mode {
 /**
  * @brief Enum that represents the UDP Security Mode.
  *
- * @note Only Pre-Shared Key and NoSec modes are currently supported.
+ * @note Certificate mode is not supported yet.
  */
 enum sol_lwm2m_security_mode {
     /**
@@ -156,8 +156,8 @@ enum sol_lwm2m_security_mode {
     /**
      * Raw Public Key security mode with Cipher Suite TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8
      * In this case, the following Resource IDs have to be filled as well:
-     * /3 "Public Key or Identity":                    Client's Raw Public Key [256-bit ECC key; 32 Opaque bytes];
-     * /4 "Server Public Key or Identity Resource":    [Expected] Server's Raw Public Key [256-bit ECC key; 32 Opaque bytes];
+     * /3 "Public Key or Identity":                    Client's Raw Public Key [2x256-bit ECC key (one for each ECC Coordinate); 64 Opaque bytes];
+     * /4 "Server Public Key or Identity Resource":    [Expected] Server's Raw Public Key [2x256-bit ECC key (one for each ECC Coordinate); 64 Opaque bytes];
      * /5 "Secret Key":                                Client's Private Key [256-bit ECC key; 32 Opaque bytes];
      */
     SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY = 1,
@@ -282,7 +282,7 @@ enum sol_lwm2m_resource_type {
 /**
  * @brief Struct that represents a Pre-Shared Key (PSK).
  *
- * A sol_vector holding elements of this type is used by the LWM2M Server
+ * A @c sol_vector holding elements of this type is used by the LWM2M Server
  * and LWM2M Bootstrap Server to keep a list of known Clients' Pre-Shared Keys.
  *
  * @see sol_lwm2m_server_new()
@@ -294,6 +294,28 @@ typedef struct sol_lwm2m_security_psk {
     /** @brief The PSK Key, composed of an Opaque 16-bytes (128-bit) AES Key */
     struct sol_blob *key;
 } sol_lwm2m_security_psk;
+
+/**
+ * @brief Struct that represents a Raw Public Key (RPK) pair.
+ *
+ * An element of this type is used by the LWM2M Server
+ * and LWM2M Bootstrap Server to store its own Private and Public keys.
+ *
+ * @see sol_lwm2m_server_new()
+ * @see sol_lwm2m_bootstrap_server_new()
+ */
+typedef struct sol_lwm2m_security_rpk {
+    /** @brief The Private Key, composed of an Opaque 32-bytes (128-bit) ECC key */
+    struct sol_blob *private_key;
+    /** @brief The Public Key, composed of an Opaque 64-bytes (2x256-bit) ECC key.
+     *
+     * This represents the X and Y coordinates in a contiguous set of bytes.
+     * A @c sol_ptr_vector of @c sol_blob following this structure is used
+     * by the LWM2M Server and LWM2M Bootstrap Server to keep a list of known
+     * Clients' Public Keys.
+     */
+    struct sol_blob *public_key;
+} sol_lwm2m_security_rpk;
 
 /**
  * @brief Struct that represents TLV data.

--- a/src/lib/comms/include/sol-lwm2m.h
+++ b/src/lib/comms/include/sol-lwm2m.h
@@ -525,11 +525,11 @@ void sol_lwm2m_resource_clear(struct sol_lwm2m_resource *resource);
  *
  * Resource type | Last argument type
  * ------------- | ------------------
- * SOL_LWM2M_RESOURCE_DATA_TYPE_STRING | struct sol_str_slice
+ * SOL_LWM2M_RESOURCE_DATA_TYPE_STRING | struct sol_blob *
  * SOL_LWM2M_RESOURCE_DATA_TYPE_INT | int64_t
  * SOL_LWM2M_RESOURCE_DATA_TYPE_FLOAT | double
  * SOL_LWM2M_RESOURCE_DATA_TYPE_BOOL | bool
- * SOL_LWM2M_RESOURCE_DATA_TYPE_OPAQUE | struct sol_str_slice
+ * SOL_LWM2M_RESOURCE_DATA_TYPE_OPAQUE | struct sol_blob *
  * SOL_LWM2M_RESOURCE_DATA_TYPE_TIME | int64_t
  * SOL_LWM2M_RESOURCE_DATA_TYPE_OBJ_LINK | uint16_t, uint16_t
  *

--- a/src/lib/comms/include/sol-socket.h
+++ b/src/lib/comms/include/sol-socket.h
@@ -42,6 +42,15 @@ struct sol_socket;
 typedef struct sol_socket sol_socket;
 
 /**
+ * @brief Represents supported Cipher Suites for use with DTLS.
+ */
+enum sol_socket_dtls_cipher {
+    SOL_SOCKET_DTLS_CIPHER_ECDH_ANON_AES128_CBC_SHA256,
+    SOL_SOCKET_DTLS_CIPHER_PSK_AES128_CCM8,
+    SOL_SOCKET_DTLS_CIPHER_ECDHE_ECDSA_AES128_CCM8,
+};
+
+/**
  * @brief Defines the behaviour of a socket instance
  */
 typedef struct sol_socket_options {
@@ -116,6 +125,19 @@ typedef struct sol_socket_ip_options {
      * sol_socket_bind()
      */
     bool reuse_addr;
+
+    /**
+     * @brief If @c secure is true, this should be considered.
+     * It indicates which DTLS cipher suites are supported and could
+     * be used for communication.
+     */
+    enum sol_socket_dtls_cipher *cipher_suites;
+
+    /**
+     * @brief If @c secure is true, this should be considered.
+     * It indicates the length of the @c cipher_suites array.
+     */
+    uint16_t cipher_suites_len;
 } sol_socket_ip_options;
 
 /**

--- a/src/lib/comms/sol-coap.c
+++ b/src/lib/comms/sol-coap.c
@@ -1885,6 +1885,9 @@ sol_coap_server_new_full(struct sol_socket_ip_options *options, const struct sol
         goto err_bind;
     }
 
+    SOL_DBG("server=%p, socket=%p, addr=%p, port=%" PRIu16 ", reuse_addr=%s binded!",
+        server, s, servaddr, servaddr->port, options->reuse_addr ? "True" : "False");
+
     server->refcnt = 1;
 
     sol_vector_init(&server->contexts, sizeof(struct resource_context));
@@ -1944,19 +1947,43 @@ err:
 }
 
 SOL_API struct sol_coap_server *
-sol_coap_server_new(const struct sol_network_link_addr *addr, bool secure)
+sol_coap_server_new(const struct sol_network_link_addr *addr,
+    bool secure)
 {
     return sol_coap_server_new_full(&((struct sol_socket_ip_options) {
-        .base = {
-            SOL_SET_API_VERSION(.api_version = SOL_SOCKET_OPTIONS_API_VERSION, )
-            SOL_SET_API_VERSION(.sub_api = SOL_SOCKET_IP_OPTIONS_SUB_API_VERSION, )
-            .on_can_read = on_can_read,
-            .on_can_write = on_can_write,
-        },
-        .family = addr->family,
-        .secure = secure,
-        .reuse_addr = addr->port ? true : false,
-    }), addr);
+            .base = {
+                SOL_SET_API_VERSION(.api_version = SOL_SOCKET_OPTIONS_API_VERSION, )
+                SOL_SET_API_VERSION(.sub_api = SOL_SOCKET_IP_OPTIONS_SUB_API_VERSION, )
+                .on_can_read = on_can_read,
+                .on_can_write = on_can_write,
+            },
+            .family = addr->family,
+            .secure = secure,
+            .cipher_suites = secure ?
+            (enum sol_socket_dtls_cipher []){ SOL_SOCKET_DTLS_CIPHER_PSK_AES128_CCM8 } : NULL,
+            .cipher_suites_len = secure ? 1 : 0,
+            .reuse_addr = addr->port ? true : false,
+        }), addr);
+}
+
+SOL_API struct sol_coap_server *
+sol_coap_server_new_by_cipher_suites(
+    const struct sol_network_link_addr *addr,
+    enum sol_socket_dtls_cipher *cipher_suites, uint16_t cipher_suites_len)
+{
+    return sol_coap_server_new_full(&((struct sol_socket_ip_options) {
+            .base = {
+                SOL_SET_API_VERSION(.api_version = SOL_SOCKET_OPTIONS_API_VERSION, )
+                SOL_SET_API_VERSION(.sub_api = SOL_SOCKET_IP_OPTIONS_SUB_API_VERSION, )
+                .on_can_read = on_can_read,
+                .on_can_write = on_can_write,
+            },
+            .family = addr->family,
+            .secure = true,
+            .cipher_suites = cipher_suites,
+            .cipher_suites_len = cipher_suites_len,
+            .reuse_addr = addr->port ? true : false,
+        }), addr);
 }
 
 SOL_API bool

--- a/src/lib/comms/sol-lwm2m-client.c
+++ b/src/lib/comms/sol-lwm2m-client.c
@@ -27,6 +27,7 @@
 #include "sol-log-internal.h"
 #include "sol-util-internal.h"
 #include "sol-list.h"
+#include "sol-socket.h"
 #include "sol-lwm2m.h"
 #include "sol-lwm2m-common.h"
 #include "sol-lwm2m-client.h"
@@ -50,6 +51,140 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_lwm2m_client_domain, "lwm2m-client");
         r = sol_coap_add_option(pkt, SOL_COAP_OPTION_URI_QUERY, \
             query.data, query.used); \
         SOL_INT_CHECK_GOTO(r, < 0, err_coap); \
+    } while (0);
+
+#define SOL_COAP_SERVER_UNREGISTER_RESOURCE_ALL(__resource) \
+    do { \
+        sol_coap_server_unregister_resource(client->coap_server, \
+            __resource); \
+ \
+        if (client->security) { \
+            if (sol_lwm2m_security_supports_security_mode(client->security, \
+                SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY)) \
+                sol_coap_server_unregister_resource(client->dtls_server_psk, \
+                    __resource); \
+ \
+            if (sol_lwm2m_security_supports_security_mode(client->security, \
+                SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY)) \
+                sol_coap_server_unregister_resource(client->dtls_server_rpk, \
+                    __resource); \
+        } \
+    } while (0);
+
+#define SOL_COAP_SERVER_UNREGISTER_RESOURCE_ALL_INT(__resource) \
+    do { \
+        r = sol_coap_server_unregister_resource(client->coap_server, \
+            __resource); \
+        SOL_INT_CHECK(r, < 0, r); \
+ \
+        if (client->security) { \
+            if (sol_lwm2m_security_supports_security_mode(client->security, \
+                SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY)) { \
+                r = sol_coap_server_unregister_resource(client->dtls_server_psk, \
+                    __resource); \
+                SOL_INT_CHECK(r, < 0, r); \
+            } \
+ \
+            if (sol_lwm2m_security_supports_security_mode(client->security, \
+                SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY)) { \
+                r = sol_coap_server_unregister_resource(client->dtls_server_rpk, \
+                    __resource); \
+                SOL_INT_CHECK(r, < 0, r); \
+            } \
+        } \
+    } while (0);
+
+#define SOL_COAP_SERVER_REGISTER_RESOURCE_ALL_GOTO(__resource, \
+        __err_label_1, __err_label_2, __err_label_3) \
+    do { \
+        r = sol_coap_server_register_resource(client->coap_server, \
+            __resource, client); \
+        SOL_INT_CHECK_GOTO(r, < 0, __err_label_1); \
+ \
+        if (client->security) { \
+            if (sol_lwm2m_security_supports_security_mode(client->security, \
+                SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY)) { \
+                r = sol_coap_server_register_resource(client->dtls_server_psk, \
+                    __resource, client); \
+                SOL_INT_CHECK_GOTO(r, < 0, __err_label_2); \
+            } \
+ \
+            if (sol_lwm2m_security_supports_security_mode(client->security, \
+                SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY)) { \
+                r = sol_coap_server_register_resource(client->dtls_server_rpk, \
+                    __resource, client); \
+                SOL_INT_CHECK_GOTO(r, < 0, __err_label_3); \
+            } \
+        } \
+    } while (0);
+
+#define SOL_COAP_SERVER_REGISTER_RESOURCE_ALL_INT(__resource) \
+    do { \
+        r = sol_coap_server_register_resource(client->coap_server, \
+            __resource, client); \
+        SOL_INT_CHECK(r, < 0, r); \
+ \
+        if (client->security) { \
+            if (sol_lwm2m_security_supports_security_mode(client->security, \
+                SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY)) { \
+                r = sol_coap_server_register_resource(client->dtls_server_psk, \
+                    __resource, client); \
+                SOL_INT_CHECK(r, < 0, r); \
+            } \
+ \
+            if (sol_lwm2m_security_supports_security_mode(client->security, \
+                SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY)) { \
+                r = sol_coap_server_register_resource(client->dtls_server_rpk, \
+                    __resource, client); \
+                SOL_INT_CHECK(r, < 0, r); \
+            } \
+        } \
+    } while (0);
+
+#define SOL_COAP_NOTIFY_BY_CALLBACK_ALL_INT(__resource) \
+    do { \
+        r = sol_coap_notify_by_callback(client->coap_server, __resource, \
+            notification_cb, &ctx); \
+        SOL_INT_CHECK(r, < 0, false); \
+ \
+        if (client->security) { \
+            if (sol_lwm2m_security_supports_security_mode(client->security, \
+                SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY)) { \
+                r = sol_coap_notify_by_callback(client->dtls_server_psk, __resource, \
+                    notification_cb, &ctx); \
+                SOL_INT_CHECK(r, < 0, false); \
+            } \
+ \
+            if (sol_lwm2m_security_supports_security_mode(client->security, \
+                SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY)) { \
+                r = sol_coap_notify_by_callback(client->dtls_server_rpk, __resource, \
+                    notification_cb, &ctx); \
+                SOL_INT_CHECK(r, < 0, false); \
+            } \
+        } \
+    } while (0);
+
+#define SOL_COAP_NOTIFY_BY_CALLBACK_ALL_GOTO(__resource) \
+    do { \
+        r = sol_coap_notify_by_callback(client->coap_server, __resource, \
+            notification_cb, &ctx); \
+        SOL_INT_CHECK_GOTO(r, < 0, err_exit); \
+ \
+        if (client->security) { \
+            if (sol_lwm2m_security_supports_security_mode(client->security, \
+                SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY)) { \
+                r = sol_coap_notify_by_callback(client->dtls_server_psk, __resource, \
+                    notification_cb, &ctx); \
+                SOL_INT_CHECK_GOTO(r, < 0, err_exit); \
+            } \
+ \
+            if (sol_lwm2m_security_supports_security_mode(client->security, \
+                SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY)) { \
+                r = sol_coap_notify_by_callback(client->dtls_server_rpk, __resource, \
+                    notification_cb, &ctx); \
+                SOL_INT_CHECK_GOTO(r, < 0, err_exit); \
+            } \
+        } \
     } while (0);
 
 struct notification_ctx {
@@ -168,24 +303,14 @@ obj_instance_clear(struct sol_lwm2m_client *client, struct obj_ctx *obj_ctx,
 
     SOL_VECTOR_FOREACH_IDX (&obj_instance->resources_ctx, res_ctx, i) {
         if (!client->removed && res_ctx->res) {
-            sol_coap_server_unregister_resource(client->coap_server,
-                res_ctx->res);
-
-            if (client->security)
-                sol_coap_server_unregister_resource(client->dtls_server,
-                    res_ctx->res);
+            SOL_COAP_SERVER_UNREGISTER_RESOURCE_ALL(res_ctx->res);
         }
         free(res_ctx->res);
         free(res_ctx->str_id);
     }
 
     if (!client->removed && obj_instance->instance_res) {
-        sol_coap_server_unregister_resource(client->coap_server,
-            obj_instance->instance_res);
-
-        if (client->security)
-            sol_coap_server_unregister_resource(client->dtls_server,
-                obj_instance->instance_res);
+        SOL_COAP_SERVER_UNREGISTER_RESOURCE_ALL(obj_instance->instance_res);
     }
     free(obj_instance->instance_res);
     free(obj_instance->str_id);
@@ -270,15 +395,8 @@ setup_resources_ctx(struct sol_lwm2m_client *client, struct obj_ctx *obj_ctx,
         res_ctx->res->del = handle_resource;
 
         if (register_with_coap) {
-            r = sol_coap_server_register_resource(client->coap_server,
-                res_ctx->res, client);
-            SOL_INT_CHECK_GOTO(r, < 0, err_exit);
-
-            if (client->security) {
-                r = sol_coap_server_register_resource(client->dtls_server,
-                    res_ctx->res, client);
-                SOL_INT_CHECK(r, < 0, r);
-            }
+            SOL_COAP_SERVER_REGISTER_RESOURCE_ALL_GOTO(res_ctx->res,
+                err_exit, err_exit, err_exit);
         }
     }
 
@@ -287,12 +405,7 @@ setup_resources_ctx(struct sol_lwm2m_client *client, struct obj_ctx *obj_ctx,
 err_exit:
     SOL_VECTOR_FOREACH_IDX (&instance->resources_ctx, res_ctx, i) {
         if (res_ctx->res) {
-            sol_coap_server_unregister_resource(client->coap_server,
-                res_ctx->res);
-
-            if (client->security)
-                sol_coap_server_unregister_resource(client->dtls_server,
-                    res_ctx->res);
+            SOL_COAP_SERVER_UNREGISTER_RESOURCE_ALL(res_ctx->res);
 
             free(res_ctx->res);
         }
@@ -340,15 +453,8 @@ setup_instance_resource(struct sol_lwm2m_client *client,
     obj_instance->instance_res->del = handle_resource;
 
     if (register_with_coap) {
-        r = sol_coap_server_register_resource(client->coap_server,
-            obj_instance->instance_res, client);
-        SOL_INT_CHECK_GOTO(r, < 0, err_register);
-
-        if (client->security) {
-            r = sol_coap_server_register_resource(client->dtls_server,
-                obj_instance->instance_res, client);
-            SOL_INT_CHECK(r, < 0, r);
-        }
+        SOL_COAP_SERVER_REGISTER_RESOURCE_ALL_GOTO(obj_instance->instance_res,
+            err_register, err_resources, err_resources);
     }
 
     r = setup_resources_ctx(client, obj_ctx, obj_instance, register_with_coap);
@@ -357,12 +463,7 @@ setup_instance_resource(struct sol_lwm2m_client *client,
     return 0;
 
 err_resources:
-    sol_coap_server_unregister_resource(client->coap_server,
-        obj_instance->instance_res);
-
-    if (client->security)
-        sol_coap_server_unregister_resource(client->dtls_server,
-            obj_instance->instance_res);
+    SOL_COAP_SERVER_UNREGISTER_RESOURCE_ALL(obj_instance->instance_res);
 err_register:
     free(obj_instance->instance_res);
     obj_instance->instance_res = NULL;
@@ -1255,9 +1356,7 @@ dispatch_notifications(struct sol_lwm2m_client *client,
 
         ctx.obj_ctx = obj_ctx;
         ctx.resource_id = -1;
-        r = sol_coap_notify_by_callback(client->coap_server, obj_ctx->obj_res,
-            notification_cb, &ctx);
-        SOL_INT_CHECK(r, < 0, false);
+        SOL_COAP_NOTIFY_BY_CALLBACK_ALL_INT(obj_ctx->obj_res);
 
         if (!resource->path[1].len || is_delete)
             break;
@@ -1271,9 +1370,7 @@ dispatch_notifications(struct sol_lwm2m_client *client,
                 continue;
 
             ctx.obj_instance = instance;
-            r = sol_coap_notify_by_callback(client->coap_server, instance->instance_res,
-                notification_cb, &ctx);
-            SOL_INT_CHECK(r, < 0, false);
+            SOL_COAP_NOTIFY_BY_CALLBACK_ALL_INT(instance->instance_res);
 
             if (!resource->path[2].len) {
                 stop = true;
@@ -1286,9 +1383,7 @@ dispatch_notifications(struct sol_lwm2m_client *client,
                     continue;
 
                 ctx.resource_id = k;
-                r = sol_coap_notify_by_callback(client->coap_server, res_ctx->res,
-                    notification_cb, &ctx);
-                SOL_INT_CHECK(r, < 0, false);
+                SOL_COAP_NOTIFY_BY_CALLBACK_ALL_INT(res_ctx->res);
 
                 stop = true;
                 break;
@@ -1555,6 +1650,24 @@ handle_unknown_bootstrap_resource(void *data, struct sol_coap_server *server,
     return handle_resource(data, server, NULL, req, cliaddr);
 }
 
+static sol_coap_server *
+get_coap_server_by_security_mode(struct sol_lwm2m_client *client,
+    enum sol_lwm2m_security_mode sec_mode)
+{
+    switch (sec_mode) {
+    case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
+        return client->dtls_server_psk;
+    case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
+        return client->dtls_server_rpk;
+    case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
+        return NULL;
+    case SOL_LWM2M_SECURITY_MODE_NO_SEC:
+        return client->coap_server;
+    default:
+        return NULL;
+    }
+}
+
 static char **
 split_path(const char *path, uint16_t *splitted_path_len)
 {
@@ -1648,15 +1761,31 @@ sol_lwm2m_client_new(const char *name, const char *path, const char *sms,
     client->coap_server = sol_coap_server_new(&servaddr, false);
     SOL_NULL_CHECK_GOTO(client->coap_server, err_coap);
 
-    client->dtls_server = sol_coap_server_new(&servaddr, true);
-    if (!client->dtls_server) {
+    client->dtls_server_psk = sol_coap_server_new_by_cipher_suites(&servaddr,
+        (enum sol_socket_dtls_cipher []){ SOL_SOCKET_DTLS_CIPHER_PSK_AES128_CCM8 }, 1);
+    if (!client->dtls_server_psk) {
         if (errno == ENOSYS) {
             SOL_INF("DTLS support not built in, LWM2M client"
                 " running only \"NoSec\" security mode");
         } else {
-            SOL_WRN("DTLS server could not be created for LWM2M client: %s",
+            SOL_WRN("DTLS server for Pre-Shared Key mode"
+                " could not be created for LWM2M client: %s",
                 sol_util_strerrora(errno));
-            goto err_dtls;
+            goto err_dtls_psk;
+        }
+    }
+
+    client->dtls_server_rpk = sol_coap_server_new_by_cipher_suites(&servaddr,
+        (enum sol_socket_dtls_cipher []){ SOL_SOCKET_DTLS_CIPHER_ECDHE_ECDSA_AES128_CCM8 }, 1);
+    if (!client->dtls_server_rpk) {
+        if (errno == ENOSYS) {
+            SOL_INF("DTLS support not built in, LWM2M client"
+                " running only \"NoSec\" security mode");
+        } else {
+            SOL_WRN("DTLS server for Raw Public Key mode"
+                " could not be created for LWM2M client: %s",
+                sol_util_strerrora(errno));
+            goto err_dtls_rpk;
         }
     }
 
@@ -1668,7 +1797,9 @@ sol_lwm2m_client_new(const char *name, const char *path, const char *sms,
 
     return client;
 
-err_dtls:
+err_dtls_rpk:
+    sol_coap_server_unref(client->dtls_server_psk);
+err_dtls_psk:
     sol_coap_server_unref(client->coap_server);
 err_coap:
     free(client->sms);
@@ -1751,8 +1882,10 @@ sol_lwm2m_client_del(struct sol_lwm2m_client *client)
 
     sol_coap_server_unref(client->coap_server);
 
-    if (client->dtls_server)
-        sol_coap_server_unref(client->dtls_server);
+    if (client->dtls_server_psk)
+        sol_coap_server_unref(client->dtls_server_psk);
+    if (client->dtls_server_rpk)
+        sol_coap_server_unref(client->dtls_server_rpk);
 
     if (client->security)
         sol_lwm2m_client_security_del(client->security);
@@ -2085,12 +2218,12 @@ register_with_server(struct sol_lwm2m_client *client,
 
     conn_ctx->registration_time = time(NULL);
 
-    SOL_DBG("Connecting with LWM2M %s server - id %" PRId64 " - binding '%.*s' -"
-        " lifetime '%" PRId64 "'", conn_ctx->secure ? "(DTLS)" : "(CoAP)",
+    SOL_DBG("Connecting with LWM2M server - id %" PRId64 " - binding '%.*s' -"
+        " lifetime '%" PRId64 "' - sec_mode '%s'",
         conn_ctx->server_id, SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(binding)),
-        conn_ctx->lifetime);
+        conn_ctx->lifetime, get_security_mode_str(conn_ctx->sec_mode));
     r = sol_coap_send_packet_with_reply(
-        conn_ctx->secure ? client->dtls_server : client->coap_server,
+        get_coap_server_by_security_mode(client, conn_ctx->sec_mode),
         pkt,
         sol_vector_get_no_check(&conn_ctx->server_addr_list,
         conn_ctx->addr_list_idx),
@@ -2170,10 +2303,11 @@ bootstrap_with_server(struct sol_lwm2m_client *client,
 
     ADD_QUERY("ep", "%s", client->name);
 
-    SOL_DBG("Sending Bootstrap Request to LWM2M Bootstrap Server");
-    r = sol_coap_send_packet_with_reply(client->dtls_server,
-        pkt,
-        sol_vector_get_no_check(&conn_ctx->server_addr_list,
+    SOL_DBG("Sending Bootstrap Request to LWM2M Bootstrap Server"
+        " using Security Mode %s", get_security_mode_str(conn_ctx->sec_mode));
+    r = sol_coap_send_packet_with_reply(
+        get_coap_server_by_security_mode(client, conn_ctx->sec_mode),
+        pkt, sol_vector_get_no_check(&conn_ctx->server_addr_list,
         conn_ctx->addr_list_idx), bootstrap_request_reply, conn_ctx);
     sol_buffer_fini(&query);
     return r;
@@ -2220,7 +2354,8 @@ err_exit:
 
 static struct server_conn_ctx *
 server_connection_ctx_new(struct sol_lwm2m_client *client,
-    const struct sol_str_slice str_addr, int64_t server_id, bool secure)
+    const struct sol_str_slice str_addr, int64_t server_id,
+    enum sol_lwm2m_security_mode sec_mode)
 {
     struct server_conn_ctx *conn_ctx;
     struct sol_http_url uri;
@@ -2231,9 +2366,9 @@ server_connection_ctx_new(struct sol_lwm2m_client *client,
 
     SOL_NULL_CHECK(&uri.scheme, NULL);
     if (sol_str_slice_str_case_eq(uri.scheme, "coaps"))
-        SOL_EXP_CHECK(!secure, NULL);
+        SOL_EXP_CHECK(sec_mode == SOL_LWM2M_SECURITY_MODE_NO_SEC, NULL);
     else if (sol_str_slice_str_case_eq(uri.scheme, "coap"))
-        SOL_EXP_CHECK(secure, NULL);
+        SOL_EXP_CHECK(sec_mode != SOL_LWM2M_SECURITY_MODE_NO_SEC, NULL);
     else
         return NULL;
 
@@ -2244,12 +2379,12 @@ server_connection_ctx_new(struct sol_lwm2m_client *client,
     SOL_INT_CHECK_GOTO(r, < 0, err_append);
     conn_ctx->client = client;
     conn_ctx->server_id = server_id;
-    conn_ctx->secure = secure;
+    conn_ctx->sec_mode = sec_mode;
     sol_vector_init(&conn_ctx->server_addr_list,
         sizeof(struct sol_network_link_addr));
 
     if (!uri.port)
-        if (secure)
+        if (sec_mode != SOL_LWM2M_SECURITY_MODE_NO_SEC)
             conn_ctx->port = SOL_LWM2M_DEFAULT_SERVER_PORT_DTLS;
         else
             conn_ctx->port = SOL_LWM2M_DEFAULT_SERVER_PORT_COAP;
@@ -2371,16 +2506,20 @@ client_bootstrap(void *data)
     //Try client-initiated bootstrap:
     conn_ctx = server_connection_ctx_new(client,
         sol_str_slice_from_blob(client->bootstrap_ctx.server_uri),
-        DEFAULT_SHORT_SERVER_ID, true);
+        DEFAULT_SHORT_SERVER_ID, client->bootstrap_ctx.sec_mode);
 
     if (!conn_ctx) {
-        SOL_WRN("Could not perform Client-initiated Bootstrap with server %.*s",
-            SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(client->bootstrap_ctx.server_uri)));
+        SOL_WRN("Could not perform Client-initiated Bootstrap with server %.*s"
+            " through Security Mode %s",
+            SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(client->bootstrap_ctx.server_uri)),
+            get_security_mode_str(client->bootstrap_ctx.sec_mode));
 
-        if (sol_coap_server_set_unknown_resource_handler(client->dtls_server,
+        if (sol_coap_server_set_unknown_resource_handler(
+            get_coap_server_by_security_mode(client, client->bootstrap_ctx.sec_mode),
             NULL, client) < 0)
             SOL_WRN("Could not unregister Bootstrap Unknown resource for client.");
-        if (sol_coap_server_unregister_resource(client->dtls_server,
+        if (sol_coap_server_unregister_resource(
+            get_coap_server_by_security_mode(client, client->bootstrap_ctx.sec_mode),
             &bootstrap_finish_interface) < 0)
             SOL_WRN("Could not unregister Bootstrap Finish resource for client.");
     }
@@ -2579,6 +2718,8 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
     struct server_conn_ctx *conn_ctx;
     struct resource_ctx *res_ctx;
     struct sol_lwm2m_resource res[3] = { };
+    enum sol_lwm2m_security_mode sec_mode = SOL_LWM2M_SECURITY_MODE_NO_SEC,
+        bs_sec_mode = SOL_LWM2M_SECURITY_MODE_NO_SEC;
     int r;
 
     SOL_NULL_CHECK(client, -EINVAL);
@@ -2609,11 +2750,12 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
 
     //Try to register with all available [non-bootstrap] servers
     SOL_VECTOR_FOREACH_IDX (&ctx->instances, instance, i) {
-        bool secure = true;
         //Setup DTLS parameters
         r = read_resources(client, ctx, instance, res, 1,
             SECURITY_SECURITY_MODE);
         SOL_INT_CHECK_GOTO(r, < 0, err_exit);
+
+        sec_mode = res[0].data[0].content.integer;
 
         switch (res[0].data[0].content.integer) {
         case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
@@ -2628,15 +2770,21 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
             }
             break;
         case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
-            SOL_WRN("Raw Public Key security mode is not supported yet.");
-            r = -ENOTSUP;
-            goto err_clear_1;
+            client->security = sol_lwm2m_client_security_add(client,
+                SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY);
+            if (!client->security) {
+                r = -errno;
+                SOL_ERR("Could not enable Raw Public Key security mode for LWM2M client");
+                goto err_clear_1;
+            } else {
+                SOL_DBG("Using Raw Public Key security mode");
+            }
+            break;
         case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
             SOL_WRN("Certificate security mode is not supported yet.");
             r = -ENOTSUP;
             goto err_clear_1;
         case SOL_LWM2M_SECURITY_MODE_NO_SEC:
-            secure = false;
             SOL_DBG("Using NoSec Security Mode (No DTLS).");
             break;
         default:
@@ -2659,7 +2807,7 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
             SOL_INT_CHECK_GOTO(r, < 0, err_exit);
 
             conn_ctx = server_connection_ctx_new(client, sol_str_slice_from_blob(res[0].data[0].content.blob),
-                res[1].data[0].content.integer, secure);
+                res[1].data[0].content.integer, sec_mode);
             r = -ENOMEM;
             SOL_NULL_CHECK_GOTO(conn_ctx, err_clear_2);
             has_server = true;
@@ -2668,6 +2816,7 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
         } else {
             sol_lwm2m_resource_clear(&res[0]);
             bootstrap_account_idx = i;
+            bs_sec_mode = sec_mode;
         }
     }
 
@@ -2684,12 +2833,14 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
             SECURITY_BOOTSTRAP_SERVER_ACCOUNT_TIMEOUT);
 
         //Create '/bs' CoAP resource to receive Bootstrap Finish notification
-        r = sol_coap_server_register_resource(client->dtls_server,
+        r = sol_coap_server_register_resource(
+            get_coap_server_by_security_mode(client, bs_sec_mode),
             &bootstrap_finish_interface, client);
         SOL_INT_CHECK_GOTO(r, < 0, err_clear_3);
 
         //Create unknown CoAP resource to handle Bootstrap Write and Bootstrap Delete
-        r = sol_coap_server_set_unknown_resource_handler(client->dtls_server,
+        r = sol_coap_server_set_unknown_resource_handler(
+            get_coap_server_by_security_mode(client, bs_sec_mode),
             &handle_unknown_bootstrap_resource, client);
         SOL_INT_CHECK_GOTO(r, < 0, err_unregister_bs);
 
@@ -2699,6 +2850,8 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
         //Expect server-initiated bootstrap with sol_timeout before client-initiated bootstrap
         client->bootstrap_ctx.server_uri = sol_blob_ref(res[0].data[0].content.blob);
         SOL_NULL_CHECK_GOTO(client->bootstrap_ctx.server_uri, err_unregister_unknown);
+
+        client->bootstrap_ctx.sec_mode = bs_sec_mode;
 
         client->bootstrap_ctx.timeout = sol_timeout_add(res[1].data[0].content.integer * ONE_SECOND,
             client_bootstrap, client);
@@ -2710,37 +2863,13 @@ sol_lwm2m_client_start(struct sol_lwm2m_client *client)
     }
 
     SOL_VECTOR_FOREACH_IDX (&client->objects, ctx, i) {
-        r = sol_coap_server_register_resource(client->coap_server,
-            ctx->obj_res, client);
-        SOL_INT_CHECK(r, < 0, r);
-
-        if (client->security) {
-            r = sol_coap_server_register_resource(client->dtls_server,
-                ctx->obj_res, client);
-            SOL_INT_CHECK(r, < 0, r);
-        }
+        SOL_COAP_SERVER_REGISTER_RESOURCE_ALL_INT(ctx->obj_res);
 
         SOL_VECTOR_FOREACH_IDX (&ctx->instances, instance, j) {
-            r = sol_coap_server_register_resource(client->coap_server,
-                instance->instance_res, client);
-            SOL_INT_CHECK(r, < 0, r);
-
-            if (client->security) {
-                r = sol_coap_server_register_resource(client->dtls_server,
-                    instance->instance_res, client);
-                SOL_INT_CHECK(r, < 0, r);
-            }
+            SOL_COAP_SERVER_REGISTER_RESOURCE_ALL_INT(instance->instance_res);
 
             SOL_VECTOR_FOREACH_IDX (&instance->resources_ctx, res_ctx, k) {
-                r = sol_coap_server_register_resource(client->coap_server,
-                    res_ctx->res, client);
-                SOL_INT_CHECK(r, < 0, r);
-
-                if (client->security) {
-                    r = sol_coap_server_register_resource(client->dtls_server,
-                        res_ctx->res, client);
-                    SOL_INT_CHECK(r, < 0, r);
-                }
+                SOL_COAP_SERVER_REGISTER_RESOURCE_ALL_INT(res_ctx->res);
             }
         }
     }
@@ -2758,10 +2887,12 @@ err_access_control:
         sol_vector_clear(&ctx->instances);
     }
 err_unregister_unknown:
-    if (sol_coap_server_set_unknown_resource_handler(client->dtls_server, NULL, client) < 0)
+    if (sol_coap_server_set_unknown_resource_handler(
+        get_coap_server_by_security_mode(client, bs_sec_mode), NULL, client) < 0)
         SOL_WRN("Could not unregister Bootstrap Unknown resource for client.");
 err_unregister_bs:
-    if (sol_coap_server_unregister_resource(client->dtls_server, &bootstrap_finish_interface) < 0)
+    if (sol_coap_server_unregister_resource(
+        get_coap_server_by_security_mode(client, bs_sec_mode), &bootstrap_finish_interface) < 0)
         SOL_WRN("Could not unregister Bootstrap Finish resource for client.");
 err_clear_3:
     sol_lwm2m_resource_clear(&res[2]);
@@ -2783,7 +2914,7 @@ send_client_delete_request(struct sol_lwm2m_client *client,
     //Did not receive reply yet.
     if (!conn_ctx->location) {
         r = sol_coap_cancel_send_packet(
-            conn_ctx->secure ? client->dtls_server : client->coap_server,
+            get_coap_server_by_security_mode(client, conn_ctx->sec_mode),
             conn_ctx->pending_pkt,
             sol_vector_get_no_check(&conn_ctx->server_addr_list,
             conn_ctx->addr_list_idx));
@@ -2804,7 +2935,7 @@ send_client_delete_request(struct sol_lwm2m_client *client,
     SOL_INT_CHECK_GOTO(r, < 0, err_exit);
 
     return sol_coap_send_packet(
-        conn_ctx->secure ? client->dtls_server : client->coap_server, pkt,
+        get_coap_server_by_security_mode(client, conn_ctx->sec_mode), pkt,
         sol_vector_get_no_check(&conn_ctx->server_addr_list,
         conn_ctx->addr_list_idx));
 
@@ -2834,7 +2965,7 @@ sol_lwm2m_client_stop(struct sol_lwm2m_client *client)
 
         if (conn_ctx->pending_pkt) {
             r = sol_coap_cancel_send_packet(
-                conn_ctx->secure ? client->dtls_server : client->coap_server,
+                get_coap_server_by_security_mode(client, conn_ctx->sec_mode),
                 conn_ctx->pending_pkt,
                 sol_vector_get_no_check(&conn_ctx->server_addr_list,
                 conn_ctx->addr_list_idx));
@@ -2846,37 +2977,13 @@ sol_lwm2m_client_stop(struct sol_lwm2m_client *client)
 
     if (client->running) {
         SOL_VECTOR_FOREACH_IDX (&client->objects, ctx, i) {
-            r = sol_coap_server_unregister_resource(client->coap_server,
-                ctx->obj_res);
-            SOL_INT_CHECK(r, < 0, r);
-
-            if (client->security) {
-                r = sol_coap_server_unregister_resource(client->dtls_server,
-                    ctx->obj_res);
-                SOL_INT_CHECK(r, < 0, r);
-            }
+            SOL_COAP_SERVER_UNREGISTER_RESOURCE_ALL_INT(ctx->obj_res);
 
             SOL_VECTOR_FOREACH_IDX (&ctx->instances, instance, j) {
-                r = sol_coap_server_unregister_resource(client->coap_server,
-                    instance->instance_res);
-                SOL_INT_CHECK(r, < 0, r);
-
-                if (client->security) {
-                    r = sol_coap_server_unregister_resource(client->dtls_server,
-                        instance->instance_res);
-                    SOL_INT_CHECK(r, < 0, r);
-                }
+                SOL_COAP_SERVER_UNREGISTER_RESOURCE_ALL_INT(instance->instance_res);
 
                 SOL_VECTOR_FOREACH_IDX (&instance->resources_ctx, res_ctx, k) {
-                    r = sol_coap_server_unregister_resource(client->coap_server,
-                        res_ctx->res);
-                    SOL_INT_CHECK(r, < 0, r);
-
-                    if (client->security) {
-                        r = sol_coap_server_unregister_resource(client->dtls_server,
-                            res_ctx->res);
-                        SOL_INT_CHECK(r, < 0, r);
-                    }
+                    SOL_COAP_SERVER_UNREGISTER_RESOURCE_ALL_INT(res_ctx->res);
                 }
             }
         }
@@ -2983,15 +3090,7 @@ sol_lwm2m_client_notify(struct sol_lwm2m_client *client, const char **paths)
         ctx.resource_id = -1;
 
         if (!notification_already_sent(&already_sent, obj_ctx)) {
-            r = sol_coap_notify_by_callback(client->coap_server, obj_ctx->obj_res,
-                notification_cb, &ctx);
-            SOL_INT_CHECK_GOTO(r, < 0, err_exit);
-
-            if (client->security) {
-                r = sol_coap_notify_by_callback(client->dtls_server, obj_ctx->obj_res,
-                    notification_cb, &ctx);
-                SOL_INT_CHECK_GOTO(r, < 0, err_exit);
-            }
+            SOL_COAP_NOTIFY_BY_CALLBACK_ALL_GOTO(obj_ctx->obj_res);
 
             r = sol_ptr_vector_append(&already_sent, obj_ctx);
             SOL_INT_CHECK_GOTO(r, < 0, err_exit);
@@ -2999,30 +3098,14 @@ sol_lwm2m_client_notify(struct sol_lwm2m_client *client, const char **paths)
 
         if (!notification_already_sent(&already_sent, obj_instance)) {
             ctx.obj_instance = obj_instance;
-            r = sol_coap_notify_by_callback(client->coap_server, obj_instance->instance_res,
-                notification_cb, &ctx);
-            SOL_INT_CHECK_GOTO(r, < 0, err_exit);
-
-            if (client->security) {
-                r = sol_coap_notify_by_callback(client->dtls_server, obj_instance->instance_res,
-                    notification_cb, &ctx);
-                SOL_INT_CHECK_GOTO(r, < 0, err_exit);
-            }
+            SOL_COAP_NOTIFY_BY_CALLBACK_ALL_GOTO(obj_instance->instance_res);
 
             r = sol_ptr_vector_append(&already_sent, obj_instance);
             SOL_INT_CHECK_GOTO(r, < 0, err_exit);
         }
 
         ctx.resource_id = path[2];
-        r = sol_coap_notify_by_callback(client->coap_server, res_ctx->res,
-            notification_cb, &ctx);
-        SOL_INT_CHECK_GOTO(r, < 0, err_exit);
-
-        if (client->security) {
-            r = sol_coap_notify_by_callback(client->dtls_server, res_ctx->res,
-                notification_cb, &ctx);
-            SOL_INT_CHECK_GOTO(r, < 0, err_exit);
-        }
+        SOL_COAP_NOTIFY_BY_CALLBACK_ALL_GOTO(res_ctx->res);
     }
 
     sol_ptr_vector_clear(&already_sent);

--- a/src/lib/comms/sol-lwm2m-common.c
+++ b/src/lib/comms/sol-lwm2m-common.c
@@ -44,6 +44,36 @@ SOL_LOG_INTERNAL_DECLARE_STATIC(_lwm2m_common_domain, "lwm2m-common");
 int sol_lwm2m_common_init(void);
 void sol_lwm2m_common_shutdown(void);
 
+bool
+sec_mode_is_repeated(enum sol_lwm2m_security_mode new_sec_mode,
+    enum sol_lwm2m_security_mode *sec_modes, uint16_t sec_modes_len)
+{
+    uint16_t i;
+
+    for (i = 0; i < sec_modes_len; i++)
+        if (sec_modes[i] == new_sec_mode)
+            return true;
+
+    return false;
+}
+
+const char *
+get_security_mode_str(enum sol_lwm2m_security_mode sec_mode)
+{
+    switch (sec_mode) {
+    case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
+        return "Pre-Shared Key";
+    case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
+        return "Raw Public Key";
+    case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
+        return "Certificate";
+    case SOL_LWM2M_SECURITY_MODE_NO_SEC:
+        return "NoSec";
+    default:
+        return "Unknown";
+    }
+}
+
 int
 read_resources(struct sol_lwm2m_client *client,
     struct obj_ctx *obj_ctx, struct obj_instance *instance,

--- a/src/lib/comms/sol-lwm2m-common.h
+++ b/src/lib/comms/sol-lwm2m-common.h
@@ -222,6 +222,8 @@ struct sol_lwm2m_bootstrap_server {
     struct sol_monitors bootstrap;
     struct sol_lwm2m_security *security;
     struct sol_vector known_psks;
+    struct sol_ptr_vector known_pub_keys;
+    struct sol_lwm2m_security_rpk rpk_pair;
     const char **known_clients;
 };
 
@@ -231,6 +233,13 @@ enum sol_lwm2m_path_props {
     PATH_HAS_INSTANCE = (1 << 2),
     PATH_HAS_RESOURCE = (1 << 3)
 };
+
+bool
+sec_mode_is_repeated(enum sol_lwm2m_security_mode new_sec_mode,
+    enum sol_lwm2m_security_mode *sec_modes, uint16_t sec_modes_len);
+
+const char *
+get_security_mode_str(enum sol_lwm2m_security_mode sec_mode);
 
 int
 read_resources(struct sol_lwm2m_client *client,

--- a/src/lib/comms/sol-lwm2m-common.h
+++ b/src/lib/comms/sol-lwm2m-common.h
@@ -161,7 +161,7 @@ struct server_conn_ctx {
     uint16_t addr_list_idx;
     time_t registration_time;
     char *location;
-    bool secure;
+    enum sol_lwm2m_security_mode sec_mode;
 };
 
 struct obj_instance {
@@ -189,8 +189,10 @@ struct sol_lwm2m_client {
     struct {
         struct sol_timeout *timeout;
         struct sol_blob *server_uri;
+        enum sol_lwm2m_security_mode sec_mode;
     } bootstrap_ctx;
-    struct sol_coap_server *dtls_server;
+    struct sol_coap_server *dtls_server_psk;
+    struct sol_coap_server *dtls_server_rpk;
     struct sol_lwm2m_security *security;
     const void *user_data;
     uint16_t splitted_path_len;

--- a/src/lib/comms/sol-lwm2m-common.h
+++ b/src/lib/comms/sol-lwm2m-common.h
@@ -214,6 +214,8 @@ struct sol_lwm2m_server {
     struct sol_coap_server *dtls_server;
     struct sol_lwm2m_security *security;
     struct sol_vector known_psks;
+    struct sol_ptr_vector known_pub_keys;
+    struct sol_lwm2m_security_rpk rpk_pair;
 };
 
 struct sol_lwm2m_bootstrap_server {

--- a/src/lib/comms/sol-lwm2m-security.c
+++ b/src/lib/comms/sol-lwm2m-security.c
@@ -33,6 +33,14 @@ SOL_LOG_INTERNAL_DECLARE(_lwm2m_security_domain, "lwm2m-security");
 
 #ifdef DTLS
 
+enum ecdsa_field_type {
+    PRIVATE_KEY,
+    PUBLIC_KEY_X,
+    PUBLIC_KEY_Y,
+    SERVER_PUBLIC_KEY_X,
+    SERVER_PUBLIC_KEY_Y
+};
+
 struct sol_socket *sol_coap_server_get_socket(const struct sol_coap_server *server);
 
 static ssize_t
@@ -255,6 +263,331 @@ err_clear:
     return r;
 }
 
+static int
+get_ecdsa_field_from_server_or_bs_server(const void *data,
+    struct sol_network_link_addr *addr,
+    unsigned char *field, enum ecdsa_field_type type)
+{
+    const struct sol_lwm2m_security *ctx = data;
+    struct sol_lwm2m_server *lwm2m_server;
+    struct sol_lwm2m_bootstrap_server *lwm2m_bs_server;
+    struct sol_lwm2m_security_rpk *server_rpk;
+    struct sol_blob *src_field;
+    size_t type_len;
+    int offset = 0;
+    const char *desc;
+
+    if (ctx->type == LWM2M_SERVER) {
+        SOL_DBG("ctx->type = LWM2M_SERVER");
+        lwm2m_server = ctx->entity;
+        server_rpk = &lwm2m_server->rpk_pair;
+    } else {
+        SOL_DBG("ctx->type = LWM2M_BOOTSTRAP_SERVER");
+        lwm2m_bs_server = ctx->entity;
+        server_rpk = &lwm2m_bs_server->rpk_pair;
+    }
+
+    switch (type) {
+    case PRIVATE_KEY:
+        desc = "Private Key";
+        type_len = SOL_DTLS_ECDSA_PRIV_KEY_LEN;
+        src_field = server_rpk->private_key;
+        break;
+    case PUBLIC_KEY_X:
+        desc = "Public Key (x coord.)";
+        type_len = SOL_DTLS_ECDSA_PUB_KEY_X_LEN;
+        src_field = server_rpk->public_key;
+        break;
+    case PUBLIC_KEY_Y:
+        desc = "Public Key (y coord.)";
+        type_len = SOL_DTLS_ECDSA_PUB_KEY_Y_LEN;
+        src_field = server_rpk->public_key;
+        offset = SOL_DTLS_ECDSA_PUB_KEY_X_LEN;
+        break;
+    default:
+        return -EINVAL;
+    }
+
+    if (src_field->size !=
+        (type == PRIVATE_KEY ? SOL_DTLS_ECDSA_PRIV_KEY_LEN :
+        SOL_DTLS_ECDSA_PUB_KEY_X_LEN + SOL_DTLS_ECDSA_PUB_KEY_Y_LEN)) {
+        SOL_WRN("The %s '%.*s' is %zu-bytes long; expecting a %d-bytes long %s",
+            desc, SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(src_field)),
+            src_field->size, type == PRIVATE_KEY ? SOL_DTLS_ECDSA_PRIV_KEY_LEN :
+            SOL_DTLS_ECDSA_PUB_KEY_X_LEN + SOL_DTLS_ECDSA_PUB_KEY_Y_LEN, desc);
+        return -EINVAL;
+    } else {
+        SOL_DBG("Found %s!", desc);
+        memcpy(field, (unsigned char *)src_field->mem + offset, type_len);
+        return 0;
+    }
+
+}
+
+static int
+get_ecdsa_priv_key_from_server_or_bs_server(const void *data,
+    struct sol_network_link_addr *addr,
+    unsigned char *ecdsa_priv_key)
+{
+    return get_ecdsa_field_from_server_or_bs_server(data, addr,
+        ecdsa_priv_key, PRIVATE_KEY);
+}
+
+static int
+get_ecdsa_pub_key_x_from_server_or_bs_server(const void *data,
+    struct sol_network_link_addr *addr,
+    unsigned char *ecdsa_pub_key_x)
+{
+    return get_ecdsa_field_from_server_or_bs_server(data, addr,
+        ecdsa_pub_key_x, PUBLIC_KEY_X);
+}
+
+static int
+get_ecdsa_pub_key_y_from_server_or_bs_server(const void *data,
+    struct sol_network_link_addr *addr,
+    unsigned char *ecdsa_pub_key_y)
+{
+    return get_ecdsa_field_from_server_or_bs_server(data, addr,
+        ecdsa_pub_key_y, PUBLIC_KEY_Y);
+}
+
+static int
+get_ecdsa_field_from_res_id(const void *data,
+    struct sol_network_link_addr *addr,
+    unsigned char *field, enum ecdsa_field_type type, int res_id)
+{
+    const struct sol_lwm2m_security *ctx = data;
+    struct sol_lwm2m_client *lwm2m_client = ctx->entity;
+    struct obj_ctx *obj_ctx;
+    struct obj_instance *instance;
+    struct sol_lwm2m_resource res[4] = { };
+    int64_t server_id, server_id_res;
+    uint16_t i;
+    int r, offset = 0; //offset is used for the y coordinate only
+    size_t type_len;
+    const char *desc;
+
+    SOL_BUFFER_DECLARE_STATIC(addr_str, SOL_NETWORK_INET_ADDR_STR_LEN);
+
+    switch (type) {
+    case PRIVATE_KEY:
+        desc = "Private Key";
+        type_len = SOL_DTLS_ECDSA_PRIV_KEY_LEN;
+        break;
+    case PUBLIC_KEY_X:
+        desc = "Public Key (x coord.)";
+        type_len = SOL_DTLS_ECDSA_PUB_KEY_X_LEN;
+        break;
+    case PUBLIC_KEY_Y:
+        desc = "Public Key (y coord.)";
+        type_len = SOL_DTLS_ECDSA_PUB_KEY_Y_LEN;
+        offset = SOL_DTLS_ECDSA_PUB_KEY_X_LEN;
+        break;
+    case SERVER_PUBLIC_KEY_X:
+        desc = "Server's Public Key (x coord.)";
+        type_len = SOL_DTLS_ECDSA_PUB_KEY_X_LEN;
+        break;
+    case SERVER_PUBLIC_KEY_Y:
+        desc = "Server's Public Key (y coord.)";
+        type_len = SOL_DTLS_ECDSA_PUB_KEY_Y_LEN;
+        offset = SOL_DTLS_ECDSA_PUB_KEY_X_LEN;
+        break;
+    default:
+        return -EINVAL;
+    }
+
+    r = get_server_id_by_link_addr(&lwm2m_client->connections, addr, &server_id);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (!sol_network_link_addr_to_str(addr, &addr_str))
+        SOL_WRN("Could not convert the server address to string");
+    else
+        SOL_DBG("Looking for %s for communication with server_id=%" PRId64
+            " and server_addr=%.*s", desc, server_id,
+            SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr_str)));
+
+    obj_ctx = find_object_ctx_by_id(lwm2m_client, SECURITY_OBJECT_ID);
+    if (!obj_ctx) {
+        SOL_WRN("LWM2M Security object not provided!");
+        return -ENOENT;
+    }
+
+    if (!obj_ctx->instances.len) {
+        SOL_WRN("There are no Security Server instances");
+        return -ENOENT;
+    }
+
+    SOL_VECTOR_FOREACH_IDX (&obj_ctx->instances, instance, i) {
+        r = read_resources(lwm2m_client, obj_ctx, instance, res, 4,
+            SECURITY_IS_BOOTSTRAP,
+            SECURITY_SECURITY_MODE,
+            res_id,
+            SECURITY_SERVER_ID);
+        SOL_INT_CHECK_GOTO(r, < 0, err_clear);
+
+        //If -ENOENT when reading res_id or
+        // SECURITY_SECURITY_MODE != SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY
+        if (res[2].data_len == 0 ||
+            res[1].data[0].content.integer != SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY) {
+            clear_resource_array(res, sol_util_array_size(res));
+            continue;
+        }
+
+        //If it's a Bootstrap Server, the comparison should be done with UINT16_MAX,
+        // not the value from SECURITY_SERVER_ID (which is 0/NULL for a Bootstrap Server)
+        if (res[0].data[0].content.b == true)
+            server_id_res = UINT16_MAX;
+        else
+            server_id_res = res[3].data[0].content.integer;
+
+        SOL_DBG("Looking for %s. server_id=%" PRId64 " server_id_res=%" PRId64 "."
+            " Instance /0/%" PRIu16 " i=%" PRIu16 ".",
+            desc, server_id, server_id_res,
+            instance->id, i);
+        if (server_id == server_id_res) {
+            if (res[2].data[0].content.blob->size !=
+                (type == PRIVATE_KEY ? SOL_DTLS_ECDSA_PRIV_KEY_LEN :
+                SOL_DTLS_ECDSA_PUB_KEY_X_LEN + SOL_DTLS_ECDSA_PUB_KEY_Y_LEN)) {
+                SOL_WRN("The %s '%.*s' is %zu-bytes long; expecting a %d-bytes long %s",
+                    desc, SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(res[2].data[0].content.blob)),
+                    res[2].data[0].content.blob->size, type == PRIVATE_KEY ? SOL_DTLS_ECDSA_PRIV_KEY_LEN :
+                    SOL_DTLS_ECDSA_PUB_KEY_X_LEN + SOL_DTLS_ECDSA_PUB_KEY_Y_LEN, desc);
+                r = -EINVAL;
+                goto err_clear;
+            }
+
+            memcpy(field, (unsigned char *)res[2].data[0].content.blob->mem + offset, type_len);
+            clear_resource_array(res, sol_util_array_size(res));
+            return 0;
+        }
+
+        clear_resource_array(res, sol_util_array_size(res));
+    }
+
+    SOL_WRN("Could not find %s for communication with server_id=%" PRId64
+        " and server_addr=%.*s", desc, server_id,
+        SOL_STR_SLICE_PRINT(sol_buffer_get_slice(&addr_str)));
+
+    return -ENOENT;
+
+err_clear:
+    clear_resource_array(res, sol_util_array_size(res));
+    return r;
+}
+
+static int
+get_ecdsa_priv_key_from_client(const void *data,
+    struct sol_network_link_addr *addr,
+    unsigned char *ecdsa_priv_key)
+{
+    return get_ecdsa_field_from_res_id(data, addr, ecdsa_priv_key,
+        PRIVATE_KEY, SECURITY_SECRET_KEY);
+}
+
+static int
+get_ecdsa_pub_key_x_from_client(const void *data,
+    struct sol_network_link_addr *addr,
+    unsigned char *ecdsa_pub_key_x)
+{
+    return get_ecdsa_field_from_res_id(data, addr, ecdsa_pub_key_x,
+        PUBLIC_KEY_X, SECURITY_PUBLIC_KEY_OR_IDENTITY);
+}
+
+static int
+get_ecdsa_pub_key_y_from_client(const void *data,
+    struct sol_network_link_addr *addr,
+    unsigned char *ecdsa_pub_key_y)
+{
+    return get_ecdsa_field_from_res_id(data, addr, ecdsa_pub_key_y,
+        PUBLIC_KEY_Y, SECURITY_PUBLIC_KEY_OR_IDENTITY);
+}
+
+static int
+verify_ecdsa_key_from_server_or_bs_server(const void *data,
+    struct sol_network_link_addr *addr, const unsigned char *other_pub_x,
+    const unsigned char *other_pub_y, size_t key_size)
+{
+    unsigned char buf_aux[SOL_DTLS_ECDSA_PUB_KEY_X_LEN];
+    int r;
+
+    r = get_ecdsa_field_from_res_id(data, addr, buf_aux,
+        SERVER_PUBLIC_KEY_X, SECURITY_SERVER_PUBLIC_KEY);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (!memcmp(other_pub_x, buf_aux, SOL_DTLS_ECDSA_PUB_KEY_X_LEN))
+        SOL_DBG("Server's Public Key (x coord.) matches");
+    else {
+        SOL_WRN("Server's Public Key (x coord.) does not match");
+        return -EINVAL;
+    }
+
+    r = get_ecdsa_field_from_res_id(data, addr, buf_aux,
+        SERVER_PUBLIC_KEY_Y, SECURITY_SERVER_PUBLIC_KEY);
+    SOL_INT_CHECK(r, < 0, r);
+
+    if (!memcmp(other_pub_y, buf_aux, SOL_DTLS_ECDSA_PUB_KEY_Y_LEN))
+        SOL_DBG("Server's Public Key (y coord.) matches");
+    else {
+        SOL_WRN("Server's Public Key (y coord.) does not match");
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+static int
+verify_ecdsa_key_from_client(const void *data,
+    struct sol_network_link_addr *addr, const unsigned char *other_pub_x,
+    const unsigned char *other_pub_y, size_t key_size)
+{
+    const struct sol_lwm2m_security *ctx = data;
+    struct sol_lwm2m_server *lwm2m_server;
+    struct sol_lwm2m_bootstrap_server *lwm2m_bs_server;
+    struct sol_ptr_vector *known_pub_keys;
+    struct sol_blob *cli_pub_key;
+    uint16_t i;
+
+    if (ctx->type == LWM2M_SERVER) {
+        SOL_DBG("ctx->type = LWM2M_SERVER");
+        lwm2m_server = ctx->entity;
+        known_pub_keys = &lwm2m_server->known_pub_keys;
+    } else {
+        SOL_DBG("ctx->type = LWM2M_BOOTSTRAP_SERVER");
+        lwm2m_bs_server = ctx->entity;
+        known_pub_keys = &lwm2m_bs_server->known_pub_keys;
+    }
+
+    SOL_PTR_VECTOR_FOREACH_IDX (known_pub_keys, cli_pub_key, i) {
+        if (cli_pub_key->size !=
+            (SOL_DTLS_ECDSA_PUB_KEY_X_LEN + SOL_DTLS_ECDSA_PUB_KEY_Y_LEN)) {
+            SOL_WRN("The stored Client's Public Key '%.*s' is %zu-bytes long;"
+                " expecting a %d-bytes long Public Key",
+                SOL_STR_SLICE_PRINT(sol_str_slice_from_blob(cli_pub_key)),
+                cli_pub_key->size,
+                SOL_DTLS_ECDSA_PUB_KEY_X_LEN + SOL_DTLS_ECDSA_PUB_KEY_Y_LEN);
+            return -EINVAL;
+        }
+
+        if (!memcmp(other_pub_x, cli_pub_key->mem, SOL_DTLS_ECDSA_PUB_KEY_X_LEN)) {
+            SOL_DBG("Stored Client's Public Key (x coord.) matches");
+            if (!memcmp(other_pub_y,
+                (unsigned char *)cli_pub_key->mem + SOL_DTLS_ECDSA_PUB_KEY_X_LEN,
+                SOL_DTLS_ECDSA_PUB_KEY_Y_LEN)) {
+                SOL_DBG("Stored Client's Public Key (y coord.) matches");
+                return 0;
+            } else { /* If X matches, Y MUST match as well, since it can even be computed from X */
+                SOL_WRN("Stored Client's Public Key (y coord.) does not match");
+                return -EINVAL;
+            }
+        }
+    }
+
+    SOL_WRN("Could not find a stored Client's Public Key matching the"
+        " Public Key presented by the Client");
+
+    return -ENOENT;
+}
+
 static void
 sol_lwm2m_security_del_full(struct sol_lwm2m_security *security,
     enum lwm2m_entity_type type)
@@ -270,13 +603,24 @@ sol_lwm2m_security_add_full(void *entity, enum lwm2m_entity_type type,
     enum sol_lwm2m_security_mode sec_mode)
 {
     struct sol_lwm2m_security *security;
-    struct sol_socket *socket_dtls = NULL;
+    struct sol_socket *socket_dtls;
     int r = 0;
 
     ssize_t (*get_psk_cb)(const void *creds, struct sol_str_slice id,
         char *psk, size_t psk_len) = NULL;
     ssize_t (*get_id_cb)(const void *creds, struct sol_network_link_addr *addr,
         char *id, size_t id_len) = NULL;
+
+    int (*get_ecdsa_priv_key_cb)(const void *creds, struct sol_network_link_addr *addr,
+        unsigned char *ecdsa_priv_key) = NULL;
+    int (*get_ecdsa_pub_key_x_cb)(const void *creds, struct sol_network_link_addr *addr,
+        unsigned char *ecdsa_pub_key_x) = NULL;
+    int (*get_ecdsa_pub_key_y_cb)(const void *creds, struct sol_network_link_addr *addr,
+        unsigned char *ecdsa_pub_key_y) = NULL;
+    int (*verify_ecdsa_key_cb)(const void *data, struct sol_network_link_addr *addr,
+        const unsigned char *other_pub_x, const unsigned char *other_pub_y,
+        size_t key_size) = NULL;
+
     bool has_security = false;
 
     SOL_LOG_INTERNAL_INIT_ONCE;
@@ -285,8 +629,34 @@ sol_lwm2m_security_add_full(void *entity, enum lwm2m_entity_type type,
     case LWM2M_CLIENT:
         get_psk_cb = get_psk_from_client;
         get_id_cb = get_id_from_client;
-        socket_dtls = sol_coap_server_get_socket(
-            ((struct sol_lwm2m_client *)entity)->dtls_server);
+        get_ecdsa_priv_key_cb = get_ecdsa_priv_key_from_client;
+        get_ecdsa_pub_key_x_cb = get_ecdsa_pub_key_x_from_client;
+        get_ecdsa_pub_key_y_cb = get_ecdsa_pub_key_y_from_client;
+        verify_ecdsa_key_cb = verify_ecdsa_key_from_server_or_bs_server;
+
+        switch (sec_mode) {
+        case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
+            socket_dtls = sol_coap_server_get_socket(
+                ((struct sol_lwm2m_client *)entity)->dtls_server_psk);
+            break;
+        case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
+            socket_dtls = sol_coap_server_get_socket(
+                ((struct sol_lwm2m_client *)entity)->dtls_server_rpk);
+            break;
+        case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
+            SOL_WRN("Certificate security mode is not supported yet.");
+            errno = ENOTSUP;
+            return NULL;
+        case SOL_LWM2M_SECURITY_MODE_NO_SEC:
+            SOL_WRN("NoSec Security Mode does not use DTLS.");
+            errno = EINVAL;
+            return NULL;
+        default:
+            SOL_WRN("Unknown DTLS [Security Mode] Resource from Security Object: %d", sec_mode);
+            errno = EINVAL;
+            return NULL;
+        }
+
         if (((struct sol_lwm2m_client *)entity)->security) {
             security = ((struct sol_lwm2m_client *)entity)->security;
             has_security = true;
@@ -295,8 +665,14 @@ sol_lwm2m_security_add_full(void *entity, enum lwm2m_entity_type type,
     case LWM2M_SERVER:
         get_psk_cb = get_psk_from_server_or_bs_server;
         get_id_cb = get_id_from_server_or_bs_server;
+        get_ecdsa_priv_key_cb = get_ecdsa_priv_key_from_server_or_bs_server;
+        get_ecdsa_pub_key_x_cb = get_ecdsa_pub_key_x_from_server_or_bs_server;
+        get_ecdsa_pub_key_y_cb = get_ecdsa_pub_key_y_from_server_or_bs_server;
+        verify_ecdsa_key_cb = verify_ecdsa_key_from_client;
+
         socket_dtls = sol_coap_server_get_socket(
             ((struct sol_lwm2m_server *)entity)->dtls_server);
+
         if (((struct sol_lwm2m_server *)entity)->security) {
             security = ((struct sol_lwm2m_server *)entity)->security;
             has_security = true;
@@ -305,8 +681,14 @@ sol_lwm2m_security_add_full(void *entity, enum lwm2m_entity_type type,
     case LWM2M_BOOTSTRAP_SERVER:
         get_psk_cb = get_psk_from_server_or_bs_server;
         get_id_cb = get_id_from_server_or_bs_server;
+        get_ecdsa_priv_key_cb = get_ecdsa_priv_key_from_server_or_bs_server;
+        get_ecdsa_pub_key_x_cb = get_ecdsa_pub_key_x_from_server_or_bs_server;
+        get_ecdsa_pub_key_y_cb = get_ecdsa_pub_key_y_from_server_or_bs_server;
+        verify_ecdsa_key_cb = verify_ecdsa_key_from_client;
+
         socket_dtls = sol_coap_server_get_socket(
             ((struct sol_lwm2m_bootstrap_server *)entity)->coap);
+
         if (((struct sol_lwm2m_bootstrap_server *)entity)->security) {
             security = ((struct sol_lwm2m_bootstrap_server *)entity)->security;
             has_security = true;
@@ -327,15 +709,8 @@ sol_lwm2m_security_add_full(void *entity, enum lwm2m_entity_type type,
         SOL_NULL_CHECK_ERRNO(security, ENOMEM, NULL);
 
         security->callbacks = (struct sol_socket_dtls_credential_cb) {
-            .data = security,
-            .get_id = get_id_cb
+            .data = security
         };
-        r = sol_socket_dtls_set_credentials_callbacks(socket_dtls,
-            &security->callbacks);
-        if (r < 0) {
-            SOL_WRN("Passed DTLS socket is not a valid sol_socket_dtls");
-            goto err_sec;
-        }
 
         security->type = type;
         security->entity = entity;
@@ -343,12 +718,35 @@ sol_lwm2m_security_add_full(void *entity, enum lwm2m_entity_type type,
 
     switch (sec_mode) {
     case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
+        security->callbacks.get_id = get_id_cb;
         security->callbacks.get_psk = get_psk_cb;
+
+        SOL_DBG("Setting PSK credential_cb %p to sol_socket_dtls %p",
+            &security->callbacks, socket_dtls);
+
+        r = sol_socket_dtls_set_credentials_callbacks(socket_dtls,
+            &security->callbacks);
+        if (r < 0) {
+            SOL_DBG("Passed DTLS socket is not a valid sol_socket_dtls");
+            goto err_sec;
+        }
         break;
     case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
-        SOL_WRN("Raw Public Key security mode is not supported yet.");
-        r = -ENOTSUP;
-        goto err_sec;
+        security->callbacks.get_ecdsa_priv_key = get_ecdsa_priv_key_cb;
+        security->callbacks.get_ecdsa_pub_key_x = get_ecdsa_pub_key_x_cb;
+        security->callbacks.get_ecdsa_pub_key_y = get_ecdsa_pub_key_y_cb;
+        security->callbacks.verify_ecdsa_key = verify_ecdsa_key_cb;
+
+        SOL_DBG("Setting RPK credential_cb %p to sol_socket_dtls %p",
+            &security->callbacks, socket_dtls);
+
+        r = sol_socket_dtls_set_credentials_callbacks(socket_dtls,
+            &security->callbacks);
+        if (r < 0) {
+            SOL_WRN("Passed DTLS socket is not a valid sol_socket_dtls");
+            goto err_sec;
+        }
+        break;
     case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
         SOL_WRN("Certificate security mode is not supported yet.");
         r = -ENOTSUP;
@@ -366,12 +764,39 @@ sol_lwm2m_security_add_full(void *entity, enum lwm2m_entity_type type,
     return security;
 
 err_sec:
-    free(security);
+    sol_lwm2m_security_del_full(security, type);
 err_socket_dtls:
     errno = -r;
     return NULL;
 }
 #endif
+
+bool
+sol_lwm2m_security_supports_security_mode(struct sol_lwm2m_security *security,
+    enum sol_lwm2m_security_mode sec_mode)
+{
+    SOL_NULL_CHECK(security, false);
+
+    switch (sec_mode) {
+    case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
+        return security->callbacks.get_id &&
+               security->callbacks.get_psk;
+    case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
+        return security->callbacks.get_ecdsa_priv_key &&
+               security->callbacks.get_ecdsa_pub_key_x &&
+               security->callbacks.get_ecdsa_pub_key_y &&
+               security->callbacks.verify_ecdsa_key;
+    case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
+        SOL_WRN("Certificate security mode is not supported yet.");
+        return false;
+    case SOL_LWM2M_SECURITY_MODE_NO_SEC:
+        SOL_WRN("NoSec Security Mode does not use DTLS.");
+        return false;
+    default:
+        SOL_WRN("Unknown DTLS [Security Mode] Resource from Security Object: %d", sec_mode);
+        return false;
+    }
+}
 
 struct sol_lwm2m_security *
 sol_lwm2m_client_security_add(struct sol_lwm2m_client *lwm2m_client,

--- a/src/lib/comms/sol-lwm2m-security.h
+++ b/src/lib/comms/sol-lwm2m-security.h
@@ -44,6 +44,10 @@ struct sol_lwm2m_security {
     void *entity;
 };
 
+bool
+sol_lwm2m_security_supports_security_mode(struct sol_lwm2m_security *security,
+    enum sol_lwm2m_security_mode sec_mode);
+
 struct sol_lwm2m_security *sol_lwm2m_client_security_add(
     struct sol_lwm2m_client *lwm2m_client, enum sol_lwm2m_security_mode sec_mode);
 

--- a/src/lib/comms/sol-lwm2m-server.c
+++ b/src/lib/comms/sol-lwm2m-server.c
@@ -27,6 +27,7 @@
 #include "sol-log-internal.h"
 #include "sol-util-internal.h"
 #include "sol-list.h"
+#include "sol-socket.h"
 #include "sol-lwm2m.h"
 #include "sol-lwm2m-common.h"
 #include "sol-lwm2m-server.h"
@@ -812,67 +813,118 @@ observer_entry_del_monitor(struct observer_entry *entry,
 }
 
 SOL_API struct sol_lwm2m_server *
-sol_lwm2m_server_new(uint16_t coap_port, uint16_t dtls_port,
-    enum sol_lwm2m_security_mode sec_mode, struct sol_vector *known_psks)
+sol_lwm2m_server_new(uint16_t coap_port, uint16_t num_sec_modes, ...)
 {
     struct sol_lwm2m_server *server;
     struct sol_network_link_addr servaddr_coap = { .family = SOL_NETWORK_FAMILY_INET6,
                                                    .port = coap_port };
     struct sol_network_link_addr servaddr_dtls = { .family = SOL_NETWORK_FAMILY_INET6,
-                                                   .port = dtls_port };
-    int r;
-    const char *sec_mode_str;
-    struct sol_lwm2m_security_psk *psk, *given_psk;
-    uint16_t i;
+                                                   .port = SOL_LWM2M_DEFAULT_SERVER_PORT_DTLS };
+    int r, dtls_port;
+    struct sol_lwm2m_security_psk **known_psks = NULL, *cli_psk;
+    struct sol_lwm2m_security_rpk *my_rpk = NULL;
+    struct sol_blob **known_pub_keys = NULL, *cli_pub_key;
+    enum sol_lwm2m_security_mode *sec_modes = NULL;
+    enum sol_socket_dtls_cipher *cipher_suites = NULL;
+    uint16_t i, j;
+    va_list ap;
 
     SOL_LOG_INTERNAL_INIT_ONCE;
 
-    switch (sec_mode) {
-    case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
-        SOL_NULL_CHECK(known_psks, NULL);
-        sec_mode_str = "Pre-Shared Key";
-        break;
-    case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
-        sec_mode_str = "Raw Public Key";
-        SOL_WRN("Raw Public Key security mode is not supported yet.");
-        return NULL;
-    case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
-        sec_mode_str = "Certificate";
-        SOL_WRN("Certificate security mode is not supported yet.");
-        return NULL;
-    case SOL_LWM2M_SECURITY_MODE_NO_SEC:
-        sec_mode_str = "NoSec";
-        SOL_DBG("Using NoSec Security Mode (No DTLS).");
-        break;
-    default:
-        SOL_WRN("Unknown DTLS Security Mode: %d", sec_mode);
-        return NULL;
+    va_start(ap, num_sec_modes);
+
+    if (num_sec_modes > 0) {
+        cipher_suites = calloc(num_sec_modes, sizeof(enum sol_socket_dtls_cipher));
+        SOL_NULL_CHECK_GOTO(cipher_suites, err_va_list);
+
+        sec_modes = calloc(num_sec_modes, sizeof(enum sol_lwm2m_security_mode));
+        SOL_NULL_CHECK_GOTO(sec_modes, err_cipher_suites);
+
+        dtls_port = va_arg(ap, int);
+        SOL_INT_CHECK_GOTO(dtls_port, < 0, err_sec_modes);
+        servaddr_dtls.port = dtls_port;
+
+        for (i = 0; i < num_sec_modes; i++) {
+            sec_modes[i] = va_arg(ap, enum sol_lwm2m_security_mode);
+            SOL_EXP_CHECK_GOTO(sec_mode_is_repeated(sec_modes[i], sec_modes, i), err_sec_modes);
+
+            switch (sec_modes[i]) {
+            case SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY:
+                known_psks = va_arg(ap, struct sol_lwm2m_security_psk **);
+                SOL_NULL_CHECK_GOTO(known_psks, err_sec_modes);
+
+                cipher_suites[i] = SOL_SOCKET_DTLS_CIPHER_PSK_AES128_CCM8;
+                break;
+            case SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY:
+                my_rpk = va_arg(ap, struct sol_lwm2m_security_rpk *);
+                SOL_NULL_CHECK_GOTO(my_rpk, err_sec_modes);
+                known_pub_keys = va_arg(ap, struct sol_blob **);
+                SOL_NULL_CHECK_GOTO(known_pub_keys, err_sec_modes);
+
+                cipher_suites[i] = SOL_SOCKET_DTLS_CIPHER_ECDHE_ECDSA_AES128_CCM8;
+                break;
+            case SOL_LWM2M_SECURITY_MODE_CERTIFICATE:
+                SOL_WRN("Certificate security mode is not supported yet.");
+                goto err_sec_modes;
+            case SOL_LWM2M_SECURITY_MODE_NO_SEC:
+                SOL_WRN("NoSec Security Mode (No DTLS) was found."
+                    "If DTLS should not be used, num_sec_modes should be 0");
+                goto err_sec_modes;
+            default:
+                SOL_WRN("Unknown DTLS Security Mode: %d", sec_modes[i]);
+                goto err_sec_modes;
+            }
+        }
     }
 
     server = calloc(1, sizeof(struct sol_lwm2m_server));
-    SOL_NULL_CHECK(server, NULL);
+    SOL_NULL_CHECK_GOTO(server, err_sec_modes);
 
     server->coap = sol_coap_server_new(&servaddr_coap, false);
     SOL_NULL_CHECK_GOTO(server->coap, err_coap);
 
-    if (sec_mode != SOL_LWM2M_SECURITY_MODE_NO_SEC) {
-        if (sec_mode == SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY) {
-            sol_vector_init(&server->known_psks, sizeof(sol_lwm2m_security_psk));
+    if (num_sec_modes > 0) {
+        for (i = 0; i < num_sec_modes; i++) {
+            if (sec_modes[i] == SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY) {
+                sol_vector_init(&server->known_psks, sizeof(sol_lwm2m_security_psk));
 
-            SOL_VECTOR_FOREACH_IDX (known_psks, given_psk, i) {
-                psk = sol_vector_append(&server->known_psks);
-                SOL_NULL_CHECK_GOTO(psk, err_psk);
-                psk->id = sol_blob_ref(given_psk->id);
-                psk->key = sol_blob_ref(given_psk->key);
+                for (j = 0; known_psks[j]; j++) {
+                    cli_psk = sol_vector_append(&server->known_psks);
+                    SOL_NULL_CHECK_GOTO(cli_psk, err_copy_keys);
+                    cli_psk->id = sol_blob_ref(known_psks[j]->id);
+                    cli_psk->key = sol_blob_ref(known_psks[j]->key);
+                }
+            } else if (sec_modes[i] == SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY) {
+                sol_ptr_vector_init(&server->known_pub_keys);
+
+                for (j = 0; known_pub_keys[j]; j++) {
+                    r = sol_ptr_vector_append(&server->known_pub_keys,
+                        sol_blob_ref(known_pub_keys[j]));
+                    SOL_INT_CHECK_GOTO(r, < 0, err_copy_keys);
+                }
+
+                server->rpk_pair.private_key = sol_blob_ref(my_rpk->private_key);
+                server->rpk_pair.public_key = sol_blob_ref(my_rpk->public_key);
             }
         }
 
-        server->dtls_server = sol_coap_server_new(&servaddr_dtls, true);
-        SOL_NULL_CHECK_GOTO(server->dtls_server, err_dtls);
+        server->dtls_server = sol_coap_server_new_by_cipher_suites(&servaddr_dtls,
+            cipher_suites, num_sec_modes);
+        SOL_NULL_CHECK_GOTO(server->dtls_server, err_copy_keys);
 
-        server->security = sol_lwm2m_server_security_add(server, sec_mode);
-        SOL_NULL_CHECK_GOTO(server->security, err_security);
-        SOL_DBG("Using %s security mode", sec_mode_str);
+        for (i = 0; i < num_sec_modes; i++) {
+            server->security = sol_lwm2m_server_security_add(server, sec_modes[i]);
+            if (!server->security) {
+                SOL_ERR("Could not enable %s security mode for LWM2M Server",
+                    get_security_mode_str(sec_modes[i]));
+                goto err_security;
+            } else {
+                SOL_DBG("Using %s security mode", get_security_mode_str(sec_modes[i]));
+            }
+        }
+
+        free(sec_modes);
+        free(cipher_suites);
     }
 
     sol_ptr_vector_init(&server->clients);
@@ -882,7 +934,7 @@ sol_lwm2m_server_new(uint16_t coap_port, uint16_t dtls_port,
 
     r = sol_coap_server_register_resource(server->coap,
         &registration_interface, server);
-    SOL_INT_CHECK_GOTO(r, < 0, err_register_coap);
+    SOL_INT_CHECK_GOTO(r, < 0, err_security);
 
     if (server->security) {
         r = sol_coap_server_register_resource(server->dtls_server,
@@ -890,29 +942,44 @@ sol_lwm2m_server_new(uint16_t coap_port, uint16_t dtls_port,
         SOL_INT_CHECK_GOTO(r, < 0, err_register_dtls);
     }
 
+    va_end(ap);
+
     return server;
 
 err_register_dtls:
     if (sol_coap_server_unregister_resource(server->coap, &registration_interface) < 0)
         SOL_WRN("Could not unregister resource for"
             " Registration Interface at insecure CoAP Server");
-err_register_coap:
-    if (sec_mode != SOL_LWM2M_SECURITY_MODE_NO_SEC)
-        sol_lwm2m_server_security_del(server->security);
 err_security:
     sol_coap_server_unref(server->dtls_server);
-err_dtls:
+    sol_lwm2m_server_security_del(server->security);
+err_copy_keys:
     sol_coap_server_unref(server->coap);
-err_psk:
-    if (sec_mode == SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY) {
-        SOL_VECTOR_FOREACH_IDX (&server->known_psks, psk, i) {
-            sol_blob_unref(psk->id);
-            sol_blob_unref(psk->key);
+
+    for (i = 0; i < num_sec_modes; i++) {
+        if (sec_modes[i] == SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY) {
+            SOL_VECTOR_FOREACH_IDX (&server->known_psks, cli_psk, j) {
+                sol_blob_unref(cli_psk->id);
+                sol_blob_unref(cli_psk->key);
+            }
+            sol_vector_clear(&server->known_psks);
+        } else if (sec_modes[i] == SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY) {
+            SOL_PTR_VECTOR_FOREACH_IDX (&server->known_pub_keys, cli_pub_key, j)
+                sol_blob_unref(cli_pub_key);
+            sol_ptr_vector_clear(&server->known_pub_keys);
+
+            sol_blob_unref(server->rpk_pair.private_key);
+            sol_blob_unref(server->rpk_pair.public_key);
         }
-        sol_vector_clear(&server->known_psks);
     }
 err_coap:
     free(server);
+err_sec_modes:
+    free(sec_modes);
+err_cipher_suites:
+    free(cipher_suites);
+err_va_list:
+    va_end(ap);
     return NULL;
 }
 
@@ -922,6 +989,8 @@ sol_lwm2m_server_del(struct sol_lwm2m_server *server)
     uint16_t i;
     struct sol_lwm2m_client_info *cinfo;
     struct observer_entry *entry;
+    struct sol_lwm2m_security_psk *cli_psk;
+    struct sol_blob *cli_pub_key;
 
     SOL_NULL_CHECK(server);
 
@@ -932,16 +1001,26 @@ sol_lwm2m_server_del(struct sol_lwm2m_server *server)
 
     if (server->security) {
         sol_coap_server_unref(server->dtls_server);
-        sol_lwm2m_server_security_del(server->security);
-        if (&server->known_psks) {
-            struct sol_lwm2m_security_psk *psk;
 
-            SOL_VECTOR_FOREACH_IDX (&server->known_psks, psk, i) {
-                sol_blob_unref(psk->id);
-                sol_blob_unref(psk->key);
+        if (sol_lwm2m_security_supports_security_mode(server->security,
+            SOL_LWM2M_SECURITY_MODE_PRE_SHARED_KEY)) {
+            SOL_VECTOR_FOREACH_IDX (&server->known_psks, cli_psk, i) {
+                sol_blob_unref(cli_psk->id);
+                sol_blob_unref(cli_psk->key);
             }
             sol_vector_clear(&server->known_psks);
         }
+        if (sol_lwm2m_security_supports_security_mode(server->security,
+            SOL_LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY)) {
+            SOL_PTR_VECTOR_FOREACH_IDX (&server->known_pub_keys, cli_pub_key, i)
+                sol_blob_unref(cli_pub_key);
+            sol_ptr_vector_clear(&server->known_pub_keys);
+
+            sol_blob_unref(server->rpk_pair.private_key);
+            sol_blob_unref(server->rpk_pair.public_key);
+        }
+
+        sol_lwm2m_server_security_del(server->security);
     }
 
     SOL_PTR_VECTOR_FOREACH_IDX (&server->clients, cinfo, i)

--- a/src/lib/comms/sol-socket-dtls-impl-tinydtls.c
+++ b/src/lib/comms/sol-socket-dtls-impl-tinydtls.c
@@ -47,6 +47,8 @@ struct sol_socket_dtls {
     struct sol_socket *wrapped;
     struct sol_timeout *retransmit_timeout;
     dtls_context_t *context;
+    dtls_handler_t handler;
+    dtls_ecdsa_key_t ecdsa_key;
     struct {
         bool (*cb)(void *data, struct sol_socket *s);
         struct sol_vector queue;
@@ -171,6 +173,10 @@ sol_socket_dtls_del(struct sol_socket *socket)
     dtls_free_context(s->context);
 
     sol_socket_del(s->wrapped);
+
+    free(s->ecdsa_key.priv_key);
+    free(s->ecdsa_key.pub_key_x);
+    free(s->ecdsa_key.pub_key_y);
 
     sol_util_clear_memory_secure(s, sizeof(*s));
     free(s);
@@ -655,6 +661,110 @@ get_psk_info(struct dtls_context_t *ctx, const session_t *session,
     return r;
 }
 
+static int
+get_ecdsa_key(struct dtls_context_t *ctx, const session_t *session,
+    const dtls_ecdsa_key_t **result)
+{
+    struct sol_socket_dtls *socket = dtls_get_app_data(ctx);
+    struct sol_network_link_addr addr;
+    int r;
+
+    SOL_DBG("Peer asked for ECDSA Key");
+
+    SOL_NULL_CHECK(socket->credentials,
+        dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR));
+    SOL_NULL_CHECK(socket->credentials->get_ecdsa_priv_key,
+        dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR));
+    SOL_NULL_CHECK(socket->credentials->get_ecdsa_pub_key_x,
+        dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR));
+    SOL_NULL_CHECK(socket->credentials->get_ecdsa_pub_key_y,
+        dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR));
+
+    if (socket->credentials->init &&
+        socket->credentials->init(socket->credentials->data) < 0) {
+        SOL_WRN("Could not initialize credential storage");
+        return dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR);
+    }
+
+    if (from_sockaddr(&session->addr.sa, session->size, &addr) < 0) {
+        SOL_DBG("Could not get link address from session");
+        return -EINVAL;
+    }
+
+    socket->ecdsa_key.priv_key = calloc(SOL_DTLS_ECDSA_PRIV_KEY_LEN, sizeof(unsigned char));
+    SOL_NULL_CHECK(socket->ecdsa_key.priv_key, -ENOMEM);
+
+    socket->ecdsa_key.pub_key_x = calloc(SOL_DTLS_ECDSA_PUB_KEY_X_LEN, sizeof(unsigned char));
+    r = -ENOMEM;
+    SOL_NULL_CHECK_GOTO(socket->ecdsa_key.pub_key_x, err_pub_key_x);
+
+    socket->ecdsa_key.pub_key_y = calloc(SOL_DTLS_ECDSA_PUB_KEY_Y_LEN, sizeof(unsigned char));
+    r = -ENOMEM;
+    SOL_NULL_CHECK_GOTO(socket->ecdsa_key.pub_key_y, err_pub_key_y);
+
+    r = socket->credentials->get_ecdsa_priv_key(socket->credentials->data,
+        &addr, socket->ecdsa_key.priv_key);
+    SOL_INT_CHECK_GOTO(r, < 0, err_getters);
+
+    r = socket->credentials->get_ecdsa_pub_key_x(socket->credentials->data,
+        &addr, socket->ecdsa_key.pub_key_x);
+    SOL_INT_CHECK_GOTO(r, < 0, err_getters);
+
+    r = socket->credentials->get_ecdsa_pub_key_y(socket->credentials->data,
+        &addr, socket->ecdsa_key.pub_key_y);
+    SOL_INT_CHECK_GOTO(r, < 0, err_getters);
+
+    /* From CoAP [RFC7252], Section 9.1.3.2. Raw Public Key Certificates:
+       Implementations in RawPublicKey mode MUST support the mandatory-to-implement
+       cipher suite TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8 as specified in [RFC7251],
+       [RFC5246], and [RFC4492].  The key used MUST be ECDSA capable.
+       The curve secp256r1 MUST be supported [RFC4492]; this curve is equivalent to
+       the NIST P-256 curve.  The hash algorithm is SHA-256. */
+    socket->ecdsa_key.curve = DTLS_ECDH_CURVE_SECP256R1;
+
+    *result = &socket->ecdsa_key;
+
+    if (socket->credentials->clear)
+        socket->credentials->clear(socket->credentials->data);
+
+    return 0;
+
+err_getters:
+    free(socket->ecdsa_key.pub_key_y);
+err_pub_key_y:
+    free(socket->ecdsa_key.pub_key_x);
+err_pub_key_x:
+    free(socket->ecdsa_key.priv_key);
+    return r;
+}
+
+static int
+verify_ecdsa_key(struct dtls_context_t *ctx, const session_t *session,
+    const unsigned char *other_pub_x, const unsigned char *other_pub_y,
+    size_t key_size)
+{
+    struct sol_socket_dtls *socket = dtls_get_app_data(ctx);
+    struct sol_network_link_addr addr;
+
+    SOL_DBG("Verifying peer's ECDSA Public Key");
+
+    SOL_INT_CHECK(key_size, != SOL_DTLS_ECDSA_PUB_KEY_X_LEN, -EINVAL);
+    SOL_INT_CHECK(key_size, != SOL_DTLS_ECDSA_PUB_KEY_Y_LEN, -EINVAL);
+
+    SOL_NULL_CHECK(socket->credentials,
+        dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR));
+    SOL_NULL_CHECK(socket->credentials->verify_ecdsa_key,
+        dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR));
+
+    if (from_sockaddr(&session->addr.sa, session->size, &addr) < 0) {
+        SOL_DBG("Could not get link address from session");
+        return -EINVAL;
+    }
+
+    return socket->credentials->verify_ecdsa_key(socket->credentials->data,
+        &addr, other_pub_x, other_pub_y, key_size);
+}
+
 struct sol_socket *
 sol_socket_default_dtls_new(const struct sol_socket_options *options)
 {
@@ -668,15 +778,10 @@ sol_socket_default_dtls_new(const struct sol_socket_options *options)
         .set_read_monitor = sol_socket_dtls_set_read_monitor,
         .del = sol_socket_dtls_del
     };
-    static const dtls_handler_t dtls_handler = {
-        .write = write_encrypted,
-        .read = call_user_read_cb,
-        .event = handle_dtls_event,
-        .get_psk_info = get_psk_info
-    };
     struct sol_socket_ip_options opts;
     struct sol_socket_dtls *s;
     int r = 0;
+    uint16_t i;
 
     SOL_SOCKET_OPTIONS_CHECK_SUB_API_VERSION(options, SOL_SOCKET_IP_OPTIONS_SUB_API_VERSION, NULL);
 
@@ -695,7 +800,7 @@ sol_socket_default_dtls_new(const struct sol_socket_options *options)
     opts.base.on_can_write = call_user_write_cb;
 
     s->wrapped = sol_socket_ip_default_new(&opts);
-    if (!s) {
+    if (!s->wrapped) {
         r = -errno;
         goto err;
     }
@@ -708,13 +813,45 @@ sol_socket_default_dtls_new(const struct sol_socket_options *options)
         goto err;
     }
 
-    dtls_set_handler(s->context, &dtls_handler);
+    s->handler.write = write_encrypted;
+    s->handler.read = call_user_read_cb;
+    s->handler.event = handle_dtls_event;
+
+    for (i = 0; i < opts.cipher_suites_len; i++) {
+        switch (opts.cipher_suites[i]) {
+        case SOL_SOCKET_DTLS_CIPHER_PSK_AES128_CCM8:
+            SOL_DBG("Adding get_psk_info callback to %p handler", &s->handler);
+            s->handler.get_psk_info = get_psk_info;
+            break;
+        case SOL_SOCKET_DTLS_CIPHER_ECDHE_ECDSA_AES128_CCM8:
+            SOL_DBG("Adding get_ecdsa_* callbacks to %p handler", &s->handler);
+            s->handler.get_ecdsa_key = get_ecdsa_key;
+            s->handler.verify_ecdsa_key = verify_ecdsa_key;
+            break;
+        case SOL_SOCKET_DTLS_CIPHER_ECDH_ANON_AES128_CBC_SHA256:
+            SOL_WRN("Unsupported DTLS Cipher Suite at position %" PRIu16
+                ": %d", i, opts.cipher_suites[i]);
+            errno = EINVAL;
+            goto err;
+        default:
+            SOL_WRN("Unsupported DTLS Cipher Suite at position %" PRIu16
+                ": %d", i, opts.cipher_suites[i]);
+            errno = EINVAL;
+            goto err;
+        }
+    }
+
+    dtls_set_handler(s->context, &s->handler);
 
     s->base.type = &type;
     s->dtls_magic = dtls_magic;
 
     sol_vector_init(&s->write.queue, sizeof(struct queue_item));
     sol_vector_init(&s->read.queue, sizeof(struct queue_item));
+
+    SOL_DBG("sol_socket_dtls %p with wrapped socket %p, base socket %p,"
+        " base.type %p, context %p and handler %p created!",
+        s, s->wrapped, &s->base, s->base.type, s->context, &s->handler);
 
     return &s->base;
 

--- a/src/lib/comms/sol-socket-dtls.h
+++ b/src/lib/comms/sol-socket-dtls.h
@@ -28,6 +28,9 @@
 #define SOL_DTLS_PSK_ID_LEN 16
 #define SOL_DTLS_PSK_KEY_LEN 16
 
+#define SOL_DTLS_ECDSA_PRIV_KEY_LEN 32
+#define SOL_DTLS_ECDSA_PUB_KEY_X_LEN 32
+#define SOL_DTLS_ECDSA_PUB_KEY_Y_LEN 32
 
 struct sol_socket_dtls_credential_cb {
     const void *data;
@@ -39,6 +42,16 @@ struct sol_socket_dtls_credential_cb {
         char *id, size_t id_len);
     ssize_t (*get_psk)(const void *creds, struct sol_str_slice id,
         char *psk, size_t psk_len);
+
+    int (*get_ecdsa_priv_key)(const void *creds, struct sol_network_link_addr *addr,
+        unsigned char *ecdsa_priv_key);
+    int (*get_ecdsa_pub_key_x)(const void *creds, struct sol_network_link_addr *addr,
+        unsigned char *ecdsa_pub_key_x);
+    int (*get_ecdsa_pub_key_y)(const void *creds, struct sol_network_link_addr *addr,
+        unsigned char *ecdsa_pub_key_y);
+    int (*verify_ecdsa_key)(const void *creds, struct sol_network_link_addr *addr,
+        const unsigned char *other_pub_x, const unsigned char *other_pub_y,
+        size_t key_size);
 };
 
 struct sol_socket *sol_socket_dtls_wrap_socket(struct sol_socket *socket);

--- a/src/lib/comms/sol-socket-dtls.h
+++ b/src/lib/comms/sol-socket-dtls.h
@@ -28,11 +28,6 @@
 #define SOL_DTLS_PSK_ID_LEN 16
 #define SOL_DTLS_PSK_KEY_LEN 16
 
-enum sol_socket_dtls_cipher {
-    SOL_SOCKET_DTLS_CIPHER_ECDH_ANON_AES128_CBC_SHA256,
-    SOL_SOCKET_DTLS_CIPHER_PSK_AES128_CCM8,
-    SOL_SOCKET_DTLS_CIPHER_ECDHE_ECDSA_AES128_CCM8
-};
 
 struct sol_socket_dtls_credential_cb {
     const void *data;


### PR DESCRIPTION
Main changes since v2 (#2298)
- Minor memory leaking fixes
- Removed the "Ugly" patch for CoAP timeout. The timeout issue (which generates duplicated packets) seems to happen only in Client-Server/BSServer communication between the samples, and not in the same communication when it's done inside the `test-lwm2m.c` program. I guess it has something to do with the fact that the samples are running in different processes (since that's the only difference between samples and tests), but I still don't know what/where exactly is the issue.

Signed-off-by: Bruno Melo bsilva.melo@gmail.com