### PR TITLE
LWM2M: Change type of bs_server->known_clients

### DIFF
--- a/src/lib/comms/sol-lwm2m-common.h
+++ b/src/lib/comms/sol-lwm2m-common.h
@@ -228,7 +228,7 @@ struct sol_lwm2m_bootstrap_server {
     struct sol_vector known_psks;
     struct sol_ptr_vector known_pub_keys;
     struct sol_lwm2m_security_rpk rpk_pair;
-    const char **known_clients;
+    struct sol_vector known_clients;
 };
 
 enum sol_lwm2m_path_props {


### PR DESCRIPTION
This patch changes the type of the `known_clients` frield from
`struct sol_lwm2m_bootstrap_server`, to avoid possible issues in
case the user of the API deallocates the strings with the clients'
names.

Signed-off-by: Bruno Melo <bsilva.melo@gmail.com>