### PR TITLE
linux:mainloop:log: Fix multiple initializations

### DIFF
--- a/src/lib/common/sol-log-impl-linux.c
+++ b/src/lib/common/sol-log-impl-linux.c
@@ -266,7 +266,6 @@ sol_log_impl_shutdown(void)
     _main_pid = 0;
 #ifdef PTHREAD
     _main_thread = 0;
-    pthread_mutex_destroy(&_mutex);
 #endif
 }
 


### PR DESCRIPTION
There is problem when sol_log_impl_init()/sol_log_impl_shutdown() is
called more than once. The global mutex _mutex is statically initialized
but soletta is destroying it on shutdown(). So, all further functions
that use this mutex (for lock() and unlock())will fail because the init
is not initializing it.

This commit remove the destroy() from the shutdown(). Because there is
no reason to init/destroy the mutex instead of let it available.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>