### PR TITLE
LWM2M: Change type of bs_server->known_clients [v2]

### DIFF
--- a/src/lib/comms/sol-lwm2m-bs-server.c
+++ b/src/lib/comms/sol-lwm2m-bs-server.c
@@ -149,6 +149,7 @@ bootstrap_request(void *data, struct sol_coap_server *coap,
     struct sol_lwm2m_bootstrap_server *server = data;
     struct sol_coap_packet *response;
     struct sol_str_slice client_name = SOL_STR_SLICE_EMPTY;
+    char *known_client;
     int r;
     size_t i;
     bool know_client = false;
@@ -161,8 +162,8 @@ bootstrap_request(void *data, struct sol_coap_server *coap,
     r = extract_bootstrap_client_info(req, &client_name);
     SOL_INT_CHECK_GOTO(r, < 0, err_exit);
 
-    for (i = 0; server->known_clients[i]; i++) {
-        if (sol_str_slice_str_eq(client_name, server->known_clients[i]))
+    SOL_PTR_VECTOR_FOREACH_IDX (&server->known_clients, known_client, i) {
+        if (sol_str_slice_str_eq(client_name, known_client))
             know_client = true;
     }
 
@@ -224,6 +225,7 @@ sol_lwm2m_bootstrap_server_new(uint16_t port, const char **known_clients,
     struct sol_blob **known_pub_keys = NULL, *cli_pub_key;
     enum sol_lwm2m_security_mode *sec_modes;
     enum sol_socket_dtls_cipher *cipher_suites;
+    char *known_client;
     uint16_t i, j;
     va_list ap;
 
@@ -314,10 +316,13 @@ sol_lwm2m_bootstrap_server_new(uint16_t port, const char **known_clients,
         }
     }
 
-    free(sec_modes);
-    free(cipher_suites);
+    sol_ptr_vector_init(&server->known_clients);
 
-    server->known_clients = known_clients;
+    for (i = 0; known_clients[i]; i++) {
+        r = sol_ptr_vector_append(&server->known_clients,
+            strdup(known_clients[i]));
+        SOL_INT_CHECK_GOTO(r, < 0, err_known_clients);
+    }
 
     sol_ptr_vector_init(&server->clients);
 
@@ -325,12 +330,19 @@ sol_lwm2m_bootstrap_server_new(uint16_t port, const char **known_clients,
 
     r = sol_coap_server_register_resource(server->coap,
         &bootstrap_request_interface, server);
-    SOL_INT_CHECK_GOTO(r, < 0, err_security);
+    SOL_INT_CHECK_GOTO(r, < 0, err_known_clients);
+
+    free(sec_modes);
+    free(cipher_suites);
 
     va_end(ap);
 
     return server;
 
+err_known_clients:
+    SOL_PTR_VECTOR_FOREACH_IDX (&server->known_clients, known_client, i)
+        free(known_client);
+    sol_ptr_vector_clear(&server->known_clients);
 err_security:
     sol_coap_server_unref(server->coap);
     sol_lwm2m_bootstrap_server_security_del(server->security);
@@ -369,6 +381,7 @@ sol_lwm2m_bootstrap_server_del(struct sol_lwm2m_bootstrap_server *server)
     struct sol_lwm2m_bootstrap_client_info *bs_cinfo;
     struct sol_lwm2m_security_psk *cli_psk;
     struct sol_blob *cli_pub_key;
+    char *known_client;
 
     SOL_NULL_CHECK(server);
 
@@ -393,6 +406,10 @@ sol_lwm2m_bootstrap_server_del(struct sol_lwm2m_bootstrap_server *server)
     }
 
     sol_lwm2m_bootstrap_server_security_del(server->security);
+
+    SOL_PTR_VECTOR_FOREACH_IDX (&server->known_clients, known_client, i)
+        free(known_client);
+    sol_ptr_vector_clear(&server->known_clients);
 
     SOL_PTR_VECTOR_FOREACH_IDX (&server->clients, bs_cinfo, i)
         bootstrap_client_info_del(bs_cinfo);

--- a/src/lib/comms/sol-lwm2m-common.h
+++ b/src/lib/comms/sol-lwm2m-common.h
@@ -228,7 +228,7 @@ struct sol_lwm2m_bootstrap_server {
     struct sol_vector known_psks;
     struct sol_ptr_vector known_pub_keys;
     struct sol_lwm2m_security_rpk rpk_pair;
-    const char **known_clients;
+    struct sol_ptr_vector known_clients;
 };
 
 enum sol_lwm2m_path_props {


### PR DESCRIPTION
This patch changes the type of the known_clients frield from
struct sol_lwm2m_bootstrap_server, to avoid possible issues in
case the user of the API deallocates the strings with the clients'
names.

Changes from v1 (#2302):
`bs_server->known_clients` as a `sol_ptr_vector` of `char *` instead of a `sol_vector` of `sol_str_slice`.

Signed-off-by: Bruno Melo <bsilva.melo@gmail.com>