### PR TITLE
comms: Add sol-netctl agent API V5

### DIFF
--- a/data/scripts/libsoletta.sym
+++ b/data/scripts/libsoletta.sym
@@ -892,4 +892,5 @@ global:
         sol_netctl_unregister_agent;
         sol_netctl_request_retry;
         sol_netctl_request_input;
+        sol_netctl_scan;
 } LIBSOLETTA_1;

--- a/data/scripts/libsoletta.sym
+++ b/data/scripts/libsoletta.sym
@@ -885,3 +885,11 @@ global:
 local:
         *;
 };
+
+LIBSOLETTA_2 {
+global:
+        sol_netctl_register_agent;
+        sol_netctl_unregister_agent;
+        sol_netctl_request_retry;
+        sol_netctl_request_input;
+} LIBSOLETTA_1;

--- a/src/lib/comms/include/sol-netctl.h
+++ b/src/lib/comms/include/sol-netctl.h
@@ -679,6 +679,18 @@ int sol_netctl_request_input(struct sol_netctl_service *service,
     const struct sol_ptr_vector *inputs);
 
 /**
+ * @brief request scan the surrounding devices
+ *
+ * Request scan for the surrounding devices.
+ * This must be inovked AFTER sol_netctl_add_service_monitor.
+ *
+ * @see sol_netctl_add_service_monitor
+ *
+ * @return 0 on success, -errno on failure.
+ */
+int sol_netctl_scan(void);
+
+/**
  * @}
  */
 

--- a/src/lib/comms/include/sol-netctl.h
+++ b/src/lib/comms/include/sol-netctl.h
@@ -75,6 +75,13 @@ typedef struct sol_netctl_network_params {
     struct sol_network_link_addr gateway;
 } sol_netctl_network_params;
 
+#define SOL_NETCTL_AGENT_NAME         "Name"    /**< @brief the agent input name type string */
+#define SOL_NETCTL_AGENT_IDENTITY     "Identity"    /**< @brief the agent input identity type string */
+#define SOL_NETCTL_AGENT_PASSPHRASE   "Passphrase"    /**< @brief the agent input passphrase type string */
+#define SOL_NETCTL_AGENT_WPS          "WPS"    /**< @brief the agent input WPS type string */
+#define SOL_NETCTL_AGENT_USERNAME     "Username"    /**< @brief the agent input username type string */
+#define SOL_NETCTL_AGENT_PASSWORD     "Password"    /**< @brief the agent input password type string */
+
 /**
  * @enum sol_netctl_service_state
  *
@@ -207,6 +214,60 @@ enum sol_netctl_state {
      */
     SOL_NETCTL_STATE_OFFLINE,
 };
+
+/**
+ * @brief agent input struct
+ *
+ * This struct contains the information of agent input.
+ */
+typedef struct sol_netctl_agent_input {
+    /**
+     * @brief The agent prompt type
+     */
+    char *type;
+    /**
+     * @brief The agent input value
+     */
+    char *input;
+} sol_netctl_agent_input;
+
+/**
+ * @brief agent callback functions
+ *
+ * This struct contains the callback functions of agent.
+ */
+typedef struct sol_netctl_agent {
+    /**
+     * @brief connection error callback used to inform connection failure
+     *
+     * @param data the user data
+     * @param service the connection failure service
+     * @param error the error information
+     */
+    void (*report_error)(void *data, const struct sol_netctl_service *service,
+        const char *error);
+    /**
+     * @brief connection input callback used to inform connection login input
+     *
+     * @param data the user data
+     * @param service the connection login input service
+     * @param inputs the ptr vector of login input type
+     */
+    void (*request_input)(void *data, const struct sol_netctl_service *service,
+        const struct sol_ptr_vector *inputs);
+    /**
+     * @brief connection cancel callback used to inform connection cancel
+     *
+     * @param data the user data
+     */
+    void (*cancel)(void *data);
+    /**
+     * @brief agent release callback used to inform agent release
+     *
+     * @param data the user data
+     */
+    void (*release)(void *data);
+} sol_netctl_agent;
 
 /**
  * @brief Service monitor callback used to inform a service changed
@@ -551,6 +612,71 @@ sol_netctl_find_service_by_name(const char *service_name)
     }
     return NULL;
 }
+
+/**
+ * @brief register a agent for network connection
+ *
+ * A single agent is registered for an application that registering a new agent.
+ *
+ * @see struct sol_netctl_agent
+ *
+ * @param agent the agent Callback struct to be called when the related information is updated.
+ * @param data Add a user data per callback.
+ *
+ * @return 0 on success, -errno on failure.
+ */
+int sol_netctl_register_agent(const struct sol_netctl_agent *agent, const void *data);
+
+/**
+ * @brief unregister a agent for network connection
+ *
+ * @see sol_netctl_register_agent
+ *
+ * @return 0 on success, -errno on failure.
+ */
+int sol_netctl_unregister_agent(void);
+
+/**
+ * @brief request retry the connection or not when error type is reported
+ *
+ * Request retry the network connection or not when error type is reported.
+ * When the network connection failure, the user can select retry the connection or
+ * not retry it. The function can be used to select it.
+ * If retry connection is selected, the failure network connection will be tried to
+ * connect. If not retry connection is selected, the failure network connection will
+ * not be tried to connect.
+ * The connection failure information is informed via the agent callback.
+ * The agent must be registered before using sol_netctl_request_retry.
+ *
+ * @see sol_netctl_register_agent
+ *
+ * @param service The service structure which the network connection is desired.
+ * @param retry True is retry the failure selected network connection,
+ * false is not retry the failure selected network connection.
+ *
+ * @return 0 on success, -errno on failure.
+ */
+int sol_netctl_request_retry(struct sol_netctl_service *service,
+    bool retry);
+
+/**
+ * @brief request the login input to connection
+ *
+ * Request the login input for network connection.
+ * When the login information is needed in the process of network connection,
+ * the funcation can be used to input the login information for network connection.
+ * The login input information is informed via the agent callback.
+ * The agent must be registered before using sol_netctl_request_input.
+ *
+ * @see sol_netctl_register_agent
+ *
+ * @param service The service structure which the network connection is desired.
+ * @param inputs the ptr vector of input types and inputs from the user.
+ *
+ * @return 0 on success, -errno on failure.
+ */
+int sol_netctl_request_input(struct sol_netctl_service *service,
+    const struct sol_ptr_vector *inputs);
 
 /**
  * @}

--- a/src/lib/comms/sol-netctl-impl-connman.c
+++ b/src/lib/comms/sol-netctl-impl-connman.c
@@ -63,6 +63,7 @@ struct ctx {
     sd_bus_slot *state_slot;
     sd_bus_slot *agent_slot;
     sd_bus_slot *vtable_slot;
+    sd_bus_slot *scan_slot;
     sd_bus_message *agent_msg;
     struct sol_netctl_service *auth_service;
     const struct sol_netctl_agent *agent;
@@ -848,6 +849,8 @@ sol_netctl_shutdown(void)
         sd_bus_slot_unref(_ctx.manager_slot);
     _ctx.service_slot =
         sd_bus_slot_unref(_ctx.service_slot);
+    _ctx.scan_slot =
+        sd_bus_slot_unref(_ctx.scan_slot);
 
     SOL_PTR_VECTOR_FOREACH_IDX (&_ctx.service_vector, service, id)
         _free_connman_service(service);
@@ -915,6 +918,8 @@ sol_netctl_shutdown_lazy(void)
         sd_bus_slot_unref(_ctx.manager_slot);
     _ctx.service_slot =
         sd_bus_slot_unref(_ctx.service_slot);
+    _ctx.scan_slot =
+        sd_bus_slot_unref(_ctx.scan_slot);
 
     SOL_PTR_VECTOR_FOREACH_IDX (&_ctx.service_vector, service, id)
         _free_connman_service(service);
@@ -1614,6 +1619,48 @@ sol_netctl_unregister_agent(void)
         "net.connman", "/", "net.connman.Manager", "UnregisterAgent",
         sol_bus_log_callback, NULL, "o", CONNMAN_AGENT_PATH);
 
+    SOL_INT_CHECK(r, < 0, r);
+
+    return 0;
+}
+
+static int
+_scan_return(sd_bus_message *reply, void *userdata,
+    sd_bus_error *ret_error)
+{
+    const sd_bus_error *error;
+
+    _ctx.scan_slot = sd_bus_slot_unref(_ctx.scan_slot);
+
+    if (sol_bus_log_callback(reply, userdata, ret_error) < 0) {
+        error = sd_bus_message_get_error(reply);
+        _set_error_to_callback(NULL, error);
+    }
+
+    return 0;
+}
+
+static int
+_scan_services(void)
+{
+    sd_bus *bus = sol_bus_client_get_bus(_ctx.connman);
+
+    SOL_NULL_CHECK(bus, -EINVAL);
+
+    if (_ctx.scan_slot)
+        return -EBUSY;
+
+    return sd_bus_call_method_async(bus, &_ctx.scan_slot, "net.connman",
+        "/net/connman/technology/wifi", "net.connman.Technology",
+        "Scan", _scan_return, NULL, NULL);
+}
+
+SOL_API int
+sol_netctl_scan(void)
+{
+    int r;
+
+    r = _scan_services();
     SOL_INT_CHECK(r, < 0, r);
 
     return 0;

--- a/src/lib/comms/sol-netctl-impl-connman.c
+++ b/src/lib/comms/sol-netctl-impl-connman.c
@@ -35,6 +35,9 @@
 
 SOL_LOG_INTERNAL_DECLARE_STATIC(_sol_netctl_log_domain, "netctl");
 
+#define CONNMAN_AGENT_PATH "/net/solettaproject/connman"
+#define CONNMAN_AGENT_INTERFACE "net.connman.Agent"
+
 int sol_netctl_init(void);
 void sol_netctl_shutdown(void);
 
@@ -58,6 +61,13 @@ struct ctx {
     sd_bus_slot *manager_slot;
     sd_bus_slot *service_slot;
     sd_bus_slot *state_slot;
+    sd_bus_slot *agent_slot;
+    sd_bus_slot *vtable_slot;
+    sd_bus_message *agent_msg;
+    struct sol_netctl_service *auth_service;
+    const struct sol_netctl_agent *agent;
+    const void *agent_data;
+    struct sol_ptr_vector agent_vector;
     enum sol_netctl_state connman_state;
     int32_t refcount;
 };
@@ -797,6 +807,22 @@ sol_netctl_service_disconnect(struct sol_netctl_service *service)
         "net.connman.Service", "Disconnect", _service_disconnect, service, NULL);
 }
 
+static void
+_destroy_agent_vector(struct sol_ptr_vector *vector)
+{
+    uint16_t i;
+    char *input;
+
+    if (!vector)
+        return;
+
+    SOL_PTR_VECTOR_FOREACH_IDX (vector, input, i) {
+        free(input);
+    }
+
+    sol_ptr_vector_clear(vector);
+}
+
 int
 sol_netctl_init(void)
 {
@@ -830,6 +856,7 @@ sol_netctl_shutdown(void)
     sol_monitors_clear(&_ctx.service_ms);
     sol_monitors_clear(&_ctx.manager_ms);
     sol_monitors_clear(&_ctx.error_ms);
+    _destroy_agent_vector(&_ctx.agent_vector);
 
     _ctx.connman_state = SOL_NETCTL_STATE_UNKNOWN;
 }
@@ -861,6 +888,7 @@ sol_netctl_init_lazy(void)
     sol_monitors_init(&_ctx.service_ms, NULL);
     sol_monitors_init(&_ctx.manager_ms, NULL);
     sol_monitors_init(&_ctx.error_ms, NULL);
+    sol_ptr_vector_init(&_ctx.agent_vector);
 
     return 0;
 }
@@ -895,6 +923,7 @@ sol_netctl_shutdown_lazy(void)
     sol_monitors_clear(&_ctx.service_ms);
     sol_monitors_clear(&_ctx.manager_ms);
     sol_monitors_clear(&_ctx.error_ms);
+    _destroy_agent_vector(&_ctx.agent_vector);
 
     _ctx.connman_state = SOL_NETCTL_STATE_UNKNOWN;
 }
@@ -1211,4 +1240,381 @@ sol_netctl_service_state_to_str(enum sol_netctl_service_state state)
         return service_states[state];
 
     return NULL;
+}
+
+static void
+_release_agent(struct ctx *pending)
+{
+    pending->agent_slot = sd_bus_slot_unref(pending->agent_slot);
+    pending->vtable_slot = sd_bus_slot_unref(pending->vtable_slot);
+    pending->agent = NULL;
+    pending->agent_data = NULL;
+
+    _ctx.agent_msg = sd_bus_message_unref(_ctx.agent_msg);
+    _ctx.auth_service = NULL;
+}
+
+static int
+agent_cancel(sd_bus_message *m, void *data, sd_bus_error *ret_error)
+{
+    struct ctx *context = data;
+    const struct sol_netctl_agent *agent = context->agent;
+
+    context->agent_msg = sd_bus_message_unref(context->agent_msg);
+    context->auth_service = NULL;
+
+    _destroy_agent_vector(&context->agent_vector);
+
+    if (agent->cancel)
+        agent->cancel((void *)context->agent_data);
+
+    return 0;
+}
+
+static int
+agent_release(sd_bus_message *m, void *data, sd_bus_error *ret_error)
+{
+    struct ctx *context = data;
+    const struct sol_netctl_agent *agent = context->agent;
+
+    _destroy_agent_vector(&context->agent_vector);
+    _release_agent(context);
+
+    if (agent->release)
+        agent->release((void *)context->agent_data);
+
+    return 0;
+}
+
+static int
+agent_report_error(sd_bus_message *m, void *data, sd_bus_error *ret_error)
+{
+    struct sol_netctl_service *service;
+    struct ctx *context = data;
+    const struct sol_netctl_agent *agent = context->agent;
+    const char *path, *err;
+    int r;
+
+    if (sol_bus_log_callback(m, data, ret_error) < 0)
+        goto error;
+
+    r = sd_bus_message_read(m, "os", &path, &err);
+    SOL_INT_CHECK_GOTO(r, < 0, error);
+
+    service = find_service_by_path(path);
+    SOL_NULL_CHECK_GOTO(service, error);
+
+    context->agent_msg = sd_bus_message_unref(context->agent_msg);
+    context->agent_msg = sd_bus_message_ref(m);
+    SOL_NULL_CHECK_GOTO(context->agent_msg, error);
+
+    context->auth_service = service;
+    if (agent->report_error)
+        agent->report_error((void *)context->agent_data,
+            (const struct sol_netctl_service *)service, err);
+
+    return 0;
+error:
+    sd_bus_reply_method_return(m, NULL);
+    return -EINVAL;
+}
+
+static int
+_agent_input_properties(sd_bus_message *m, struct ctx *context)
+{
+    const struct sol_netctl_agent *agent = context->agent;
+    char *str, *input;
+    int r;
+    bool is_wps = false;
+
+    r = sd_bus_message_enter_container(m, SD_BUS_TYPE_ARRAY, "{sv}");
+    SOL_INT_CHECK(r, < 0, r);
+
+    _destroy_agent_vector(&_ctx.agent_vector);
+    sol_ptr_vector_init(&_ctx.agent_vector);
+
+    do {
+        r = sd_bus_message_enter_container(m, SD_BUS_TYPE_DICT_ENTRY, "sv");
+        SOL_INT_CHECK_GOTO(r, < 1, end);
+
+        str = NULL;
+        r = sd_bus_message_read_basic(m, SD_BUS_TYPE_STRING, &str);
+        SOL_INT_CHECK_GOTO(r, < 0, fail);
+
+        if (str != NULL) {
+            if (streq(str, SOL_NETCTL_AGENT_WPS)) {
+                _destroy_agent_vector(&_ctx.agent_vector);
+                sol_ptr_vector_init(&_ctx.agent_vector);
+                is_wps = true;
+            }
+
+            input = strdup(str);
+            SOL_NULL_CHECK_GOTO(input, fail);
+            r = sol_ptr_vector_append(&_ctx.agent_vector, input);
+            SOL_INT_CHECK_GOTO(r, < 0, fail);
+        }
+
+        r = sd_bus_message_skip(m, "v");
+        SOL_INT_CHECK_GOTO(r, < 0, fail);
+
+        r = sd_bus_message_exit_container(m);
+        SOL_INT_CHECK_GOTO(r, < 0, fail);
+
+        if (is_wps) {
+            r = 0;
+            break;
+        }
+    } while (1);
+
+end:
+    if (r == 0) {
+        r = sd_bus_message_exit_container(m);
+        SOL_INT_CHECK_GOTO(r, < 0, fail);
+
+        if (agent->request_input)
+            agent->request_input((void *)context->agent_data,
+                (const struct sol_netctl_service *)context->auth_service,
+                (const struct sol_ptr_vector *)&_ctx.agent_vector);
+    }
+
+    return r;
+
+fail:
+    _destroy_agent_vector(&_ctx.agent_vector);
+
+    if (r < 0)
+        return r;
+
+    return -ENOMEM;
+}
+
+static int
+agent_request_input(sd_bus_message *m, void *data, sd_bus_error *ret_error)
+{
+    struct sol_netctl_service *service;
+    const char *path;
+    struct ctx *context = data;
+    int r;
+
+    if (sol_bus_log_callback(m, data, ret_error) < 0)
+        goto error;
+
+    r = sd_bus_message_read(m, "o", &path);
+    SOL_INT_CHECK(r, < 0, r);
+
+    service = find_service_by_path(path);
+    SOL_NULL_CHECK_GOTO(service, error);
+
+    context->agent_msg = sd_bus_message_unref(context->agent_msg);
+    context->agent_msg = sd_bus_message_ref(m);
+    context->auth_service = service;
+
+    return _agent_input_properties(m, context);
+
+error:
+    sd_bus_reply_method_return(m, NULL);
+    return -EINVAL;
+}
+
+static const sd_bus_vtable agent_vtable[] = {
+    SD_BUS_VTABLE_START(0),
+    SD_BUS_METHOD("Release", NULL, NULL,
+        agent_release, SD_BUS_VTABLE_UNPRIVILEGED),
+    SD_BUS_METHOD("ReportError", "os", NULL,
+        agent_report_error, SD_BUS_VTABLE_UNPRIVILEGED),
+    SD_BUS_METHOD("RequestInput", "oa{sv}", "a{sv}",
+        agent_request_input, SD_BUS_VTABLE_UNPRIVILEGED),
+    SD_BUS_METHOD("Cancel", NULL, NULL, agent_cancel,
+        SD_BUS_VTABLE_UNPRIVILEGED | SD_BUS_VTABLE_METHOD_NO_REPLY),
+    SD_BUS_VTABLE_END,
+};
+
+static int
+_agent_callback(sd_bus_message *reply, void *userdata,
+    sd_bus_error *ret_error)
+{
+    struct ctx *pending = userdata;
+    const sd_bus_error *error;
+
+    pending->agent_slot = sd_bus_slot_unref(pending->agent_slot);
+
+    if (sol_bus_log_callback(reply, userdata, ret_error) < 0) {
+        error = sd_bus_message_get_error(reply);
+        _release_agent(pending);
+        _set_error_to_callback(NULL, error);
+    }
+
+    return 0;
+}
+
+SOL_API int
+sol_netctl_request_input(struct sol_netctl_service *service,
+    const struct sol_ptr_vector *inputs)
+{
+    int r;
+    uint16_t i;
+    sd_bus_message *reply = NULL;
+    sol_netctl_agent_input *input;
+
+    SOL_NULL_CHECK(service, -EINVAL);
+    SOL_NULL_CHECK(inputs, -EINVAL);
+    SOL_NULL_CHECK(_ctx.agent, -EINVAL);
+    SOL_NULL_CHECK(_ctx.agent_msg, -EINVAL);
+
+    if (_ctx.auth_service != service) {
+        SOL_WRN("The connection is not the one being authenticated");
+        return -EINVAL;
+    }
+
+    r = sd_bus_message_new_method_return(_ctx.agent_msg, &reply);
+    SOL_INT_CHECK_GOTO(r, < 0, fail);
+
+    r = sd_bus_message_open_container(reply, 'a', "{sv}");
+    SOL_INT_CHECK_GOTO(r, < 0, fail);
+
+    SOL_PTR_VECTOR_FOREACH_IDX (inputs, input, i) {
+        if (!input->input || !input->type)
+            continue;
+        if (streq(input->type, SOL_NETCTL_AGENT_NAME)) {
+            r = sd_bus_message_append(reply, "{sv}", "Name", "s", input->input);
+            SOL_INT_CHECK_GOTO(r, < 0, fail);
+        } else if (streq(input->type, SOL_NETCTL_AGENT_PASSPHRASE)) {
+            r = sd_bus_message_append(reply, "{sv}", "Passphrase", "s", input->input);
+            SOL_INT_CHECK_GOTO(r, < 0, fail);
+        } else if (streq(input->type, SOL_NETCTL_AGENT_IDENTITY)) {
+            r = sd_bus_message_append(reply, "{sv}", "Identity", "s", input->input);
+            SOL_INT_CHECK_GOTO(r, < 0, fail);
+        } else if (streq(input->type, SOL_NETCTL_AGENT_WPS)) {
+            r = sd_bus_message_append(reply, "{sv}", "WPS", "s", input->input);
+            SOL_INT_CHECK_GOTO(r, < 0, fail);
+        } else if (streq(input->type, SOL_NETCTL_AGENT_USERNAME)) {
+            r = sd_bus_message_append(reply, "{sv}", "Username", "s", input->input);
+            SOL_INT_CHECK_GOTO(r, < 0, fail);
+        } else if (streq(input->type, SOL_NETCTL_AGENT_PASSWORD)) {
+            r = sd_bus_message_append(reply, "{sv}", "Password", "s", input->input);
+            SOL_INT_CHECK_GOTO(r, < 0, fail);
+        } else {
+            SOL_WRN("The input type is not right");
+            break;
+        }
+    }
+
+    r = sd_bus_message_close_container(reply);
+    SOL_INT_CHECK_GOTO(r, < 0, fail);
+
+    r = sd_bus_send(NULL, reply, NULL);
+    sd_bus_message_unref(reply);
+
+    _ctx.agent_msg = sd_bus_message_unref(_ctx.agent_msg);
+
+    return 0;
+fail:
+    sd_bus_message_unref(reply);
+
+    if (r < 0)
+        return r;
+
+    return -EINVAL;
+}
+
+SOL_API int
+sol_netctl_request_retry(struct sol_netctl_service *service,
+    bool retry)
+{
+    int r = 0;
+    sd_bus_message *reply = false;
+    const char *interface;
+
+    SOL_NULL_CHECK(service, -EINVAL);
+    SOL_NULL_CHECK(_ctx.agent, -EINVAL);
+    SOL_NULL_CHECK(_ctx.agent_msg, -EINVAL);
+
+    if (_ctx.auth_service != service) {
+        SOL_WRN("The connection is not the one being authenticated");
+        return -EINVAL;
+    }
+
+    if (retry) {
+        interface = sd_bus_message_get_interface(_ctx.agent_msg);
+        SOL_NULL_CHECK_GOTO(interface, fail);
+        if (strcmp(interface, CONNMAN_AGENT_INTERFACE) == 0)
+            r = sd_bus_message_new_method_errorf(_ctx.agent_msg, &reply,
+                "net.connman.Agent.Error.Retry", NULL);
+        else
+            r = sd_bus_message_new_method_errorf(_ctx.agent_msg, &reply,
+                "net.connman.vpn.Agent.Error.Retry", NULL);
+        SOL_INT_CHECK_GOTO(r, < 0, fail);
+
+        r = sd_bus_send(NULL, reply, NULL);
+        sd_bus_message_unref(reply);
+        SOL_INT_CHECK_GOTO(r, < 0, fail);
+    } else {
+        r = sd_bus_reply_method_return(_ctx.agent_msg, NULL);
+        SOL_INT_CHECK_GOTO(r, < 0, fail);
+    }
+
+    _ctx.agent_msg = sd_bus_message_unref(_ctx.agent_msg);
+
+    return 0;
+fail:
+    sd_bus_message_unref(reply);
+
+    if (r < 0)
+        return r;
+
+    return -EINVAL;
+}
+
+SOL_API int
+sol_netctl_register_agent(const struct sol_netctl_agent *agent, const void *data)
+{
+    int r;
+    sd_bus *bus = sol_bus_client_get_bus(_ctx.connman);
+
+    SOL_NULL_CHECK(bus, -EINVAL);
+    SOL_NULL_CHECK(agent, -EINVAL);
+
+    if (_ctx.agent && agent)
+        return -EEXIST;
+
+    _ctx.agent = agent;
+    _ctx.agent_data = data;
+
+    r = sd_bus_add_object_vtable(bus, &_ctx.vtable_slot, CONNMAN_AGENT_PATH,
+        "net.connman.Agent", agent_vtable, &_ctx);
+    SOL_INT_CHECK(r, < 0, -ENOMEM);
+
+    r = sd_bus_call_method_async(bus, &_ctx.agent_slot,
+        "net.connman", "/", "net.connman.Manager", "RegisterAgent",
+        _agent_callback, &_ctx, "o", CONNMAN_AGENT_PATH);
+    SOL_INT_CHECK_GOTO(r, < 0, error);
+
+    return 0;
+
+error:
+    _release_agent(&_ctx);
+
+    return 0;
+}
+
+SOL_API int
+sol_netctl_unregister_agent(void)
+{
+    int r;
+    sd_bus *bus = sol_bus_client_get_bus(_ctx.connman);
+
+    SOL_NULL_CHECK(bus, -EINVAL);
+
+    if (!_ctx.agent)
+        return -ENOENT;
+
+    _release_agent(&_ctx);
+
+    r = sd_bus_call_method_async(bus, NULL,
+        "net.connman", "/", "net.connman.Manager", "UnregisterAgent",
+        sol_bus_log_callback, NULL, "o", CONNMAN_AGENT_PATH);
+
+    SOL_INT_CHECK(r, < 0, r);
+
+    return 0;
 }

--- a/src/lib/comms/sol-netctl-impl-connman.c
+++ b/src/lib/comms/sol-netctl-impl-connman.c
@@ -406,6 +406,7 @@ get_services_properties(sd_bus_message *m, const char *path)
 {
     int r;
     struct sol_netctl_service *service;
+    bool is_changed = false;
 
     service = find_service_by_path(path);
     SOL_NULL_CHECK(service, -ENOMEM);
@@ -435,6 +436,8 @@ get_services_properties(sd_bus_message *m, const char *path)
 
             r = sd_bus_message_exit_container(m);
             SOL_INT_CHECK(r, < 0, r);
+
+            is_changed = true;
         } else if (streq(str, "State")) {
             char *state;
             static const struct sol_str_table table[] = {
@@ -468,6 +471,8 @@ get_services_properties(sd_bus_message *m, const char *path)
 
             r = sd_bus_message_exit_container(m);
             SOL_INT_CHECK(r, < 0, r);
+
+            is_changed = true;
         } else if (streq(str, "Strength")) {
             uint8_t strength = 0;
 
@@ -481,6 +486,8 @@ get_services_properties(sd_bus_message *m, const char *path)
 
             r = sd_bus_message_exit_container(m);
             SOL_INT_CHECK(r, < 0, r);
+
+            is_changed = true;
         } else if (streq(str, "Type")) {
             char *type;
 
@@ -495,6 +502,8 @@ get_services_properties(sd_bus_message *m, const char *path)
 
             r = sd_bus_message_exit_container(m);
             SOL_INT_CHECK(r, < 0, r);
+
+            is_changed = true;
         } else if (streq(str, "IPv4")) {
             r = sd_bus_message_enter_container(m, SD_BUS_TYPE_VARIANT, "a{sv}");
             SOL_INT_CHECK(r, < 0, r);
@@ -503,6 +512,8 @@ get_services_properties(sd_bus_message *m, const char *path)
 
             r = sd_bus_message_exit_container(m);
             SOL_INT_CHECK(r, < 0, r);
+
+            is_changed = true;
         } else if (streq(str, "IPv6")) {
             r = sd_bus_message_enter_container(m, SD_BUS_TYPE_VARIANT, "a{sv}");
             SOL_INT_CHECK(r, < 0, r);
@@ -511,6 +522,8 @@ get_services_properties(sd_bus_message *m, const char *path)
 
             r = sd_bus_message_exit_container(m);
             SOL_INT_CHECK(r, < 0, r);
+
+            is_changed = true;
         }  else {
             SOL_DBG("Ignored service property: %s", str);
             r = sd_bus_message_skip(m, NULL);
@@ -527,7 +540,8 @@ end:
     } else
         return r;
 
-    call_service_monitor_callback(service);
+    if (is_changed)
+        call_service_monitor_callback(service);
 
     return 0;
 }

--- a/src/samples/network/netctl.c
+++ b/src/samples/network/netctl.c
@@ -28,6 +28,9 @@
 #include "sol-log.h"
 
 #define CONN_AP "Guest"
+#define INPUT   "12345678"
+
+struct sol_netctl_agent agent;
 
 static void
 manager_cb(void *data)
@@ -94,8 +97,91 @@ error_cb(void *data, const struct sol_netctl_service *service,
 }
 
 static void
+report_error(void *data, const struct sol_netctl_service *service,
+    const char *error)
+{
+    int r;
+
+    printf("The agent action error is %s\n", error);
+    r = sol_netctl_request_retry((struct sol_netctl_service *)service,
+        false);
+    printf("The agent request retry return value is %d\n", r);
+}
+
+static void
+request_input(void *data, const struct sol_netctl_service *service,
+    const struct sol_ptr_vector *vector)
+{
+    int r;
+    uint16_t i;
+    char *value;
+    struct sol_netctl_agent_input *input;
+    struct sol_ptr_vector input_vector;
+
+    printf("The agent action is input\n");
+    sol_ptr_vector_init(&input_vector);
+
+    SOL_PTR_VECTOR_FOREACH_IDX (vector, value, i) {
+        printf("The agent input type is %s\n", value);
+        input = calloc(1, sizeof(struct sol_netctl_agent_input));
+        if (!input) {
+            printf("No Memory for the agent input\n");
+            goto fail;
+        }
+
+        input->type = strdup(value);
+        if (!input->type) {
+            printf("No Memory for the agent input\n");
+            goto fail;
+        }
+
+        input->input = strdup(INPUT);
+        if (!input->input) {
+            printf("No Memory for the agent input\n");
+            goto fail;
+        }
+
+        r = sol_ptr_vector_append(&input_vector, input);
+        if (r < 0) {
+            printf("append the agent input error\n");
+            goto fail;
+        }
+    }
+
+    r = sol_netctl_request_input((struct sol_netctl_service *)service,
+        &input_vector);
+    printf("The agent report input return value is %d\n", r);
+
+fail:
+    SOL_PTR_VECTOR_FOREACH_IDX (&input_vector, input, i) {
+        if (input->input)
+            free(input->input);
+        if (input->type)
+            free(input->type);
+    }
+
+    sol_ptr_vector_clear(&input_vector);
+}
+
+static void
+cancel(void *data)
+{
+    printf("The agent action is cancelled\n");
+}
+
+static void
+release(void *data)
+{
+    printf("The agent action is release\n");
+}
+
+static void
 shutdown(void)
 {
+    int r;
+
+    r = sol_netctl_unregister_agent();
+    printf("unregister agent return value r = %d\n", r);
     sol_netctl_del_manager_monitor(manager_cb, NULL);
     sol_netctl_del_service_monitor(service_cb, NULL);
     sol_netctl_del_error_monitor(error_cb, NULL);
@@ -104,9 +190,19 @@ shutdown(void)
 static void
 startup(void)
 {
+    int r;
+
     sol_netctl_add_service_monitor(service_cb, NULL);
     sol_netctl_add_manager_monitor(manager_cb, NULL);
     sol_netctl_add_error_monitor(error_cb, NULL);
+
+    agent.report_error = report_error;
+    agent.request_input = request_input;
+    agent.cancel = cancel;
+    agent.release = release;
+
+    r = sol_netctl_register_agent(&agent, NULL);
+    printf("register agent return value r = %d\n", r);
 }
 
 SOL_MAIN_DEFAULT(startup, shutdown);

--- a/src/samples/network/netctl.c
+++ b/src/samples/network/netctl.c
@@ -203,6 +203,9 @@ startup(void)
 
     r = sol_netctl_register_agent(&agent, NULL);
     printf("register agent return value r = %d\n", r);
+
+    r = sol_netctl_scan();
+    printf("scan devices return value r = %d\n", r);
 }
 
 SOL_MAIN_DEFAULT(startup, shutdown);


### PR DESCRIPTION
The agent is necessary in the process of network connection,
that will receive input information from the user and send it
to the network(such as AP and so on).

The API is based on connman D-Bus APIs, it provides register agent,
input login information and so on netctl agent API.

Signed-off-by: Wu Zheng wu.zheng@intel.com