### PR TITLE
mqtt: Check libmosquitto version

### DIFF
--- a/data/jsons/dependencies.json
+++ b/data/jsons/dependencies.json
@@ -203,7 +203,7 @@
       "headers": [
         "<mosquitto.h>"
       ],
-      "fragment": "mosquitto_opts_set(0, 0, 0);",
+      "fragment": "#if LIBMOSQUITTO_VERSION_NUMBER < 1004002\n#error \"Unsupported LIBMOSQUITTO version\"\n#endif",
       "ldflags": {
         "value": "-lmosquitto"
       }


### PR DESCRIPTION
Soletta requires libmosquitto >= 1.4.2
Since libmosquitto does not have a pkg-config to check the library
version, it's checking for the version exported in mosquitto.h

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>