### PR TITLE
iio:cpp: Fix build when compiling with g++

### DIFF
--- a/src/lib/io/include/sol-iio.h
+++ b/src/lib/io/include/sol-iio.h
@@ -21,6 +21,8 @@
 #include <sol-buffer.h>
 #include <sol-common-buildopts.h>
 
+#include <linux/limits.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
NAME_MAX is defined in linux/limits.h, as sol-iio is linux specific,
there is no problem in including a linux header.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>