### PR TITLE
check-api: Change regex to not match LIBSOLETTA_X on extends

### DIFF
--- a/data/scripts/check-api.py
+++ b/data/scripts/check-api.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     missingSymbols = {}
 
     with open(args.version_script) as fData:
-        versionScriptSymbols = re.findall('\s*(\w+);\s*', fData.read())
+        versionScriptSymbols = re.findall('(?<!})\s+(\w+);', fData.read())
 
     for root, dirs, files in os.walk(args.src_dir):
         if not root.endswith("include"):


### PR DESCRIPTION
Current regex was matching everything ended in ';'. Changed to do so
only if not preceeded by '}'.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>