### PR TITLE
Fix tinycbor API calls

### DIFF
--- a/src/lib/comms/Makefile
+++ b/src/lib/comms/Makefile
@@ -64,6 +64,7 @@ obj-tinycbor-y = \
     $(TINYCBOR_SRC_PATH)/cborencoder.o \
     $(TINYCBOR_SRC_PATH)/cborerrorstrings.o \
     $(TINYCBOR_SRC_PATH)/cborparser.o \
+    $(TINYCBOR_SRC_PATH)/cborparser_dup_string.o \
     $(TINYCBOR_SRC_PATH)/cborpretty.o
 
 obj-tinycbor-private-headers += \


### PR DESCRIPTION
Since tinycbor 0.3.2, ptr and bytes_needed of CborEncoder structure are
accessible through a named union called data instead of an unnamed union
so add the data structure when needed

Signed-off-by: Fabrice Fontaine fabrice.fontaine@orange.com
