### PR TITLE
build: Add missing symbol to libsoletta.sym

### DIFF
--- a/data/scripts/libsoletta.sym
+++ b/data/scripts/libsoletta.sym
@@ -904,4 +904,5 @@ global:
         sol_netctl_service_get_proxy;
         sol_netctl_service_get_provider;
         sol_netctl_service_get_ethernet;
+        sol_netctl_service_get_security;
 } LIBSOLETTA_1;


### PR DESCRIPTION
Add sol_netctl_service_get_security to libsoletta.sym.
Issue identified by check-api.

Signed-off-by: Anselmo L. S. Melo <anselmo.melo@intel.com>