### PR TITLE
Openssl

### DIFF
--- a/src/lib/comms/sol-gatt-impl-bluez.c
+++ b/src/lib/comms/sol-gatt-impl-bluez.c
@@ -229,6 +229,7 @@ attr_method(enum pending_type type, sd_bus_message *m, void *userdata, sd_bus_er
 
         r = attr->write(pending, &buf, 0);
         SOL_INT_CHECK_GOTO(r, < 0, error_op);
+    /* fall through */
     default:
         r = -EINVAL;
         goto error_op;

--- a/src/lib/comms/sol-network-impl-linux.c
+++ b/src/lib/comms/sol-network-impl-linux.c
@@ -282,6 +282,7 @@ _on_event(void *data, int nl_socket, uint32_t cond)
             switch (h->nlmsg_type) {
             case NLMSG_ERROR:
                 SOL_WRN("read_netlink: Message is an error");
+            /* fall through */
             case NLMSG_DONE:
                 return true;
             case RTM_NEWADDR:

--- a/src/lib/crypto/sol-message-digest-common.h
+++ b/src/lib/crypto/sol-message-digest-common.h
@@ -131,6 +131,23 @@ struct sol_message_digest_common_new_params {
      */
     const void *context_template;
     /**
+     * The algorithm-specific context as an external handle (i.e. life
+     * cycle not managed by Soletta). If set, context_template will be
+     * ignored and context_size will be set to sizeof(void *) forcibly
+     * in order to accomodate this pointer exactly. context_free()
+     * must be set when this one is non-NULL.
+     *
+     * The actual context may be retrieved with
+     * sol_message_digest_common_get_context().
+     */
+    const void *context_handle;
+    /**
+     * Free external context handle at exit.
+     *
+     * This function is called from the main thread.
+     */
+    void (*context_free)(void *context_handle);
+    /**
      * Size in bytes of @c context_template, to copy with @c memcpy().
      */
     size_t context_size;

--- a/src/lib/datatypes/include/sol-memdesc.h
+++ b/src/lib/datatypes/include/sol-memdesc.h
@@ -741,6 +741,7 @@ sol_memdesc_get_size(const struct sol_memdesc *desc)
         return sizeof(const char *);
     case SOL_MEMDESC_TYPE_PTR:
         return sizeof(void *);
+    /* fall through */
     case SOL_MEMDESC_TYPE_STRUCTURE:
     case SOL_MEMDESC_TYPE_ARRAY:
     case SOL_MEMDESC_TYPE_ENUMERATION:
@@ -748,6 +749,7 @@ sol_memdesc_get_size(const struct sol_memdesc *desc)
             return desc->size;
 
     /* must provide size */
+    /* fall through */
     default:
         errno = EINVAL;
         return 0;


### PR DESCRIPTION
Bring make check back to life on current distros. make check-valgrind is b0rked for test-mainloop-linux, gotta figure out why now.